### PR TITLE
fix: add bedrock bearer token quickstart option

### DIFF
--- a/quickstart.ps1
+++ b/quickstart.ps1
@@ -504,14 +504,15 @@ if (-not $SkipCredentials) {
     Write-Host ""
     Write-Host "  1) AWS Bedrock (with SSO/Profile) - For users with AWS profiles configured"
     Write-Host "  2) AWS Bedrock (with Access Keys) - For users with AWS access keys"
-    Write-Host "  3) Anthropic API - Direct Anthropic access"
-    Write-Host "  4) OpenAI - GPT-4 models, o1 reasoning models"
-    Write-Host "  5) Azure OpenAI - Enterprise Microsoft integration"
-    Write-Host "  6) Mistral AI - Open & commercial models"
-    Write-Host "  7) Google Gemini - Google's latest AI models"
-    Write-Host "  8) HuggingFace - 1M+ open source models"
-    Write-Host "  9) Ollama - Local/offline models (requires tool calling support)"
-    Write-Host " 10) Skip for now - Configure later manually"
+    Write-Host "  3) AWS Bedrock (with Bearer Token) - For AWS IAM Identity Center bearer tokens"
+    Write-Host "  4) Anthropic API - Direct Anthropic access"
+    Write-Host "  5) OpenAI - GPT-4 models, o1 reasoning models"
+    Write-Host "  6) Azure OpenAI - Enterprise Microsoft integration"
+    Write-Host "  7) Mistral AI - Open & commercial models"
+    Write-Host "  8) Google Gemini - Google's latest AI models"
+    Write-Host "  9) HuggingFace - 1M+ open source models"
+    Write-Host " 10) Ollama - Local/offline models (requires tool calling support)"
+    Write-Host " 11) Skip for now - Configure later manually"
     Write-Host ""
 
     $LLMChoice = Read-Host "Enter choice [1]"
@@ -621,6 +622,48 @@ if (-not $SkipCredentials) {
         }
 
         "3" {
+            # AWS Bedrock with Bearer Token
+            $ConfigureLLM = "y"
+            Write-Host ""
+            Write-Info "Configuring AWS Bedrock with bearer token (stored securely)..."
+            Write-Host ""
+
+            $AWSRegion = Read-Host "Enter your AWS region [us-west-2]"
+            if ([string]::IsNullOrWhiteSpace($AWSRegion)) { $AWSRegion = "us-west-2" }
+
+            Write-Host ""
+            Write-Info "Bedrock inference profile configuration:"
+            Write-Host "Available Claude models on Bedrock:"
+            Write-Host "  1) us.anthropic.claude-sonnet-4-5-20250929-v1:0  (Sonnet 4.5)"
+            Write-Host "  2) us.anthropic.claude-opus-4-5-20251101-v1:0   (Opus 4.5)"
+            Write-Host "  3) us.anthropic.claude-3-5-sonnet-20241022-v2:0 (Sonnet 3.5 v2)"
+            Write-Host ""
+
+            $ModelChoice = Read-Host "Enter Bedrock inference profile [1]"
+            if ([string]::IsNullOrWhiteSpace($ModelChoice)) { $ModelChoice = "1" }
+
+            $LoomModel = switch ($ModelChoice) {
+                "1" { "us.anthropic.claude-sonnet-4-5-20250929-v1:0" }
+                "2" { "us.anthropic.claude-opus-4-5-20251101-v1:0" }
+                "3" { "us.anthropic.claude-3-5-sonnet-20241022-v2:0" }
+                default { $ModelChoice }
+            }
+
+            Write-Host ""
+            Write-Info "Setting Bedrock bearer token..."
+
+            & "$BinDir\looms.exe" config set llm.provider bedrock
+            & "$BinDir\looms.exe" config set llm.bedrock_region $AWSRegion
+            & "$BinDir\looms.exe" config set llm.bedrock_model_id $LoomModel
+            & "$BinDir\looms.exe" config set-key bedrock_bearer_token
+
+            Write-Success "AWS Bedrock configured with bearer token"
+            Write-Success "  Region: $AWSRegion"
+            Write-Success "  Model: $LoomModel"
+            Write-Success "  Bearer token: Stored securely in keyring"
+        }
+
+        "4" {
             # Anthropic
             $ConfigureLLM = "y"
             Write-Host ""
@@ -633,7 +676,7 @@ if (-not $SkipCredentials) {
             Write-Success "Anthropic configured"
         }
 
-        "4" {
+        "5" {
             # OpenAI
             $ConfigureLLM = "y"
             Write-Host ""
@@ -646,7 +689,7 @@ if (-not $SkipCredentials) {
             Write-Success "OpenAI configured"
         }
 
-        "5" {
+        "6" {
             # Azure OpenAI
             $ConfigureLLM = "y"
             Write-Host ""
@@ -691,7 +734,7 @@ if (-not $SkipCredentials) {
             Write-Success "Azure OpenAI configured"
         }
 
-        "6" {
+        "7" {
             # Mistral
             $ConfigureLLM = "y"
             Write-Host ""
@@ -704,7 +747,7 @@ if (-not $SkipCredentials) {
             Write-Success "Mistral AI configured"
         }
 
-        "7" {
+        "8" {
             # Gemini
             $ConfigureLLM = "y"
             Write-Host ""
@@ -717,7 +760,7 @@ if (-not $SkipCredentials) {
             Write-Success "Google Gemini configured"
         }
 
-        "8" {
+        "9" {
             # HuggingFace
             $ConfigureLLM = "y"
             Write-Host ""
@@ -730,7 +773,7 @@ if (-not $SkipCredentials) {
             Write-Success "HuggingFace configured"
         }
 
-        "9" {
+        "10" {
             # Ollama
             $ConfigureLLM = "y"
             Write-Host ""
@@ -882,7 +925,7 @@ Write-Host ""
 $StepNum = 1
 
 # If Ollama, show start instructions
-if ((Get-Variable -Name "LLMChoice" -ErrorAction SilentlyContinue) -and $LLMChoice -eq "9" -and $ConfigureLLM -eq "y") {
+if ((Get-Variable -Name "LLMChoice" -ErrorAction SilentlyContinue) -and $LLMChoice -eq "10" -and $ConfigureLLM -eq "y") {
     Write-ColorOutput "$StepNum. Start Ollama (required for local inference):" "Cyan"
     Write-Host ""
     Write-Info "   In a terminal window:"

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -472,14 +472,15 @@ else
   echo ""
   echo "  1) AWS Bedrock (with SSO/Profile) - For users with AWS profiles configured"
   echo "  2) AWS Bedrock (with Access Keys) - For users with AWS access keys"
-  echo "  3) Anthropic API - Direct Anthropic access"
-  echo "  4) OpenAI - GPT-4 models, o1 reasoning models"
-  echo "  5) Azure OpenAI - Enterprise Microsoft integration"
-  echo "  6) Mistral AI - Open & commercial models"
-  echo "  7) Google Gemini - Google's latest AI models"
-  echo "  8) HuggingFace - 1M+ open source models"
-  echo "  9) Ollama - Local/offline models (requires tool calling support)"
-  echo " 10) Skip for now - Configure later manually"
+  echo "  3) AWS Bedrock (with Bearer Token) - For AWS IAM Identity Center bearer tokens"
+  echo "  4) Anthropic API - Direct Anthropic access"
+  echo "  5) OpenAI - GPT-4 models, o1 reasoning models"
+  echo "  6) Azure OpenAI - Enterprise Microsoft integration"
+  echo "  7) Mistral AI - Open & commercial models"
+  echo "  8) Google Gemini - Google's latest AI models"
+  echo "  9) HuggingFace - 1M+ open source models"
+  echo " 10) Ollama - Local/offline models (requires tool calling support)"
+  echo " 11) Skip for now - Configure later manually"
   echo ""
   read -r -p "Enter choice [1]: " llm_choice
   llm_choice=${llm_choice:-1}
@@ -601,6 +602,49 @@ else
   elif [ "$llm_choice" = "3" ]; then
     configure_llm="y"
     echo ""
+    echo "Configuring AWS Bedrock with bearer token (stored securely in keyring)..."
+    echo ""
+
+    # Prompt for AWS region
+    read -r -p "Enter your AWS region [us-west-2]: " aws_region
+    aws_region=${aws_region:-us-west-2}
+
+    # Prompt for model inference profile
+    echo ""
+    echo "Bedrock inference profile configuration:"
+    echo "(Inference profiles use the 'us.' prefix for cross-region availability)"
+    echo ""
+    echo "Available Claude models on Bedrock:"
+    echo "  1) us.anthropic.claude-sonnet-4-5-20250929-v1:0  (Sonnet 4.5 - balanced)"
+    echo "  2) us.anthropic.claude-opus-4-5-20251101-v1:0   (Opus 4.5 - most capable)"
+    echo "  3) us.anthropic.claude-3-5-sonnet-20241022-v2:0 (Sonnet 3.5 v2)"
+    echo ""
+    read -r -p "Enter Bedrock inference profile [1]: " model_choice
+    model_choice=${model_choice:-1}
+    case "$model_choice" in
+      1) loom_model="us.anthropic.claude-sonnet-4-5-20250929-v1:0" ;;
+      2) loom_model="us.anthropic.claude-opus-4-5-20251101-v1:0" ;;
+      3) loom_model="us.anthropic.claude-3-5-sonnet-20241022-v2:0" ;;
+      *) loom_model="$model_choice" ;; # Allow custom input
+    esac
+
+    echo ""
+    echo "Setting Bedrock bearer token..."
+    echo ""
+
+    "$BIN_DIR/looms" config set llm.provider bedrock
+    "$BIN_DIR/looms" config set llm.bedrock_region "$aws_region"
+    "$BIN_DIR/looms" config set llm.bedrock_model_id "$loom_model"
+    "$BIN_DIR/looms" config set-key bedrock_bearer_token
+
+    echo -e "${GREEN}✓ AWS Bedrock configured with bearer token${NC}"
+    echo -e "${GREEN}  Region: $aws_region${NC}"
+    echo -e "${GREEN}  Model: $loom_model${NC}"
+    echo -e "${GREEN}  Bearer token: Stored securely in keyring${NC}"
+
+  elif [ "$llm_choice" = "4" ]; then
+    configure_llm="y"
+    echo ""
     echo "Configuring Anthropic API..."
     echo ""
 
@@ -609,7 +653,7 @@ else
 
     echo -e "${GREEN}✓ Anthropic configured${NC}"
 
-  elif [ "$llm_choice" = "4" ]; then
+  elif [ "$llm_choice" = "5" ]; then
     configure_llm="y"
     echo ""
     echo "Configuring OpenAI API..."
@@ -620,7 +664,7 @@ else
 
     echo -e "${GREEN}✓ OpenAI configured${NC}"
 
-  elif [ "$llm_choice" = "5" ]; then
+  elif [ "$llm_choice" = "6" ]; then
     configure_llm="y"
     echo ""
     echo "Configuring Azure OpenAI..."
@@ -673,7 +717,7 @@ else
 
     echo -e "${GREEN}✓ Azure OpenAI configured${NC}"
 
-  elif [ "$llm_choice" = "6" ]; then
+  elif [ "$llm_choice" = "7" ]; then
     configure_llm="y"
     echo ""
     echo "Configuring Mistral AI..."
@@ -684,7 +728,7 @@ else
 
     echo -e "${GREEN}✓ Mistral AI configured${NC}"
 
-  elif [ "$llm_choice" = "7" ]; then
+  elif [ "$llm_choice" = "8" ]; then
     configure_llm="y"
     echo ""
     echo "Configuring Google Gemini..."
@@ -695,7 +739,7 @@ else
 
     echo -e "${GREEN}✓ Google Gemini configured${NC}"
 
-  elif [ "$llm_choice" = "8" ]; then
+  elif [ "$llm_choice" = "9" ]; then
     configure_llm="y"
     echo ""
     echo "Configuring HuggingFace..."
@@ -706,7 +750,7 @@ else
 
     echo -e "${GREEN}✓ HuggingFace configured${NC}"
 
-  elif [ "$llm_choice" = "9" ]; then
+  elif [ "$llm_choice" = "10" ]; then
     configure_llm="y"
     echo ""
     echo "Configuring Ollama (local/offline inference)..."
@@ -872,7 +916,7 @@ echo ""
 STEP_NUM=1
 
 # If Ollama was configured, remind them to start it first
-if [ "$llm_choice" = "9" ] && [[ "$configure_llm" =~ ^[Yy]$ ]]; then
+if [ "$llm_choice" = "10" ] && [[ "$configure_llm" =~ ^[Yy]$ ]]; then
   echo -e "$STEP_NUM. Start Ollama (required for local inference):"
   echo ""
   echo -e "   In a terminal window:"

--- a/tests/quickstart_scripts_test.go
+++ b/tests/quickstart_scripts_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestQuickstartScriptsOfferBedrockBearerToken(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Dir(filepath.Dir(filename))
+
+	for _, path := range []string{"quickstart.sh", "quickstart.ps1"} {
+		t.Run(path, func(t *testing.T) {
+			content, err := os.ReadFile(filepath.Join(repoRoot, path))
+			if err != nil {
+				t.Fatal(err)
+			}
+			script := string(content)
+
+			if !strings.Contains(script, "AWS Bedrock (with Bearer Token)") {
+				t.Fatalf("%s does not expose the Bedrock bearer token quickstart option", path)
+			}
+			if !strings.Contains(script, "bedrock_bearer_token") {
+				t.Fatalf("%s does not configure the bedrock_bearer_token keyring entry", path)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add an AWS Bedrock bearer token choice to the Unix and Windows quickstart provider menus
- configure `llm.provider`, region, model, and the `bedrock_bearer_token` keyring entry for that path
- add a regression test that both quickstart scripts expose and wire the bearer token option

Closes #166

## Tests
- go test ./tests -run TestQuickstartScriptsOfferBedrockBearerToken -count=1
- go test ./tests -count=1
- go test ./cmd/looms -count=1
- bash -n quickstart.sh
- git diff --check