### PR TITLE
fix: show configured thread model on startup

### DIFF
--- a/internal/tui/components/chat/sidebar/sidebar.go
+++ b/internal/tui/components/chat/sidebar/sidebar.go
@@ -651,7 +651,8 @@ func (s *sidebarCmp) currentModelBlock() string {
 	// Determine model to display — use the most specific/current source available:
 	// 1. session.Model (actual model from the last LLM cost report — most accurate)
 	// 2. current agent's ModelInfo from the agents list (configured model)
-	// 3. global config fallback
+	// 3. active provider from ListProviders RPC
+	// 4. global config fallback
 	var modelDisplayName string
 	var showReasoning bool
 	contextWindow := 200000 // Reasonable default for frontier models
@@ -663,17 +664,19 @@ func (s *sidebarCmp) currentModelBlock() string {
 		} else {
 			modelDisplayName = s.session.Model
 		}
-	} else if s.activeProvider != "" {
-		// Second: active provider name from ListProviders RPC (e.g., "gemini-flash")
-		modelDisplayName = s.activeProvider
 	} else if s.currentAgent != "" {
-		// Third: agent's configured model from the agents list
+		// Second: agent's configured model from the agents list
 		for _, ag := range s.agents {
 			if ag.ID == s.currentAgent && ag.ModelInfo != "" {
 				modelDisplayName = ag.ModelInfo
 				break
 			}
 		}
+	}
+
+	if modelDisplayName == "" && s.activeProvider != "" {
+		// Third: active provider name from ListProviders RPC (e.g., "gemini-flash")
+		modelDisplayName = s.activeProvider
 	}
 
 	if modelDisplayName == "" {

--- a/internal/tui/components/chat/sidebar/sidebar_test.go
+++ b/internal/tui/components/chat/sidebar/sidebar_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package sidebar
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCurrentModelBlockPrefersCurrentAgentModelInfoOverActiveProvider(t *testing.T) {
+	s := &sidebarCmp{
+		currentAgent:   "weaver",
+		activeProvider: "Claude Sonnet 4",
+		agents: []AgentInfo{
+			{
+				ID:        "weaver",
+				Name:      "weaver",
+				ModelInfo: "anthropic/claude-opus-4-5",
+			},
+		},
+	}
+
+	block := s.currentModelBlock()
+
+	if !strings.Contains(block, "anthropic/claude-opus-4-5") {
+		t.Fatalf("currentModelBlock() = %q, want current agent model info", block)
+	}
+	if strings.Contains(block, "Claude Sonnet 4") {
+		t.Fatalf("currentModelBlock() = %q, should not prefer active provider over current agent model", block)
+	}
+}


### PR DESCRIPTION
## Summary
- prefer the current thread agent model info before the active provider fallback in the TUI sidebar
- keep the session-reported model as the highest-priority display source
- add a regression test for startup rendering when the active provider differs from the configured thread model

Closes #170

## Tests
- go test ./internal/tui/components/chat/sidebar -run TestCurrentModelBlockPrefersCurrentAgentModelInfoOverActiveProvider -count=1
- go test ./internal/tui/components/chat/sidebar -count=1
- go test ./internal/tui/components/chat/... -count=1
- go test ./internal/tui/page/chat -count=1
- go test ./internal/tui/... -count=1
- go test ./cmd/loom -count=1
- git diff --check