### PR TITLE
fix(bedrock): fall back to streaming when the SDK refuses non-streaming Chat

### DIFF
--- a/pkg/llm/bedrock/client_sdk.go
+++ b/pkg/llm/bedrock/client_sdk.go
@@ -193,8 +193,28 @@ func (c *SDKClient) Model() string {
 	return c.modelID
 }
 
+// requiresStreaming reports whether the Anthropic SDK would reject a
+// non-streaming Messages.New call for this client's model + max_tokens.
+// The SDK pre-flights non-streaming requests via CalculateNonStreamingTimeout
+// and errors with "streaming is required for operations that may take longer
+// than 10 minutes" when max_tokens implies >10 minutes of generation
+// (max_tokens > ~21,333) or exceeds the model's non-streaming token cap.
+// Claude models are routinely configured with 32k–64k max output tokens,
+// which trips that guard even for trivial prompts.
+func (c *SDKClient) requiresStreaming() bool {
+	_, err := anthropic.CalculateNonStreamingTimeout(int(c.maxTokens), anthropic.Model(c.modelID), nil)
+	return err != nil
+}
+
 // Chat sends a conversation to Bedrock using the Anthropic SDK and returns the response.
+// When the SDK would refuse the non-streaming API for this max_tokens (see
+// requiresStreaming), the request transparently runs over the streaming API
+// and returns the fully accumulated response instead of erroring.
 func (c *SDKClient) Chat(ctx context.Context, messages []llmtypes.Message, tools []shuttle.Tool) (*llmtypes.LLMResponse, error) {
+	if c.requiresStreaming() {
+		return c.ChatStream(ctx, messages, tools, nil)
+	}
+
 	// Convert messages to Anthropic SDK format
 	systemPrompt, sdkMessages := c.convertMessagesToSDK(messages)
 

--- a/pkg/llm/bedrock/client_sdk_test.go
+++ b/pkg/llm/bedrock/client_sdk_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package bedrock
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+)
+
+// sdkTestServer captures whether each request asked for streaming and serves
+// a canned "ok" completion over the matching wire format (SSE vs JSON).
+type sdkTestServer struct {
+	mu          sync.Mutex
+	streamFlags []bool
+}
+
+func (s *sdkTestServer) handler(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	var req map[string]interface{}
+	_ = json.Unmarshal(body, &req)
+	stream, _ := req["stream"].(bool)
+
+	s.mu.Lock()
+	s.streamFlags = append(s.streamFlags, stream)
+	s.mu.Unlock()
+
+	if !stream {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_test","type":"message","role":"assistant",` +
+			`"content":[{"type":"text","text":"ok"}],"model":"test-model",` +
+			`"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":2}}`))
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	for _, ev := range []struct{ event, data string }{
+		{"message_start", `{"type":"message_start","message":{"id":"msg_test","type":"message","role":"assistant","content":[],"model":"test-model","usage":{"input_tokens":10,"output_tokens":0}}}`},
+		{"content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`},
+		{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`},
+		{"content_block_stop", `{"type":"content_block_stop","index":0}`},
+		{"message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":2}}`},
+		{"message_stop", `{"type":"message_stop"}`},
+	} {
+		_, _ = w.Write([]byte("event: " + ev.event + "\ndata: " + ev.data + "\n\n"))
+	}
+}
+
+func (s *sdkTestServer) requests() []bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]bool(nil), s.streamFlags...)
+}
+
+// TestSDKClient_Chat_RoutesByMaxTokens verifies the non-streaming pre-flight
+// routing in Chat: catalog-sized max_tokens must transparently go over the
+// streaming API (the SDK would reject non-streaming Messages.New client-side),
+// while small max_tokens keeps the plain non-streaming call.
+func TestSDKClient_Chat_RoutesByMaxTokens(t *testing.T) {
+	messages := []llmtypes.Message{{Role: "user", Content: "Reply with exactly: ok"}}
+
+	tests := []struct {
+		name       string
+		maxTokens  int64
+		wantStream bool
+	}{
+		{
+			name:       "catalog-sized max_tokens falls back to streaming",
+			maxTokens:  64000,
+			wantStream: true,
+		},
+		{
+			name:       "small max_tokens stays non-streaming",
+			maxTokens:  4096,
+			wantStream: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := &sdkTestServer{}
+			ts := httptest.NewServer(http.HandlerFunc(srv.handler))
+			defer ts.Close()
+
+			client := &SDKClient{
+				client: anthropic.NewClient(
+					option.WithBaseURL(ts.URL),
+					option.WithAPIKey("test-key"),
+				),
+				modelID:     "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+				maxTokens:   tt.maxTokens,
+				temperature: 1.0,
+			}
+
+			resp, err := client.Chat(context.Background(), messages, nil)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			assert.Equal(t, "ok", resp.Content)
+			assert.Equal(t, "end_turn", resp.StopReason)
+			assert.Equal(t, 10, resp.Usage.InputTokens)
+			assert.Equal(t, 2, resp.Usage.OutputTokens)
+
+			flags := srv.requests()
+			require.Len(t, flags, 1, "expected exactly one upstream request")
+			assert.Equal(t, tt.wantStream, flags[0],
+				"wire stream flag for max_tokens=%d", tt.maxTokens)
+			if tt.wantStream {
+				assert.Equal(t, true, resp.Metadata["streaming"])
+			} else {
+				assert.Nil(t, resp.Metadata["streaming"])
+			}
+		})
+	}
+}

