### PR TITLE
feat(skills): end-of-turn task-board hygiene for skill-emitted tasks

### DIFF
--- a/docs/architecture/skill-hygiene.md
+++ b/docs/architecture/skill-hygiene.md
@@ -1,0 +1,401 @@
+---
+title: "Skill Hygiene Architecture"
+weight: 15
+---
+
+# Skill Hygiene Architecture
+
+End-of-turn task-board hygiene enforcement for skill-emitted tasks. Catches three failure modes — orphan `IN_PROGRESS` tasks, `BLOCKED` tasks the agent never surfaced as a question, and `OPEN` tasks the agent created but never started — before the agent returns control to the user.
+
+**Target Audience**: Architects, academics, advanced developers
+
+---
+
+## Design Goals
+
+- **No silent abandonment**: A turn must not end with an active skill's tasks in a misleading intermediate state. The board's status must match the agent's actual intent.
+- **Agent-driven repair preferred**: The default policy injects a structured message and lets the LLM resolve violations itself, because mechanical state changes erase the diagnostic signal that an agent left work hanging.
+- **Bounded retries**: The repair loop must terminate. After a configured cap, the auditor falls through to deterministic machine repair so the turn always returns.
+- **Skill-scoped**: Tasks the agent created directly via `TaskBoardTool` (no `SkillIdempotencyKey`) are out of scope. Hygiene addresses the specific failure mode where a skill activation produces tasks that the skill itself never closes; general agent task discipline is a separate concern.
+- **Non-fatal**: Hygiene failures (audit errors, transition errors) are logged and the agent still returns. A broken hygiene path must not block the user response.
+
+**Non-goals**:
+- Hygiene is not a general task-board policy engine. It runs once per turn at a single hook point.
+- It does not adjudicate dependency violations or WIP-limit overruns — those belong to `task.Manager`.
+- It does not modify or replace the human-in-the-loop flow under `ContactHumanTool`; it only spawns HITL requests as a fallback under `AUTO_FIX`.
+
+---
+
+## System Context
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│                        Agent Conversation Loop                     │
+│                                                                    │
+│  [User]                                                            │
+│    │                                                               │
+│    │ message                                                       │
+│    ▼                                                               │
+│  ┌────────────────┐   tool calls    ┌────────────────┐             │
+│  │  runConversa-  │────────────────▶│   Tool Exec    │             │
+│  │  tionLoop      │◀────────────────│                │             │
+│  └────────┬───────┘    results      └────────────────┘             │
+│           │                                                        │
+│           │ text-only response (no tool calls)                     │
+│           ▼                                                        │
+│  ┌──────────────────────────────────────────────────────────────┐  │
+│  │              runEndOfTurnHygiene (hook)                      │  │
+│  │  ┌─────────────┐    Audit     ┌────────────────────┐         │  │
+│  │  │  Auditor    │────────────▶│  Report (Violations)│         │  │
+│  │  └─────────────┘             └─────────┬──────────┘          │  │
+│  │                                        │                     │  │
+│  │                                        ▼                     │  │
+│  │  ┌─────────────┐    Enforce  ┌────────────────────┐          │  │
+│  │  │  Enforcer   │────────────▶│ EnforcementOutcome │          │  │
+│  │  └──────┬──────┘             └─────────┬──────────┘          │  │
+│  │         │                              │                     │  │
+│  │         │ REQUIRE_FIX            AUTO_FIX │ WARN_ONLY         │  │
+│  │         ▼                              ▼                     │  │
+│  │  inject user message            transition tasks /           │  │
+│  │  → continue loop                spawn HITL / log             │  │
+│  └──────────────────────────────────────────────────────────────┘  │
+│           │                                                        │
+│           │ retry? continue : return                               │
+│           ▼                                                        │
+│  [Response] ─────────────────────────────────────────▶ [User]      │
+│                                                                    │
+│  ┌────────────────┐                                                │
+│  │ task.Manager   │ ─── persisted state (SQLite/Postgres)          │
+│  │  + TaskStore   │                                                │
+│  └────────────────┘                                                │
+│  ┌────────────────┐                                                │
+│  │skills.Orches-  │ ─── active-skill set per session               │
+│  │ trator         │                                                │
+│  └────────────────┘                                                │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+**Description**: The auditor runs only when both the skills subsystem and the task subsystem are wired into the agent. It reads the active-skill set from `skills.Orchestrator` and the per-skill task inventory from `task.Manager`. It produces a `Report`; the enforcer applies the configured `HygienePolicy` and may append a synthetic user message to the session (`REQUIRE_FIX`) or mutate task state directly (`AUTO_FIX`).
+
+---
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                  pkg/skills/hygiene                              │
+│                                                                  │
+│  ┌─────────────────┐                                             │
+│  │     Auditor     │                                             │
+│  │                 │   uses                                      │
+│  │ - Audit()       │────▶ (SkillRunLister)    ── task.Manager    │
+│  │ - ResolvePolicy │────▶ (ActiveSkillSource) ── skills.Orches.  │
+│  │ - Enabled       │                                             │
+│  └────────┬────────┘                                             │
+│           │ Report                                               │
+│           ▼                                                      │
+│  ┌─────────────────┐                                             │
+│  │    Enforcer     │                                             │
+│  │                 │   uses                                      │
+│  │ - Enforce()     │────▶ (TaskMutator)       ── task.Manager    │
+│  │ - autoFix()     │────▶ (HITLSpawner)       ── (optional)      │
+│  │ - applyNote()   │                                             │
+│  └────────┬────────┘                                             │
+│           │ EnforcementOutcome                                   │
+│           ▼                                                      │
+│  ┌─────────────────┐                                             │
+│  │      Report     │                                             │
+│  │                 │                                             │
+│  │ - Violations    │                                             │
+│  │ - CountByKind() │                                             │
+│  │ - FormatTool-   │                                             │
+│  │   Message()     │                                             │
+│  └─────────────────┘                                             │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+**Description**: Three types form the hygiene package. `Auditor` reads state and produces a `Report`. `Enforcer` consumes the `Report` and produces an `EnforcementOutcome`. Both depend on small interfaces (`SkillRunLister`, `ActiveSkillSource`, `TaskMutator`, `HITLSpawner`) so tests can substitute stubs without standing up the full storage stack.
+
+---
+
+## Components
+
+### Auditor
+
+**Responsibility**: Inventory the task board for currently-active skills and classify each task into a `ViolationKind` (or "healthy" and ignore it).
+
+**Interface**: `Audit(ctx, sessionID, cfg) → (*Report, error)`. The `cfg` argument is the per-session `HygieneConfig` from `SkillsConfig.Hygiene`. The auditor resolves nil-or-unspecified fields to defaults (enabled, `REQUIRE_FIX`, `max_retries=2`).
+
+**Invariants**:
+- Only inspects tasks emitted by currently-active skills, via `task.Manager.ListBySkillRun(skillName, sessionID)`. This in turn matches the `SkillIdempotencyKey` prefix `skill:<name>|sess:<sessionID>|%`.
+- Never mutates task state.
+- Returns an empty (but non-nil) `Report` when no violations are found.
+
+### Enforcer
+
+**Responsibility**: Apply the resolved `HygienePolicy` to a `Report`. Produces an `EnforcementOutcome` describing what was done; surfaces an `InjectionMessage` when the policy demands the LLM re-attempt.
+
+**Interface**: `Enforce(ctx, *Report, retryCount, maxRetries) → (*EnforcementOutcome, error)`. `retryCount` is supplied by the agent loop; the enforcer is stateless across calls.
+
+**Invariants**:
+- `REQUIRE_FIX` never mutates state. It produces an `InjectionMessage` for the caller to append to the session.
+- `AUTO_FIX` mutates state and stamps each modified task with a `[hygiene]`-prefixed note in `Task.Notes`, so audit logs can distinguish machine writes from agent writes.
+- When `retryCount >= maxRetries` under `REQUIRE_FIX`, the policy is silently downgraded to `AUTO_FIX` so the loop terminates. The outcome records the fallthrough reason.
+- HITL spawning is best-effort: when no `HITLSpawner` is wired, `BLOCKED` violations under `AUTO_FIX` are logged and the task is left in `BLOCKED` (still a violation but at least transparent).
+
+### Report
+
+**Responsibility**: A passive value type carrying the list of `Violation` records, the resolved `Policy`, and helpers for formatting (`FormatToolMessage`) and counting (`CountByKind`).
+
+**Invariants**:
+- `FormatToolMessage` is deterministic given a fixed set of violations: skills are alphabetically sorted, violation kinds appear in a fixed order (`IN_PROGRESS`, `BLOCKED`, `OPEN`). This matters for golden-test stability and for the agent: a stable message means the LLM's cache-friendly patterns aren't disturbed by hygiene noise.
+
+---
+
+## Key Interactions
+
+### End-of-Turn Audit and Repair Loop
+
+```
+Agent           runEndOfTurn-       Auditor          Enforcer        Session       task.Manager
+  │             Hygiene                │                │              │              │
+  │ no tool        │                   │                │              │              │
+  │ calls          │                   │                │              │              │
+  ├──────────────▶ │                   │                │              │              │
+  │                ├─ Audit ──────────▶│                │              │              │
+  │                │                   ├─ ListBySkillRun ──────────────┼─────────────▶│
+  │                │                   │◀────tasks──────┼──────────────┼──────────────┤
+  │                │◀─── Report ───────┤                │              │              │
+  │                ├─ Enforce ─────────────────────────▶│              │              │
+  │                │                                    │              │              │
+  │     ┌─ REQUIRE_FIX (retries < cap) ──┐              │              │              │
+  │                │                     │              │              │              │
+  │                │◀── Outcome.ShouldRetry=true ───────┤              │              │
+  │                ├─ AddMessage(synthetic user msg) ──────────────────┼──────────────┤
+  │                │                                    │              │              │
+  │◀── retry=true ─┤                                    │              │              │
+  ├──────── continue conversation loop ────────────────────────────────┼──────────────┤
+  │                                                                    │              │
+  │     └─ AUTO_FIX or fallthrough ─┐                                  │              │
+  │                                 │                                  │              │
+  │                                 ├─ TransitionTask / UpdateTask ────┼─────────────▶│
+  │                                 ├─ SpawnHITL (optional) ───────────┤              │
+  │                                 │                                  │              │
+  │◀── retry=false ─────────────────┤                                  │              │
+  ├── return Response with hygiene_* metadata ──────────────────────────────────────▶ │
+```
+
+**Properties**:
+- **Synchronous**: every step blocks the turn return. Hygiene runs in the request path because correctness is the goal; latency is a secondary cost.
+- **Bounded**: `maxRetries` (default 2) caps `REQUIRE_FIX` retries. Worst case adds two extra LLM turns per skill that left dirty state.
+- **Non-fatal errors**: audit or enforce errors log a warning and the agent returns its existing response. The agent never fails a turn because hygiene itself broke.
+
+---
+
+## Data Structures
+
+### Violation
+
+```
+type Violation struct {
+    SkillName string         // which active skill owns the dirty task
+    Kind      ViolationKind  // IN_PROGRESS_ORPHAN | BLOCKED_NO_HITL | OPEN_UNSTARTED
+    Task      *task.Task     // the offending task (snapshot)
+    Reason    string         // CloseReason or Notes, when present
+}
+```
+
+**Invariants**: `SkillName` is always the name of a currently-active skill. `Task.SkillIdempotencyKey` always matches the prefix `skill:<SkillName>|sess:<Report.SessionID>|`.
+
+### EnforcementOutcome
+
+```
+type EnforcementOutcome struct {
+    Policy            loomv1.HygienePolicy
+    ViolationsFound   int
+    ViolationsByKind  map[string]int
+    Resolved          int      // tasks transitioned under AUTO_FIX
+    HITLSpawned       int      // BLOCKED tasks turned into HITL
+    FallthroughReason string   // populated when REQUIRE_FIX fell through
+    InjectionMessage  string   // synthetic user message under REQUIRE_FIX
+    ShouldRetry       bool     // caller should re-enter the loop
+}
+```
+
+**Invariants**: `ShouldRetry == true` implies `InjectionMessage != ""` and `Policy == REQUIRE_FIX`. `FallthroughReason != ""` implies `ShouldRetry == false` and `Policy == REQUIRE_FIX` (the original, not the downgrade).
+
+---
+
+## Algorithms
+
+### Violation Classification
+
+```
+classify(task) -> (ViolationKind, ok)
+   if task.Status == IN_PROGRESS:    return IN_PROGRESS_ORPHAN, true
+   if task.Status == BLOCKED:        return BLOCKED_NO_HITL,    true
+   if task.Status == OPEN and task.ClaimedAt == nil:
+                                     return OPEN_UNSTARTED,     true
+   otherwise:                        return _,                  false
+```
+
+**Rationale**:
+- `IN_PROGRESS` is always a violation: the lane semantics say "an agent is on this right now," but the turn is ending, so no agent is on it. This is the highest-confidence dirty state.
+- `BLOCKED` is conservatively a violation. The auditor cannot inspect the conversation transcript to verify whether the blocking question was surfaced, so it assumes nothing was surfaced. False positives are tolerable; the cost is one extra LLM turn where the agent re-states the question.
+- `OPEN` distinguishes "never claimed" from "claimed-then-released." The latter is not a violation: the agent at least tried. The former is the failure mode the original requirement describes — tasks created and silently abandoned.
+- `DEFERRED`, `DONE`, `CANCELLED` are healthy terminal states.
+
+**Complexity**: O(active_skills × tasks_per_skill). For typical agent state (1–3 active skills, ~5 tasks each), the audit is a fixed-cost millisecond-range operation dominated by the SQL prefix scan.
+
+### Fallthrough Logic
+
+The retry-with-fallthrough algorithm is:
+
+```
+if policy == REQUIRE_FIX and retries >= max_retries:
+    downgrade policy to AUTO_FIX
+    record fallthrough_reason
+```
+
+This ensures the loop terminates even if the LLM is stuck (returning identical text on every retry). Two retries is enough to recover from transient inattention; further loops typically indicate a deeper failure mode that no amount of retry will fix.
+
+---
+
+## Design Trade-offs
+
+### Decision 1: Default to REQUIRE_FIX, not AUTO_FIX
+
+**Chosen Approach**: `REQUIRE_FIX` is the default policy. The auditor injects a structured user message describing the violations; the agent is expected to resolve them with its own tool calls on the next turn.
+
+**Rationale**: Mechanical state changes destroy diagnostic signal. If `IN_PROGRESS` silently becomes `OPEN` without an audit trail, an operator looking at the kanban board can no longer tell that the agent left work hanging. Forcing the agent to fix its own mistakes preserves both the user-visible audit trail and the agent's learning loop — if the same agent leaves dirty state every turn, that pattern is visible in conversation history, not buried in a `[hygiene]` note.
+
+**Alternatives Considered**:
+- `AUTO_FIX` default: cheaper (no extra LLM turn) but masks bugs. Rejected for default.
+- `WARN_ONLY` default: lowest cost but doesn't actually fix anything. The original failure mode persists; only logging changes. Rejected.
+
+**Consequences**: Worst-case latency adds two LLM turns per dirty-state turn. For agents that never leave dirty state (the expected case), zero overhead. The cap is configurable per agent.
+
+### Decision 2: Skill-scoped, not session-scoped
+
+**Chosen Approach**: Only tasks carrying `SkillIdempotencyKey` matching an active skill are audited.
+
+**Rationale**: Hygiene addresses one specific failure mode: a skill activation produces tasks that the skill never closes. Tasks the agent creates ad-hoc via `TaskBoardTool` are general agent discipline, governed by the agent's own prompt and the user's expectations. Conflating the two creates false positives: a user may intentionally leave an `OPEN` task on the board across sessions; that is not a hygiene violation, it is a deliberate state.
+
+**Alternatives Considered**:
+- Audit all tasks on the session's board: broader coverage, but high false-positive rate for long-lived tasks the user wants to keep around.
+- Per-task opt-in: most flexible, but no concrete use case justifies the configuration surface.
+
+**Consequences**: Tasks created without a `SkillIdempotencyKey` are invisible to the auditor. This is intentional. The trade-off is that agent-created tasks rely on the agent's own discipline (prompt + system message), not on the hygiene mechanism.
+
+### Decision 3: HITLSpawner is optional, not required
+
+**Chosen Approach**: `Enforcer.WithHITLSpawner(h)` is optional. When unset, `BLOCKED` tasks under `AUTO_FIX` are logged and left in place.
+
+**Rationale**: `ContactHumanTool` is wired into the tool registry at server startup, not into the agent struct. Passing it down into the hygiene path would either require a circular import or a large refactor. The optional spawner is a small interface (`SpawnHITL(ctx, sessionID, agentID, question, *task.Task) error`) the agent layer can adapt to whatever HITL surface is wired for that deployment.
+
+**Alternatives Considered**:
+- Require a spawner: forces every embedding to construct a HITL adapter even when HITL is irrelevant (CLI-only deployments, batch runs).
+- Vendor a default spawner: would couple `hygiene` to `shuttle`, breaking layering.
+
+**Consequences**: Embeddings without HITL wiring lose the auto-fix behavior for `BLOCKED` tasks. Under `REQUIRE_FIX` (default) this is still handled — the agent is told to surface the question itself.
+
+---
+
+## Constraints and Limitations
+
+### Constraint 1: No retroactive audit
+
+**Description**: Only tasks emitted by *currently-active* skills are audited. If a skill is evicted from the active set during the turn, its tasks become invisible to the hygiene pass.
+
+**Rationale**: The skills orchestrator already has a stickiness checker that keeps skills active while they have open tasks. Skills only evict when all their tasks are terminal — so by construction, evicted skills have no dirty state.
+
+**Impact**: A pathological eviction sequence (sticky check returns false despite open tasks) would leave dirty state unaudited. The stickiness checker is conservative and treats lookup failures as "not sticky," but this remains a possible blind spot.
+
+### Constraint 2: Conversation-blind classification
+
+**Description**: The auditor cannot read the conversation transcript. It classifies `BLOCKED` as a violation whether or not the agent actually surfaced the question.
+
+**Rationale**: Reading the transcript would couple hygiene to the memory layer's representation and make false-negative classification (missing a real violation) more likely than false-positive classification (flagging a non-violation). A false positive costs one LLM turn; a false negative defeats the purpose.
+
+**Impact**: An agent that already surfaced a `BLOCKED` question may be told to surface it again. The injected message is structured so the agent can simply re-state the question; the cost is one extra turn.
+
+### Constraint 3: Best-effort error handling
+
+**Description**: Audit and enforcement errors are logged and the agent returns its existing response. Hygiene cannot block the turn even when its own machinery fails.
+
+**Rationale**: The user-facing contract is "the agent always returns." A hygiene bug must not become an availability incident.
+
+**Impact**: Persistent hygiene failures (e.g., a broken `task.Manager.ListBySkillRun`) silently degrade enforcement. Observability events (`hygiene.audit_failed`) surface this in dashboards.
+
+---
+
+## Performance Characteristics
+
+### Latency
+
+**Audit**: dominated by one SQL prefix scan per active skill. With FTS5 + the partial unique index on `skill_idempotency_key`, this is a single B-tree range scan, ~1ms for typical task counts.
+
+**Enforcement under REQUIRE_FIX**: O(1) — produces a string, appends a session message. ~0.1ms.
+
+**Enforcement under AUTO_FIX**: O(violations) — each violation triggers one `UpdateTask` (for the note) and one `TransitionTask`, plus optionally one HITL spawn. With ~5 violations, ~10–30ms depending on the storage backend.
+
+**Worst-case retry cost**: `max_retries` extra LLM turns. With the default cap of 2 and Claude Sonnet 4.5 at ~1–3 second turn latency, hygiene adds 2–6 seconds to a dirty-state turn. For clean turns, the cost is the audit alone (~1ms).
+
+### Throughput
+
+The hygiene pass runs once per conversation turn at the no-tool-call return path. It does not run mid-turn or during tool execution, so it has no effect on tool throughput.
+
+### Resource Usage
+
+**Memory**: One `Report` per turn (a few KB at most for typical task counts). Released when the turn returns.
+
+**CPU**: Negligible. Classification is a status-field check; message formatting is a single `strings.Builder` pass.
+
+---
+
+## Concurrency Model
+
+The `Auditor` and `Enforcer` are goroutine-safe. They are constructed once per agent and shared across turns. Internally they hold no state — every call passes in the report and outcome as values, and the underlying `task.Manager` is responsible for its own concurrency control.
+
+The `*retryCount` pointer is owned by the conversation loop and accessed only on the goroutine running the loop, so no synchronization is required around it.
+
+---
+
+## Error Handling Philosophy
+
+**Strategy**: Best-effort with structured logging. Hygiene errors never propagate to the caller as failures.
+
+**Error Propagation**:
+- Audit errors return `(nil, err)`. The agent logs and returns `false, nil` from `runEndOfTurnHygiene` so the conversation loop returns its existing response.
+- Enforcement errors return `(outcome, err)`. The agent logs and surfaces whatever partial outcome was built into `Response.Metadata`.
+
+**Recovery**: None. Hygiene is a quality check, not a correctness check. If it fails, the user still gets a response.
+
+**Observability**: every failure path emits a zap warning with `session`, `skill`, and the underlying error. Span events under `skills.hygiene.audit` record `hygiene.violation_found`, `hygiene.fixup_injected`, `hygiene.fallthrough_to_autofix`, and structured counts per `ViolationKind`.
+
+---
+
+## Evolution and Extensibility
+
+**Extension Points**:
+- `SkillRunLister`, `ActiveSkillSource`, `TaskMutator`, `HITLSpawner` are all interfaces. Custom backends or test doubles slot in without modifying hygiene internals.
+- New `ViolationKind` values can be added by extending `classify`; `Report.FormatToolMessage` and `kindAction` need matching cases.
+- New `HygienePolicy` values can be added to the proto enum; the `Enforce` switch needs a new branch.
+
+**Stability**: The `HygieneConfig` proto message and the `Auditor`/`Enforcer` interfaces are stable. Implementation details (the exact wording of the injection message, the precise ordering inside `FormatToolMessage`) may change between minor releases — they are not API.
+
+**Migration**: When `HygieneConfig.enabled` is unset on an existing agent config, hygiene defaults to enabled. Operators who need the old (no-hygiene) behavior must explicitly set `enabled: false`. The choice favors safety over backward compatibility because the old behavior is the bug being fixed.
+
+---
+
+## Related Work
+
+- **Workflow orchestration**: BPMN-style boundary events fire when activities end in unexpected states. Hygiene's end-of-turn audit is a degenerate version of this pattern applied to a single hook point.
+- **Garbage collection**: AUTO_FIX is analogous to a sweep phase: it reclaims state that the producer never finalized. The choice to default to REQUIRE_FIX over AUTO_FIX mirrors the choice between RAII (force the producer to clean up) and GC (have the runtime clean up).
+
+---
+
+## Further Reading
+
+- [Task System Architecture](./task-system.md) — for the underlying task lifecycle and `SkillIdempotencyKey` scheme.
+- [Skills Overhaul](./skills-overhaul.md) — for the active-skill set, stickiness, and eviction model.

