### PR TITLE
fix(visualization): fail fast on styleguide endpoint; bump golang.org/x/net

### DIFF
--- a/pkg/visualization/styleguide_client.go
+++ b/pkg/visualization/styleguide_client.go
@@ -7,8 +7,14 @@ package visualization
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log"
 )
+
+// ErrStyleGuideRemoteNotImplemented is returned when a non-empty StyleGuide
+// endpoint is configured but the remote gRPC client is not implemented yet.
+var ErrStyleGuideRemoteNotImplemented = errors.New("styleguide: remote fetch not implemented")
 
 // StyleGuideClient fetches styling from Hawk StyleGuide service
 type StyleGuideClient struct {
@@ -23,45 +29,47 @@ func NewStyleGuideClient(endpoint string) *StyleGuideClient {
 	}
 }
 
-// FetchStyle retrieves the current style configuration from Hawk
-// TODO: Implement gRPC client to Hawk StyleGuide service
+// FetchStyle retrieves the current style configuration from Hawk.
+// It respects ctx cancellation: if ctx is done, it returns ctx.Err().
+// An empty endpoint returns default styling without calling the network.
+// A non-empty endpoint returns [ErrStyleGuideRemoteNotImplemented] until the
+// gRPC client exists. The theme argument is reserved for the future RPC; it is
+// not used until that client is implemented.
 func (sgc *StyleGuideClient) FetchStyle(ctx context.Context, theme string) (*StyleConfig, error) {
-	// For now, return default Hawk styling
-	// In future, this will make gRPC call to Hawk StyleGuide service
-	// to fetch current design tokens, color palettes, fonts, etc.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
 	if sgc.endpoint == "" {
-		// No endpoint configured, use defaults
 		return DefaultStyleConfig(), nil
 	}
 
-	// TODO: Implement gRPC call
-	// Example:
-	// conn, err := grpc.Dial(sgc.endpoint, grpc.WithInsecure())
+	_ = theme // Used by future gRPC GetStyle(theme).
+
+	// TODO: Implement gRPC call, for example (local dev only — use TLS creds in production):
+	// conn, err := grpc.NewClient(sgc.endpoint,
+	//     grpc.WithTransportCredentials(insecure.NewCredentials()))
 	// if err != nil {
-	//     return nil, fmt.Errorf("failed to connect to StyleGuide service: %w", err)
+	//     return nil, fmt.Errorf("styleguide dial: %w", err)
 	// }
 	// defer conn.Close()
 	//
 	// client := styleguide.NewStyleGuideServiceClient(conn)
 	// resp, err := client.GetStyle(ctx, &styleguide.GetStyleRequest{Theme: theme})
-	// if err != nil {
-	//     return nil, fmt.Errorf("failed to fetch style: %w", err)
-	// }
-	//
-	// return convertProtoToStyleConfig(resp.Style), nil
+	// ...
 
-	// For now, return default config
-	return DefaultStyleConfig(), nil
+	return nil, fmt.Errorf("%w: endpoint is set but remote client is not implemented", ErrStyleGuideRemoteNotImplemented)
 }
 
-// FetchStyleWithFallback attempts to fetch from Hawk, falls back to defaults on error
+// FetchStyleWithFallback calls [StyleGuideClient.FetchStyle] and returns [DefaultStyleConfig]
+// on any error, including context cancellation, [ErrStyleGuideRemoteNotImplemented] when the
+// endpoint is non-empty but the remote client is not implemented yet, and future RPC failures.
+// It logs the error with the default package logger (stderr). Callers that need to detect
+// misconfiguration, respect cancellation, or surface errors to users should use FetchStyle instead.
 func (sgc *StyleGuideClient) FetchStyleWithFallback(ctx context.Context, theme string) *StyleConfig {
 	style, err := sgc.FetchStyle(ctx, theme)
 	if err != nil {
-		// Log error and return defaults
-		// In production, would use proper logger
-		fmt.Printf("Warning: Failed to fetch style from Hawk, using defaults: %v\n", err)
+		log.Printf("visualization: failed to fetch style, using defaults: %v", err)
 		return DefaultStyleConfig()
 	}
 	return style

--- a/pkg/visualization/visualization_test.go
+++ b/pkg/visualization/visualization_test.go
@@ -7,6 +7,7 @@ package visualization
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -300,6 +301,44 @@ func TestStyleGuideClient_FetchStyleWithFallback(t *testing.T) {
 	}
 	if style.FontFamily == "" {
 		t.Error("FontFamily should not be empty")
+	}
+}
+
+// styleGuideTestEndpoint is a non-reserved example host (example.com is reserved by IANA for documentation).
+const styleGuideTestEndpoint = "https://hawk.example.com"
+
+func TestStyleGuideClient_FetchStyle_RemoteNotImplemented(t *testing.T) {
+	sgc := NewStyleGuideClient(styleGuideTestEndpoint)
+	_, err := sgc.FetchStyle(context.Background(), "dark")
+	if err == nil {
+		t.Fatal("expected error when endpoint is set")
+	}
+	if !errors.Is(err, ErrStyleGuideRemoteNotImplemented) {
+		t.Fatalf("expected ErrStyleGuideRemoteNotImplemented, got %v", err)
+	}
+}
+
+func TestStyleGuideClient_FetchStyle_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	sgc := NewStyleGuideClient("")
+	_, err := sgc.FetchStyle(ctx, "dark")
+	if err == nil {
+		t.Fatal("expected error for canceled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestStyleGuideClient_FetchStyleWithFallback_NonEmptyEndpoint(t *testing.T) {
+	sgc := NewStyleGuideClient(styleGuideTestEndpoint)
+	style := sgc.FetchStyleWithFallback(context.Background(), "dark")
+	if style == nil {
+		t.Fatal("FetchStyleWithFallback returned nil")
+	}
+	if style.ColorPrimary == "" {
+		t.Error("ColorPrimary should not be empty after fallback")
 	}
 }
 


### PR DESCRIPTION
## Description

When a non-empty StyleGuide endpoint is configured, `FetchStyle` no longer returns default styling as if the remote were healthy. It returns a stable, documented error (`ErrStyleGuideRemoteNotImplemented`) until the gRPC client exists. `FetchStyleWithFallback` logs and returns defaults so UIs or batch paths can keep working. This PR also bumps `golang.org/x/net` to v0.51.0 to address GO-2026-4559 (HTTP/2 frame handling) reported by `govulncheck`.

**Why:** A configured endpoint with no real client looked like success, which hides misconfiguration.

**How:** New sentinel error and wrapped return from `FetchStyle` when `endpoint != ""`; `ctx.Err()` checked first; expanded godoc and tests (including canceled context); sample endpoint `https://hawk.acme.com`; `go mod` / `go.sum` for `x/net`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] 🧪 Test update
- [x] 🏗️ Infrastructure/Build change

