### PR TITLE
Automate Scoop and winget publishing on releases

### DIFF
--- a/.github/workflows/publish-scoop.yml
+++ b/.github/workflows/publish-scoop.yml
@@ -1,0 +1,213 @@
+name: Publish to Scoop
+
+permissions:
+  contents: read
+
+on:
+  # Run on release tags
+  push:
+    tags:
+      - 'v*.*.*'
+
+  # Manual trigger
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 1.0.2)'
+        required: true
+        type: string
+
+jobs:
+  submit-to-scoop:
+    name: Submit PR to Scoop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout loom repo
+        uses: actions/checkout@v4
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Publishing version: $VERSION"
+
+      - name: Verify release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Check if release exists
+          if ! gh release view "v$VERSION" --repo ${{ github.repository }}; then
+            echo "Error: Release v$VERSION does not exist"
+            exit 1
+          fi
+
+          # Verify binaries exist
+          URLS=(
+            "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/loom-windows-amd64.exe.zip"
+            "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/looms-windows-amd64.exe.zip"
+          )
+
+          for url in "${URLS[@]}"; do
+            echo "Checking $url..."
+            if ! curl --head --silent --fail "$url" > /dev/null; then
+              echo "Error: Binary not found at $url"
+              exit 1
+            fi
+          done
+
+          echo "All release binaries verified"
+
+      - name: Calculate SHA256 hashes
+        id: hashes
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Download and hash loom
+          curl -L -o loom.zip "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/loom-windows-amd64.exe.zip"
+          LOOM_HASH=$(sha256sum loom.zip | awk '{print $1}')
+
+          # Download and hash looms
+          curl -L -o looms.zip "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/looms-windows-amd64.exe.zip"
+          LOOMS_HASH=$(sha256sum looms.zip | awk '{print $1}')
+
+          echo "loom_hash=$LOOM_HASH" >> $GITHUB_OUTPUT
+          echo "looms_hash=$LOOMS_HASH" >> $GITHUB_OUTPUT
+
+          echo "loom hash: $LOOM_HASH"
+          echo "looms hash: $LOOMS_HASH"
+
+      - name: Update Scoop manifests
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          LOOM_HASH="${{ steps.hashes.outputs.loom_hash }}"
+          LOOMS_HASH="${{ steps.hashes.outputs.looms_hash }}"
+
+          # Update loom.json
+          cat > /tmp/loom.json <<EOF
+          {
+              "version": "$VERSION",
+              "description": "LLM agent framework with natural language agent creation",
+              "homepage": "https://github.com/teradata-labs/loom",
+              "license": "Apache-2.0",
+              "architecture": {
+                  "64bit": {
+                      "url": "https://github.com/teradata-labs/loom/releases/download/v$VERSION/loom-windows-amd64.exe.zip",
+                      "hash": "$LOOM_HASH",
+                      "extract_dir": ""
+                  }
+              },
+              "bin": "loom-windows-amd64.exe",
+              "checkver": {
+                  "github": "https://github.com/teradata-labs/loom"
+              },
+              "autoupdate": {
+                  "architecture": {
+                      "64bit": {
+                          "url": "https://github.com/teradata-labs/loom/releases/download/v\$version/loom-windows-amd64.exe.zip"
+                      }
+                  }
+              },
+              "notes": [
+                  "Loom TUI client installed successfully!",
+                  "",
+                  "To install the Loom server as well:",
+                  "  scoop install loom-server",
+                  "",
+                  "Documentation: https://github.com/teradata-labs/loom#readme"
+              ]
+          }
+          EOF
+
+          # Update loom-server.json (using packaging file as template, just update version and hashes)
+          jq --arg ver "$VERSION" \
+             --arg hash "$LOOMS_HASH" \
+             '.version = $ver | .architecture."64bit".hash = $hash' \
+             packaging/windows/scoop/loom-server.json > /tmp/loom-server.json
+
+      - name: Fork and clone Scoop Main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check if fork exists, if not create it
+          if ! gh repo view ${{ github.actor }}/Main &>/dev/null; then
+            echo "Forking ScoopInstaller/Main..."
+            gh repo fork ScoopInstaller/Main --clone=false
+            sleep 5  # Wait for fork to be ready
+          fi
+
+          # Clone the fork
+          gh repo clone ${{ github.actor }}/Main scoop-main
+          cd scoop-main
+
+          # Add upstream
+          git remote add upstream https://github.com/ScoopInstaller/Main.git
+          git fetch upstream
+
+          # Sync with upstream main
+          git checkout main
+          git merge upstream/main
+          git push origin main
+
+      - name: Create update branch and commit
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          cd scoop-main
+
+          # Create branch
+          BRANCH="loom-${VERSION}"
+          git checkout -b "$BRANCH"
+
+          # Copy updated manifests
+          cp /tmp/loom.json bucket/loom.json
+          cp /tmp/loom-server.json bucket/loom-server.json
+
+          # Commit
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add bucket/loom.json bucket/loom-server.json
+          git commit -m "loom: Update to version $VERSION"
+
+          # Push to fork
+          git push origin "$BRANCH"
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          BRANCH="loom-${VERSION}"
+
+          cd scoop-main
+
+          gh pr create \
+            --repo ScoopInstaller/Main \
+            --title "loom: Update to version $VERSION" \
+            --body "Updates Loom to version $VERSION
+
+          ## Changes
+          - Update loom to v$VERSION
+          - Update loom-server to v$VERSION
+          - Update SHA256 hashes
+
+          ## Verification
+          - Release: https://github.com/teradata-labs/loom/releases/tag/v$VERSION
+          - Binaries verified and hashes calculated from official release
+
+          Automated PR from GitHub Actions." \
+            --head "${{ github.actor }}:$BRANCH" \
+            --base main
+
+      - name: Summary
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          echo "✅ Scoop PR submitted successfully!"
+          echo ""
+          echo "Version: $VERSION"
+          echo "Check PR status at: https://github.com/ScoopInstaller/Main/pulls"

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -1,0 +1,224 @@
+name: Publish to winget
+
+permissions:
+  contents: read
+
+on:
+  # Run on release tags
+  push:
+    tags:
+      - 'v*.*.*'
+
+  # Manual trigger
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 1.0.2)'
+        required: true
+        type: string
+
+jobs:
+  submit-to-winget:
+    name: Submit PR to winget-pkgs
+    runs-on: windows-latest
+    steps:
+      - name: Checkout loom repo
+        uses: actions/checkout@v4
+
+      - name: Determine version
+        id: version
+        shell: pwsh
+        run: |
+          if ("${{ github.event_name }}" -eq "workflow_dispatch") {
+            $version = "${{ github.event.inputs.version }}"
+          } else {
+            $version = "$env:GITHUB_REF" -replace 'refs/tags/v', ''
+          }
+          "version=$version" >> $env:GITHUB_OUTPUT
+          Write-Host "Publishing version: $version"
+
+      - name: Verify release exists
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+
+          # Check if release exists
+          $release = gh release view "v$version" --repo ${{ github.repository }} --json assets 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            throw "Error: Release v$version does not exist"
+          }
+
+          # Verify binaries exist
+          $urls = @(
+            "https://github.com/${{ github.repository }}/releases/download/v$version/loom-windows-amd64.exe.zip",
+            "https://github.com/${{ github.repository }}/releases/download/v$version/looms-windows-amd64.exe.zip"
+          )
+
+          foreach ($url in $urls) {
+            Write-Host "Checking $url..."
+            try {
+              $response = Invoke-WebRequest -Uri $url -Method Head -ErrorAction Stop
+            } catch {
+              throw "Error: Binary not found at $url"
+            }
+          }
+
+          Write-Host "All release binaries verified"
+
+      - name: Calculate SHA256 hashes
+        id: hashes
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+
+          # Download and hash loom
+          Invoke-WebRequest -Uri "https://github.com/${{ github.repository }}/releases/download/v$version/loom-windows-amd64.exe.zip" -OutFile loom.zip
+          $loomHash = (Get-FileHash loom.zip -Algorithm SHA256).Hash
+
+          # Download and hash looms
+          Invoke-WebRequest -Uri "https://github.com/${{ github.repository }}/releases/download/v$version/looms-windows-amd64.exe.zip" -OutFile looms.zip
+          $loomsHash = (Get-FileHash looms.zip -Algorithm SHA256).Hash
+
+          "loom_hash=$loomHash" >> $env:GITHUB_OUTPUT
+          "looms_hash=$loomsHash" >> $env:GITHUB_OUTPUT
+
+          Write-Host "loom hash: $loomHash"
+          Write-Host "looms hash: $loomsHash"
+
+      - name: Install wingetcreate
+        shell: pwsh
+        run: |
+          Write-Host "Installing wingetcreate..."
+          Invoke-WebRequest -Uri "https://aka.ms/wingetcreate/latest" -OutFile wingetcreate.exe
+
+      - name: Fork and clone winget-pkgs
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check if fork exists, if not create it
+          $forkExists = gh repo view "${{ github.actor }}/winget-pkgs" 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "Forking microsoft/winget-pkgs..."
+            gh repo fork microsoft/winget-pkgs --clone=false
+            Start-Sleep -Seconds 10
+          }
+
+          # Clone the fork
+          gh repo clone "${{ github.actor }}/winget-pkgs" winget-pkgs
+          cd winget-pkgs
+
+          # Add upstream
+          git remote add upstream https://github.com/microsoft/winget-pkgs.git
+          git fetch upstream
+
+          # Sync with upstream master
+          git checkout master
+          git merge upstream/master
+          git push origin master
+
+      - name: Update manifests with wingetcreate
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+          $loomHash = "${{ steps.hashes.outputs.loom_hash }}"
+          $loomsHash = "${{ steps.hashes.outputs.looms_hash }}"
+
+          cd winget-pkgs
+
+          # Create branch
+          $branch = "teradata-loom-$version"
+          git checkout -b $branch
+
+          # Create manifest directory
+          $manifestDir = "manifests/t/Teradata/Loom/$version"
+          New-Item -ItemType Directory -Force -Path $manifestDir | Out-Null
+
+          # Use wingetcreate to update manifests
+          ..\wingetcreate.exe update `
+            --id Teradata.Loom `
+            --version $version `
+            --urls "https://github.com/${{ github.repository }}/releases/download/v$version/loom-windows-amd64.exe.zip" "https://github.com/${{ github.repository }}/releases/download/v$version/looms-windows-amd64.exe.zip" `
+            --submit `
+            --token $env:GH_TOKEN
+
+          Write-Host "✅ wingetcreate submitted PR successfully"
+
+      - name: Alternative - Manual PR creation (if wingetcreate submit fails)
+        if: failure()
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+          $loomHash = "${{ steps.hashes.outputs.loom_hash }}"
+          $loomsHash = "${{ steps.hashes.outputs.looms_hash }}"
+
+          cd winget-pkgs
+
+          $branch = "teradata-loom-$version"
+          git checkout -b $branch 2>$null || git checkout $branch
+
+          # Create manifests directory
+          $manifestDir = "manifests/t/Teradata/Loom/$version"
+          New-Item -ItemType Directory -Force -Path $manifestDir | Out-Null
+
+          # Copy and update manifests from packaging directory
+          Copy-Item ..\packaging\windows\winget\*.yaml $manifestDir\
+
+          # Update version in version manifest
+          $versionFile = "$manifestDir\Teradata.Loom.yaml"
+          (Get-Content $versionFile) -replace 'PackageVersion:.*', "PackageVersion: $version" | Set-Content $versionFile
+
+          # Update hashes in installer manifest
+          $installerFile = "$manifestDir\Teradata.Loom.installer.yaml"
+          $content = Get-Content $installerFile -Raw
+          $content = $content -replace 'InstallerSha256: [A-F0-9]{64}', "InstallerSha256: $loomHash", 1
+          $content = $content -replace 'InstallerSha256: [A-F0-9]{64}', "InstallerSha256: $loomsHash"
+          $content | Set-Content $installerFile
+
+          # Commit
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add manifests/
+          git commit -m "New version: Teradata.Loom version $version"
+
+          # Push to fork
+          git push origin $branch
+
+          # Create PR
+          gh pr create `
+            --repo microsoft/winget-pkgs `
+            --title "New version: Teradata.Loom version $version" `
+            --body "Updates Teradata.Loom to version $version
+
+          ## Changes
+          - Update to v$version
+          - Update SHA256 hashes for both installers
+
+          ## Verification
+          - Release: https://github.com/teradata-labs/loom/releases/tag/v$version
+          - Binaries verified and hashes calculated from official release
+
+          Automated PR from GitHub Actions.
+
+          @microsoft-github-policy-service agree" `
+            --head "${{ github.actor }}:$branch" `
+            --base master
+
+          Write-Host "✅ Manual PR created successfully"
+
+      - name: Summary
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+          Write-Host "✅ winget PR submitted successfully!"
+          Write-Host ""
+          Write-Host "Version: $version"
+          Write-Host "Check PR status at: https://github.com/microsoft/winget-pkgs/pulls"
+          Write-Host ""
+          Write-Host "Note: Microsoft's CLA bot may comment - you've already signed the CLA, so it will auto-verify."


### PR DESCRIPTION
## Summary

Adds GitHub Actions workflows to automatically submit PRs to Scoop and winget package repositories when a new version is released.

## New Workflows

### 1. Scoop Automation (`publish-scoop.yml`)

**Triggers:**
- ✅ Release tags (`v*.*.*`)
- ✅ Manual workflow dispatch

**What it does:**
1. Verifies release and binaries exist
2. Downloads binaries and calculates SHA256 hashes
3. Forks `ScoopInstaller/Main` (if not already forked)
4. Updates `loom.json` and `loom-server.json` manifests
5. Creates PR to ScoopInstaller/Main automatically
6. Waits for Scoop maintainers to review and merge

**Benefits:**
- Zero manual work - just push a release tag
- Consistent hash calculation from official releases
- No copy-paste errors

### 2. winget Automation (`publish-winget.yml`)

**Triggers:**
- ✅ Release tags (`v*.*.*`)
- ✅ Manual workflow dispatch

**What it does:**
1. Verifies release and binaries exist
2. Downloads binaries and calculates SHA256 hashes (UPPERCASE for winget)
3. Uses `wingetcreate` tool for manifest generation
4. Forks `microsoft/winget-pkgs` (if not already forked)
5. Updates all three manifest files:
   - `Teradata.Loom.yaml`
   - `Teradata.Loom.installer.yaml`
   - `Teradata.Loom.locale.en-US.yaml`
6. Creates PR with CLA agreement included
7. Fallback to manual manifest creation if `wingetcreate` fails

**CLA Note:**
- Only needs to be signed once (already done in PR #330620)
- Workflow includes `@microsoft-github-policy-service agree` in PR body
- Bot auto-verifies based on previous signature

**Benefits:**
- Fully automated - no manual manifest editing
- UPPERCASE hash format enforced automatically
- CLA handled via PR description

## Combined Package Publishing Status

After this PR merges, releasing a new version is fully automated:

```bash
git tag -a v1.0.2 -m "Release v1.0.2"
git push origin v1.0.2
```

**All package managers update automatically:**
- ✅ **Chocolatey** - Builds + tests + publishes (from PR #14)
- ✅ **Scoop** - Creates PR to ScoopInstaller/Main (this PR)
- ✅ **winget** - Creates PR to microsoft/winget-pkgs (this PR)
- 📋 **Homebrew** - Manual tap update (could automate later)

## Testing

Both workflows support manual triggers for testing:
1. Go to Actions → Select workflow
2. Click "Run workflow"
3. Enter version (e.g., `1.0.1`)
4. Run without creating a release tag

## Security

Both workflows use:
- `permissions: contents: read` (minimal required permissions)
- Official GitHub token for forking/PRs
- No external secrets required

🤖 Generated with [Claude Code](https://claude.com/claude-code)