--- a/gen/go/loom/v1/skill.pb.go
+++ b/gen/go/loom/v1/skill.pb.go
@@ -199,6 +199,67 @@ func (SkillRiskLevel) EnumDescriptor() ([]byte, []int) {
 	return file_loom_v1_skill_proto_rawDescGZIP(), []int{2}
 }
 
+// HygienePolicy controls how the end-of-turn auditor handles task-board
+// violations left by an active skill.
+type HygienePolicy int32
+
+const (
+	HygienePolicy_HYGIENE_POLICY_UNSPECIFIED HygienePolicy = 0
+	// Inject a synthetic user message describing the violations and re-run the
+	// LLM turn so the agent resolves them itself. Capped by max_retries; on
+	// exhaustion the auditor falls through to AUTO_FIX so the loop terminates.
+	HygienePolicy_HYGIENE_POLICY_REQUIRE_FIX HygienePolicy = 1
+	// Machine-transition tasks (OPEN→DEFERRED, IN_PROGRESS→OPEN, BLOCKED→HITL)
+	// with reason notes. Cheaper but hides agent bugs.
+	HygienePolicy_HYGIENE_POLICY_AUTO_FIX HygienePolicy = 2
+	// Emit observability events and add a violations summary to the response
+	// metadata; do not change task state and do not retry.
+	HygienePolicy_HYGIENE_POLICY_WARN_ONLY HygienePolicy = 3
+)
+
+// Enum value maps for HygienePolicy.
+var (
+	HygienePolicy_name = map[int32]string{
+		0: "HYGIENE_POLICY_UNSPECIFIED",
+		1: "HYGIENE_POLICY_REQUIRE_FIX",
+		2: "HYGIENE_POLICY_AUTO_FIX",
+		3: "HYGIENE_POLICY_WARN_ONLY",
+	}
+	HygienePolicy_value = map[string]int32{
+		"HYGIENE_POLICY_UNSPECIFIED": 0,
+		"HYGIENE_POLICY_REQUIRE_FIX": 1,
+		"HYGIENE_POLICY_AUTO_FIX":    2,
+		"HYGIENE_POLICY_WARN_ONLY":   3,
+	}
+)
+
+func (x HygienePolicy) Enum() *HygienePolicy {
+	p := new(HygienePolicy)
+	*p = x
+	return p
+}
+
+func (x HygienePolicy) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (HygienePolicy) Descriptor() protoreflect.EnumDescriptor {
+	return file_loom_v1_skill_proto_enumTypes[3].Descriptor()
+}
+
+func (HygienePolicy) Type() protoreflect.EnumType {
+	return &file_loom_v1_skill_proto_enumTypes[3]
+}
+
+func (x HygienePolicy) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use HygienePolicy.Descriptor instead.
+func (HygienePolicy) EnumDescriptor() ([]byte, []int) {
+	return file_loom_v1_skill_proto_rawDescGZIP(), []int{3}
+}
+
 // SkillBindingMode controls how an agent loads a bound skill into context.
 type SkillBindingMode int32
 