**Breaking note:** Callers of `FetchStyle` with a non-empty endpoint previously received defaults with no error; they now receive an error. `FetchStyleWithFallback` still returns defaults but logs when fetch fails.

## Related Issues

N/A (no linked issue).

## Changes Made

- Add `ErrStyleGuideRemoteNotImplemented`; `FetchStyle` returns it (wrapped) when endpoint is set and remote client is not implemented.
- Check `ctx.Err()` before work; document `ctx`, `theme`, TLS note in gRPC example comment.
- Expand `FetchStyleWithFallback` godoc; use `log.Printf` on error (existing behavior, now documented).
- Tests: remote not implemented, fallback with non-empty endpoint, canceled context; `styleGuideTestEndpoint` constant.
- Bump `golang.org/x/net` v0.50.0 → v0.51.0 (`go.mod`, `go.sum`).

## Testing

Ran locally: `go test ./pkg/visualization/ -short`; `golangci-lint run ./pkg/visualization/...`; `go run golang.org/x/vuln/cmd/govulncheck@latest ./pkg/visualization/...` (clean after bump). Full-repo `govulncheck ./...` may still report unrelated findings in other modules (e.g. Docker client); unchanged by this PR.

### Test Checklist

- [ ] All new and existing tests pass (`just test`)
- [ ] Race detector shows zero race conditions (`just race-check`)
- [ ] Code builds successfully (`just build`)
- [ ] All checks pass (`just check`)

### Test Coverage

- [x] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] No tests needed (explain why):

## Proto Changes

- [x] No proto changes in this PR
- [ ] Proto changes included:
  - [ ] `buf generate` executed successfully
  - [ ] `buf lint` passes
  - [ ] `buf format --diff --exit-code` passes
  - [ ] `buf breaking --against .git#branch=main` passes (or breaking changes justified)

## Documentation

- [ ] README.md updated (if user-facing changes)
- [ ] ARCHITECTURE.md updated (if architectural changes)
- [ ] TODO.md updated (if implementation plan changed)
- [x] Code comments added/updated
- [ ] No documentation changes needed

## Security

- [ ] No security implications
- [ ] Security review required because:
- [ ] Added/updated secrets handling
- [ ] Gosec scan passes (`just security`)
- [ ] CodeQL analysis passes

**Note:** Indirect dependency `golang.org/x/net` upgraded to address GO-2026-4559. No new secrets or trust boundaries in application code from this change.

## Performance

- [x] No performance impact
- [ ] Performance benchmarks included
- [ ] Performance impact justified:

## Deployment Notes

- [x] No special deployment steps needed
- [ ] Database migrations required
- [ ] Configuration changes required
- [ ] Other deployment notes:

## Checklist

### Required

- [x] I have read the [CONTRIBUTING.md](https://github.com/teradata-labs/loom/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style (gofmt, proto format)
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] All CI checks pass (proto, lint, test, build, security)
- [ ] Zero race conditions detected
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with `go test -race ./...`
- [x] Commit messages follow convention: `<type>(<scope>): <subject>`

### Optional

- [ ] I have updated the TODO.md with implementation notes
- [ ] I have added usage examples
- [ ] I have updated relevant diagrams
- [ ] I have tested on multiple platforms (Linux, macOS, Windows)

## Screenshots/Examples

Not applicable (library behavior and dependency bump).