--- a/pkg/llm/bedrock/client_test.go
+++ b/pkg/llm/bedrock/client_test.go
@@ -617,6 +617,64 @@ func TestSDKClient_CalculateCost_ModelPricing(t *testing.T) {
 	}
 }
 
+// TestSDKClient_RequiresStreaming verifies the non-streaming pre-flight guard:
+// the Anthropic SDK rejects non-streaming Messages.New calls when max_tokens
+// implies >10 minutes of generation (max_tokens > ~21,333) or exceeds the
+// model's non-streaming token cap. Chat must route those through ChatStream.
+func TestSDKClient_RequiresStreaming(t *testing.T) {
+	tests := []struct {
+		name      string
+		modelID   string
+		maxTokens int64
+		want      bool
+	}{
+		{
+			name:      "small max_tokens stays non-streaming",
+			modelID:   "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+			maxTokens: 4096,
+			want:      false,
+		},
+		{
+			name:      "default bedrock max_tokens stays non-streaming",
+			modelID:   "us.anthropic.claude-haiku-4-5-20250929-v1:0",
+			maxTokens: DefaultBedrockMaxTokens,
+			want:      false,
+		},
+		{
+			name:      "catalog-sized 64k max_tokens requires streaming",
+			modelID:   "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+			maxTokens: 64000,
+			want:      true,
+		},
+		{
+			name:      "catalog-sized 32k max_tokens requires streaming",
+			modelID:   "us.anthropic.claude-opus-4-6-20260301-v1:0",
+			maxTokens: 32000,
+			want:      true,
+		},
+		{
+			name:      "per-model cap: opus 4 bedrock ID above 8192 requires streaming",
+			modelID:   "anthropic.claude-opus-4-20250514-v1:0",
+			maxTokens: 8193,
+			want:      true,
+		},
+		{
+			name:      "per-model cap: opus 4 bedrock ID at 8192 stays non-streaming",
+			modelID:   "anthropic.claude-opus-4-20250514-v1:0",
+			maxTokens: 8192,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &SDKClient{modelID: tt.modelID, maxTokens: tt.maxTokens}
+			assert.Equal(t, tt.want, client.requiresStreaming(),
+				"model=%s max_tokens=%d", tt.modelID, tt.maxTokens)
+		})
+	}
+}
+
 func TestClient_ImplementsInterface(t *testing.T) {
 	var _ types.LLMProvider = (*Client)(nil)
 }


### PR DESCRIPTION
## Problem

Since #205 routed Anthropic-on-Bedrock models to the SDK client (`bedrock-sdk`), every **non-streaming** `LLMProvider.Chat` call from a provider configured with Claude-scale max output tokens fails before ever reaching Bedrock:

```
bedrock SDK invocation failed: streaming is required for operations that may take longer than 10 minutes
```

`anthropic-sdk-go` pre-flights non-streaming `Messages.New` calls via `CalculateNonStreamingTimeout` and rejects them client-side when `max_tokens` implies >10 minutes of generation (`max_tokens > ~21,333`) or exceeds the model's `ModelNonStreamingTokens` cap (e.g. 8192 for `anthropic.claude-opus-4-*` Bedrock IDs). Claude providers are routinely configured with 32k–64k max output tokens, so the guard fires even for trivial prompts — the request never leaves the client.

Observed in production (loom-cloud): all five Claude Bedrock providers reported unhealthy by the health checker (which sends a one-word non-streaming connectivity probe), while Deepseek/Qwen Bedrock providers (still on the Converse client) stayed healthy and `ChatStream` user sessions kept working. Eval-judge and other non-streaming call paths break the same way. Neither the Converse client nor the direct Anthropic client (raw HTTP) has this pre-flight, which is why it only appeared with #205.

## Fix

`SDKClient.Chat` now consults the SDK's own pre-flight and, when the non-streaming API would be refused, transparently runs the request over `ChatStream` with no token callback and returns the fully accumulated response.

- `requiresStreaming()` delegates to `anthropic.CalculateNonStreamingTimeout` directly — no thresholds or model tables duplicated, so it stays correct if the SDK changes its limits.
- Requests under the limit keep using the non-streaming API unchanged.
- Streaming is what Anthropic recommends for long-max_tokens requests anyway; this also avoids idle-timeout drops on genuinely long generations.

## Testing

- `TestSDKClient_RequiresStreaming`: table-driven coverage of both guard conditions (the ~21,333 heuristic and the per-model cap) plus the non-streaming happy paths, including the 8192 boundary.
- `go build`, `go vet`, `golangci-lint run` (0 issues), and `go test -race ./pkg/llm/bedrock/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)