### PR TITLE
fix(agent): document thread chat commands

### DIFF
--- a/embedded/agents_test.go
+++ b/embedded/agents_test.go
@@ -1,6 +1,7 @@
 package embedded
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,4 +33,12 @@ func TestWeaverYAMLVariable(t *testing.T) {
 
 	// Verify it matches GetWeaver() output
 	assert.Equal(t, WeaverYAML, GetWeaver(), "GetWeaver() should return the same data as WeaverYAML")
+}
+
+func TestWeaverCreationSkillDocumentsThreadChatCommands(t *testing.T) {
+	content := string(GetWeaverCreationSkill())
+
+	assert.Contains(t, content, "loom --thread <agent-id>")
+	assert.Contains(t, content, "loom chat --thread <agent-id>")
+	assert.True(t, strings.Contains(content, "chat requires --thread"))
 }

--- a/embedded/skills/weaver-creation.yaml
+++ b/embedded/skills/weaver-creation.yaml
@@ -46,6 +46,11 @@ prompt:
     2. Exact loom commands to run the agent/workflow
     3. Skill activation commands if skills were configured
     4. Reminder that user can return for modifications
+
+    Agent command syntax:
+    - Open the interactive TUI: `loom --thread <agent-id>`
+    - Send one CLI message: `loom chat --thread <agent-id> "message"`
+    - Never use `loom chat <agent-id>`; chat requires --thread.
 tools:
   required_tools:
     - agent_management


### PR DESCRIPTION
## Description

Closes #172.

Updates the always-on `weaver-creation` skill so post-creation instructions use the actual Loom CLI syntax for agent sessions:

- interactive TUI: `loom --thread <agent-id>`
- one-off CLI chat: `loom chat --thread <agent-id> "message"`
- explicitly avoids `loom chat <agent-id>` because chat requires `--thread`

## Type of Change

- [x] Bug fix
- [x] Test update

## Testing

- `go run ./cmd/generate-weaver`
- `go test ./embedded -run TestWeaverCreationSkillDocumentsThreadChatCommands -count=1`
- `go test ./embedded -count=1`
- `go test ./cmd/generate-weaver -count=1`
- `git diff --check`

## Proto Changes

- [x] No proto changes in this PR

## Security

- [x] No security implications

## Performance

- [x] No performance impact

## Deployment Notes

- [x] No special deployment steps needed