@@ -239,11 +300,11 @@ func (x SkillBindingMode) String() string {
 }
 
 func (SkillBindingMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_loom_v1_skill_proto_enumTypes[3].Descriptor()
+	return file_loom_v1_skill_proto_enumTypes[4].Descriptor()
 }
 
 func (SkillBindingMode) Type() protoreflect.EnumType {
-	return &file_loom_v1_skill_proto_enumTypes[3]
+	return &file_loom_v1_skill_proto_enumTypes[4]
 }
 
 func (x SkillBindingMode) Number() protoreflect.EnumNumber {
@@ -252,7 +313,7 @@ func (x SkillBindingMode) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SkillBindingMode.Descriptor instead.
 func (SkillBindingMode) EnumDescriptor() ([]byte, []int) {
-	return file_loom_v1_skill_proto_rawDescGZIP(), []int{3}
+	return file_loom_v1_skill_proto_rawDescGZIP(), []int{4}
 }
 
 // Skill represents an activatable behavior that combines prompt injection,
@@ -1102,7 +1163,12 @@ type SkillsConfig struct {
 	// loader can distinguish "not specified" (default true) from "explicitly
 	// false". This is the agent-level master switch; per-skill emit_tasks
 	// overrides it for individual skills.
-	TasksEnabled  *bool `protobuf:"varint,14,opt,name=tasks_enabled,json=tasksEnabled,proto3,oneof" json:"tasks_enabled,omitempty"`
+	TasksEnabled *bool `protobuf:"varint,14,opt,name=tasks_enabled,json=tasksEnabled,proto3,oneof" json:"tasks_enabled,omitempty"`
+	// End-of-turn hygiene enforcement for skill-emitted tasks. Audits the
+	// active skill's tasks before the agent returns control to the user and
+	// surfaces or repairs IN_PROGRESS / BLOCKED / OPEN-unstarted violations.
+	// When unset, hygiene is enabled with REQUIRE_FIX policy and max_retries=2.
+	Hygiene       *HygieneConfig `protobuf:"bytes,15,opt,name=hygiene,proto3" json:"hygiene,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1235,6 +1301,84 @@ func (x *SkillsConfig) GetTasksEnabled() bool {
 	return false
 }
 
+func (x *SkillsConfig) GetHygiene() *HygieneConfig {
+	if x != nil {
+		return x.Hygiene
+	}
+	return nil
+}
+
+// HygieneConfig governs end-of-turn task-board hygiene enforcement for
+// skill-emitted tasks. The auditor only inspects tasks tied to currently
+// active skills via SkillIdempotencyKey; agent-created tasks without that
+// key are out of scope.
+type HygieneConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Whether hygiene auditing runs at end-of-turn. Uses proto3 optional so
+	// the loader can distinguish "not specified" (default true) from
+	// "explicitly false".
+	Enabled *bool `protobuf:"varint,1,opt,name=enabled,proto3,oneof" json:"enabled,omitempty"`
+	// Policy applied when violations are found. Unspecified maps to
+	// REQUIRE_FIX.
+	Policy HygienePolicy `protobuf:"varint,2,opt,name=policy,proto3,enum=loom.v1.HygienePolicy" json:"policy,omitempty"`
+	// Maximum number of REQUIRE_FIX retries per turn before falling through
+	// to AUTO_FIX. <=0 falls back to the default of 2.
+	MaxRetries    int32 `protobuf:"varint,3,opt,name=max_retries,json=maxRetries,proto3" json:"max_retries,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HygieneConfig) Reset() {
+	*x = HygieneConfig{}
+	mi := &file_loom_v1_skill_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HygieneConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HygieneConfig) ProtoMessage() {}
+
+func (x *HygieneConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_loom_v1_skill_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HygieneConfig.ProtoReflect.Descriptor instead.
+func (*HygieneConfig) Descriptor() ([]byte, []int) {
+	return file_loom_v1_skill_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *HygieneConfig) GetEnabled() bool {
+	if x != nil && x.Enabled != nil {
+		return *x.Enabled
+	}
+	return false
+}
+
+func (x *HygieneConfig) GetPolicy() HygienePolicy {
+	if x != nil {
+		return x.Policy
+	}
+	return HygienePolicy_HYGIENE_POLICY_UNSPECIFIED
+}
+
+func (x *HygieneConfig) GetMaxRetries() int32 {
+	if x != nil {
+		return x.MaxRetries
+	}
+	return 0
+}
+
 // SkillBinding ties a skill (or a glob/label-selector over the skill
 // namespace) to an agent with a specific load policy. Replaces the legacy
 // SkillsConfig.enabled_skills / disabled_skills filter pair.
@@ -1259,7 +1403,7 @@ type SkillBinding struct {
 
 func (x *SkillBinding) Reset() {
 	*x = SkillBinding{}
-	mi := &file_loom_v1_skill_proto_msgTypes[10]
+	mi := &file_loom_v1_skill_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1271,7 +1415,7 @@ func (x *SkillBinding) String() string {
 func (*SkillBinding) ProtoMessage() {}
 
 func (x *SkillBinding) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_skill_proto_msgTypes[10]
+	mi := &file_loom_v1_skill_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1284,7 +1428,7 @@ func (x *SkillBinding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkillBinding.ProtoReflect.Descriptor instead.
 func (*SkillBinding) Descriptor() ([]byte, []int) {
-	return file_loom_v1_skill_proto_rawDescGZIP(), []int{10}
+	return file_loom_v1_skill_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *SkillBinding) GetName() string {
@@ -1344,7 +1488,7 @@ type SkillTaskTemplate struct {
 
 func (x *SkillTaskTemplate) Reset() {
 	*x = SkillTaskTemplate{}
-	mi := &file_loom_v1_skill_proto_msgTypes[11]
+	mi := &file_loom_v1_skill_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1356,7 +1500,7 @@ func (x *SkillTaskTemplate) String() string {
 func (*SkillTaskTemplate) ProtoMessage() {}
 
 func (x *SkillTaskTemplate) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_skill_proto_msgTypes[11]
+	mi := &file_loom_v1_skill_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1369,7 +1513,7 @@ func (x *SkillTaskTemplate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkillTaskTemplate.ProtoReflect.Descriptor instead.
 func (*SkillTaskTemplate) Descriptor() ([]byte, []int) {
-	return file_loom_v1_skill_proto_rawDescGZIP(), []int{11}
+	return file_loom_v1_skill_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *SkillTaskTemplate) GetSteps() []*SkillTaskTemplate_Step {
@@ -1429,7 +1573,7 @@ type SkillIndexNode struct {
 
 func (x *SkillIndexNode) Reset() {
 	*x = SkillIndexNode{}
-	mi := &file_loom_v1_skill_proto_msgTypes[12]
+	mi := &file_loom_v1_skill_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1441,7 +1585,7 @@ func (x *SkillIndexNode) String() string {
 func (*SkillIndexNode) ProtoMessage() {}
 
 func (x *SkillIndexNode) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_skill_proto_msgTypes[12]
+	mi := &file_loom_v1_skill_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1454,7 +1598,7 @@ func (x *SkillIndexNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkillIndexNode.ProtoReflect.Descriptor instead.
 func (*SkillIndexNode) Descriptor() ([]byte, []int) {
-	return file_loom_v1_skill_proto_rawDescGZIP(), []int{12}
+	return file_loom_v1_skill_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *SkillIndexNode) GetId() string {
@@ -1532,7 +1676,7 @@ type SkillIndex struct {
 
 func (x *SkillIndex) Reset() {
 	*x = SkillIndex{}
-	mi := &file_loom_v1_skill_proto_msgTypes[13]
+	mi := &file_loom_v1_skill_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1544,7 +1688,7 @@ func (x *SkillIndex) String() string {
 func (*SkillIndex) ProtoMessage() {}
 
 func (x *SkillIndex) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_skill_proto_msgTypes[13]
+	mi := &file_loom_v1_skill_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1557,7 +1701,7 @@ func (x *SkillIndex) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkillIndex.ProtoReflect.Descriptor instead.
 func (*SkillIndex) Descriptor() ([]byte, []int) {
-	return file_loom_v1_skill_proto_rawDescGZIP(), []int{13}
+	return file_loom_v1_skill_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *SkillIndex) GetId() string {
@@ -1613,7 +1757,7 @@ type SkillTaskTemplate_Step struct {
 
 func (x *SkillTaskTemplate_Step) Reset() {
 	*x = SkillTaskTemplate_Step{}
-	mi := &file_loom_v1_skill_proto_msgTypes[17]
+	mi := &file_loom_v1_skill_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1625,7 +1769,7 @@ func (x *SkillTaskTemplate_Step) String() string {
 func (*SkillTaskTemplate_Step) ProtoMessage() {}
 
 func (x *SkillTaskTemplate_Step) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_skill_proto_msgTypes[17]
+	mi := &file_loom_v1_skill_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1638,7 +1782,7 @@ func (x *SkillTaskTemplate_Step) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkillTaskTemplate_Step.ProtoReflect.Descriptor instead.
 func (*SkillTaskTemplate_Step) Descriptor() ([]byte, []int) {
-	return file_loom_v1_skill_proto_rawDescGZIP(), []int{11, 0}
+	return file_loom_v1_skill_proto_rawDescGZIP(), []int{12, 0}
 }
 
 func (x *SkillTaskTemplate_Step) GetTitle() string {
@@ -1775,7 +1919,7 @@ const file_loom_v1_skill_proto_rawDesc = "" +
 	"\x0factivated_at_ms\x18\x05 \x01(\x03R\ractivatedAtMs\x12\x19\n" +
 	"\bagent_id\x18\x06 \x01(\tR\aagentId\x12\x1d\n" +
 	"\n" +
-	"session_id\x18\a \x01(\tR\tsessionId\"\xaf\x05\n" +
+	"session_id\x18\a \x01(\tR\tsessionId\"\xe1\x05\n" +
 	"\fSkillsConfig\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12%\n" +
 	"\x0eenabled_skills\x18\x02 \x03(\tR\renabledSkills\x12'\n" +
@@ -1792,9 +1936,17 @@ const file_loom_v1_skill_proto_rawDesc = "" +
 	"\x18router_cache_ttl_seconds\x18\v \x01(\x05R\x15routerCacheTtlSeconds\x122\n" +
 	"\x15router_model_override\x18\f \x01(\tR\x13routerModelOverride\x12-\n" +
 	"\x13skill_task_board_id\x18\r \x01(\tR\x10skillTaskBoardId\x12(\n" +
-	"\rtasks_enabled\x18\x0e \x01(\bH\x01R\ftasksEnabled\x88\x01\x01B\x11\n" +
+	"\rtasks_enabled\x18\x0e \x01(\bH\x01R\ftasksEnabled\x88\x01\x01\x120\n" +
+	"\ahygiene\x18\x0f \x01(\v2\x16.loom.v1.HygieneConfigR\ahygieneB\x11\n" +
 	"\x0f_router_enabledB\x10\n" +
-	"\x0e_tasks_enabled\"\x95\x02\n" +
+	"\x0e_tasks_enabled\"\x8b\x01\n" +
+	"\rHygieneConfig\x12\x1d\n" +
+	"\aenabled\x18\x01 \x01(\bH\x00R\aenabled\x88\x01\x01\x12.\n" +
+	"\x06policy\x18\x02 \x01(\x0e2\x16.loom.v1.HygienePolicyR\x06policy\x12\x1f\n" +
+	"\vmax_retries\x18\x03 \x01(\x05R\n" +
+	"maxRetriesB\n" +
+	"\n" +
+	"\b_enabled\"\x95\x02\n" +
 	"\fSkillBinding\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12-\n" +
 	"\x04mode\x18\x02 \x01(\x0e2\x19.loom.v1.SkillBindingModeR\x04mode\x12\x1a\n" +
@@ -1858,7 +2010,12 @@ const file_loom_v1_skill_proto_rawDesc = "" +
 	"\x14SKILL_RISK_LEVEL_LOW\x10\x01\x12\x1b\n" +
 	"\x17SKILL_RISK_LEVEL_MEDIUM\x10\x02\x12\x19\n" +
 	"\x15SKILL_RISK_LEVEL_HIGH\x10\x03\x12\x1f\n" +
-	"\x1bSKILL_RISK_LEVEL_RESTRICTED\x10\x04*\x90\x01\n" +
+	"\x1bSKILL_RISK_LEVEL_RESTRICTED\x10\x04*\x8a\x01\n" +
+	"\rHygienePolicy\x12\x1e\n" +
+	"\x1aHYGIENE_POLICY_UNSPECIFIED\x10\x00\x12\x1e\n" +
+	"\x1aHYGIENE_POLICY_REQUIRE_FIX\x10\x01\x12\x1b\n" +
+	"\x17HYGIENE_POLICY_AUTO_FIX\x10\x02\x12\x1c\n" +
+	"\x18HYGIENE_POLICY_WARN_ONLY\x10\x03*\x90\x01\n" +
 	"\x10SkillBindingMode\x12\"\n" +
 	"\x1eSKILL_BINDING_MODE_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18SKILL_BINDING_MODE_EAGER\x10\x01\x12\x1b\n" +
@@ -1877,62 +2034,66 @@ func file_loom_v1_skill_proto_rawDescGZIP() []byte {
 	return file_loom_v1_skill_proto_rawDescData
 }
 
-var file_loom_v1_skill_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_loom_v1_skill_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
+var file_loom_v1_skill_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
+var file_loom_v1_skill_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
 var file_loom_v1_skill_proto_goTypes = []any{
 	(SkillActivationMode)(0),       // 0: loom.v1.SkillActivationMode
 	(SkillStatus)(0),               // 1: loom.v1.SkillStatus
 	(SkillRiskLevel)(0),            // 2: loom.v1.SkillRiskLevel
-	(SkillBindingMode)(0),          // 3: loom.v1.SkillBindingMode
-	(*Skill)(nil),                  // 4: loom.v1.Skill
-	(*SkillMetadata)(nil),          // 5: loom.v1.SkillMetadata
-	(*SkillTrigger)(nil),           // 6: loom.v1.SkillTrigger
-	(*SkillPrompt)(nil),            // 7: loom.v1.SkillPrompt
-	(*SkillExample)(nil),           // 8: loom.v1.SkillExample
-	(*SkillToolConfig)(nil),        // 9: loom.v1.SkillToolConfig
-	(*SkillLibrary)(nil),           // 10: loom.v1.SkillLibrary
-	(*SkillLibraryMetadata)(nil),   // 11: loom.v1.SkillLibraryMetadata
-	(*SkillActivation)(nil),        // 12: loom.v1.SkillActivation
-	(*SkillsConfig)(nil),           // 13: loom.v1.SkillsConfig
-	(*SkillBinding)(nil),           // 14: loom.v1.SkillBinding
-	(*SkillTaskTemplate)(nil),      // 15: loom.v1.SkillTaskTemplate
-	(*SkillIndexNode)(nil),         // 16: loom.v1.SkillIndexNode
-	(*SkillIndex)(nil),             // 17: loom.v1.SkillIndex
-	nil,                            // 18: loom.v1.SkillMetadata.LabelsEntry
-	nil,                            // 19: loom.v1.SkillLibraryMetadata.LabelsEntry
-	nil,                            // 20: loom.v1.SkillBinding.LabelMatchEntry
-	(*SkillTaskTemplate_Step)(nil), // 21: loom.v1.SkillTaskTemplate.Step
-	nil,                            // 22: loom.v1.SkillIndexNode.LabelsEntry
-	(TaskCategory)(0),              // 23: loom.v1.TaskCategory
-	(TaskPriority)(0),              // 24: loom.v1.TaskPriority
+	(HygienePolicy)(0),             // 3: loom.v1.HygienePolicy
+	(SkillBindingMode)(0),          // 4: loom.v1.SkillBindingMode
+	(*Skill)(nil),                  // 5: loom.v1.Skill
+	(*SkillMetadata)(nil),          // 6: loom.v1.SkillMetadata
+	(*SkillTrigger)(nil),           // 7: loom.v1.SkillTrigger
+	(*SkillPrompt)(nil),            // 8: loom.v1.SkillPrompt
+	(*SkillExample)(nil),           // 9: loom.v1.SkillExample
+	(*SkillToolConfig)(nil),        // 10: loom.v1.SkillToolConfig
+	(*SkillLibrary)(nil),           // 11: loom.v1.SkillLibrary
+	(*SkillLibraryMetadata)(nil),   // 12: loom.v1.SkillLibraryMetadata
+	(*SkillActivation)(nil),        // 13: loom.v1.SkillActivation
+	(*SkillsConfig)(nil),           // 14: loom.v1.SkillsConfig
+	(*HygieneConfig)(nil),          // 15: loom.v1.HygieneConfig
+	(*SkillBinding)(nil),           // 16: loom.v1.SkillBinding
+	(*SkillTaskTemplate)(nil),      // 17: loom.v1.SkillTaskTemplate
+	(*SkillIndexNode)(nil),         // 18: loom.v1.SkillIndexNode
+	(*SkillIndex)(nil),             // 19: loom.v1.SkillIndex
+	nil,                            // 20: loom.v1.SkillMetadata.LabelsEntry
+	nil,                            // 21: loom.v1.SkillLibraryMetadata.LabelsEntry
+	nil,                            // 22: loom.v1.SkillBinding.LabelMatchEntry
+	(*SkillTaskTemplate_Step)(nil), // 23: loom.v1.SkillTaskTemplate.Step
+	nil,                            // 24: loom.v1.SkillIndexNode.LabelsEntry
+	(TaskCategory)(0),              // 25: loom.v1.TaskCategory
+	(TaskPriority)(0),              // 26: loom.v1.TaskPriority
 }
 var file_loom_v1_skill_proto_depIdxs = []int32{
-	5,  // 0: loom.v1.Skill.metadata:type_name -> loom.v1.SkillMetadata
-	6,  // 1: loom.v1.Skill.trigger:type_name -> loom.v1.SkillTrigger
-	7,  // 2: loom.v1.Skill.prompt:type_name -> loom.v1.SkillPrompt
-	9,  // 3: loom.v1.Skill.tools:type_name -> loom.v1.SkillToolConfig
-	15, // 4: loom.v1.Skill.task_template:type_name -> loom.v1.SkillTaskTemplate
-	18, // 5: loom.v1.SkillMetadata.labels:type_name -> loom.v1.SkillMetadata.LabelsEntry
+	6,  // 0: loom.v1.Skill.metadata:type_name -> loom.v1.SkillMetadata
+	7,  // 1: loom.v1.Skill.trigger:type_name -> loom.v1.SkillTrigger
+	8,  // 2: loom.v1.Skill.prompt:type_name -> loom.v1.SkillPrompt
+	10, // 3: loom.v1.Skill.tools:type_name -> loom.v1.SkillToolConfig
+	17, // 4: loom.v1.Skill.task_template:type_name -> loom.v1.SkillTaskTemplate
+	20, // 5: loom.v1.SkillMetadata.labels:type_name -> loom.v1.SkillMetadata.LabelsEntry
 	1,  // 6: loom.v1.SkillMetadata.status:type_name -> loom.v1.SkillStatus
 	2,  // 7: loom.v1.SkillMetadata.risk_level:type_name -> loom.v1.SkillRiskLevel
 	0,  // 8: loom.v1.SkillTrigger.mode:type_name -> loom.v1.SkillActivationMode
-	8,  // 9: loom.v1.SkillPrompt.examples:type_name -> loom.v1.SkillExample
-	11, // 10: loom.v1.SkillLibrary.metadata:type_name -> loom.v1.SkillLibraryMetadata
-	4,  // 11: loom.v1.SkillLibrary.skills:type_name -> loom.v1.Skill
-	19, // 12: loom.v1.SkillLibraryMetadata.labels:type_name -> loom.v1.SkillLibraryMetadata.LabelsEntry
-	14, // 13: loom.v1.SkillsConfig.bindings:type_name -> loom.v1.SkillBinding
-	3,  // 14: loom.v1.SkillBinding.mode:type_name -> loom.v1.SkillBindingMode
-	20, // 15: loom.v1.SkillBinding.label_match:type_name -> loom.v1.SkillBinding.LabelMatchEntry
-	21, // 16: loom.v1.SkillTaskTemplate.steps:type_name -> loom.v1.SkillTaskTemplate.Step
-	22, // 17: loom.v1.SkillIndexNode.labels:type_name -> loom.v1.SkillIndexNode.LabelsEntry
-	16, // 18: loom.v1.SkillIndex.nodes:type_name -> loom.v1.SkillIndexNode
-	23, // 19: loom.v1.SkillTaskTemplate.Step.category:type_name -> loom.v1.TaskCategory
-	24, // 20: loom.v1.SkillTaskTemplate.Step.priority:type_name -> loom.v1.TaskPriority
-	21, // [21:21] is the sub-list for method output_type
-	21, // [21:21] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	9,  // 9: loom.v1.SkillPrompt.examples:type_name -> loom.v1.SkillExample
+	12, // 10: loom.v1.SkillLibrary.metadata:type_name -> loom.v1.SkillLibraryMetadata
+	5,  // 11: loom.v1.SkillLibrary.skills:type_name -> loom.v1.Skill
+	21, // 12: loom.v1.SkillLibraryMetadata.labels:type_name -> loom.v1.SkillLibraryMetadata.LabelsEntry
+	16, // 13: loom.v1.SkillsConfig.bindings:type_name -> loom.v1.SkillBinding
+	15, // 14: loom.v1.SkillsConfig.hygiene:type_name -> loom.v1.HygieneConfig
+	3,  // 15: loom.v1.HygieneConfig.policy:type_name -> loom.v1.HygienePolicy
+	4,  // 16: loom.v1.SkillBinding.mode:type_name -> loom.v1.SkillBindingMode
+	22, // 17: loom.v1.SkillBinding.label_match:type_name -> loom.v1.SkillBinding.LabelMatchEntry
+	23, // 18: loom.v1.SkillTaskTemplate.steps:type_name -> loom.v1.SkillTaskTemplate.Step
+	24, // 19: loom.v1.SkillIndexNode.labels:type_name -> loom.v1.SkillIndexNode.LabelsEntry
+	18, // 20: loom.v1.SkillIndex.nodes:type_name -> loom.v1.SkillIndexNode
+	25, // 21: loom.v1.SkillTaskTemplate.Step.category:type_name -> loom.v1.TaskCategory
+	26, // 22: loom.v1.SkillTaskTemplate.Step.priority:type_name -> loom.v1.TaskPriority
+	23, // [23:23] is the sub-list for method output_type
+	23, // [23:23] is the sub-list for method input_type
+	23, // [23:23] is the sub-list for extension type_name
+	23, // [23:23] is the sub-list for extension extendee
+	0,  // [0:23] is the sub-list for field type_name
 }
 
 func init() { file_loom_v1_skill_proto_init() }
@@ -1943,13 +2104,14 @@ func file_loom_v1_skill_proto_init() {
 	file_loom_v1_task_proto_init()
 	file_loom_v1_skill_proto_msgTypes[0].OneofWrappers = []any{}
 	file_loom_v1_skill_proto_msgTypes[9].OneofWrappers = []any{}
+	file_loom_v1_skill_proto_msgTypes[10].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_loom_v1_skill_proto_rawDesc), len(file_loom_v1_skill_proto_rawDesc)),
-			NumEnums:      4,
-			NumMessages:   19,
+			NumEnums:      5,
+			NumMessages:   20,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/gen/openapiv2/loom/v1/loom.swagger.json
+++ b/gen/openapiv2/loom/v1/loom.swagger.json
@@ -5511,6 +5511,36 @@
       },
       "description": "HealthStatus returns system health."
     },
+    "v1HygieneConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether hygiene auditing runs at end-of-turn. Uses proto3 optional so\nthe loader can distinguish \"not specified\" (default true) from\n\"explicitly false\"."
+        },
+        "policy": {
+          "$ref": "#/definitions/v1HygienePolicy",
+          "description": "Policy applied when violations are found. Unspecified maps to\nREQUIRE_FIX."
+        },
+        "maxRetries": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of REQUIRE_FIX retries per turn before falling through\nto AUTO_FIX. \u003c=0 falls back to the default of 2."
+        }
+      },
+      "description": "HygieneConfig governs end-of-turn task-board hygiene enforcement for\nskill-emitted tasks. The auditor only inspects tasks tied to currently\nactive skills via SkillIdempotencyKey; agent-created tasks without that\nkey are out of scope."
+    },
+    "v1HygienePolicy": {
+      "type": "string",
+      "enum": [
+        "HYGIENE_POLICY_UNSPECIFIED",
+        "HYGIENE_POLICY_REQUIRE_FIX",
+        "HYGIENE_POLICY_AUTO_FIX",
+        "HYGIENE_POLICY_WARN_ONLY"
+      ],
+      "default": "HYGIENE_POLICY_UNSPECIFIED",
+      "description": "HygienePolicy controls how the end-of-turn auditor handles task-board\nviolations left by an active skill.\n\n - HYGIENE_POLICY_REQUIRE_FIX: Inject a synthetic user message describing the violations and re-run the\nLLM turn so the agent resolves them itself. Capped by max_retries; on\nexhaustion the auditor falls through to AUTO_FIX so the loop terminates.\n - HYGIENE_POLICY_AUTO_FIX: Machine-transition tasks (OPEN→DEFERRED, IN_PROGRESS→OPEN, BLOCKED→HITL)\nwith reason notes. Cheaper but hides agent bugs.\n - HYGIENE_POLICY_WARN_ONLY: Emit observability events and add a violations summary to the response\nmetadata; do not change task state and do not retry."
+    },
     "v1IterativeWorkflowPattern": {
       "type": "object",
       "properties": {
@@ -8383,6 +8413,10 @@
         "tasksEnabled": {
           "type": "boolean",
           "description": "Whether activation emits tracked tasks. Uses proto3 optional so the\nloader can distinguish \"not specified\" (default true) from \"explicitly\nfalse\". This is the agent-level master switch; per-skill emit_tasks\noverrides it for individual skills."
+        },
+        "hygiene": {
+          "$ref": "#/definitions/v1HygieneConfig",
+          "description": "End-of-turn hygiene enforcement for skill-emitted tasks. Audits the\nactive skill's tasks before the agent returns control to the user and\nsurfaces or repairs IN_PROGRESS / BLOCKED / OPEN-unstarted violations.\nWhen unset, hygiene is enabled with REQUIRE_FIX policy and max_retries=2."
         }
       },
       "description": "SkillsConfig configures the skills system for an agent."

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -35,6 +35,7 @@ import (
 	"github.com/teradata-labs/loom/pkg/shuttle/builtin"
 	"github.com/teradata-labs/loom/pkg/skills"
 	"github.com/teradata-labs/loom/pkg/skills/discovery"
+	"github.com/teradata-labs/loom/pkg/skills/hygiene"
 	skilltasks "github.com/teradata-labs/loom/pkg/skills/tasks"
 	"github.com/teradata-labs/loom/pkg/storage"
 	"github.com/teradata-labs/loom/pkg/task"
@@ -305,6 +306,29 @@ func NewAgent(backend fabric.ExecutionBackend, llmProvider LLMProvider, opts ...
 			}
 			return open
 		})
+	}
+
+	// Construct the end-of-turn hygiene auditor + enforcer when both the
+	// skill and task subsystems are wired. The auditor inspects tasks
+	// emitted by currently-active skills via SkillIdempotencyKey; the
+	// enforcer applies the resolved HygienePolicy from SkillsConfig.Hygiene
+	// at end-of-turn (see runConversationLoop). Caller can preempt by
+	// providing a non-nil pair via Option before NewAgent returns.
+	if a.hygieneAuditor == nil && a.skillOrchestrator != nil && a.taskManager != nil {
+		a.hygieneAuditor = hygiene.NewAuditor(
+			a.taskManager,
+			a.skillOrchestrator,
+			hygiene.WithTracer(a.tracer),
+			hygiene.WithLogger(zap.L()),
+		)
+	}
+	if a.hygieneEnforcer == nil && a.taskManager != nil {
+		a.hygieneEnforcer = hygiene.NewEnforcer(
+			a.taskManager,
+			hygiene.WithEnforcerTracer(a.tracer),
+			hygiene.WithEnforcerLogger(zap.L()),
+			hygiene.WithAgentID(a.id),
+		)
 	}
 
 	// Install an eviction callback that boosts graph memory salience for
@@ -1926,7 +1950,9 @@ func (a *Agent) runConversationLoop(ctx Context) (*Response, error) {
 	turnCount := 0
 	toolExecutionCount := 0
 	var allToolExecutions []ToolExecution
-	emptyRetried := false // one-shot flag: retry empty LLM response at most once per conversation
+	emptyRetried := false                       // one-shot flag: retry empty LLM response at most once per conversation
+	hygieneRetries := 0                         // capped count of REQUIRE_FIX retries the end-of-turn auditor has triggered
+	var hygieneLast *hygiene.EnforcementOutcome // last outcome, surfaced into Response.Metadata
 
 	// Debug: Print config values
 	if os.Getenv("LOOM_DEBUG_BEDROCK") == "1" {
@@ -2443,17 +2469,43 @@ func (a *Agent) runConversationLoop(ctx Context) (*Response, error) {
 			span.SetAttribute("conversation.stop_reason", llmResp.StopReason)
 			span.SetAttribute("conversation.total_tokens", llmResp.Usage.TotalTokens)
 
+			// End-of-turn hygiene check for skill-emitted tasks. Audits the
+			// active skill's tasks and either injects a fixup message and
+			// retries (REQUIRE_FIX), machine-repairs the board (AUTO_FIX), or
+			// logs and continues (WARN_ONLY). See pkg/skills/hygiene.
+			retry, outcome := a.runEndOfTurnHygiene(ctx, session, &hygieneRetries)
+			if outcome != nil {
+				hygieneLast = outcome
+			}
+			if retry {
+				// runEndOfTurnHygiene already appended the synthetic user
+				// message to the session and persisted it. Re-enter the
+				// conversation loop so the LLM sees the fixup request.
+				continue
+			}
+
+			meta := map[string]interface{}{
+				"turns":           turnCount,
+				"tool_executions": toolExecutionCount,
+				"stop_reason":     llmResp.StopReason,
+				"empty_retried":   emptyRetried,
+			}
+			if hygieneLast != nil {
+				meta["hygiene_policy"] = hygieneLast.Policy.String()
+				meta["hygiene_violations_found"] = hygieneLast.ViolationsFound
+				meta["hygiene_by_kind"] = hygieneLast.ViolationsByKind
+				meta["hygiene_resolved"] = hygieneLast.Resolved
+				meta["hygiene_hitl_spawned"] = hygieneLast.HITLSpawned
+				if hygieneLast.FallthroughReason != "" {
+					meta["hygiene_fallthrough"] = hygieneLast.FallthroughReason
+				}
+			}
 			return &Response{
 				Content:        content,
 				Usage:          llmResp.Usage,
 				ToolExecutions: allToolExecutions,
 				Thinking:       llmResp.Thinking,
-				Metadata: map[string]interface{}{
-					"turns":           turnCount,
-					"tool_executions": toolExecutionCount,
-					"stop_reason":     llmResp.StopReason,
-					"empty_retried":   emptyRetried,
-				},
+				Metadata:       meta,
 			}, nil
 		}
 

--- a/pkg/agent/hygiene.go
+++ b/pkg/agent/hygiene.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"github.com/teradata-labs/loom/pkg/skills/hygiene"
+)
+
+// runEndOfTurnHygiene audits the active skill's tasks for hygiene
+// violations and applies the configured policy. The retryCount pointer is
+// incremented when a REQUIRE_FIX retry is requested so the outer loop can
+// cap retries without leaking state across turns.
+//
+// Returns (retry, outcome). retry=true tells the caller to re-enter the
+// conversation loop after the synthetic fixup message has been appended
+// to the session. outcome is non-nil when the auditor actually ran and
+// produced a result; the caller surfaces it into Response.Metadata.
+//
+// Hygiene failures are treated as non-fatal: any error during audit or
+// enforcement is logged and the call returns (false, nil) so the agent
+// can still hand control back to the user with whatever state it has.
+func (a *Agent) runEndOfTurnHygiene(ctx context.Context, session *Session, retryCount *int) (bool, *hygiene.EnforcementOutcome) {
+	if a.hygieneAuditor == nil || a.hygieneEnforcer == nil || session == nil {
+		return false, nil
+	}
+
+	cfg := a.resolveHygieneConfig()
+	if !a.hygieneAuditor.Enabled(cfg) {
+		return false, nil
+	}
+
+	report, err := a.hygieneAuditor.Audit(ctx, session.ID, cfg)
+	if err != nil {
+		zap.L().Warn("end-of-turn hygiene audit failed; skipping",
+			zap.String("session", session.ID),
+			zap.Error(err))
+		return false, nil
+	}
+	if !report.HasViolations() {
+		return false, nil
+	}
+
+	maxRetries := a.hygieneAuditor.ResolveMaxRetries(cfg)
+	outcome, err := a.hygieneEnforcer.Enforce(ctx, report, *retryCount, maxRetries)
+	if err != nil {
+		zap.L().Warn("end-of-turn hygiene enforcement failed; surfacing partial outcome",
+			zap.String("session", session.ID),
+			zap.Error(err))
+		return false, outcome
+	}
+
+	if outcome != nil && outcome.ShouldRetry && outcome.InjectionMessage != "" {
+		// Append the synthetic message to the session so the LLM sees it
+		// on the next turn. The role is "user" because the LLM treats it
+		// as input to act on, not as a system directive.
+		msg := Message{
+			Role:      "user",
+			Content:   outcome.InjectionMessage,
+			AgentID:   a.id,
+			Timestamp: time.Now(),
+		}
+		session.AddMessage(ctx, msg)
+		if err := a.memory.PersistMessage(ctx, session.ID, msg); err != nil {
+			zap.L().Warn("failed to persist hygiene fixup message",
+				zap.String("session", session.ID),
+				zap.Error(err))
+		}
+		*retryCount++
+		return true, outcome
+	}
+
+	return false, outcome
+}
+
+// resolveHygieneConfig returns the HygieneConfig from the agent's
+// SkillsConfig, or nil when no skills config is wired. Nil is the signal
+// to the auditor to apply defaults (enabled, REQUIRE_FIX, max_retries=2).
+func (a *Agent) resolveHygieneConfig() *loomv1.HygieneConfig {
+	if a.config == nil || a.config.SkillsConfig == nil {
+		return nil
+	}
+	return a.config.SkillsConfig.Hygiene
+}

--- a/pkg/agent/hygiene_test.go
+++ b/pkg/agent/hygiene_test.go
@@ -10,6 +10,7 @@ import (
 	"database/sql"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
 	_ "github.com/teradata-labs/loom/internal/sqlitedriver"
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
 	"github.com/teradata-labs/loom/pkg/observability"
 	"github.com/teradata-labs/loom/pkg/shuttle"
 	"github.com/teradata-labs/loom/pkg/skills"
@@ -262,4 +264,214 @@ func TestEndOfTurnHygiene_FullLoop(t *testing.T) {
 	// Sanity check: the synthetic message instructed the LLM correctly.
 	assert.True(t, strings.Contains(rig.session.Messages[0].Content, "Do not silently end the turn"),
 		"injected message must include the explicit anti-silent-end-of-turn instruction")
+}
+
+// =============================================================================
+// Conversation-loop integration tests (Layer 1 e2e)
+//
+// These exercise the FULL runConversationLoop -> runEndOfTurnHygiene path
+// via the public Chat() entry point. The unit tests above call
+// runEndOfTurnHygiene directly; the tests below prove that the loop's
+// "no tool calls -> hygiene -> continue" wiring actually re-runs the LLM
+// and that retries are bounded by max_retries.
+// =============================================================================
+
+// hygieneLoopLLM is a deterministic LLM stub for the loop-integration tests.
+// It records every call, runs an optional side-effect before returning
+// (used by the happy-path test to "fix" the board between turns), and
+// always returns a text-only response with no tool calls so the agent
+// hits the end-of-turn return path on each call.
+type hygieneLoopLLM struct {
+	mu       sync.Mutex
+	calls    int
+	onCall   func(callIdx int) // optional side effect run before returning; nil = no-op
+	contents []string          // per-call content; missing index -> "ack"
+}
+
+func (m *hygieneLoopLLM) Chat(_ context.Context, _ []llmtypes.Message, _ []shuttle.Tool) (*llmtypes.LLMResponse, error) {
+	m.mu.Lock()
+	idx := m.calls
+	m.calls++
+	hook := m.onCall
+	contents := m.contents
+	m.mu.Unlock()
+
+	if hook != nil {
+		hook(idx)
+	}
+
+	content := "ack"
+	if idx < len(contents) {
+		content = contents[idx]
+	}
+	return &llmtypes.LLMResponse{
+		Content:   content,
+		ToolCalls: []llmtypes.ToolCall{},
+		Usage:     llmtypes.Usage{InputTokens: 50, OutputTokens: 25, CostUSD: 0.001},
+	}, nil
+}
+
+func (m *hygieneLoopLLM) Name() string  { return "hygiene-loop-mock" }
+func (m *hygieneLoopLLM) Model() string { return "mock-v1" }
+
+func (m *hygieneLoopLLM) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
+// newAgentWithHygieneRig wires up a real Agent via NewAgent with a real
+// SQLite-backed task manager, real skills orchestrator, the hygiene
+// auditor/enforcer (constructed by NewAgent itself), and the given LLM
+// stub. Returns the agent and the task manager so tests can seed/inspect
+// task state.
+func newAgentWithHygieneRig(t *testing.T, mockLLM LLMProvider) (*Agent, *task.Manager) {
+	t.Helper()
+
+	dir := t.TempDir()
+	db, err := sql.Open("sqlite3", filepath.Join(dir, "test.db")+"?_fk=1&_journal_mode=WAL")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	mig, err := sqlite.NewMigrator(db, observability.NewNoOpTracer())
+	require.NoError(t, err)
+	require.NoError(t, mig.MigrateUp(context.Background()))
+
+	store := sqlite.NewTaskStore(db, observability.NewNoOpTracer())
+	mgr := task.NewManager(store, nil, observability.NewNoOpTracer(), nil)
+	orch := skills.NewOrchestrator(skills.NewLibrary())
+
+	cfg := DefaultConfig()
+	cfg.Name = "hygiene-loop-agent"
+	// Disable the LLM-driven pattern classifier so the mock LLM is never
+	// invoked outside our test path.
+	cfg.PatternConfig = DefaultPatternConfig()
+	cfg.PatternConfig.UseLLMClassifier = false
+	// Keep the loop tight: 1 max tool execution and 10 max turns is plenty
+	// for hygiene retries (default cap is 2 retries -> 3 LLM calls).
+	cfg.MaxTurns = 10
+	cfg.MaxToolExecutions = 10
+
+	ag := NewAgent(
+		&mockBackend{},
+		mockLLM,
+		WithConfig(cfg),
+		WithSkillOrchestrator(orch),
+		WithTaskBoard(mgr, nil, nil),
+	)
+	return ag, mgr
+}
+
+// seedOpenUnstartedTask inserts a single OPEN-unstarted task tied to the
+// given skill + session pair. The task is the dirty state the hygiene
+// auditor must detect.
+func seedOpenUnstartedTask(t *testing.T, mgr *task.Manager, skillName, sessionID, title string) *task.Task {
+	t.Helper()
+	created, _, err := mgr.CreateTaskIdempotent(context.Background(), &task.Task{
+		Title:               title,
+		Status:              loomv1.TaskStatus_TASK_STATUS_OPEN,
+		SkillIdempotencyKey: "skill:" + skillName + "|sess:" + sessionID + "|step:" + title,
+	})
+	require.NoError(t, err)
+	return created
+}
+
+// TestHygiene_FullLoop_RequireFix_FallthroughToAutoFix proves the loop's
+// `continue` wiring drives multiple LLM calls and that REQUIRE_FIX falls
+// through to AUTO_FIX after max_retries. The LLM stub never "fixes" the
+// task, so the loop should: (1) call LLM, (2) hygiene injects, (3) call
+// LLM again (retry 1), (4) hygiene injects, (5) call LLM again (retry 2),
+// (6) hygiene caps out, falls through to AUTO_FIX, deferred the task,
+// (7) return.
+func TestHygiene_FullLoop_RequireFix_FallthroughToAutoFix(t *testing.T) {
+	mockLLM := &hygieneLoopLLM{
+		contents: []string{"first response", "second response", "third response"},
+	}
+	ag, mgr := newAgentWithHygieneRig(t, mockLLM)
+
+	sessionID := "loop-sess-fallthrough"
+	ag.skillOrchestrator.ActivateSkill(sessionID, &skills.Skill{Name: "sql"}, "test", "", 1.0)
+	task1 := seedOpenUnstartedTask(t, mgr, "sql", sessionID, "design-index")
+
+	resp, err := ag.Chat(context.Background(), sessionID, "hello")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// With max_retries=2 (default), the loop should call the LLM exactly
+	// 3 times: initial + 2 REQUIRE_FIX retries. After the third call the
+	// auditor falls through to AUTO_FIX so the loop terminates.
+	assert.Equal(t, 3, mockLLM.callCount(),
+		"loop must call LLM initial + max_retries times before fallthrough")
+
+	// Response metadata must surface hygiene state from the last pass.
+	assert.Equal(t, 1, resp.Metadata["hygiene_violations_found"],
+		"the final hygiene pass detected one OPEN-unstarted violation")
+	assert.NotEmpty(t, resp.Metadata["hygiene_fallthrough"],
+		"REQUIRE_FIX must record a fallthrough reason when it caps out")
+	assert.Equal(t, 1, resp.Metadata["hygiene_resolved"],
+		"AUTO_FIX must transition exactly one task (the OPEN-unstarted seed)")
+
+	// The seeded task must end up DEFERRED in the persisted store.
+	after, err := mgr.GetTask(context.Background(), task1.ID)
+	require.NoError(t, err)
+	assert.Equal(t, loomv1.TaskStatus_TASK_STATUS_DEFERRED, after.Status,
+		"fallthrough AUTO_FIX must move OPEN-unstarted -> DEFERRED in the store")
+	assert.Contains(t, after.Notes, "[hygiene]",
+		"AUTO_FIX must annotate the task with a hygiene note")
+}
+
+// TestHygiene_FullLoop_RequireFix_AgentFixesOnRetry simulates the
+// happy-path contract: the LLM "notices" the injected fixup message and
+// resolves the violation on its second turn. The agent's side effect is
+// modeled by the LLM stub transitioning the seeded task to DONE between
+// its first and second responses — what a real LLM would accomplish by
+// emitting a task_board tool call.
+func TestHygiene_FullLoop_RequireFix_AgentFixesOnRetry(t *testing.T) {
+	sessionID := "loop-sess-happy"
+	var fixedTaskID string
+
+	mockLLM := &hygieneLoopLLM{
+		contents: []string{"working on it", "all done"},
+	}
+	ag, mgr := newAgentWithHygieneRig(t, mockLLM)
+	ag.skillOrchestrator.ActivateSkill(sessionID, &skills.Skill{Name: "sql"}, "test", "", 1.0)
+	task1 := seedOpenUnstartedTask(t, mgr, "sql", sessionID, "tune-query")
+	fixedTaskID = task1.ID
+
+	// Side effect: just before the LLM's second response (call index 1),
+	// transition the task to DONE — the test stand-in for the agent
+	// closing the task in response to the injected fixup message.
+	mockLLM.mu.Lock()
+	mockLLM.onCall = func(callIdx int) {
+		if callIdx == 1 {
+			_, _ = mgr.TransitionTask(context.Background(), fixedTaskID, loomv1.TaskStatus_TASK_STATUS_DONE)
+		}
+	}
+	mockLLM.mu.Unlock()
+
+	resp, err := ag.Chat(context.Background(), sessionID, "hello")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Exactly two LLM calls: initial + one REQUIRE_FIX retry. The second
+	// pass sees a clean board and exits without further retry.
+	assert.Equal(t, 2, mockLLM.callCount(),
+		"agent that resolves on retry must produce exactly one extra LLM call")
+
+	// The final hygiene pass returns nil outcome (clean board) so
+	// hygiene_* metadata is absent from the response. This is by design —
+	// metadata is only stamped when the auditor actually ran AND found
+	// violations. The proof of the retry is the call count above and the
+	// task's terminal state below.
+	assert.NotContains(t, resp.Metadata, "hygiene_fallthrough",
+		"clean retry must not record a fallthrough reason")
+
+	// Task is in DONE (the agent's fix), NOT DEFERRED (AUTO_FIX). This
+	// distinguishes the happy path from the fallthrough test above.
+	after, err := mgr.GetTask(context.Background(), task1.ID)
+	require.NoError(t, err)
+	assert.Equal(t, loomv1.TaskStatus_TASK_STATUS_DONE, after.Status,
+		"happy path: the agent's own fix wins; AUTO_FIX must not run")
+	assert.NotContains(t, after.Notes, "[hygiene]",
+		"happy path: no hygiene note because AUTO_FIX never fired")
 }

--- a/pkg/agent/hygiene_test.go
+++ b/pkg/agent/hygiene_test.go
@@ -1,0 +1,265 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package agent
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	_ "github.com/teradata-labs/loom/internal/sqlitedriver"
+	"github.com/teradata-labs/loom/pkg/observability"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+	"github.com/teradata-labs/loom/pkg/skills"
+	"github.com/teradata-labs/loom/pkg/skills/hygiene"
+	"github.com/teradata-labs/loom/pkg/storage/sqlite"
+	"github.com/teradata-labs/loom/pkg/task"
+	"github.com/teradata-labs/loom/pkg/types"
+)
+
+// hygieneTestRig builds a minimal Agent wired with everything the
+// end-of-turn hygiene path depends on: a real (SQLite-backed) task
+// manager, a real skills orchestrator, an auditor+enforcer, and a
+// session. Avoids the full conversation loop and full LLM mock — the
+// goal is to exercise runEndOfTurnHygiene under realistic state.
+type hygieneTestRig struct {
+	agent       *Agent
+	taskManager *task.Manager
+	session     *Session
+}
+
+func newHygieneTestRig(t *testing.T) *hygieneTestRig {
+	t.Helper()
+
+	// Real SQLite store so SkillIdempotencyKey + state transitions exercise
+	// the same code path the production agent uses.
+	dir := t.TempDir()
+	db, err := sql.Open("sqlite3", filepath.Join(dir, "test.db")+"?_fk=1&_journal_mode=WAL")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	mig, err := sqlite.NewMigrator(db, observability.NewNoOpTracer())
+	require.NoError(t, err)
+	require.NoError(t, mig.MigrateUp(context.Background()))
+
+	store := sqlite.NewTaskStore(db, observability.NewNoOpTracer())
+	mgr := task.NewManager(store, nil, observability.NewNoOpTracer(), nil)
+
+	orch := skills.NewOrchestrator(skills.NewLibrary())
+
+	a := &Agent{
+		id:                "test-agent",
+		tools:             shuttle.NewRegistry(),
+		memory:            NewMemory(),
+		skillOrchestrator: orch,
+		taskManager:       mgr,
+		hygieneAuditor: hygiene.NewAuditor(mgr, orch,
+			hygiene.WithTracer(observability.NewNoOpTracer()),
+		),
+		hygieneEnforcer: hygiene.NewEnforcer(mgr,
+			hygiene.WithEnforcerTracer(observability.NewNoOpTracer()),
+			hygiene.WithAgentID("test-agent"),
+		),
+		config: &Config{Name: "test-agent"},
+	}
+
+	sess := &Session{ID: "sess-1", AgentID: "test-agent", Messages: []types.Message{}}
+
+	return &hygieneTestRig{
+		agent:       a,
+		taskManager: mgr,
+		session:     sess,
+	}
+}
+
+// seedTask inserts a task carrying the (skill, session) idempotency key
+// at the requested status. ClaimedAt is set when the status is
+// IN_PROGRESS or the caller passes wantClaimed=true (to model an OPEN
+// task that was claimed-and-released, which is NOT a violation).
+func (r *hygieneTestRig) seedTask(t *testing.T, skillName, title string, status loomv1.TaskStatus, wantClaimed bool) *task.Task {
+	t.Helper()
+	var claimedAt *time.Time
+	if status == loomv1.TaskStatus_TASK_STATUS_IN_PROGRESS || wantClaimed {
+		now := time.Now().UTC()
+		claimedAt = &now
+	}
+	created, _, err := r.taskManager.CreateTaskIdempotent(context.Background(), &task.Task{
+		Title:               title,
+		Status:              status,
+		SkillIdempotencyKey: "skill:" + skillName + "|sess:" + r.session.ID + "|step:" + title,
+		ClaimedAt:           claimedAt,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	return created
+}
+
+func TestEndOfTurnHygiene_NoActiveSkills_NoOp(t *testing.T) {
+	rig := newHygieneTestRig(t)
+
+	retries := 0
+	retry, outcome := rig.agent.runEndOfTurnHygiene(context.Background(), rig.session, &retries)
+	assert.False(t, retry, "no active skills -> no retry")
+	assert.Nil(t, outcome, "no active skills -> no outcome (clean report short-circuits)")
+	assert.Equal(t, 0, retries)
+	assert.Empty(t, rig.session.Messages, "no injection when board is clean")
+}
+
+func TestEndOfTurnHygiene_CleanBoard_NoOp(t *testing.T) {
+	rig := newHygieneTestRig(t)
+	rig.agent.skillOrchestrator.ActivateSkill(rig.session.ID, &skills.Skill{Name: "sql"}, "test", "", 1.0)
+
+	// Seed a DONE task — not a violation.
+	rig.seedTask(t, "sql", "done-step", loomv1.TaskStatus_TASK_STATUS_DONE, false)
+
+	retries := 0
+	retry, outcome := rig.agent.runEndOfTurnHygiene(context.Background(), rig.session, &retries)
+	assert.False(t, retry)
+	assert.Nil(t, outcome, "clean board returns nil outcome")
+	assert.Empty(t, rig.session.Messages)
+}
+
+func TestEndOfTurnHygiene_RequireFix_InjectsAndRetriesOnce(t *testing.T) {
+	rig := newHygieneTestRig(t)
+	rig.agent.skillOrchestrator.ActivateSkill(rig.session.ID, &skills.Skill{Name: "sql"}, "test", "", 1.0)
+
+	// Seed each violation kind so the report covers the full surface.
+	rig.seedTask(t, "sql", "open-unstarted", loomv1.TaskStatus_TASK_STATUS_OPEN, false)
+	rig.seedTask(t, "sql", "in-progress-orphan", loomv1.TaskStatus_TASK_STATUS_IN_PROGRESS, false)
+	rig.seedTask(t, "sql", "blocked-no-hitl", loomv1.TaskStatus_TASK_STATUS_BLOCKED, false)
+
+	// Default policy is REQUIRE_FIX; default max_retries is 2.
+	retries := 0
+	retry, outcome := rig.agent.runEndOfTurnHygiene(context.Background(), rig.session, &retries)
+	require.True(t, retry, "REQUIRE_FIX with violations must request a retry")
+	require.NotNil(t, outcome)
+	assert.True(t, outcome.ShouldRetry)
+	assert.Equal(t, 3, outcome.ViolationsFound)
+	assert.Equal(t, 1, retries, "retries counter must be incremented exactly once per retry")
+
+	// The synthetic fixup message must be appended to the session so the
+	// LLM sees it on the next turn.
+	require.Len(t, rig.session.Messages, 1)
+	msg := rig.session.Messages[0]
+	assert.Equal(t, "user", msg.Role)
+	assert.Contains(t, msg.Content, "Task-board hygiene check found violations")
+	assert.Contains(t, msg.Content, "open-unstarted")
+	assert.Contains(t, msg.Content, "in-progress-orphan")
+	assert.Contains(t, msg.Content, "blocked-no-hitl")
+}
+
+func TestEndOfTurnHygiene_RequireFix_FallthroughAtCap(t *testing.T) {
+	rig := newHygieneTestRig(t)
+	rig.agent.skillOrchestrator.ActivateSkill(rig.session.ID, &skills.Skill{Name: "sql"}, "test", "", 1.0)
+
+	// One OPEN-unstarted violation; AUTO_FIX must transition it to DEFERRED.
+	created := rig.seedTask(t, "sql", "open-unstarted", loomv1.TaskStatus_TASK_STATUS_OPEN, false)
+
+	// Pre-seed retries at the cap so the next pass falls through to AUTO_FIX.
+	retries := hygiene.DefaultMaxRetries
+	retry, outcome := rig.agent.runEndOfTurnHygiene(context.Background(), rig.session, &retries)
+
+	assert.False(t, retry, "at-cap REQUIRE_FIX must fall through, not retry again")
+	require.NotNil(t, outcome)
+	assert.NotEmpty(t, outcome.FallthroughReason, "fallthrough reason must be recorded")
+	assert.Equal(t, 1, outcome.Resolved, "one OPEN task must be auto-deferred")
+	assert.Empty(t, rig.session.Messages, "fallthrough does not inject a message")
+
+	// Verify the task was actually transitioned to DEFERRED in the store.
+	got, err := rig.taskManager.GetTask(context.Background(), created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, loomv1.TaskStatus_TASK_STATUS_DEFERRED, got.Status,
+		"auto-fix must transition OPEN-unstarted -> DEFERRED in the persisted task store")
+	assert.Contains(t, got.Notes, "[hygiene]", "auto-fix must annotate the task with a hygiene note")
+}
+
+func TestEndOfTurnHygiene_AutoFixPolicy_MutatesBoardImmediately(t *testing.T) {
+	rig := newHygieneTestRig(t)
+	rig.agent.skillOrchestrator.ActivateSkill(rig.session.ID, &skills.Skill{Name: "sql"}, "test", "", 1.0)
+
+	open := rig.seedTask(t, "sql", "open", loomv1.TaskStatus_TASK_STATUS_OPEN, false)
+	inProg := rig.seedTask(t, "sql", "in-prog", loomv1.TaskStatus_TASK_STATUS_IN_PROGRESS, false)
+
+	// Configure AUTO_FIX policy on the agent's SkillsConfig.
+	rig.agent.config.SkillsConfig = &skills.SkillsConfig{
+		Hygiene: &loomv1.HygieneConfig{
+			Policy: loomv1.HygienePolicy_HYGIENE_POLICY_AUTO_FIX,
+		},
+	}
+
+	retries := 0
+	retry, outcome := rig.agent.runEndOfTurnHygiene(context.Background(), rig.session, &retries)
+	assert.False(t, retry, "AUTO_FIX must not request a retry")
+	require.NotNil(t, outcome)
+	assert.Equal(t, 2, outcome.Resolved)
+
+	openAfter, err := rig.taskManager.GetTask(context.Background(), open.ID)
+	require.NoError(t, err)
+	assert.Equal(t, loomv1.TaskStatus_TASK_STATUS_DEFERRED, openAfter.Status,
+		"AUTO_FIX must defer OPEN-unstarted tasks")
+
+	ipAfter, err := rig.taskManager.GetTask(context.Background(), inProg.ID)
+	require.NoError(t, err)
+	assert.Equal(t, loomv1.TaskStatus_TASK_STATUS_OPEN, ipAfter.Status,
+		"AUTO_FIX must release IN_PROGRESS orphans back to OPEN")
+}
+
+func TestEndOfTurnHygiene_DisabledConfig_NoOp(t *testing.T) {
+	rig := newHygieneTestRig(t)
+	rig.agent.skillOrchestrator.ActivateSkill(rig.session.ID, &skills.Skill{Name: "sql"}, "test", "", 1.0)
+	rig.seedTask(t, "sql", "open", loomv1.TaskStatus_TASK_STATUS_OPEN, false)
+
+	// Explicitly disable hygiene.
+	off := false
+	rig.agent.config.SkillsConfig = &skills.SkillsConfig{
+		Hygiene: &loomv1.HygieneConfig{Enabled: &off},
+	}
+
+	retries := 0
+	retry, outcome := rig.agent.runEndOfTurnHygiene(context.Background(), rig.session, &retries)
+	assert.False(t, retry)
+	assert.Nil(t, outcome, "disabled hygiene must short-circuit before audit")
+	assert.Empty(t, rig.session.Messages)
+}
+
+// TestEndOfTurnHygiene_FullLoop simulates the full retry contract: first
+// pass produces a violation and injects a fixup; the caller "resolves"
+// the violation (mimicking what the LLM would do on the next turn); the
+// second pass returns clean.
+func TestEndOfTurnHygiene_FullLoop(t *testing.T) {
+	rig := newHygieneTestRig(t)
+	rig.agent.skillOrchestrator.ActivateSkill(rig.session.ID, &skills.Skill{Name: "sql"}, "test", "", 1.0)
+	created := rig.seedTask(t, "sql", "step", loomv1.TaskStatus_TASK_STATUS_OPEN, false)
+
+	retries := 0
+	retry, _ := rig.agent.runEndOfTurnHygiene(context.Background(), rig.session, &retries)
+	require.True(t, retry, "first pass must request a retry")
+	require.Equal(t, 1, retries)
+	require.Len(t, rig.session.Messages, 1)
+
+	// Simulate the LLM resolving the violation in the next turn by
+	// transitioning the task to DONE.
+	_, err := rig.taskManager.TransitionTask(context.Background(), created.ID, loomv1.TaskStatus_TASK_STATUS_DONE)
+	require.NoError(t, err)
+
+	// Second pass: board is clean, no further retry.
+	retry, outcome := rig.agent.runEndOfTurnHygiene(context.Background(), rig.session, &retries)
+	assert.False(t, retry, "second pass must not retry — board is clean")
+	assert.Nil(t, outcome, "clean second pass returns nil outcome")
+	assert.Equal(t, 1, retries, "retries counter must not advance when the second pass is clean")
+	assert.Len(t, rig.session.Messages, 1, "no further message injection on clean retry")
+
+	// Sanity check: the synthetic message instructed the LLM correctly.
+	assert.True(t, strings.Contains(rig.session.Messages[0].Content, "Do not silently end the turn"),
+		"injected message must include the explicit anti-silent-end-of-turn instruction")
+}

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -29,6 +29,7 @@ import (
 	"github.com/teradata-labs/loom/pkg/shuttle"
 	"github.com/teradata-labs/loom/pkg/skills"
 	"github.com/teradata-labs/loom/pkg/skills/discovery"
+	"github.com/teradata-labs/loom/pkg/skills/hygiene"
 	skilltasks "github.com/teradata-labs/loom/pkg/skills/tasks"
 	"github.com/teradata-labs/loom/pkg/storage"
 	"github.com/teradata-labs/loom/pkg/task"
@@ -117,6 +118,13 @@ type Agent struct {
 	// skillsTurnState tracks which skills were activated in the current
 	// turn so phase D can emit tasks only for the newly-activated set.
 	skillsTurnState map[string]map[string]bool // sessionID -> skillName -> activated-this-turn
+
+	// End-of-turn hygiene enforcement for skill-emitted tasks. Constructed
+	// when both skillOrchestrator and taskManager are present; runs at the
+	// conversation-loop return path to audit IN_PROGRESS / BLOCKED /
+	// OPEN-unstarted tasks left dirty by an active skill.
+	hygieneAuditor  *hygiene.Auditor
+	hygieneEnforcer *hygiene.Enforcer
 
 	// Inter-agent communication (optional)
 	refStore     communication.ReferenceStore // Reference storage for agent-to-agent communication

--- a/pkg/skills/hygiene/auditor.go
+++ b/pkg/skills/hygiene/auditor.go
@@ -1,0 +1,255 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package hygiene
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"github.com/teradata-labs/loom/pkg/observability"
+	"github.com/teradata-labs/loom/pkg/skills"
+	"github.com/teradata-labs/loom/pkg/task"
+)
+
+// DefaultMaxRetries is the cap on REQUIRE_FIX retries per turn when
+// HygieneConfig.max_retries <= 0. Two retries is enough for the agent to
+// notice the message and act; further loops typically indicate a stuck
+// LLM rather than a hygiene gap, so we fall through to AUTO_FIX.
+const DefaultMaxRetries = 2
+
+// SkillRunLister is the subset of task.Manager the auditor needs. Defined
+// as an interface so tests can substitute a stub without standing up a
+// real store.
+type SkillRunLister interface {
+	ListBySkillRun(ctx context.Context, skillName, sessionID string) ([]*task.Task, error)
+}
+
+// ActiveSkillSource exposes the orchestrator's active-skill view. Defined
+// as an interface so tests don't need a real Orchestrator.
+type ActiveSkillSource interface {
+	GetActiveSkills(sessionID string) []*skills.ActiveSkill
+}
+
+// Auditor inventories the task board for currently-active skills and
+// classifies any incoherent state as a Violation. Goroutine-safe; one
+// instance per agent is normal.
+type Auditor struct {
+	lister      SkillRunLister
+	activeSrc   ActiveSkillSource
+	tracer      observability.Tracer
+	logger      *zap.Logger
+	defaultPol  loomv1.HygienePolicy
+	defaultMaxR int
+}
+
+// Option configures an Auditor at construction.
+type Option func(*Auditor)
+
+// WithTracer wires an observability tracer. Audit creates one span per
+// invocation and emits a violation-count event.
+func WithTracer(t observability.Tracer) Option {
+	return func(a *Auditor) {
+		if t != nil {
+			a.tracer = t
+		}
+	}
+}
+
+// WithLogger wires a zap logger. Defaults to zap.NewNop().
+func WithLogger(l *zap.Logger) Option {
+	return func(a *Auditor) {
+		if l != nil {
+			a.logger = l
+		}
+	}
+}
+
+// WithDefaultPolicy sets the fallback policy used when HygieneConfig is
+// nil or has POLICY_UNSPECIFIED. Defaults to REQUIRE_FIX.
+func WithDefaultPolicy(p loomv1.HygienePolicy) Option {
+	return func(a *Auditor) {
+		if p != loomv1.HygienePolicy_HYGIENE_POLICY_UNSPECIFIED {
+			a.defaultPol = p
+		}
+	}
+}
+
+// WithDefaultMaxRetries sets the fallback retry cap used when
+// HygieneConfig.max_retries <= 0. Defaults to DefaultMaxRetries.
+func WithDefaultMaxRetries(n int) Option {
+	return func(a *Auditor) {
+		if n > 0 {
+			a.defaultMaxR = n
+		}
+	}
+}
+
+// NewAuditor constructs an Auditor. lister and activeSrc must be non-nil.
+func NewAuditor(lister SkillRunLister, activeSrc ActiveSkillSource, opts ...Option) *Auditor {
+	if lister == nil {
+		panic("hygiene.NewAuditor: lister must not be nil")
+	}
+	if activeSrc == nil {
+		panic("hygiene.NewAuditor: activeSrc must not be nil")
+	}
+	a := &Auditor{
+		lister:      lister,
+		activeSrc:   activeSrc,
+		tracer:      observability.NewNoOpTracer(),
+		logger:      zap.NewNop(),
+		defaultPol:  loomv1.HygienePolicy_HYGIENE_POLICY_REQUIRE_FIX,
+		defaultMaxR: DefaultMaxRetries,
+	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
+}
+
+// ResolvePolicy returns the effective policy for the given config. nil or
+// UNSPECIFIED falls back to the auditor's default. Exposed so the agent
+// hook can decide before calling Audit (e.g., short-circuit on
+// !enabled).
+func (a *Auditor) ResolvePolicy(cfg *loomv1.HygieneConfig) loomv1.HygienePolicy {
+	if cfg == nil || cfg.Policy == loomv1.HygienePolicy_HYGIENE_POLICY_UNSPECIFIED {
+		return a.defaultPol
+	}
+	return cfg.Policy
+}
+
+// ResolveMaxRetries returns the effective retry cap for the given config.
+func (a *Auditor) ResolveMaxRetries(cfg *loomv1.HygieneConfig) int {
+	if cfg == nil || cfg.MaxRetries <= 0 {
+		return a.defaultMaxR
+	}
+	return int(cfg.MaxRetries)
+}
+
+// Enabled reports whether the auditor should run for the given config.
+// Nil config defaults to enabled (proto3 optional "not specified" -> true).
+func (a *Auditor) Enabled(cfg *loomv1.HygieneConfig) bool {
+	if cfg == nil {
+		return true
+	}
+	if cfg.Enabled == nil {
+		return true
+	}
+	return *cfg.Enabled
+}
+
+// Audit inspects every currently-active skill for the session and returns
+// a Report of any violations. An empty Report (HasViolations() == false)
+// means the board is clean. Errors from the underlying lister are
+// surfaced; the caller should treat them as non-fatal (log and skip
+// hygiene rather than block the turn).
+func (a *Auditor) Audit(ctx context.Context, sessionID string, cfg *loomv1.HygieneConfig) (*Report, error) {
+	ctx, span := a.tracer.StartSpan(ctx, "skills.hygiene.audit")
+	defer a.tracer.EndSpan(span)
+
+	report := &Report{
+		SessionID: sessionID,
+		Policy:    a.ResolvePolicy(cfg),
+	}
+
+	active := a.activeSrc.GetActiveSkills(sessionID)
+	if len(active) == 0 {
+		span.SetAttribute("hygiene.active_skills", 0)
+		return report, nil
+	}
+
+	start := time.Now()
+	for _, as := range active {
+		if as == nil || as.Skill == nil {
+			continue
+		}
+		tasks, err := a.lister.ListBySkillRun(ctx, as.Skill.Name, sessionID)
+		if err != nil {
+			return nil, fmt.Errorf("list tasks for skill %q: %w", as.Skill.Name, err)
+		}
+		for _, t := range tasks {
+			if t == nil {
+				continue
+			}
+			kind, ok := classify(t)
+			if !ok {
+				continue
+			}
+			report.Violations = append(report.Violations, Violation{
+				SkillName: as.Skill.Name,
+				Kind:      kind,
+				Task:      t,
+				Reason:    extractReason(t),
+			})
+		}
+	}
+
+	counts := report.CountByKind()
+	span.SetAttribute("hygiene.active_skills", int64(len(active)))
+	span.SetAttribute("hygiene.violations_total", int64(len(report.Violations)))
+	span.SetAttribute("hygiene.duration_ms", time.Since(start).Milliseconds())
+	if report.HasViolations() {
+		span.AddEvent("hygiene.violation_found", map[string]any{
+			"session_id":         sessionID,
+			"in_progress_orphan": counts[ViolationInProgressOrphan.String()],
+			"blocked_no_hitl":    counts[ViolationBlockedNoHITL.String()],
+			"open_unstarted":     counts[ViolationOpenUnstarted.String()],
+			"policy":             report.Policy.String(),
+		})
+		a.logger.Info("hygiene violations found",
+			zap.String("session", sessionID),
+			zap.Int("count", len(report.Violations)),
+			zap.Any("by_kind", counts),
+			zap.String("policy", report.Policy.String()),
+		)
+	}
+
+	return report, nil
+}
+
+// classify maps a task's current status to a ViolationKind. Returns
+// (_, false) when the task is in a healthy terminal/non-violating state.
+//
+// Decision rules:
+//   - IN_PROGRESS  -> always a violation (orphan claim).
+//   - BLOCKED      -> always a violation (no HITL was surfaced from inside
+//     the hygiene-relevant lifecycle; the auditor can't see the chat, so
+//     it conservatively treats every BLOCKED as needing surfacing).
+//   - OPEN         -> violation only when never claimed (ClaimedAt == nil).
+//     OPEN tasks that were claimed-and-released are not the same failure
+//     mode; the agent at least tried.
+//   - DONE / DEFERRED / CANCELLED -> healthy.
+func classify(t *task.Task) (ViolationKind, bool) {
+	switch t.Status {
+	case loomv1.TaskStatus_TASK_STATUS_IN_PROGRESS:
+		return ViolationInProgressOrphan, true
+	case loomv1.TaskStatus_TASK_STATUS_BLOCKED:
+		return ViolationBlockedNoHITL, true
+	case loomv1.TaskStatus_TASK_STATUS_OPEN:
+		if t.ClaimedAt == nil {
+			return ViolationOpenUnstarted, true
+		}
+		return ViolationUnknown, false
+	default:
+		return ViolationUnknown, false
+	}
+}
+
+// extractReason picks the most informative human-readable text the agent
+// already wrote about why this task is in its current state. Falls back
+// to an empty string when no notes were captured.
+func extractReason(t *task.Task) string {
+	if t.CloseReason != "" {
+		return t.CloseReason
+	}
+	if t.Notes != "" {
+		return t.Notes
+	}
+	return ""
+}

--- a/pkg/skills/hygiene/auditor_test.go
+++ b/pkg/skills/hygiene/auditor_test.go
@@ -1,0 +1,258 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package hygiene
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"github.com/teradata-labs/loom/pkg/skills"
+	"github.com/teradata-labs/loom/pkg/task"
+)
+
+// stubLister returns canned tasks per (skillName, sessionID). Tests
+// construct one before each call to Audit.
+type stubLister struct {
+	byKey map[string][]*task.Task
+	err   error
+}
+
+func (s *stubLister) ListBySkillRun(_ context.Context, skillName, sessionID string) ([]*task.Task, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.byKey[skillName+"|"+sessionID], nil
+}
+
+// stubActiveSrc returns canned active skills per session.
+type stubActiveSrc struct {
+	bySession map[string][]*skills.ActiveSkill
+}
+
+func (s *stubActiveSrc) GetActiveSkills(sessionID string) []*skills.ActiveSkill {
+	return s.bySession[sessionID]
+}
+
+// active is a small helper that builds an ActiveSkill stub with just the
+// fields the auditor reads.
+func active(name string) *skills.ActiveSkill {
+	return &skills.ActiveSkill{Skill: &skills.Skill{Name: name}}
+}
+
+// tcase is one row of the table for TestAuditor_Audit.
+type tcase struct {
+	name           string
+	activeSkills   []*skills.ActiveSkill
+	tasksBySkill   map[string][]*task.Task
+	wantViolations int
+	wantByKind     map[string]int
+}
+
+func TestAuditor_Audit(t *testing.T) {
+	now := time.Now()
+	claimed := now.Add(-1 * time.Minute)
+
+	cases := []tcase{
+		{
+			name:           "no active skills returns clean report",
+			activeSkills:   nil,
+			tasksBySkill:   nil,
+			wantViolations: 0,
+			wantByKind: map[string]int{
+				ViolationInProgressOrphan.String(): 0,
+				ViolationBlockedNoHITL.String():    0,
+				ViolationOpenUnstarted.String():    0,
+			},
+		},
+		{
+			name:         "all tasks DONE -> clean",
+			activeSkills: []*skills.ActiveSkill{active("sql")},
+			tasksBySkill: map[string][]*task.Task{
+				"sql|s1": {
+					{ID: "t1", Status: loomv1.TaskStatus_TASK_STATUS_DONE},
+				},
+			},
+			wantViolations: 0,
+		},
+		{
+			name:         "IN_PROGRESS orphan flagged",
+			activeSkills: []*skills.ActiveSkill{active("sql")},
+			tasksBySkill: map[string][]*task.Task{
+				"sql|s1": {
+					{ID: "t1", Title: "tune query", Status: loomv1.TaskStatus_TASK_STATUS_IN_PROGRESS, ClaimedAt: &claimed},
+				},
+			},
+			wantViolations: 1,
+			wantByKind: map[string]int{
+				ViolationInProgressOrphan.String(): 1,
+				ViolationBlockedNoHITL.String():    0,
+				ViolationOpenUnstarted.String():    0,
+			},
+		},
+		{
+			name:         "BLOCKED with no HITL flagged",
+			activeSkills: []*skills.ActiveSkill{active("sql")},
+			tasksBySkill: map[string][]*task.Task{
+				"sql|s1": {
+					{ID: "t1", Title: "tune query", Status: loomv1.TaskStatus_TASK_STATUS_BLOCKED, Notes: "need DBA cred"},
+				},
+			},
+			wantViolations: 1,
+			wantByKind: map[string]int{
+				ViolationInProgressOrphan.String(): 0,
+				ViolationBlockedNoHITL.String():    1,
+				ViolationOpenUnstarted.String():    0,
+			},
+		},
+		{
+			name:         "OPEN with no ClaimedAt flagged as unstarted",
+			activeSkills: []*skills.ActiveSkill{active("sql")},
+			tasksBySkill: map[string][]*task.Task{
+				"sql|s1": {
+					{ID: "t1", Title: "design index", Status: loomv1.TaskStatus_TASK_STATUS_OPEN},
+				},
+			},
+			wantViolations: 1,
+			wantByKind: map[string]int{
+				ViolationInProgressOrphan.String(): 0,
+				ViolationBlockedNoHITL.String():    0,
+				ViolationOpenUnstarted.String():    1,
+			},
+		},
+		{
+			name:         "OPEN that was claimed-then-released is NOT a violation",
+			activeSkills: []*skills.ActiveSkill{active("sql")},
+			tasksBySkill: map[string][]*task.Task{
+				"sql|s1": {
+					{ID: "t1", Status: loomv1.TaskStatus_TASK_STATUS_OPEN, ClaimedAt: &claimed},
+				},
+			},
+			wantViolations: 0,
+		},
+		{
+			name: "mixed: two skills, each contributes violations",
+			activeSkills: []*skills.ActiveSkill{
+				active("sql"),
+				active("docs"),
+			},
+			tasksBySkill: map[string][]*task.Task{
+				"sql|s1": {
+					{ID: "t1", Status: loomv1.TaskStatus_TASK_STATUS_IN_PROGRESS, ClaimedAt: &claimed},
+					{ID: "t2", Status: loomv1.TaskStatus_TASK_STATUS_DONE},
+				},
+				"docs|s1": {
+					{ID: "t3", Status: loomv1.TaskStatus_TASK_STATUS_OPEN},
+					{ID: "t4", Status: loomv1.TaskStatus_TASK_STATUS_BLOCKED},
+				},
+			},
+			wantViolations: 3,
+			wantByKind: map[string]int{
+				ViolationInProgressOrphan.String(): 1,
+				ViolationBlockedNoHITL.String():    1,
+				ViolationOpenUnstarted.String():    1,
+			},
+		},
+		{
+			name:         "DEFERRED and CANCELLED are healthy terminal states",
+			activeSkills: []*skills.ActiveSkill{active("sql")},
+			tasksBySkill: map[string][]*task.Task{
+				"sql|s1": {
+					{ID: "t1", Status: loomv1.TaskStatus_TASK_STATUS_DEFERRED},
+					{ID: "t2", Status: loomv1.TaskStatus_TASK_STATUS_CANCELLED},
+				},
+			},
+			wantViolations: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			auditor := NewAuditor(
+				&stubLister{byKey: tc.tasksBySkill},
+				&stubActiveSrc{bySession: map[string][]*skills.ActiveSkill{"s1": tc.activeSkills}},
+			)
+
+			report, err := auditor.Audit(context.Background(), "s1", nil)
+			require.NoError(t, err)
+			require.NotNil(t, report)
+			assert.Equal(t, "s1", report.SessionID)
+			assert.Len(t, report.Violations, tc.wantViolations)
+
+			if tc.wantByKind != nil {
+				assert.Equal(t, tc.wantByKind, report.CountByKind())
+			}
+		})
+	}
+}
+
+func TestAuditor_Audit_ListerError(t *testing.T) {
+	t.Parallel()
+
+	listerErr := errors.New("simulated store failure")
+	auditor := NewAuditor(
+		&stubLister{err: listerErr},
+		&stubActiveSrc{bySession: map[string][]*skills.ActiveSkill{"s1": {active("sql")}}},
+	)
+
+	_, err := auditor.Audit(context.Background(), "s1", nil)
+	require.Error(t, err, "lister errors must propagate so the caller can decide policy")
+	assert.ErrorIs(t, err, listerErr)
+}
+
+func TestAuditor_ResolvePolicyAndMaxRetries(t *testing.T) {
+	t.Parallel()
+
+	auditor := NewAuditor(
+		&stubLister{},
+		&stubActiveSrc{},
+	)
+
+	// nil config -> defaults.
+	assert.Equal(t, loomv1.HygienePolicy_HYGIENE_POLICY_REQUIRE_FIX, auditor.ResolvePolicy(nil))
+	assert.Equal(t, DefaultMaxRetries, auditor.ResolveMaxRetries(nil))
+	assert.True(t, auditor.Enabled(nil), "nil config must default to enabled")
+
+	// Explicit policy + max_retries override.
+	cfg := &loomv1.HygieneConfig{
+		Policy:     loomv1.HygienePolicy_HYGIENE_POLICY_AUTO_FIX,
+		MaxRetries: 5,
+	}
+	assert.Equal(t, loomv1.HygienePolicy_HYGIENE_POLICY_AUTO_FIX, auditor.ResolvePolicy(cfg))
+	assert.Equal(t, 5, auditor.ResolveMaxRetries(cfg))
+
+	// Explicit enabled=false.
+	off := false
+	cfg.Enabled = &off
+	assert.False(t, auditor.Enabled(cfg), "explicit enabled=false must disable hygiene")
+
+	// UNSPECIFIED policy falls back to default.
+	cfg2 := &loomv1.HygieneConfig{Policy: loomv1.HygienePolicy_HYGIENE_POLICY_UNSPECIFIED}
+	assert.Equal(t, loomv1.HygienePolicy_HYGIENE_POLICY_REQUIRE_FIX, auditor.ResolvePolicy(cfg2))
+
+	// max_retries <= 0 falls back to default.
+	cfg3 := &loomv1.HygieneConfig{MaxRetries: 0}
+	assert.Equal(t, DefaultMaxRetries, auditor.ResolveMaxRetries(cfg3))
+	cfg3.MaxRetries = -1
+	assert.Equal(t, DefaultMaxRetries, auditor.ResolveMaxRetries(cfg3))
+}
+
+func TestAuditor_NewAuditor_PanicsOnNil(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() {
+		NewAuditor(nil, &stubActiveSrc{})
+	})
+	assert.Panics(t, func() {
+		NewAuditor(&stubLister{}, nil)
+	})
+}

--- a/pkg/skills/hygiene/doc.go
+++ b/pkg/skills/hygiene/doc.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package hygiene enforces end-of-turn task-board hygiene for skill-emitted
+// tasks. When a skill run leaves the board in an incoherent state — orphan
+// IN_PROGRESS tasks, BLOCKED tasks with no HITL surfaced, or OPEN tasks
+// that were never started — the auditor catches it before control returns
+// to the user.
+//
+// Three violation kinds are detected:
+//
+//   - IN_PROGRESS_ORPHAN: agent claimed the task but never moved it to
+//     DONE or BLOCKED before the turn ended. Misleading: the board says
+//     work is in flight but no agent is on it.
+//   - BLOCKED_NO_HITL: agent transitioned the task to BLOCKED but did not
+//     surface a question to the user. The user only learns by reading the
+//     board, which is the bug we're fixing.
+//   - OPEN_UNSTARTED: a task was created but never claimed. The agent
+//     either silently abandoned it or chose not to work it. Either way the
+//     user is owed an explanation or a Deferred transition.
+//
+// Three policies govern enforcement (see loomv1.HygienePolicy):
+//
+//   - REQUIRE_FIX (default): inject a synthetic user message describing the
+//     violations and re-run the LLM turn so the agent resolves them itself.
+//     Capped by max_retries; on exhaustion the auditor falls through to
+//     AUTO_FIX so the loop terminates.
+//   - AUTO_FIX: machine-transition tasks with reason notes and spawn HITL
+//     for BLOCKED. Cheaper but masks agent bugs.
+//   - WARN_ONLY: emit observability events and a summary; do not change
+//     task state and do not retry.
+//
+// Scope: only tasks emitted by currently-active skills (matched via
+// SkillIdempotencyKey prefix "skill:<name>|sess:<sessionID>|") are
+// audited. Tasks the agent created directly via TaskBoardTool with no
+// idempotency key are out of scope — that is general agent hygiene, a
+// different concern.
+package hygiene

--- a/pkg/skills/hygiene/enforcer.go
+++ b/pkg/skills/hygiene/enforcer.go
@@ -1,0 +1,263 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package hygiene
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"github.com/teradata-labs/loom/pkg/observability"
+	"github.com/teradata-labs/loom/pkg/task"
+)
+
+// TaskMutator is the subset of task.Manager the enforcer needs to repair
+// task state under AUTO_FIX. Defined as an interface for test substitution.
+type TaskMutator interface {
+	TransitionTask(ctx context.Context, taskID string, newStatus loomv1.TaskStatus) (*task.Task, error)
+	UpdateTask(ctx context.Context, t *task.Task, fields []string) (*task.Task, error)
+}
+
+// HITLSpawner spawns a human-in-the-loop request for a task whose blocking
+// condition was never surfaced. Optional; when nil, BLOCKED tasks under
+// AUTO_FIX are logged but not turned into HITL requests. The agent layer
+// supplies an adapter over shuttle.ContactHumanTool.
+type HITLSpawner interface {
+	SpawnHITL(ctx context.Context, sessionID, agentID, question string, t *task.Task) error
+}
+
+// EnforcementOutcome is the structured result of one Enforce pass. It is
+// surfaced into the agent Response.Metadata so callers and tests can
+// observe what hygiene did this turn.
+type EnforcementOutcome struct {
+	Policy            loomv1.HygienePolicy
+	ViolationsFound   int
+	ViolationsByKind  map[string]int
+	Resolved          int    // tasks the enforcer mutated under AUTO_FIX
+	HITLSpawned       int    // BLOCKED tasks turned into HITL requests
+	FallthroughReason string // populated when REQUIRE_FIX fell through to AUTO_FIX
+	// InjectionMessage is the synthetic message the caller should append
+	// to the conversation under REQUIRE_FIX. Empty when no injection is
+	// needed (clean board, or non-REQUIRE_FIX policy).
+	InjectionMessage string
+	// ShouldRetry is true when the caller should re-run the LLM turn after
+	// applying InjectionMessage. False when no further work is needed.
+	ShouldRetry bool
+}
+
+// Enforcer applies a Report to the task board according to the resolved
+// HygienePolicy. Goroutine-safe.
+type Enforcer struct {
+	tasks   TaskMutator
+	hitl    HITLSpawner
+	tracer  observability.Tracer
+	logger  *zap.Logger
+	agentID string
+}
+
+// EnforcerOption configures an Enforcer at construction.
+type EnforcerOption func(*Enforcer)
+
+// WithEnforcerTracer wires an observability tracer.
+func WithEnforcerTracer(t observability.Tracer) EnforcerOption {
+	return func(e *Enforcer) {
+		if t != nil {
+			e.tracer = t
+		}
+	}
+}
+
+// WithEnforcerLogger wires a zap logger.
+func WithEnforcerLogger(l *zap.Logger) EnforcerOption {
+	return func(e *Enforcer) {
+		if l != nil {
+			e.logger = l
+		}
+	}
+}
+
+// WithHITLSpawner wires the HITL adapter used to surface BLOCKED tasks
+// when policy is AUTO_FIX (or REQUIRE_FIX fell through). Optional.
+func WithHITLSpawner(h HITLSpawner) EnforcerOption {
+	return func(e *Enforcer) {
+		e.hitl = h
+	}
+}
+
+// WithAgentID stamps the agent ID into spawned HITL requests so the UI
+// can route notifications back to the right session/agent.
+func WithAgentID(id string) EnforcerOption {
+	return func(e *Enforcer) {
+		e.agentID = id
+	}
+}
+
+// NewEnforcer constructs an Enforcer. tasks must be non-nil.
+func NewEnforcer(tasks TaskMutator, opts ...EnforcerOption) *Enforcer {
+	if tasks == nil {
+		panic("hygiene.NewEnforcer: tasks must not be nil")
+	}
+	e := &Enforcer{
+		tasks:  tasks,
+		tracer: observability.NewNoOpTracer(),
+		logger: zap.NewNop(),
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+// Enforce applies the policy carried on the Report. retryCount is the
+// number of REQUIRE_FIX retries already performed this turn; when it
+// equals or exceeds maxRetries the enforcer transparently falls through
+// to AUTO_FIX so the loop terminates.
+//
+// A nil or empty-violations Report returns a clean outcome with no work
+// done. Errors are surfaced; the caller should log and treat them as
+// non-fatal (don't block the turn on hygiene failure).
+func (e *Enforcer) Enforce(ctx context.Context, report *Report, retryCount, maxRetries int) (*EnforcementOutcome, error) {
+	ctx, span := e.tracer.StartSpan(ctx, "skills.hygiene.enforce")
+	defer e.tracer.EndSpan(span)
+
+	outcome := &EnforcementOutcome{
+		Policy:           loomv1.HygienePolicy_HYGIENE_POLICY_UNSPECIFIED,
+		ViolationsByKind: map[string]int{},
+	}
+	if report == nil || !report.HasViolations() {
+		return outcome, nil
+	}
+
+	outcome.Policy = report.Policy
+	outcome.ViolationsFound = len(report.Violations)
+	outcome.ViolationsByKind = report.CountByKind()
+	span.SetAttribute("hygiene.policy", report.Policy.String())
+	span.SetAttribute("hygiene.violations", int64(outcome.ViolationsFound))
+	span.SetAttribute("hygiene.retry_count", int64(retryCount))
+
+	policy := report.Policy
+	if policy == loomv1.HygienePolicy_HYGIENE_POLICY_REQUIRE_FIX && retryCount >= maxRetries {
+		policy = loomv1.HygienePolicy_HYGIENE_POLICY_AUTO_FIX
+		outcome.FallthroughReason = fmt.Sprintf("max_retries=%d exhausted", maxRetries)
+		span.AddEvent("hygiene.fallthrough_to_autofix", map[string]any{
+			"retries":     retryCount,
+			"max_retries": maxRetries,
+		})
+		e.logger.Warn("hygiene REQUIRE_FIX cap reached; falling through to AUTO_FIX",
+			zap.String("session", report.SessionID),
+			zap.Int("retries", retryCount),
+			zap.Int("max_retries", maxRetries),
+		)
+	}
+
+	switch policy {
+	case loomv1.HygienePolicy_HYGIENE_POLICY_REQUIRE_FIX:
+		outcome.InjectionMessage = report.FormatToolMessage()
+		outcome.ShouldRetry = true
+		span.AddEvent("hygiene.fixup_injected", map[string]any{
+			"retry":      retryCount + 1,
+			"violations": outcome.ViolationsFound,
+		})
+		e.logger.Info("hygiene injected fixup message",
+			zap.String("session", report.SessionID),
+			zap.Int("retry", retryCount+1),
+			zap.Int("violations", outcome.ViolationsFound),
+		)
+	case loomv1.HygienePolicy_HYGIENE_POLICY_AUTO_FIX:
+		if err := e.autoFix(ctx, report, outcome); err != nil {
+			return outcome, err
+		}
+	case loomv1.HygienePolicy_HYGIENE_POLICY_WARN_ONLY,
+		loomv1.HygienePolicy_HYGIENE_POLICY_UNSPECIFIED:
+		// Observability events were already emitted during Audit; nothing
+		// further to do. The caller surfaces ViolationsByKind in the
+		// response metadata.
+		e.logger.Warn("hygiene WARN_ONLY: violations left in place",
+			zap.String("session", report.SessionID),
+			zap.Int("violations", outcome.ViolationsFound),
+		)
+	}
+
+	return outcome, nil
+}
+
+// autoFix machine-repairs the board:
+//   - OPEN-unstarted  -> DEFERRED + note explaining the auto-fix
+//   - IN_PROGRESS     -> OPEN + note (releases the orphan claim so a fresh
+//     run can pick it back up)
+//   - BLOCKED         -> spawn HITL when a spawner is wired; otherwise log
+func (e *Enforcer) autoFix(ctx context.Context, report *Report, outcome *EnforcementOutcome) error {
+	now := time.Now().UTC()
+	for _, v := range report.Violations {
+		switch v.Kind {
+		case ViolationOpenUnstarted:
+			note := fmt.Sprintf("auto-fix: deferred at end of turn; skill %q never started this task (%s)",
+				v.SkillName, now.Format(time.RFC3339))
+			if err := e.applyNote(ctx, v.Task, note); err != nil {
+				return err
+			}
+			if _, err := e.tasks.TransitionTask(ctx, v.Task.ID, loomv1.TaskStatus_TASK_STATUS_DEFERRED); err != nil {
+				return fmt.Errorf("auto-fix open->deferred %s: %w", v.Task.ID, err)
+			}
+			outcome.Resolved++
+		case ViolationInProgressOrphan:
+			note := fmt.Sprintf("auto-fix: released orphan claim at end of turn; skill %q left IN_PROGRESS (%s)",
+				v.SkillName, now.Format(time.RFC3339))
+			if err := e.applyNote(ctx, v.Task, note); err != nil {
+				return err
+			}
+			if _, err := e.tasks.TransitionTask(ctx, v.Task.ID, loomv1.TaskStatus_TASK_STATUS_OPEN); err != nil {
+				return fmt.Errorf("auto-fix in_progress->open %s: %w", v.Task.ID, err)
+			}
+			outcome.Resolved++
+		case ViolationBlockedNoHITL:
+			if e.hitl == nil {
+				e.logger.Warn("hygiene BLOCKED task left unhandled: no HITL spawner wired",
+					zap.String("session", report.SessionID),
+					zap.String("task", v.Task.ID),
+					zap.String("skill", v.SkillName),
+				)
+				continue
+			}
+			question := blockedQuestion(v)
+			if err := e.hitl.SpawnHITL(ctx, report.SessionID, e.agentID, question, v.Task); err != nil {
+				return fmt.Errorf("auto-fix spawn HITL for %s: %w", v.Task.ID, err)
+			}
+			outcome.HITLSpawned++
+		}
+	}
+	return nil
+}
+
+// applyNote appends a hygiene note to a task without changing status. The
+// agent and the audit log share the same Notes field, so we prefix with
+// "[hygiene] " to keep machine-written notes distinguishable from agent
+// commentary.
+func (e *Enforcer) applyNote(ctx context.Context, t *task.Task, note string) error {
+	if t.Notes == "" {
+		t.Notes = "[hygiene] " + note
+	} else {
+		t.Notes = t.Notes + "\n[hygiene] " + note
+	}
+	_, err := e.tasks.UpdateTask(ctx, t, []string{"notes"})
+	if err != nil {
+		return fmt.Errorf("apply hygiene note to %s: %w", t.ID, err)
+	}
+	return nil
+}
+
+func blockedQuestion(v Violation) string {
+	label := taskLabel(v.Task)
+	if v.Reason != "" {
+		return fmt.Sprintf("Skill %q has a BLOCKED task (%q) that was never surfaced for human input. The agent left this reason: %s. How should we proceed?",
+			v.SkillName, label, v.Reason)
+	}
+	return fmt.Sprintf("Skill %q has a BLOCKED task (%q) that was never surfaced for human input, and no reason was recorded. How should we proceed?",
+		v.SkillName, label)
+}

--- a/pkg/skills/hygiene/enforcer_test.go
+++ b/pkg/skills/hygiene/enforcer_test.go
@@ -1,0 +1,256 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package hygiene
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"github.com/teradata-labs/loom/pkg/task"
+)
+
+// fakeMutator records every transition and update so tests can assert
+// what the enforcer did. Goroutine-safe.
+type fakeMutator struct {
+	mu          sync.Mutex
+	transitions []transitionCall
+	updates     []*task.Task
+}
+
+type transitionCall struct {
+	taskID    string
+	newStatus loomv1.TaskStatus
+}
+
+func (f *fakeMutator) TransitionTask(_ context.Context, taskID string, newStatus loomv1.TaskStatus) (*task.Task, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.transitions = append(f.transitions, transitionCall{taskID: taskID, newStatus: newStatus})
+	return &task.Task{ID: taskID, Status: newStatus}, nil
+}
+
+func (f *fakeMutator) UpdateTask(_ context.Context, t *task.Task, _ []string) (*task.Task, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	// Snapshot the task so later mutations don't race with assertions.
+	clone := *t
+	f.updates = append(f.updates, &clone)
+	return &clone, nil
+}
+
+// fakeSpawner records every HITL request the enforcer would have spawned.
+type fakeSpawner struct {
+	mu    sync.Mutex
+	calls []hitlCall
+	err   error
+}
+
+type hitlCall struct {
+	sessionID string
+	agentID   string
+	question  string
+	taskID    string
+}
+
+func (f *fakeSpawner) SpawnHITL(_ context.Context, sessionID, agentID, question string, t *task.Task) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return f.err
+	}
+	f.calls = append(f.calls, hitlCall{
+		sessionID: sessionID,
+		agentID:   agentID,
+		question:  question,
+		taskID:    t.ID,
+	})
+	return nil
+}
+
+func sampleReport(policy loomv1.HygienePolicy) *Report {
+	return &Report{
+		SessionID: "s1",
+		Policy:    policy,
+		Violations: []Violation{
+			{SkillName: "sql", Kind: ViolationOpenUnstarted, Task: &task.Task{ID: "t-open", Title: "design index"}},
+			{SkillName: "sql", Kind: ViolationInProgressOrphan, Task: &task.Task{ID: "t-ip", Title: "tune query"}},
+			{SkillName: "sql", Kind: ViolationBlockedNoHITL, Task: &task.Task{ID: "t-blk", Title: "patch schema"}, Reason: "missing DBA cred"},
+		},
+	}
+}
+
+func TestEnforcer_NilOrEmptyReport_NoOp(t *testing.T) {
+	t.Parallel()
+	mut := &fakeMutator{}
+	e := NewEnforcer(mut)
+	out, err := e.Enforce(context.Background(), nil, 0, 2)
+	require.NoError(t, err)
+	assert.Equal(t, 0, out.ViolationsFound)
+	assert.Empty(t, mut.transitions)
+
+	out, err = e.Enforce(context.Background(), &Report{SessionID: "s1"}, 0, 2)
+	require.NoError(t, err)
+	assert.Equal(t, 0, out.ViolationsFound)
+	assert.False(t, out.ShouldRetry)
+}
+
+func TestEnforcer_RequireFix_InjectsAndAsksToRetry(t *testing.T) {
+	t.Parallel()
+	mut := &fakeMutator{}
+	e := NewEnforcer(mut)
+
+	report := sampleReport(loomv1.HygienePolicy_HYGIENE_POLICY_REQUIRE_FIX)
+	out, err := e.Enforce(context.Background(), report, 0, 2)
+	require.NoError(t, err)
+	assert.Equal(t, 3, out.ViolationsFound)
+	assert.True(t, out.ShouldRetry)
+	assert.NotEmpty(t, out.InjectionMessage, "REQUIRE_FIX must produce an injection message")
+	assert.Contains(t, out.InjectionMessage, "design index")
+	assert.Contains(t, out.InjectionMessage, "tune query")
+	assert.Contains(t, out.InjectionMessage, "patch schema")
+	assert.Empty(t, mut.transitions, "REQUIRE_FIX must not mutate task state itself")
+}
+
+func TestEnforcer_RequireFix_FallsThroughToAutoFix_AtCap(t *testing.T) {
+	t.Parallel()
+	mut := &fakeMutator{}
+	spawner := &fakeSpawner{}
+	e := NewEnforcer(mut, WithHITLSpawner(spawner), WithAgentID("agent-1"))
+
+	report := sampleReport(loomv1.HygienePolicy_HYGIENE_POLICY_REQUIRE_FIX)
+	out, err := e.Enforce(context.Background(), report, 2, 2)
+	require.NoError(t, err)
+	assert.NotEmpty(t, out.FallthroughReason, "at-cap REQUIRE_FIX must record fallthrough reason")
+	assert.False(t, out.ShouldRetry, "fallthrough must not request another retry")
+
+	// AUTO_FIX should have transitioned OPEN->DEFERRED and IN_PROGRESS->OPEN
+	// and spawned exactly one HITL for the BLOCKED task.
+	assert.Equal(t, 2, out.Resolved, "two tasks transitioned")
+	assert.Equal(t, 1, out.HITLSpawned, "one BLOCKED task surfaced as HITL")
+
+	// Assert the specific transitions happened.
+	transitionsByID := map[string]loomv1.TaskStatus{}
+	for _, c := range mut.transitions {
+		transitionsByID[c.taskID] = c.newStatus
+	}
+	assert.Equal(t, loomv1.TaskStatus_TASK_STATUS_DEFERRED, transitionsByID["t-open"])
+	assert.Equal(t, loomv1.TaskStatus_TASK_STATUS_OPEN, transitionsByID["t-ip"])
+
+	require.Len(t, spawner.calls, 1)
+	assert.Equal(t, "t-blk", spawner.calls[0].taskID)
+	assert.Equal(t, "agent-1", spawner.calls[0].agentID)
+	assert.Contains(t, spawner.calls[0].question, "missing DBA cred")
+}
+
+func TestEnforcer_AutoFix_MutatesAndSpawnsHITL(t *testing.T) {
+	t.Parallel()
+	mut := &fakeMutator{}
+	spawner := &fakeSpawner{}
+	e := NewEnforcer(mut, WithHITLSpawner(spawner))
+
+	report := sampleReport(loomv1.HygienePolicy_HYGIENE_POLICY_AUTO_FIX)
+	out, err := e.Enforce(context.Background(), report, 0, 2)
+	require.NoError(t, err)
+	assert.Equal(t, 2, out.Resolved)
+	assert.Equal(t, 1, out.HITLSpawned)
+	assert.False(t, out.ShouldRetry)
+	assert.Empty(t, out.InjectionMessage)
+
+	// Each mutated task got a hygiene note appended via UpdateTask.
+	assert.Len(t, mut.updates, 2, "AUTO_FIX must annotate every transitioned task")
+	for _, upd := range mut.updates {
+		assert.Contains(t, upd.Notes, "[hygiene]", "auto-fix notes must be prefixed with [hygiene] for audit clarity")
+	}
+}
+
+func TestEnforcer_AutoFix_BlockedWithoutSpawner_LogsAndContinues(t *testing.T) {
+	t.Parallel()
+	mut := &fakeMutator{}
+	// No HITL spawner wired.
+	e := NewEnforcer(mut)
+
+	report := &Report{
+		SessionID: "s1",
+		Policy:    loomv1.HygienePolicy_HYGIENE_POLICY_AUTO_FIX,
+		Violations: []Violation{
+			{SkillName: "sql", Kind: ViolationBlockedNoHITL, Task: &task.Task{ID: "t-blk", Title: "x"}},
+		},
+	}
+	out, err := e.Enforce(context.Background(), report, 0, 2)
+	require.NoError(t, err, "missing spawner must not be fatal under AUTO_FIX")
+	assert.Equal(t, 0, out.HITLSpawned)
+	assert.Empty(t, mut.transitions, "BLOCKED tasks aren't transitioned by AUTO_FIX")
+}
+
+func TestEnforcer_WarnOnly_NoMutation(t *testing.T) {
+	t.Parallel()
+	mut := &fakeMutator{}
+	spawner := &fakeSpawner{}
+	e := NewEnforcer(mut, WithHITLSpawner(spawner))
+
+	report := sampleReport(loomv1.HygienePolicy_HYGIENE_POLICY_WARN_ONLY)
+	out, err := e.Enforce(context.Background(), report, 0, 2)
+	require.NoError(t, err)
+	assert.Equal(t, 3, out.ViolationsFound)
+	assert.Equal(t, 0, out.Resolved)
+	assert.Equal(t, 0, out.HITLSpawned)
+	assert.False(t, out.ShouldRetry)
+	assert.Empty(t, mut.transitions, "WARN_ONLY must not mutate state")
+	assert.Empty(t, spawner.calls, "WARN_ONLY must not spawn HITL")
+}
+
+func TestReport_FormatToolMessage(t *testing.T) {
+	t.Parallel()
+	// Empty report yields empty message.
+	empty := &Report{}
+	assert.Empty(t, empty.FormatToolMessage())
+
+	// Multi-skill report sorts skills alphabetically; each section
+	// includes the three required action lines.
+	r := &Report{
+		Violations: []Violation{
+			{SkillName: "zsk", Kind: ViolationOpenUnstarted, Task: &task.Task{ID: "z1", Title: "z-title"}},
+			{SkillName: "ask", Kind: ViolationInProgressOrphan, Task: &task.Task{ID: "a1", Title: "a-title"}},
+		},
+	}
+	msg := r.FormatToolMessage()
+	assert.Contains(t, msg, "Skill: ask")
+	assert.Contains(t, msg, "Skill: zsk")
+	// "ask" must appear before "zsk".
+	askIdx := assertContainsBefore(t, msg, "Skill: ask", "Skill: zsk")
+	assert.GreaterOrEqual(t, askIdx, 0)
+	assert.Contains(t, msg, "Action required")
+	assert.Contains(t, msg, "Do not silently end the turn")
+}
+
+// assertContainsBefore returns the index of `first` in `s` and fails the
+// test if either substring is missing or if `first` does not appear before
+// `second`.
+func assertContainsBefore(t *testing.T, s, first, second string) int {
+	t.Helper()
+	i := indexOf(s, first)
+	j := indexOf(s, second)
+	require.NotEqual(t, -1, i, "missing substring %q", first)
+	require.NotEqual(t, -1, j, "missing substring %q", second)
+	assert.Less(t, i, j, "expected %q to appear before %q", first, second)
+	return i
+}
+
+// indexOf is a tiny strings.Index without importing strings into the test
+// file twice — keeps the test focused on the subject matter.
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/skills/hygiene/report.go
+++ b/pkg/skills/hygiene/report.go
@@ -1,0 +1,171 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package hygiene
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"github.com/teradata-labs/loom/pkg/task"
+)
+
+// ViolationKind classifies the way a task left the board in an incoherent
+// state. See package doc for full definitions.
+type ViolationKind int
+
+const (
+	// ViolationUnknown is the zero value and must never appear in a Report.
+	ViolationUnknown ViolationKind = iota
+	// ViolationInProgressOrphan: task is IN_PROGRESS but the agent never
+	// closed or blocked it before the turn ended.
+	ViolationInProgressOrphan
+	// ViolationBlockedNoHITL: task is BLOCKED but no HITL request was
+	// surfaced to the user.
+	ViolationBlockedNoHITL
+	// ViolationOpenUnstarted: task is OPEN and was never claimed/started.
+	ViolationOpenUnstarted
+)
+
+// String renders the kind for log/event/message use. Stable strings —
+// observability dashboards depend on these values.
+func (k ViolationKind) String() string {
+	switch k {
+	case ViolationInProgressOrphan:
+		return "in_progress_orphan"
+	case ViolationBlockedNoHITL:
+		return "blocked_no_hitl"
+	case ViolationOpenUnstarted:
+		return "open_unstarted"
+	default:
+		return "unknown"
+	}
+}
+
+// Violation is a single offending (task, kind) pair tied to the skill run
+// that produced it.
+type Violation struct {
+	SkillName string
+	Kind      ViolationKind
+	Task      *task.Task
+	// Reason mirrors the task's CloseReason / Notes when present, so the
+	// formatted message can echo the agent's own explanation back to it.
+	Reason string
+}
+
+// Report is the output of one Audit pass.
+type Report struct {
+	SessionID  string
+	Violations []Violation
+	// Policy that produced this report. Auditor copies the resolved policy
+	// here so the enforcer can act without re-resolving.
+	Policy loomv1.HygienePolicy
+}
+
+// HasViolations is true when at least one violation was found.
+func (r *Report) HasViolations() bool {
+	return len(r.Violations) > 0
+}
+
+// CountByKind returns a map from violation-kind string to count. Useful
+// for observability events and response metadata. Unknown kinds are
+// omitted; the zero-violation case returns a non-nil empty map.
+func (r *Report) CountByKind() map[string]int {
+	out := map[string]int{
+		ViolationInProgressOrphan.String(): 0,
+		ViolationBlockedNoHITL.String():    0,
+		ViolationOpenUnstarted.String():    0,
+	}
+	for _, v := range r.Violations {
+		out[v.Kind.String()]++
+	}
+	return out
+}
+
+// FormatToolMessage renders the violations as a synthetic user message the
+// agent will see at the start of the next turn under REQUIRE_FIX policy.
+// The message is direct and task-oriented, listing every violation with a
+// clear instruction for resolution. Grouped by skill, then by kind.
+func (r *Report) FormatToolMessage() string {
+	if !r.HasViolations() {
+		return ""
+	}
+
+	// Group by skill -> kind -> tasks for deterministic output.
+	bySkill := map[string]map[ViolationKind][]Violation{}
+	skills := []string{}
+	for _, v := range r.Violations {
+		if _, ok := bySkill[v.SkillName]; !ok {
+			bySkill[v.SkillName] = map[ViolationKind][]Violation{}
+			skills = append(skills, v.SkillName)
+		}
+		bySkill[v.SkillName][v.Kind] = append(bySkill[v.SkillName][v.Kind], v)
+	}
+	sort.Strings(skills)
+
+	var b strings.Builder
+	b.WriteString("Task-board hygiene check found violations from your skill run that must be resolved before this turn ends.\n\n")
+
+	for _, skill := range skills {
+		fmt.Fprintf(&b, "Skill: %s\n", skill)
+		// Stable kind order: IN_PROGRESS, BLOCKED, OPEN.
+		for _, kind := range []ViolationKind{ViolationInProgressOrphan, ViolationBlockedNoHITL, ViolationOpenUnstarted} {
+			items := bySkill[skill][kind]
+			if len(items) == 0 {
+				continue
+			}
+			fmt.Fprintf(&b, "  %s (%d):\n", kindHeader(kind), len(items))
+			for _, v := range items {
+				fmt.Fprintf(&b, "    - %q (id=%s)", taskLabel(v.Task), v.Task.ID)
+				if v.Reason != "" {
+					fmt.Fprintf(&b, " — reason: %s", v.Reason)
+				}
+				b.WriteString("\n")
+			}
+			fmt.Fprintf(&b, "    Action required: %s\n", kindAction(kind))
+		}
+	}
+
+	b.WriteString("\nResolve each violation now, then return your final response. Do not silently end the turn.")
+	return b.String()
+}
+
+func kindHeader(k ViolationKind) string {
+	switch k {
+	case ViolationInProgressOrphan:
+		return "IN_PROGRESS but not closed"
+	case ViolationBlockedNoHITL:
+		return "BLOCKED without surfacing a question"
+	case ViolationOpenUnstarted:
+		return "OPEN and never started"
+	default:
+		return "unknown"
+	}
+}
+
+func kindAction(k ViolationKind) string {
+	switch k {
+	case ViolationInProgressOrphan:
+		return "Move each task to DONE if work is complete, or to BLOCKED with a clear reason if you cannot proceed."
+	case ViolationBlockedNoHITL:
+		return "Surface the blocking question to the user in your response, or transition the task off BLOCKED if no longer blocked."
+	case ViolationOpenUnstarted:
+		return "Start each task now, or transition it to DEFERRED with a reason note, or explain in your response why these tasks remain unstarted."
+	default:
+		return ""
+	}
+}
+
+func taskLabel(t *task.Task) string {
+	if t.Title != "" {
+		return t.Title
+	}
+	if t.Objective != "" {
+		return t.Objective
+	}
+	return t.ID
+}

--- a/pkg/skills/orchestrator.go
+++ b/pkg/skills/orchestrator.go
@@ -24,6 +24,7 @@ import (
 
 	"go.uber.org/zap"
 
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
 	"github.com/teradata-labs/loom/pkg/observability"
 )
 
@@ -187,6 +188,12 @@ type SkillsConfig struct {
 	// nil mirrors proto3 optional default-true. Per-skill EmitTasks overrides
 	// this for individual skills.
 	TasksEnabled *bool
+
+	// Hygiene controls end-of-turn task-board hygiene enforcement for
+	// skill-emitted tasks. nil falls back to defaults (enabled, REQUIRE_FIX
+	// policy, max_retries=2). The agent layer constructs the auditor when
+	// both skillOrchestrator and taskManager are present.
+	Hygiene *loomv1.HygieneConfig
 }
 
 // DefaultSkillsConfig returns a SkillsConfig with sensible defaults.

--- a/pkg/storage/postgres/task_store.go
+++ b/pkg/storage/postgres/task_store.go
@@ -154,6 +154,41 @@ func (s *TaskStore) HasOpenSkillTasks(ctx context.Context, skillName, sessionID 
 	return count > 0, nil
 }
 
+// ListBySkillRun returns every non-deleted task whose skill_idempotency_key
+// matches skill:<name>|sess:<sess>|%, regardless of status. Used by the
+// end-of-turn hygiene auditor to inventory the active skill's tasks.
+func (s *TaskStore) ListBySkillRun(ctx context.Context, skillName, sessionID string) ([]*task.Task, error) {
+	if skillName == "" || sessionID == "" {
+		return []*task.Task{}, nil
+	}
+	ctx, span := s.tracer.StartSpan(ctx, "pg.task.list_by_skill_run")
+	defer s.tracer.EndSpan(span)
+
+	prefix := fmt.Sprintf("skill:%s|sess:%s|%%", skillName, sessionID)
+	tasks := make([]*task.Task, 0)
+	err := execInTx(ctx, s.pool, func(ctx context.Context, tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT `+taskColumns+
+			` FROM tasks WHERE skill_idempotency_key LIKE $1 AND deleted_at IS NULL ORDER BY created_at ASC`,
+			prefix)
+		if err != nil {
+			return fmt.Errorf("list by skill run: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			t, err := pgScanTaskRows(rows)
+			if err != nil {
+				return err
+			}
+			tasks = append(tasks, t)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tasks, nil
+}
+
 // GetTaskByIdempotencyKey returns the task that owns the given idempotency
 // key, or (nil, nil) when no such task exists. Used by the skills task
 // emitter to dedupe concurrent skill activations.

--- a/pkg/storage/sqlite/task_idempotency_test.go
+++ b/pkg/storage/sqlite/task_idempotency_test.go
@@ -177,6 +177,70 @@ func TestTask_HasOpenSkillTasks_BlockedCountsAsOpen(t *testing.T) {
 		"BLOCKED is still in-flight (waiting on dependencies); must count as open")
 }
 
+func TestTask_ListBySkillRun(t *testing.T) {
+	db := migratedDB(t)
+	store := NewTaskStore(db, observability.NewNoOpTracer())
+	ctx := context.Background()
+
+	// Seed: three tasks under (skill=sql-opt, sess=s1) in different states,
+	// one task under (skill=sql-opt, sess=s2), and one with no skill key.
+	for _, seed := range []struct {
+		title  string
+		key    string
+		status loomv1.TaskStatus
+	}{
+		{"opt-s1-open", "skill:sql-opt|sess:s1|step:0", loomv1.TaskStatus_TASK_STATUS_OPEN},
+		{"opt-s1-inprog", "skill:sql-opt|sess:s1|step:1", loomv1.TaskStatus_TASK_STATUS_IN_PROGRESS},
+		{"opt-s1-done", "skill:sql-opt|sess:s1|step:2", loomv1.TaskStatus_TASK_STATUS_DONE},
+		{"opt-s2-open", "skill:sql-opt|sess:s2|step:0", loomv1.TaskStatus_TASK_STATUS_OPEN},
+		{"no-key", "", loomv1.TaskStatus_TASK_STATUS_OPEN},
+	} {
+		_, err := store.CreateTask(ctx, &task.Task{
+			Title:               seed.title,
+			Status:              seed.status,
+			SkillIdempotencyKey: seed.key,
+		})
+		require.NoError(t, err, seed.title)
+	}
+
+	// All three statuses for (sql-opt, s1) come back regardless of state.
+	// Order isn't load-bearing for the hygiene auditor — rapid inserts share
+	// a created_at timestamp, so the SQL ORDER BY created_at ASC ties resolve
+	// in implementation-defined order. Assert membership only.
+	tasks, err := store.ListBySkillRun(ctx, "sql-opt", "s1")
+	require.NoError(t, err)
+	require.Len(t, tasks, 3)
+	gotTitles := make(map[string]bool, len(tasks))
+	for _, tk := range tasks {
+		gotTitles[tk.Title] = true
+	}
+	assert.Equal(t, map[string]bool{
+		"opt-s1-open":   true,
+		"opt-s1-inprog": true,
+		"opt-s1-done":   true,
+	}, gotTitles, "ListBySkillRun must surface every task for the (skill, session) tuple, regardless of status")
+
+	// Different session is isolated.
+	tasks, err = store.ListBySkillRun(ctx, "sql-opt", "s2")
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, "opt-s2-open", tasks[0].Title)
+
+	// Unknown (skill, session) returns an empty slice, not nil.
+	tasks, err = store.ListBySkillRun(ctx, "unknown", "s1")
+	require.NoError(t, err)
+	assert.NotNil(t, tasks)
+	assert.Len(t, tasks, 0)
+
+	// Empty inputs short-circuit to an empty slice.
+	tasks, err = store.ListBySkillRun(ctx, "", "s1")
+	require.NoError(t, err)
+	assert.Len(t, tasks, 0)
+	tasks, err = store.ListBySkillRun(ctx, "sql-opt", "")
+	require.NoError(t, err)
+	assert.Len(t, tasks, 0)
+}
+
 func TestTask_IdempotencyKeyEmptyAllowsMany(t *testing.T) {
 	// Partial index covers only non-null keys; many tasks with empty key
 	// must coexist without triggering the constraint.

--- a/pkg/storage/sqlite/task_store.go
+++ b/pkg/storage/sqlite/task_store.go
@@ -142,6 +142,48 @@ func (s *TaskStore) HasOpenSkillTasks(ctx context.Context, skillName, sessionID 
 	return count > 0, nil
 }
 
+// ListBySkillRun returns every non-deleted task whose skill_idempotency_key
+// matches skill:<name>|sess:<sess>|%, regardless of status. Used by the
+// end-of-turn hygiene auditor to inventory the active skill's tasks.
+func (s *TaskStore) ListBySkillRun(ctx context.Context, skillName, sessionID string) ([]*task.Task, error) {
+	if skillName == "" || sessionID == "" {
+		return []*task.Task{}, nil
+	}
+	ctx, span := s.tracer.StartSpan(ctx, "sqlite.task.list_by_skill_run")
+	defer s.tracer.EndSpan(span)
+
+	prefix := fmt.Sprintf("skill:%s|sess:%s|%%", skillName, sessionID)
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, title, description, objective, approach, acceptance_criteria, notes,
+			status, priority, category, tags_json,
+			owner_agent_id, COALESCE(assignee_agent_id,''), COALESCE(claimed_by_session,''),
+			COALESCE(parent_id,''), COALESCE(board_id,''), entity_ids_json, metadata_json,
+			compaction_level, compacted_summary, output_policy_json, estimated_effort,
+			created_at, updated_at, claimed_at, closed_at, close_reason,
+			COALESCE(skill_idempotency_key,'')
+		FROM tasks
+		WHERE skill_idempotency_key LIKE ?
+		  AND deleted_at IS NULL
+		ORDER BY created_at ASC`, prefix)
+	if err != nil {
+		return nil, fmt.Errorf("list by skill run: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	tasks := make([]*task.Task, 0)
+	for rows.Next() {
+		t, err := scanTaskRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return tasks, nil
+}
+
 // GetTaskByIdempotencyKey returns the task that owns the given idempotency
 // key, or (nil, nil) when no such task exists. Used by the skills task
 // emitter to dedupe concurrent skill activations.

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -113,6 +113,14 @@ func (m *Manager) HasOpenSkillTasks(ctx context.Context, skillName, sessionID st
 	return m.store.HasOpenSkillTasks(ctx, skillName, sessionID)
 }
 
+// ListBySkillRun returns every non-deleted task emitted by the given
+// (skill, session) tuple, regardless of status. Used by the end-of-turn
+// hygiene auditor to inventory the active skill's tasks. Returns an
+// empty slice (never nil) when no tasks match.
+func (m *Manager) ListBySkillRun(ctx context.Context, skillName, sessionID string) ([]*Task, error) {
+	return m.store.ListBySkillRun(ctx, skillName, sessionID)
+}
+
 // CreateTaskIdempotent looks up an existing task by SkillIdempotencyKey and
 // returns it when present; otherwise it creates the task normally. The
 // boolean return is true when the task was newly created (and history +

--- a/pkg/task/store.go
+++ b/pkg/task/store.go
@@ -40,6 +40,12 @@ type TaskStore interface {
 	// (status not DONE and not CANCELLED). Used by the skills orchestrator
 	// to keep skills sticky while they have open work on the board.
 	HasOpenSkillTasks(ctx context.Context, skillName, sessionID string) (bool, error)
+	// ListBySkillRun returns every non-deleted task whose
+	// skill_idempotency_key matches the (skill, session) prefix, regardless
+	// of status. Used by the end-of-turn hygiene auditor to inventory the
+	// active skill's tasks. Returns an empty slice (never nil) when no
+	// tasks match. Empty skillName or sessionID returns an empty slice.
+	ListBySkillRun(ctx context.Context, skillName, sessionID string) ([]*Task, error)
 	UpdateTask(ctx context.Context, task *Task, fields []string) (*Task, error)
 	DeleteTask(ctx context.Context, id string) error
 	ListTasks(ctx context.Context, opts ListTasksOpts) ([]*Task, int, error)

--- a/proto/loom/v1/skill.proto
+++ b/proto/loom/v1/skill.proto
@@ -230,6 +230,45 @@ message SkillsConfig {
   // false". This is the agent-level master switch; per-skill emit_tasks
   // overrides it for individual skills.
   optional bool tasks_enabled = 14;
+
+  // End-of-turn hygiene enforcement for skill-emitted tasks. Audits the
+  // active skill's tasks before the agent returns control to the user and
+  // surfaces or repairs IN_PROGRESS / BLOCKED / OPEN-unstarted violations.
+  // When unset, hygiene is enabled with REQUIRE_FIX policy and max_retries=2.
+  HygieneConfig hygiene = 15;
+}
+
+// HygienePolicy controls how the end-of-turn auditor handles task-board
+// violations left by an active skill.
+enum HygienePolicy {
+  HYGIENE_POLICY_UNSPECIFIED = 0;
+  // Inject a synthetic user message describing the violations and re-run the
+  // LLM turn so the agent resolves them itself. Capped by max_retries; on
+  // exhaustion the auditor falls through to AUTO_FIX so the loop terminates.
+  HYGIENE_POLICY_REQUIRE_FIX = 1;
+  // Machine-transition tasks (OPEN→DEFERRED, IN_PROGRESS→OPEN, BLOCKED→HITL)
+  // with reason notes. Cheaper but hides agent bugs.
+  HYGIENE_POLICY_AUTO_FIX = 2;
+  // Emit observability events and add a violations summary to the response
+  // metadata; do not change task state and do not retry.
+  HYGIENE_POLICY_WARN_ONLY = 3;
+}
+
+// HygieneConfig governs end-of-turn task-board hygiene enforcement for
+// skill-emitted tasks. The auditor only inspects tasks tied to currently
+// active skills via SkillIdempotencyKey; agent-created tasks without that
+// key are out of scope.
+message HygieneConfig {
+  // Whether hygiene auditing runs at end-of-turn. Uses proto3 optional so
+  // the loader can distinguish "not specified" (default true) from
+  // "explicitly false".
+  optional bool enabled = 1;
+  // Policy applied when violations are found. Unspecified maps to
+  // REQUIRE_FIX.
+  HygienePolicy policy = 2;
+  // Maximum number of REQUIRE_FIX retries per turn before falling through
+  // to AUTO_FIX. <=0 falls back to the default of 2.
+  int32 max_retries = 3;
 }
 
 // SkillBindingMode controls how an agent loads a bound skill into context.


### PR DESCRIPTION
## Summary

Catches three failure modes left behind by skill runs before the agent returns control to the user:

- **`IN_PROGRESS` orphan** — agent claimed a task but never closed or blocked it before the turn ended
- **`BLOCKED` no-HITL** — agent transitioned a task to `BLOCKED` but never surfaced the question to the user
- **`OPEN` unstarted** — task was created but never claimed

Default policy is `REQUIRE_FIX`: inject a structured fixup message and re-run the LLM turn so the agent resolves violations itself. Capped by `max_retries` (default 2); on exhaustion the auditor falls through to `AUTO_FIX` (machine repair + reason notes) so the loop always terminates.

Scope is **skill-emitted tasks only** — tasks tied to a currently-active skill via `SkillIdempotencyKey` prefix `skill:<name>|sess:<sessionID>|`. Tasks the agent created directly via `TaskBoardTool` are out of scope; that's general agent task discipline, a different concern.

## What's in the change

- **Proto** (`proto/loom/v1/skill.proto`): new `HygieneConfig` message + `HygienePolicy` enum (`REQUIRE_FIX` / `AUTO_FIX` / `WARN_ONLY`) on `SkillsConfig`.
- **Storage** (`pkg/task/store.go`, sqlite + postgres impls): new `ListBySkillRun(skillName, sessionID)` prefix-scan on `SkillIdempotencyKey`. Complements existing `HasOpenSkillTasks`.
- **`pkg/skills/hygiene/`** (new package): `Auditor`, `Enforcer`, `Report`. Small interfaces (`SkillRunLister`, `ActiveSkillSource`, `TaskMutator`, `HITLSpawner`) so tests substitute stubs without standing up the full storage stack. Optional `HITLSpawner` for spawning `ContactHumanTool` requests under `AUTO_FIX`.
- **Agent hook** (`pkg/agent/hygiene.go`, `agent.go`): `runEndOfTurnHygiene` runs at the no-tool-call return path. On `ShouldRetry` it appends a synthetic user message and `continue`s the loop. Surfaces `hygiene_*` counters into `Response.Metadata`.
- **Docs** (`docs/architecture/skill-hygiene.md`): full architecture page per `docs/architecture/CLAUDE.md` standard — diagrams, design rationale, trade-off analysis, performance characteristics.

Size: ~2.3k lines added across 20 files (60% tests + docs). Hygiene failures are non-fatal — broken hygiene logs a warning and the agent returns its existing response.

## Test plan

- [x] Table-driven unit tests for `Auditor`, `Enforcer`, `Report` (`pkg/skills/hygiene/*_test.go`)
- [x] Integration tests for `runEndOfTurnHygiene` with real SQLite store covering: no-active-skills, clean-board, REQUIRE_FIX with all three violation kinds, fallthrough-at-cap, AUTO_FIX policy, disabled config, full loop (inject → resolve → clean)
- [x] New `task.Manager.ListBySkillRun` tests (`pkg/storage/sqlite/task_idempotency_test.go`)
- [x] All tests run with `-race`
- [x] `just lint` clean (`0 issues`)
- [x] `just test` clean
- [x] `just fmt-check` clean
- [x] `just proto-lint` clean
- [ ] Manual smoke test by reviewer with a real skill that emits tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)