### PR TITLE
Add dynamic Ollama model discovery and tool support probing

### DIFF
--- a/pkg/llm/factory/models_test.go
+++ b/pkg/llm/factory/models_test.go
@@ -1,0 +1,106 @@
+package factory
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModelRegistry_GetModelsForProvider(t *testing.T) {
+	reg := NewModelRegistry()
+
+	// Static Ollama models should be present
+	models := reg.GetModelsForProvider("ollama")
+	require.NotNil(t, models)
+	assert.Len(t, models, 3) // llama3.1, llama3.2, qwen2.5
+}
+
+func TestModelRegistry_DiscoverOllamaModels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/tags", r.URL.Path)
+		resp := ollamaTagsResponse{
+			Models: []ollamaModelEntry{
+				{Name: "qwen3:8b", Model: "qwen3:8b", Size: 5000000000},
+				{Name: "llama3.3:70b", Model: "llama3.3:70b", Size: 40000000000},
+				{Name: "mistral-small3.1:latest", Model: "mistral-small3.1:latest", Size: 15000000000},
+				{Name: "qwen3-coder:30b", Model: "qwen3-coder:30b", Size: 18000000000},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	reg := NewModelRegistry()
+
+	err := reg.DiscoverOllamaModels(server.URL)
+	require.NoError(t, err)
+
+	models := reg.GetModelsForProvider("ollama")
+	require.Len(t, models, 4)
+
+	// Verify model IDs match what Ollama reported
+	ids := make([]string, len(models))
+	for i, m := range models {
+		ids[i] = m.Id
+		assert.Equal(t, "ollama", m.Provider)
+		assert.Equal(t, float64(0), m.CostPer_1MInputUsd)
+		assert.True(t, m.Available)
+	}
+	assert.Contains(t, ids, "qwen3:8b")
+	assert.Contains(t, ids, "llama3.3:70b")
+	assert.Contains(t, ids, "mistral-small3.1:latest")
+	assert.Contains(t, ids, "qwen3-coder:30b")
+}
+
+func TestModelRegistry_DiscoverOllamaModels_Unreachable(t *testing.T) {
+	reg := NewModelRegistry()
+
+	err := reg.DiscoverOllamaModels("http://localhost:1")
+	assert.Error(t, err)
+
+	// Static models should remain intact
+	models := reg.GetModelsForProvider("ollama")
+	assert.Len(t, models, 3)
+}
+
+func TestModelRegistry_DiscoverOllamaModels_EmptyResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := ollamaTagsResponse{Models: []ollamaModelEntry{}}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	reg := NewModelRegistry()
+
+	err := reg.DiscoverOllamaModels(server.URL)
+	require.NoError(t, err)
+
+	// Should keep static defaults when no models discovered
+	models := reg.GetModelsForProvider("ollama")
+	assert.Len(t, models, 3)
+}
+
+func TestFormatOllamaDisplayName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"llama3.1", "Llama3.1 (Ollama)"},
+		{"qwen3-coder:30b", "Qwen3 coder 30B (Ollama)"},
+		{"mistral-small3.1:latest", "Mistral small3.1 (Ollama)"},
+		{"llama3.3:70b", "Llama3.3 70B (Ollama)"},
+		{"qwen3:8b", "Qwen3 8B (Ollama)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, formatOllamaDisplayName(tt.input))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- **Dynamic model discovery**: Query Ollama's `/api/tags` at startup to replace hardcoded model registry with actually-installed models
- **Runtime tool support probing**: Detect native tool calling by inspecting model templates via `/api/show`, with cached results and static fallback list
- **Updated model recommendations**: Added qwen3, qwen3-coder, mistral-small3.1, command-r, phi4 families; model-aware default max_tokens by parameter size (7B→4096, 13-34B→6144, 70B+→8192)

## Changes
- `pkg/llm/ollama/client.go` — `probeToolSupport()` via `/api/show`, updated fallback model list, 30B/34B max token tier
- `pkg/llm/factory/models.go` — `DiscoverOllamaModels()` queries `/api/tags` to populate model registry
- `pkg/llm/ollama/client_test.go` — Tests for probe detection, fallback, explicit modes, max token tiers
- `pkg/llm/factory/models_test.go` — Tests for model discovery
- `docs/reference/llm-ollama.md` — New "Dynamic Model Discovery" section, refreshed model tables and recommendations

## Test plan
- [x] `go test -tags fts5 -race ./pkg/llm/ollama/...` passes
- [x] `go test -tags fts5 -race ./pkg/llm/factory/...` passes
- [ ] Manual: pull a new Ollama model, verify it appears without config changes
- [ ] Manual: verify `auto` tool mode probes `/api/show` and caches result

🤖 Generated with [Claude Code](https://claude.com/claude-code)