### PR TITLE
fix: detect quickstart shell config from SHELL

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -350,17 +350,29 @@ echo ""
 echo -e "${GREEN}[5/9] Configuring environment variables...${NC}"
 echo ""
 
-# Detect shell (ZSH_VERSION is unset under bash; expand safely with set -u)
+# Detect the user's login shell rather than the shell executing this script.
 SHELL_RC=""
-if [ -n "${BASH_VERSION:-}" ]; then
-  SHELL_RC="$HOME/.bashrc"
-elif [ -n "${ZSH_VERSION:-}" ]; then
-  SHELL_RC="$HOME/.zshrc"
+if [ -n "${SHELL:-}" ]; then
+  case "$(basename "$SHELL")" in
+    bash)
+      SHELL_RC="$HOME/.bashrc"
+      ;;
+    zsh)
+      SHELL_RC="$HOME/.zshrc"
+      ;;
+  esac
 fi
 
+LOOM_DATA_DIR_EXPORT="export LOOM_DATA_DIR=\"$DATA_DIR\""
+LOOM_BIN_DIR_EXPORT="export LOOM_BIN_DIR=\"$BIN_DIR\""
+LOOM_PATH_EXPORT="export PATH=\"$BIN_DIR:\$PATH\""
+
 if [ -n "${SHELL_RC:-}" ] && [ "$CI_MODE" = false ]; then
-  echo -e "${YELLOW}Add environment variables to $SHELL_RC?${NC}"
-  read -r -p "This will append export statements to your shell config (Y/n): " add_to_rc
+  echo -e "${YELLOW}Add these environment variables to $SHELL_RC?${NC}"
+  echo -e "${BLUE}  $LOOM_DATA_DIR_EXPORT${NC}"
+  echo -e "${BLUE}  $LOOM_BIN_DIR_EXPORT${NC}"
+  echo -e "${BLUE}  $LOOM_PATH_EXPORT${NC}"
+  read -r -p "This will append the lines above to your shell config (Y/n): " add_to_rc
   add_to_rc=${add_to_rc:-y}
 
   if [[ "$add_to_rc" =~ ^[Yy]$ ]]; then
@@ -369,9 +381,9 @@ if [ -n "${SHELL_RC:-}" ] && [ "$CI_MODE" = false ]; then
       {
         echo ""
         echo "# Loom environment variables"
-        echo "export LOOM_DATA_DIR=\"$DATA_DIR\""
-        echo "export LOOM_BIN_DIR=\"$BIN_DIR\""
-        echo "export PATH=\"$BIN_DIR:\$PATH\""
+        echo "$LOOM_DATA_DIR_EXPORT"
+        echo "$LOOM_BIN_DIR_EXPORT"
+        echo "$LOOM_PATH_EXPORT"
       } >> "$SHELL_RC"
       echo -e "${GREEN}✓ Added environment variables to $SHELL_RC${NC}"
       echo -e "${YELLOW}  Run 'source $SHELL_RC' to reload, or restart your terminal${NC}"
@@ -380,16 +392,16 @@ if [ -n "${SHELL_RC:-}" ] && [ "$CI_MODE" = false ]; then
     fi
   else
     echo -e "${YELLOW}⚠ Skipped shell config - add manually:${NC}"
-    echo -e "${BLUE}  export LOOM_DATA_DIR=\"$DATA_DIR\"${NC}"
-    echo -e "${BLUE}  export LOOM_BIN_DIR=\"$BIN_DIR\"${NC}"
-    echo -e "${BLUE}  export PATH=\"$BIN_DIR:\$PATH\"${NC}"
+    echo -e "${BLUE}  $LOOM_DATA_DIR_EXPORT${NC}"
+    echo -e "${BLUE}  $LOOM_BIN_DIR_EXPORT${NC}"
+    echo -e "${BLUE}  $LOOM_PATH_EXPORT${NC}"
   fi
 else
   echo -e "${YELLOW}⚠ Could not detect shell config file${NC}"
   echo -e "${YELLOW}  Add manually to your shell config:${NC}"
-  echo -e "${BLUE}  export LOOM_DATA_DIR=\"$DATA_DIR\"${NC}"
-  echo -e "${BLUE}  export LOOM_BIN_DIR=\"$BIN_DIR\"${NC}"
-  echo -e "${BLUE}  export PATH=\"$BIN_DIR:\$PATH\"${NC}"
+  echo -e "${BLUE}  $LOOM_DATA_DIR_EXPORT${NC}"
+  echo -e "${BLUE}  $LOOM_BIN_DIR_EXPORT${NC}"
+  echo -e "${BLUE}  $LOOM_PATH_EXPORT${NC}"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Fixes #167.

`quickstart.sh` now chooses the shell rc file from the user's login `$SHELL` instead of the shell currently running the script. Because the script runs under Bash, checking `BASH_VERSION` always selected `~/.bashrc`; zsh users running the Bash installer now get `~/.zshrc` instead.

The environment-variable prompt also shows the exact lines that will be appended before asking for confirmation, matching the issue request to make the pending changes visible.

## Verification

- `bash -n quickstart.sh`
- Targeted Bash checks for `/bin/bash`, `/usr/local/bin/zsh`, bare `zsh`, unsupported `/usr/bin/fish`, and generated export-line text
