### PR TITLE
fix(postgres): looms upgrade could not bootstrap a fresh database

### DIFF
--- a/pkg/storage/postgres/migrator.go
+++ b/pkg/storage/postgres/migrator.go
@@ -16,11 +16,13 @@ package postgres
 import (
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/teradata-labs/loom/pkg/observability"
@@ -162,6 +164,15 @@ func (m *Migrator) CurrentVersion(ctx context.Context) (int, error) {
 		"SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
 	).Scan(&version)
 	if err != nil {
+		// A missing schema_migrations table means no migrations have been applied
+		// yet (a fresh database). Report version 0 instead of erroring, so
+		// introspection — PendingMigrations and `looms upgrade [--dry-run]` —
+		// works during bootstrap. This stays read-only; the table is created at
+		// apply time by ensureMigrationsTable.
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "42P01" { // undefined_table
+			return 0, nil
+		}
 		return 0, fmt.Errorf("failed to get current migration version: %w", err)
 	}
 	return version, nil

--- a/pkg/storage/postgres/migrator_bootstrap_integration_test.go
+++ b/pkg/storage/postgres/migrator_bootstrap_integration_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMigrator_FreshDatabaseBootstrap is the regression test for the
+// upgrade-bootstrap bug: on a database with no schema_migrations table,
+// CurrentVersion must report 0 — and PendingMigrations must list every
+// migration — instead of erroring with `relation "schema_migrations" does not
+// exist` (SQLSTATE 42P01). Without the fix, `looms upgrade [--dry-run]` could
+// not introspect a brand-new Postgres/Supabase database.
+//
+// The test isolates in a fresh, empty schema and pins the connection
+// search_path to it, so schema_migrations is absent without touching public.
+func TestMigrator_FreshDatabaseBootstrap(t *testing.T) {
+	dsn := os.Getenv("TEST_POSTGRES_URL")
+	if dsn == "" {
+		t.Skip("TEST_POSTGRES_URL not set; skipping PostgreSQL integration test")
+	}
+	ctx := context.Background()
+	schema := fmt.Sprintf("boot_test_%d", os.Getpid())
+
+	// Admin pool (default search_path) to create/drop the isolated schema.
+	admin, err := pgxpool.New(ctx, dsn)
+	require.NoError(t, err)
+	_, err = admin.Exec(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", schema))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = admin.Exec(context.Background(), fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", schema))
+		admin.Close()
+	})
+
+	// Migrator pool pinned to the empty schema only (public excluded), so the
+	// unqualified schema_migrations lookup finds nothing — a fresh DB.
+	cfg, err := pgxpool.ParseConfig(dsn)
+	require.NoError(t, err)
+	cfg.AfterConnect = func(ctx context.Context, c *pgx.Conn) error {
+		_, err := c.Exec(ctx, fmt.Sprintf("SET search_path TO %s", schema))
+		return err
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	m, err := NewMigrator(pool, nil)
+	require.NoError(t, err)
+
+	v, err := m.CurrentVersion(ctx)
+	require.NoError(t, err, "CurrentVersion must not error on a fresh DB (no schema_migrations)")
+	assert.Equal(t, 0, v, "a fresh database should report version 0")
+
+	pending, err := m.PendingMigrations(ctx)
+	require.NoError(t, err, "PendingMigrations must not error on a fresh DB")
+	assert.Len(t, pending, len(m.migrations), "all migrations should be pending on a fresh DB")
+}


### PR DESCRIPTION
## Summary

`looms upgrade` (and `--dry-run`) failed against a brand-new Postgres/Supabase database with `relation "schema_migrations" does not exist` (SQLSTATE 42P01). `Migrator.CurrentVersion` treated the missing table as a hard error, and both `PendingMigrations` and the upgrade CLI call it **before** the table is ever created — so the one command a new user reaches for first could not bootstrap. (`MigrateUp` itself bootstraps fine via `ensureMigrationsTable`; only the read-side introspection was broken.)

## Change

`CurrentVersion` now treats `undefined_table` (matched precisely via `pgconn.PgError` code `42P01`, not string matching) as **version 0** — a fresh database. Read-only: the table is still only created at apply time.

## Verification

Against a fresh database:
- `looms upgrade --dry-run` → `Current schema version: 0`, `Pending migrations: 14` (was: error)
- `looms upgrade --yes` → applies all 14, `New schema version: 14`
- Re-run → `Database is up to date.`

Also exercised for real during the Dreambase-meetup Gate A setup: this exact failure occurred against a brand-new Supabase project.

Adds `TestMigrator_FreshDatabaseBootstrap` (integration-tagged): pins an empty schema on the connection search_path to reproduce the fresh-DB state without touching `public`; asserts `CurrentVersion()==0` and all migrations pending.

`gofmt`, `golangci-lint` (0 issues), and the package race suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
