### PR TITLE
Fix documentation path from website/content/en/docs to docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,14 +263,12 @@ go test -race -count=50 ./pkg/agent  # Extensive testing
 ```
 
 ### Key Documentation
-- `website/content/en/docs/_index.md` - Documentation home
-- `website/content/en/docs/concepts/architecture.md` - System design deep dive
-- `website/content/en/docs/development/TODO.md` - Implementation checklist
-- `website/content/en/docs/guides/integration/observability.md` - Hawk integration details
-- `website/content/en/docs/guides/integration/prompt-management.md` - Prompt management with FileRegistry
-- `website/content/en/docs/guides/llm-providers/` - LLM provider guides
+- `docs/_index.md` - Documentation home
+- `docs/architecture/` - System design and architecture documentation
+- `docs/guides/` - User guides and tutorials
+- `docs/reference/` - API and CLI reference documentation
 
-**IMPORTANT**: Always edit documentation in `website/content/en/docs/`
+**IMPORTANT**: Always edit documentation in `docs/`
 
 ## Questions to Ask Before Implementing
 1. Does this need a proto definition first?
@@ -284,6 +282,6 @@ go test -race -count=50 ./pkg/agent  # Extensive testing
 **Remember**:
 - Proto is law. Race detector is mandatory. Observability is not optional.
 - **Documentation honesty is non-negotiable.** Verify features exist before claiming them.
-- **Documentation lives in `website/content/en/docs/`** (NOT `docs-archived/`)
-- Commit often, use checklists, write honest docs in the website directory (YOLO mode)
+- **Documentation lives in `docs/`** (top-level docs directory)
+- Commit often, use checklists, write honest docs in the docs directory (YOLO mode)
 - run just check enough to not build up tech debt.

--- a/cmd/looms/cmd_serve.go
+++ b/cmd/looms/cmd_serve.go
@@ -450,13 +450,13 @@ func runServe(cmd *cobra.Command, args []string) {
 	}
 	logger.Info("Scratchpad directory initialized", zap.String("path", scratchpadDir))
 
-	// Copy documentation from website/content/en/docs to loom data directory
+	// Copy documentation from docs to loom data directory
 	docsDestDir := filepath.Join(loomDataDir, "documentation")
 	// Try to find the docs source directory (might be in current dir or parent dir)
 	var docsSourceDir string
 	possiblePaths := []string{
-		filepath.Join("website", "content", "en", "docs"),
-		filepath.Join("..", "website", "content", "en", "docs"),
+		"docs",
+		filepath.Join("..", "docs"),
 	}
 	for _, path := range possiblePaths {
 		if info, err := os.Stat(path); err == nil && info.IsDir() {

--- a/quickstart.ps1
+++ b/quickstart.ps1
@@ -273,8 +273,8 @@ try {
     $DocsDir = "$DataDir\documentation"
     New-Item -ItemType Directory -Force -Path $DocsDir | Out-Null
 
-    if (Test-Path "$ScriptDir\website\content\en\docs") {
-        Copy-Item -Path "$ScriptDir\website\content\en\docs\*" -Destination $DocsDir -Recurse -Force
+    if (Test-Path "$ScriptDir\docs") {
+        Copy-Item -Path "$ScriptDir\docs\*" -Destination $DocsDir -Recurse -Force
         $DocCount = (Get-ChildItem -Path $DocsDir -Filter "*.md" -Recurse).Count
         Write-Success "Installed $DocCount documentation files to $DocsDir"
     } else {

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -279,8 +279,8 @@ echo ""
 # Install documentation
 echo "Installing documentation to $DATA_DIR/documentation..."
 mkdir -p "$DATA_DIR/documentation"
-if [ -d "$SCRIPT_DIR/website/content/en/docs" ]; then
-    rsync -av --delete "$SCRIPT_DIR/website/content/en/docs/" "$DATA_DIR/documentation/"
+if [ -d "$SCRIPT_DIR/docs" ]; then
+    rsync -av --delete "$SCRIPT_DIR/docs/" "$DATA_DIR/documentation/"
     DOC_COUNT=$(find "$DATA_DIR/documentation" -name '*.md' | wc -l | tr -d ' ')
     echo -e "${GREEN}✓ Installed $DOC_COUNT documentation files to $DATA_DIR/documentation${NC}"
 else


### PR DESCRIPTION
## Summary
Fixed documentation copying paths after the documentation was moved from `website/content/en/docs` to the top-level `docs/` directory.

This resolves the error where documentation was not being copied to `LOOM_DATA_DIR` during installation and server startup.

## Changes
- **quickstart.sh**: Updated rsync source path from `website/content/en/docs/` to `docs/`
- **quickstart.ps1**: Updated Copy-Item source path from `website\content\en\docs` to `docs`
- **cmd_serve.go**: Updated documentation copy logic to look for `docs/` instead of `website/content/en/docs/`
- **CLAUDE.md**: Updated documentation location instructions to reflect new path

## Testing
- ✅ Build passes: `just build`
- ✅ Lint passes: `buf lint`, `golangci-lint`, `go vet`
- ✅ Documentation copying tested successfully (76 markdown files)
- ⚠️ Test failures in Docker and example packages are pre-existing (confirmed on main branch)

## Verification
```bash
# Test documentation copy
rsync -av --delete docs/ /tmp/test-loom-docs/
# Result: 76 markdown files copied successfully
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)