### PR TITLE
feat(agent): add ChatWithContentBlocks for multimodal user turns

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1488,10 +1488,16 @@ func (a *Agent) ChatWithProgress(ctx context.Context, sessionID string, userMess
 // ChatWithContentBlocks is like ChatWithProgress but the user turn carries
 // multimodal content blocks (text and/or images) alongside the plain-text
 // content. userMessage remains the canonical text (used for persistence,
-// graph-memory extraction, and providers without multimodal support);
-// contentBlocks take precedence when building the provider request for
-// providers that support them. progressCallback may be nil, in which case no
-// progress events are emitted (equivalent to Chat).
+// graph-memory extraction, and providers without multimodal support).
+//
+// When contentBlocks is non-empty, providers build the request from the blocks
+// only — Content is not sent. To keep userMessage canonical, if contentBlocks
+// contains no text block, userMessage is automatically prepended as one, so an
+// image-only call still delivers the question text to the model. Callers that
+// include their own text block are unaffected.
+//
+// progressCallback may be nil, in which case no progress events are emitted
+// (equivalent to Chat).
 func (a *Agent) ChatWithContentBlocks(ctx context.Context, sessionID string, userMessage string, contentBlocks []ContentBlock, progressCallback ProgressCallback) (*Response, error) {
 	return a.chat(ctx, sessionID, userMessage, chatParams{
 		spanName:            "agent.chat_with_content_blocks",
@@ -1528,12 +1534,31 @@ type chatParams struct {
 	reportContentBlocks bool
 }
 
+// hasTextBlock reports whether any of the blocks is a text block.
+func hasTextBlock(blocks []ContentBlock) bool {
+	for _, b := range blocks {
+		if b.Type == "text" {
+			return true
+		}
+	}
+	return false
+}
+
 // chat runs the full conversation lifecycle — span setup, user-message
 // persistence, graph-memory kick-off, the conversation loop, and success/error
 // telemetry — shared by the three public chat entry points. See chatParams for
 // how each entry point tailors span name, multimodal content, and progress
 // reporting.
 func (a *Agent) chat(ctx context.Context, sessionID string, userMessage string, p chatParams) (*Response, error) {
+	// Providers build the request exclusively from ContentBlocks when present,
+	// dropping Content — so an image-only block set would silently send the
+	// image without the question text. Keep userMessage truly canonical by
+	// prepending it as a text block when the caller didn't include one. This is
+	// a no-op for callers that already carry their prompt in a text block.
+	if len(p.contentBlocks) > 0 && !hasTextBlock(p.contentBlocks) && userMessage != "" {
+		p.contentBlocks = append([]ContentBlock{{Type: "text", Text: userMessage}}, p.contentBlocks...)
+	}
+
 	// Inject session ID into context for tool access
 	ctx = session.WithSessionID(ctx, sessionID)
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1469,18 +1469,86 @@ func truncatePreview(s string) string {
 // Chat processes a user message and returns a response.
 // This is the main entry point for conversational interaction.
 func (a *Agent) Chat(ctx context.Context, sessionID string, userMessage string) (*Response, error) {
+	return a.chat(ctx, sessionID, userMessage, chatParams{
+		spanName: "agent.chat",
+	})
+}
+
+// ChatWithProgress is like Chat but supports streaming progress updates.
+// The progressCallback will be called at key execution stages to report progress.
+// This is used by StreamWeave to provide real-time feedback to clients.
+func (a *Agent) ChatWithProgress(ctx context.Context, sessionID string, userMessage string, progressCallback ProgressCallback) (*Response, error) {
+	return a.chat(ctx, sessionID, userMessage, chatParams{
+		spanName:         "agent.chat_with_progress",
+		progressCallback: progressCallback,
+		reportProgress:   true,
+	})
+}
+
+// ChatWithContentBlocks is like ChatWithProgress but the user turn carries
+// multimodal content blocks (text and/or images) alongside the plain-text
+// content. userMessage remains the canonical text (used for persistence,
+// graph-memory extraction, and providers without multimodal support);
+// contentBlocks take precedence when building the provider request for
+// providers that support them. progressCallback may be nil, in which case no
+// progress events are emitted (equivalent to Chat).
+func (a *Agent) ChatWithContentBlocks(ctx context.Context, sessionID string, userMessage string, contentBlocks []ContentBlock, progressCallback ProgressCallback) (*Response, error) {
+	return a.chat(ctx, sessionID, userMessage, chatParams{
+		spanName:            "agent.chat_with_content_blocks",
+		contentBlocks:       contentBlocks,
+		progressCallback:    progressCallback,
+		reportProgress:      true,
+		reportContentBlocks: true,
+	})
+}
+
+// chatParams configures the shared conversation lifecycle behind Chat,
+// ChatWithProgress, and ChatWithContentBlocks. Each public entry point sets only
+// the fields it needs so its span and telemetry stay identical to the
+// pre-refactor, hand-written form.
+type chatParams struct {
+	// spanName is the trace span name for this entry point.
+	spanName string
+
+	// contentBlocks, when present, is attached to the user turn so multimodal
+	// content reaches providers that support it. nil for text-only entry points.
+	contentBlocks []ContentBlock
+
+	// progressCallback, when non-nil, is threaded into context so nested
+	// operations (tools, backends, sub-agents) can report progress, and it
+	// receives a StageFailed event if the conversation loop errors.
+	progressCallback ProgressCallback
+
+	// reportProgress adds the "has_progress" field to the conversation.started
+	// event. Chat omits it; ChatWithProgress and ChatWithContentBlocks set it.
+	reportProgress bool
+
+	// reportContentBlocks adds the "message.content_blocks" span attribute and
+	// the "content_blocks" started-event field. ChatWithContentBlocks only.
+	reportContentBlocks bool
+}
+
+// chat runs the full conversation lifecycle — span setup, user-message
+// persistence, graph-memory kick-off, the conversation loop, and success/error
+// telemetry — shared by the three public chat entry points. See chatParams for
+// how each entry point tailors span name, multimodal content, and progress
+// reporting.
+func (a *Agent) chat(ctx context.Context, sessionID string, userMessage string, p chatParams) (*Response, error) {
 	// Inject session ID into context for tool access
 	ctx = session.WithSessionID(ctx, sessionID)
 
 	// Start trace span — always created; NoOpTracer handles disabled case
 	startTime := time.Now()
-	ctx, span := a.tracer.StartSpan(ctx, "agent.chat")
+	ctx, span := a.tracer.StartSpan(ctx, p.spanName)
 	defer a.tracer.EndSpan(span)
 
 	// Set initial attributes
 	span.SetAttribute(observability.AttrSessionID, sessionID)
 	span.SetAttribute("message.length", len(userMessage))
 	span.SetAttribute("message.preview", truncatePreview(userMessage))
+	if p.reportContentBlocks {
+		span.SetAttribute("message.content_blocks", len(p.contentBlocks))
+	}
 	a.mu.RLock()
 	currentLLM := a.llm
 	a.mu.RUnlock()
@@ -1490,20 +1558,31 @@ func (a *Agent) Chat(ctx context.Context, sessionID string, userMessage string) 
 	span.SetAttribute("config.max_tool_executions", a.config.MaxToolExecutions)
 
 	// Record conversation started event
-	span.AddEvent("conversation.started", map[string]interface{}{
+	startedEvent := map[string]interface{}{
 		"session_id":     sessionID,
 		"message_length": len(userMessage),
-	})
+	}
+	if p.reportContentBlocks {
+		startedEvent["content_blocks"] = len(p.contentBlocks)
+	}
+	if p.reportProgress {
+		startedEvent["has_progress"] = p.progressCallback != nil
+	}
+	span.AddEvent("conversation.started", startedEvent)
 
 	// Get or create session with agent metadata for proper ReferenceStore namespacing
 	session := a.memory.GetOrCreateSessionWithAgent(ctx, sessionID, a.config.Name, "")
 
-	// Add user message to history
+	// Add user message to history. ContentBlocks (when present) take precedence
+	// over Content as providers build the request, so multimodal content reaches
+	// the model; Content remains the canonical text for persistence and providers
+	// without multimodal support.
 	userMsg := Message{
-		Role:      "user",
-		Content:   userMessage,
-		AgentID:   a.id, // Track which agent received this message
-		Timestamp: time.Now(),
+		Role:          "user",
+		Content:       userMessage,
+		ContentBlocks: p.contentBlocks,
+		AgentID:       a.id, // Track which agent received this message
+		Timestamp:     time.Now(),
 	}
 	session.AddMessage(ctx, userMsg)
 
@@ -1528,12 +1607,18 @@ func (a *Agent) Chat(ctx context.Context, sessionID string, userMessage string) 
 		}()
 	}
 
-	// Create agent context
+	// Store progressCallback in context so nested operations (tools, backends) can access it.
+	// This enables sub-agent progress reporting (e.g., weaver's sub-agents).
+	if p.progressCallback != nil {
+		ctx = ContextWithProgressCallback(ctx, p.progressCallback)
+	}
+
+	// Create agent context (a nil progressCallback is fine — no events emitted)
 	agentCtx := &agentContext{
 		Context:          ctx,
 		session:          session,
 		tracer:           a.tracer,
-		progressCallback: nil, // No progress callback for regular Chat
+		progressCallback: p.progressCallback,
 	}
 
 	// Run conversation loop
@@ -1563,6 +1648,16 @@ func (a *Agent) Chat(ctx context.Context, sessionID string, userMessage string) 
 		a.tracer.RecordMetric("agent.conversations.failed", 1, map[string]string{
 			observability.AttrSessionID: sessionID,
 		})
+
+		// Emit failure event to the progress callback when one is registered.
+		if p.progressCallback != nil {
+			p.progressCallback(ProgressEvent{
+				Stage:     StageFailed,
+				Progress:  0,
+				Message:   fmt.Sprintf("Execution failed: %v", err),
+				Timestamp: time.Now(),
+			})
+		}
 
 		return nil, fmt.Errorf("conversation loop failed: %w", err)
 	}
@@ -1612,434 +1707,6 @@ func (a *Agent) Chat(ctx context.Context, sessionID string, userMessage string) 
 	span.SetAttribute("conversation.stop_reason", response.Metadata["stop_reason"])
 	span.SetAttribute("response.length", len(response.Content))
 	span.SetAttribute("response.preview", truncatePreview(response.Content))
-
-	// Check if we hit limits
-	if maxTurnsHit, ok := response.Metadata["max_turns_hit"].(bool); ok && maxTurnsHit {
-		span.SetAttribute("conversation.max_turns_hit", true)
-	}
-	if maxExecHit, ok := response.Metadata["max_exec_hit"].(bool); ok && maxExecHit {
-		span.SetAttribute("conversation.max_executions_hit", true)
-	}
-
-	// Record completion event
-	span.AddEvent("conversation.completed", map[string]interface{}{
-		"duration_ms":     duration.Milliseconds(),
-		"turns":           turns,
-		"tool_executions": toolExecs,
-		"cost_usd":        response.Usage.CostUSD,
-		"tokens":          response.Usage.TotalTokens,
-	})
-
-	// Emit metrics
-	a.tracer.RecordMetric(observability.MetricAgentConversations, 1, map[string]string{
-		observability.AttrSessionID: sessionID,
-		"status":                    "success",
-	})
-
-	a.tracer.RecordMetric(observability.MetricAgentConversationDuration, float64(duration.Milliseconds()), map[string]string{
-		observability.AttrSessionID: sessionID,
-	})
-
-	a.tracer.RecordMetric("agent.turns.total", float64(turns), map[string]string{
-		observability.AttrSessionID: sessionID,
-	})
-
-	a.tracer.RecordMetric("agent.tool_executions.total", float64(toolExecs), map[string]string{
-		observability.AttrSessionID: sessionID,
-	})
-
-	a.tracer.RecordMetric("agent.cost.usd", response.Usage.CostUSD, map[string]string{
-		observability.AttrSessionID: sessionID,
-	})
-
-	a.tracer.RecordMetric("agent.tokens.total", float64(response.Usage.TotalTokens), map[string]string{
-		observability.AttrSessionID: sessionID,
-	})
-
-	return response, nil
-}
-
-// ChatWithProgress is like Chat but supports streaming progress updates.
-// The progressCallback will be called at key execution stages to report progress.
-// This is used by StreamWeave to provide real-time feedback to clients.
-func (a *Agent) ChatWithProgress(ctx context.Context, sessionID string, userMessage string, progressCallback ProgressCallback) (*Response, error) {
-	// Inject session ID into context for tool access
-	ctx = session.WithSessionID(ctx, sessionID)
-
-	// Start trace span — always created; NoOpTracer handles disabled case
-	startTime := time.Now()
-	ctx, span := a.tracer.StartSpan(ctx, "agent.chat_with_progress")
-	defer a.tracer.EndSpan(span)
-
-	// Set initial attributes
-	span.SetAttribute(observability.AttrSessionID, sessionID)
-	span.SetAttribute("message.length", len(userMessage))
-	span.SetAttribute("message.preview", truncatePreview(userMessage))
-	a.mu.RLock()
-	currentLLM := a.llm
-	a.mu.RUnlock()
-	span.SetAttribute("llm.provider", currentLLM.Name())
-	span.SetAttribute("llm.model", currentLLM.Model())
-	span.SetAttribute("config.max_turns", a.config.MaxTurns)
-	span.SetAttribute("config.max_tool_executions", a.config.MaxToolExecutions)
-
-	// Record conversation started event
-	span.AddEvent("conversation.started", map[string]interface{}{
-		"session_id":     sessionID,
-		"message_length": len(userMessage),
-		"has_progress":   true,
-	})
-
-	// Get or create session with agent metadata for proper ReferenceStore namespacing
-	session := a.memory.GetOrCreateSessionWithAgent(ctx, sessionID, a.config.Name, "")
-
-	// Add user message to history
-	userMsg := Message{
-		Role:      "user",
-		Content:   userMessage,
-		AgentID:   a.id, // Track which agent received this message
-		Timestamp: time.Now(),
-	}
-	session.AddMessage(ctx, userMsg)
-
-	// Persist message if storage configured
-	if err := a.memory.PersistMessage(ctx, sessionID, userMsg); err != nil {
-		// Log error but don't fail the request
-		zap.L().Warn("Failed to persist message",
-			zap.String("session_id", sessionID),
-			zap.String("role", userMsg.Role),
-			zap.Error(err))
-		span.RecordError(err)
-	}
-
-	// Fire graph memory extraction on the incoming user message immediately,
-	// in parallel with the LLM processing it.
-	if a.enableGraphMemoryExtraction {
-		a.graphExtractionWG.Add(1)
-		go func() {
-			defer a.graphExtractionWG.Done()
-			a.extractGraphMemoryAsync(ctx, sessionID)
-		}()
-	}
-
-	// Store progressCallback in context so nested operations (tools, backends) can access it
-	// This enables sub-agent progress reporting (e.g., weaver's sub-agents)
-	if progressCallback != nil {
-		ctx = ContextWithProgressCallback(ctx, progressCallback)
-	}
-
-	// Create agent context with progress callback
-	agentCtx := &agentContext{
-		Context:          ctx, // Now contains progressCallback
-		session:          session,
-		tracer:           a.tracer,
-		progressCallback: progressCallback,
-	}
-
-	// Run conversation loop (will emit progress events)
-	response, err := a.runConversationLoop(agentCtx)
-
-	// Progressive disclosure: Check if conversation_memory tool should be registered
-	// (after first L2 swap event)
-	a.checkAndRegisterConversationMemoryTool(sessionID)
-	a.checkAndRegisterSessionMemoryTool(ctx)
-	a.checkAndRegisterGraphMemoryTool()
-	a.checkAndRegisterTaskBoardTool()
-
-	// Calculate total duration
-	duration := time.Since(startTime)
-
-	if err != nil {
-		span.Status = observability.Status{
-			Code:    observability.StatusError,
-			Message: err.Error(),
-		}
-		span.SetAttribute(observability.AttrErrorMessage, err.Error())
-		span.AddEvent("conversation.failed", map[string]interface{}{
-			"error":       err.Error(),
-			"duration_ms": duration.Milliseconds(),
-		})
-
-		a.tracer.RecordMetric("agent.conversations.failed", 1, map[string]string{
-			observability.AttrSessionID: sessionID,
-		})
-
-		// Emit failure event
-		if progressCallback != nil {
-			progressCallback(ProgressEvent{
-				Stage:     StageFailed,
-				Progress:  0,
-				Message:   fmt.Sprintf("Execution failed: %v", err),
-				Timestamp: time.Now(),
-			})
-		}
-		return nil, fmt.Errorf("conversation loop failed: %w", err)
-	}
-
-	// Add assistant response to history
-	assistantMsg := Message{
-		Role:       "assistant",
-		Content:    response.Content,
-		AgentID:    a.id, // Track which agent generated this response
-		Timestamp:  time.Now(),
-		TokenCount: response.Usage.TotalTokens,
-		CostUSD:    response.Usage.CostUSD,
-	}
-	session.AddMessage(ctx, assistantMsg)
-
-	// Persist final message and session
-	if err := a.memory.PersistMessage(ctx, sessionID, assistantMsg); err != nil {
-		zap.L().Warn("Failed to persist message",
-			zap.String("session_id", sessionID),
-			zap.String("role", assistantMsg.Role),
-			zap.Error(err))
-		span.RecordError(err)
-	}
-	if err := a.memory.PersistSession(ctx, session); err != nil {
-		zap.L().Warn("Failed to persist session",
-			zap.String("session_id", sessionID),
-			zap.Error(err))
-		span.RecordError(err)
-	}
-
-	// Record success metrics and span attributes
-	span.Status = observability.Status{
-		Code: observability.StatusOK,
-	}
-
-	// Capture conversation metrics
-	turns := response.Metadata["turns"].(int)
-	toolExecs := response.Metadata["tool_executions"].(int)
-
-	span.SetAttribute("conversation.turns", turns)
-	span.SetAttribute("conversation.tool_executions", toolExecs)
-	span.SetAttribute("conversation.duration_ms", duration.Milliseconds())
-	span.SetAttribute("conversation.tokens.total", response.Usage.TotalTokens)
-	span.SetAttribute("conversation.tokens.input", response.Usage.InputTokens)
-	span.SetAttribute("conversation.tokens.output", response.Usage.OutputTokens)
-	span.SetAttribute("conversation.cost.usd", response.Usage.CostUSD)
-	span.SetAttribute("conversation.stop_reason", response.Metadata["stop_reason"])
-	span.SetAttribute("response.length", len(response.Content))
-	span.SetAttribute("response.preview", truncatePreview(response.Content))
-
-	// Check if we hit limits
-	if maxTurnsHit, ok := response.Metadata["max_turns_hit"].(bool); ok && maxTurnsHit {
-		span.SetAttribute("conversation.max_turns_hit", true)
-	}
-	if maxExecHit, ok := response.Metadata["max_exec_hit"].(bool); ok && maxExecHit {
-		span.SetAttribute("conversation.max_executions_hit", true)
-	}
-
-	// Record completion event
-	span.AddEvent("conversation.completed", map[string]interface{}{
-		"duration_ms":     duration.Milliseconds(),
-		"turns":           turns,
-		"tool_executions": toolExecs,
-		"cost_usd":        response.Usage.CostUSD,
-		"tokens":          response.Usage.TotalTokens,
-	})
-
-	// Emit metrics
-	a.tracer.RecordMetric(observability.MetricAgentConversations, 1, map[string]string{
-		observability.AttrSessionID: sessionID,
-		"status":                    "success",
-	})
-
-	a.tracer.RecordMetric(observability.MetricAgentConversationDuration, float64(duration.Milliseconds()), map[string]string{
-		observability.AttrSessionID: sessionID,
-	})
-
-	a.tracer.RecordMetric("agent.turns.total", float64(turns), map[string]string{
-		observability.AttrSessionID: sessionID,
-	})
-
-	a.tracer.RecordMetric("agent.tool_executions.total", float64(toolExecs), map[string]string{
-		observability.AttrSessionID: sessionID,
-	})
-
-	a.tracer.RecordMetric("agent.cost.usd", response.Usage.CostUSD, map[string]string{
-		observability.AttrSessionID: sessionID,
-	})
-
-	a.tracer.RecordMetric("agent.tokens.total", float64(response.Usage.TotalTokens), map[string]string{
-		observability.AttrSessionID: sessionID,
-	})
-
-	// Note: We don't emit StageCompleted here - the caller (StreamWeave) will
-	// emit it with the full result included in the progress event
-
-	return response, nil
-}
-
-// ChatWithContentBlocks is like ChatWithProgress but the user turn carries
-// multimodal content blocks (text and/or images) alongside the plain-text
-// content. userMessage remains the canonical text (used for persistence,
-// graph-memory extraction, and providers without multimodal support);
-// contentBlocks take precedence when building the provider request for
-// providers that support them. progressCallback may be nil, in which case no
-// progress events are emitted (equivalent to Chat).
-func (a *Agent) ChatWithContentBlocks(ctx context.Context, sessionID string, userMessage string, contentBlocks []ContentBlock, progressCallback ProgressCallback) (*Response, error) {
-	// Inject session ID into context for tool access
-	ctx = session.WithSessionID(ctx, sessionID)
-
-	// Start trace span — always created; NoOpTracer handles disabled case
-	startTime := time.Now()
-	ctx, span := a.tracer.StartSpan(ctx, "agent.chat_with_content_blocks")
-	defer a.tracer.EndSpan(span)
-
-	// Set initial attributes
-	span.SetAttribute(observability.AttrSessionID, sessionID)
-	span.SetAttribute("message.length", len(userMessage))
-	span.SetAttribute("message.preview", truncateString(userMessage, 100))
-	span.SetAttribute("message.content_blocks", len(contentBlocks))
-	a.mu.RLock()
-	currentLLM := a.llm
-	a.mu.RUnlock()
-	span.SetAttribute("llm.provider", currentLLM.Name())
-	span.SetAttribute("llm.model", currentLLM.Model())
-	span.SetAttribute("config.max_turns", a.config.MaxTurns)
-	span.SetAttribute("config.max_tool_executions", a.config.MaxToolExecutions)
-
-	// Record conversation started event
-	span.AddEvent("conversation.started", map[string]interface{}{
-		"session_id":     sessionID,
-		"message_length": len(userMessage),
-		"content_blocks": len(contentBlocks),
-		"has_progress":   progressCallback != nil,
-	})
-
-	// Get or create session with agent metadata for proper ReferenceStore namespacing
-	session := a.memory.GetOrCreateSessionWithAgent(ctx, sessionID, a.config.Name, "")
-
-	// Add user message to history — ContentBlocks take precedence over Content
-	// when providers build the request, so multimodal content reaches the model.
-	userMsg := Message{
-		Role:          "user",
-		Content:       userMessage,
-		ContentBlocks: contentBlocks,
-		AgentID:       a.id, // Track which agent received this message
-		Timestamp:     time.Now(),
-	}
-	session.AddMessage(ctx, userMsg)
-
-	// Persist message if storage configured
-	if err := a.memory.PersistMessage(ctx, sessionID, userMsg); err != nil {
-		// Log error but don't fail the request
-		zap.L().Warn("Failed to persist message",
-			zap.String("session_id", sessionID),
-			zap.String("role", userMsg.Role),
-			zap.Error(err))
-		span.RecordError(err)
-	}
-
-	// Fire graph memory extraction on the incoming user message immediately,
-	// in parallel with the LLM processing it.
-	if a.enableGraphMemoryExtraction {
-		a.graphExtractionWG.Add(1)
-		go func() {
-			defer a.graphExtractionWG.Done()
-			a.extractGraphMemoryAsync(ctx, sessionID)
-		}()
-	}
-
-	// Store progressCallback in context so nested operations (tools, backends) can access it
-	if progressCallback != nil {
-		ctx = ContextWithProgressCallback(ctx, progressCallback)
-	}
-
-	// Create agent context with progress callback (nil is fine — no events emitted)
-	agentCtx := &agentContext{
-		Context:          ctx,
-		session:          session,
-		tracer:           a.tracer,
-		progressCallback: progressCallback,
-	}
-
-	// Run conversation loop
-	response, err := a.runConversationLoop(agentCtx)
-
-	// Progressive disclosure: Check if conversation_memory tool should be registered
-	// (after first L2 swap event)
-	a.checkAndRegisterConversationMemoryTool(sessionID)
-	a.checkAndRegisterSessionMemoryTool(ctx)
-	a.checkAndRegisterGraphMemoryTool()
-	a.checkAndRegisterTaskBoardTool()
-
-	// Calculate total duration
-	duration := time.Since(startTime)
-
-	if err != nil {
-		span.Status = observability.Status{
-			Code:    observability.StatusError,
-			Message: err.Error(),
-		}
-		span.SetAttribute(observability.AttrErrorMessage, err.Error())
-		span.AddEvent("conversation.failed", map[string]interface{}{
-			"error":       err.Error(),
-			"duration_ms": duration.Milliseconds(),
-		})
-
-		a.tracer.RecordMetric("agent.conversations.failed", 1, map[string]string{
-			observability.AttrSessionID: sessionID,
-		})
-
-		// Emit failure event
-		if progressCallback != nil {
-			progressCallback(ProgressEvent{
-				Stage:     StageFailed,
-				Progress:  0,
-				Message:   fmt.Sprintf("Execution failed: %v", err),
-				Timestamp: time.Now(),
-			})
-		}
-		return nil, fmt.Errorf("conversation loop failed: %w", err)
-	}
-
-	// Add assistant response to history
-	assistantMsg := Message{
-		Role:       "assistant",
-		Content:    response.Content,
-		AgentID:    a.id, // Track which agent generated this response
-		Timestamp:  time.Now(),
-		TokenCount: response.Usage.TotalTokens,
-		CostUSD:    response.Usage.CostUSD,
-	}
-	session.AddMessage(ctx, assistantMsg)
-
-	// Persist final message and session
-	if err := a.memory.PersistMessage(ctx, sessionID, assistantMsg); err != nil {
-		zap.L().Warn("Failed to persist message",
-			zap.String("session_id", sessionID),
-			zap.String("role", assistantMsg.Role),
-			zap.Error(err))
-		span.RecordError(err)
-	}
-	if err := a.memory.PersistSession(ctx, session); err != nil {
-		zap.L().Warn("Failed to persist session",
-			zap.String("session_id", sessionID),
-			zap.Error(err))
-		span.RecordError(err)
-	}
-
-	// Record success metrics and span attributes
-	span.Status = observability.Status{
-		Code: observability.StatusOK,
-	}
-
-	// Capture conversation metrics
-	turns := response.Metadata["turns"].(int)
-	toolExecs := response.Metadata["tool_executions"].(int)
-
-	span.SetAttribute("conversation.turns", turns)
-	span.SetAttribute("conversation.tool_executions", toolExecs)
-	span.SetAttribute("conversation.duration_ms", duration.Milliseconds())
-	span.SetAttribute("conversation.tokens.total", response.Usage.TotalTokens)
-	span.SetAttribute("conversation.tokens.input", response.Usage.InputTokens)
-	span.SetAttribute("conversation.tokens.output", response.Usage.OutputTokens)
-	span.SetAttribute("conversation.cost.usd", response.Usage.CostUSD)
-	span.SetAttribute("conversation.stop_reason", response.Metadata["stop_reason"])
-	span.SetAttribute("response.length", len(response.Content))
-	span.SetAttribute("response.preview", truncateString(response.Content, 100))
 
 	// Check if we hit limits
 	if maxTurnsHit, ok := response.Metadata["max_turns_hit"].(bool); ok && maxTurnsHit {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1871,6 +1871,222 @@ func (a *Agent) ChatWithProgress(ctx context.Context, sessionID string, userMess
 	return response, nil
 }
 
+// ChatWithContentBlocks is like ChatWithProgress but the user turn carries
+// multimodal content blocks (text and/or images) alongside the plain-text
+// content. userMessage remains the canonical text (used for persistence,
+// graph-memory extraction, and providers without multimodal support);
+// contentBlocks take precedence when building the provider request for
+// providers that support them. progressCallback may be nil, in which case no
+// progress events are emitted (equivalent to Chat).
+func (a *Agent) ChatWithContentBlocks(ctx context.Context, sessionID string, userMessage string, contentBlocks []ContentBlock, progressCallback ProgressCallback) (*Response, error) {
+	// Inject session ID into context for tool access
+	ctx = session.WithSessionID(ctx, sessionID)
+
+	// Start trace span — always created; NoOpTracer handles disabled case
+	startTime := time.Now()
+	ctx, span := a.tracer.StartSpan(ctx, "agent.chat_with_content_blocks")
+	defer a.tracer.EndSpan(span)
+
+	// Set initial attributes
+	span.SetAttribute(observability.AttrSessionID, sessionID)
+	span.SetAttribute("message.length", len(userMessage))
+	span.SetAttribute("message.preview", truncateString(userMessage, 100))
+	span.SetAttribute("message.content_blocks", len(contentBlocks))
+	a.mu.RLock()
+	currentLLM := a.llm
+	a.mu.RUnlock()
+	span.SetAttribute("llm.provider", currentLLM.Name())
+	span.SetAttribute("llm.model", currentLLM.Model())
+	span.SetAttribute("config.max_turns", a.config.MaxTurns)
+	span.SetAttribute("config.max_tool_executions", a.config.MaxToolExecutions)
+
+	// Record conversation started event
+	span.AddEvent("conversation.started", map[string]interface{}{
+		"session_id":     sessionID,
+		"message_length": len(userMessage),
+		"content_blocks": len(contentBlocks),
+		"has_progress":   progressCallback != nil,
+	})
+
+	// Get or create session with agent metadata for proper ReferenceStore namespacing
+	session := a.memory.GetOrCreateSessionWithAgent(ctx, sessionID, a.config.Name, "")
+
+	// Add user message to history — ContentBlocks take precedence over Content
+	// when providers build the request, so multimodal content reaches the model.
+	userMsg := Message{
+		Role:          "user",
+		Content:       userMessage,
+		ContentBlocks: contentBlocks,
+		AgentID:       a.id, // Track which agent received this message
+		Timestamp:     time.Now(),
+	}
+	session.AddMessage(ctx, userMsg)
+
+	// Persist message if storage configured
+	if err := a.memory.PersistMessage(ctx, sessionID, userMsg); err != nil {
+		// Log error but don't fail the request
+		zap.L().Warn("Failed to persist message",
+			zap.String("session_id", sessionID),
+			zap.String("role", userMsg.Role),
+			zap.Error(err))
+		span.RecordError(err)
+	}
+
+	// Fire graph memory extraction on the incoming user message immediately,
+	// in parallel with the LLM processing it.
+	if a.enableGraphMemoryExtraction {
+		a.graphExtractionWG.Add(1)
+		go func() {
+			defer a.graphExtractionWG.Done()
+			a.extractGraphMemoryAsync(ctx, sessionID)
+		}()
+	}
+
+	// Store progressCallback in context so nested operations (tools, backends) can access it
+	if progressCallback != nil {
+		ctx = ContextWithProgressCallback(ctx, progressCallback)
+	}
+
+	// Create agent context with progress callback (nil is fine — no events emitted)
+	agentCtx := &agentContext{
+		Context:          ctx,
+		session:          session,
+		tracer:           a.tracer,
+		progressCallback: progressCallback,
+	}
+
+	// Run conversation loop
+	response, err := a.runConversationLoop(agentCtx)
+
+	// Progressive disclosure: Check if conversation_memory tool should be registered
+	// (after first L2 swap event)
+	a.checkAndRegisterConversationMemoryTool(sessionID)
+	a.checkAndRegisterSessionMemoryTool(ctx)
+	a.checkAndRegisterGraphMemoryTool()
+	a.checkAndRegisterTaskBoardTool()
+
+	// Calculate total duration
+	duration := time.Since(startTime)
+
+	if err != nil {
+		span.Status = observability.Status{
+			Code:    observability.StatusError,
+			Message: err.Error(),
+		}
+		span.SetAttribute(observability.AttrErrorMessage, err.Error())
+		span.AddEvent("conversation.failed", map[string]interface{}{
+			"error":       err.Error(),
+			"duration_ms": duration.Milliseconds(),
+		})
+
+		a.tracer.RecordMetric("agent.conversations.failed", 1, map[string]string{
+			observability.AttrSessionID: sessionID,
+		})
+
+		// Emit failure event
+		if progressCallback != nil {
+			progressCallback(ProgressEvent{
+				Stage:     StageFailed,
+				Progress:  0,
+				Message:   fmt.Sprintf("Execution failed: %v", err),
+				Timestamp: time.Now(),
+			})
+		}
+		return nil, fmt.Errorf("conversation loop failed: %w", err)
+	}
+
+	// Add assistant response to history
+	assistantMsg := Message{
+		Role:       "assistant",
+		Content:    response.Content,
+		AgentID:    a.id, // Track which agent generated this response
+		Timestamp:  time.Now(),
+		TokenCount: response.Usage.TotalTokens,
+		CostUSD:    response.Usage.CostUSD,
+	}
+	session.AddMessage(ctx, assistantMsg)
+
+	// Persist final message and session
+	if err := a.memory.PersistMessage(ctx, sessionID, assistantMsg); err != nil {
+		zap.L().Warn("Failed to persist message",
+			zap.String("session_id", sessionID),
+			zap.String("role", assistantMsg.Role),
+			zap.Error(err))
+		span.RecordError(err)
+	}
+	if err := a.memory.PersistSession(ctx, session); err != nil {
+		zap.L().Warn("Failed to persist session",
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+		span.RecordError(err)
+	}
+
+	// Record success metrics and span attributes
+	span.Status = observability.Status{
+		Code: observability.StatusOK,
+	}
+
+	// Capture conversation metrics
+	turns := response.Metadata["turns"].(int)
+	toolExecs := response.Metadata["tool_executions"].(int)
+
+	span.SetAttribute("conversation.turns", turns)
+	span.SetAttribute("conversation.tool_executions", toolExecs)
+	span.SetAttribute("conversation.duration_ms", duration.Milliseconds())
+	span.SetAttribute("conversation.tokens.total", response.Usage.TotalTokens)
+	span.SetAttribute("conversation.tokens.input", response.Usage.InputTokens)
+	span.SetAttribute("conversation.tokens.output", response.Usage.OutputTokens)
+	span.SetAttribute("conversation.cost.usd", response.Usage.CostUSD)
+	span.SetAttribute("conversation.stop_reason", response.Metadata["stop_reason"])
+	span.SetAttribute("response.length", len(response.Content))
+	span.SetAttribute("response.preview", truncateString(response.Content, 100))
+
+	// Check if we hit limits
+	if maxTurnsHit, ok := response.Metadata["max_turns_hit"].(bool); ok && maxTurnsHit {
+		span.SetAttribute("conversation.max_turns_hit", true)
+	}
+	if maxExecHit, ok := response.Metadata["max_exec_hit"].(bool); ok && maxExecHit {
+		span.SetAttribute("conversation.max_executions_hit", true)
+	}
+
+	// Record completion event
+	span.AddEvent("conversation.completed", map[string]interface{}{
+		"duration_ms":     duration.Milliseconds(),
+		"turns":           turns,
+		"tool_executions": toolExecs,
+		"cost_usd":        response.Usage.CostUSD,
+		"tokens":          response.Usage.TotalTokens,
+	})
+
+	// Emit metrics
+	a.tracer.RecordMetric(observability.MetricAgentConversations, 1, map[string]string{
+		observability.AttrSessionID: sessionID,
+		"status":                    "success",
+	})
+
+	a.tracer.RecordMetric(observability.MetricAgentConversationDuration, float64(duration.Milliseconds()), map[string]string{
+		observability.AttrSessionID: sessionID,
+	})
+
+	a.tracer.RecordMetric("agent.turns.total", float64(turns), map[string]string{
+		observability.AttrSessionID: sessionID,
+	})
+
+	a.tracer.RecordMetric("agent.tool_executions.total", float64(toolExecs), map[string]string{
+		observability.AttrSessionID: sessionID,
+	})
+
+	a.tracer.RecordMetric("agent.cost.usd", response.Usage.CostUSD, map[string]string{
+		observability.AttrSessionID: sessionID,
+	})
+
+	a.tracer.RecordMetric("agent.tokens.total", float64(response.Usage.TotalTokens), map[string]string{
+		observability.AttrSessionID: sessionID,
+	})
+
+	return response, nil
+}
+
 // Response represents the agent's response to a user message.
 type Response struct {
 	// Content is the text response

--- a/pkg/agent/chat_content_blocks_test.go
+++ b/pkg/agent/chat_content_blocks_test.go
@@ -193,6 +193,31 @@ func TestAgent_ChatWithContentBlocks_EmptyBlocks(t *testing.T) {
 	assert.Empty(t, userMsg.ContentBlocks, "no blocks supplied means none forwarded")
 }
 
+// TestAgent_ChatWithContentBlocks_SuccessWithProgressCallback exercises the
+// success path with a non-nil progress callback: the call succeeds, returns a
+// response, and — unlike the error path — never emits a StageFailed event.
+func TestAgent_ChatWithContentBlocks_SuccessWithProgressCallback(t *testing.T) {
+	llm := &capturingLLM{response: "described"}
+	ag := contentBlocksTestAgent(llm)
+
+	var mu sync.Mutex
+	var stages []ExecutionStage
+	cb := func(ev ProgressEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		stages = append(stages, ev.Stage)
+	}
+
+	resp, err := ag.ChatWithContentBlocks(context.Background(), "ok_cb_session", "describe this", sampleBlocks(), cb)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "described", resp.Content)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.NotContains(t, stages, StageFailed, "successful turn must not emit a failure event")
+}
+
 // TestAgent_ChatWithContentBlocks_ErrorEmitsFailureEvent covers the error path:
 // a failing LLM propagates the error, returns a nil response, and — when a
 // progress callback is supplied — emits a StageFailed event.

--- a/pkg/agent/chat_content_blocks_test.go
+++ b/pkg/agent/chat_content_blocks_test.go
@@ -193,6 +193,49 @@ func TestAgent_ChatWithContentBlocks_EmptyBlocks(t *testing.T) {
 	assert.Empty(t, userMsg.ContentBlocks, "no blocks supplied means none forwarded")
 }
 
+// TestAgent_ChatWithContentBlocks_ImageOnlyPrependsText guards against the
+// image-only footgun: providers build the request exclusively from
+// ContentBlocks when present, dropping Content — so an image-only block set
+// would silently send the image without the question. The agent must prepend
+// userMessage as a text block so the model still receives the prompt.
+func TestAgent_ChatWithContentBlocks_ImageOnlyPrependsText(t *testing.T) {
+	llm := &capturingLLM{response: "a red square on blue"}
+	ag := contentBlocksTestAgent(llm)
+
+	imageOnly := []ContentBlock{sampleBlocks()[1]} // just the image block
+
+	resp, err := ag.ChatWithContentBlocks(context.Background(), "img_only_session", "What is in this image?", imageOnly, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	userMsg, ok := findUserMessage(llm.lastMessages(), "What is in this image?")
+	require.True(t, ok)
+	require.Len(t, userMsg.ContentBlocks, 2, "text block must be prepended to the image-only set")
+	assert.Equal(t, "text", userMsg.ContentBlocks[0].Type)
+	assert.Equal(t, "What is in this image?", userMsg.ContentBlocks[0].Text, "prepended text must be the canonical userMessage")
+	assert.Equal(t, "image", userMsg.ContentBlocks[1].Type)
+}
+
+// TestAgent_ChatWithContentBlocks_ExistingTextBlockNotDuplicated verifies the
+// prepend guard is a no-op when the caller already includes a text block: the
+// block set reaches the provider unchanged, with no duplicate prompt text.
+func TestAgent_ChatWithContentBlocks_ExistingTextBlockNotDuplicated(t *testing.T) {
+	llm := &capturingLLM{response: "ok"}
+	ag := contentBlocksTestAgent(llm)
+
+	blocks := sampleBlocks() // already text + image
+
+	resp, err := ag.ChatWithContentBlocks(context.Background(), "has_text_session", "What is in this image?", blocks, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	userMsg, ok := findUserMessage(llm.lastMessages(), "What is in this image?")
+	require.True(t, ok)
+	require.Len(t, userMsg.ContentBlocks, 2, "caller-supplied blocks must pass through unchanged")
+	assert.Equal(t, "text", userMsg.ContentBlocks[0].Type)
+	assert.Equal(t, "image", userMsg.ContentBlocks[1].Type)
+}
+
 // TestAgent_ChatWithContentBlocks_SuccessWithProgressCallback exercises the
 // success path with a non-nil progress callback: the call succeeds, returns a
 // response, and — unlike the error path — never emits a StageFailed event.

--- a/pkg/agent/chat_content_blocks_test.go
+++ b/pkg/agent/chat_content_blocks_test.go
@@ -1,0 +1,235 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+	"github.com/teradata-labs/loom/pkg/types"
+)
+
+// capturingLLM records the messages of the most recent Chat call so tests can
+// assert on what the agent actually forwarded to the provider. It returns a
+// fixed text response and no tool calls.
+type capturingLLM struct {
+	mu       sync.Mutex
+	response string
+	captured []llmtypes.Message
+	calls    int
+}
+
+func (m *capturingLLM) Chat(_ context.Context, messages []llmtypes.Message, _ []shuttle.Tool) (*llmtypes.LLMResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls++
+	// Copy the slice so later mutation by the agent can't race with assertions.
+	m.captured = append([]llmtypes.Message(nil), messages...)
+	content := m.response
+	if content == "" {
+		content = "ok"
+	}
+	return &llmtypes.LLMResponse{
+		Content: content,
+		Usage:   llmtypes.Usage{InputTokens: 10, OutputTokens: 5, CostUSD: 0.001},
+	}, nil
+}
+
+func (m *capturingLLM) Name() string  { return "mock-capturing" }
+func (m *capturingLLM) Model() string { return "mock-v1" }
+
+func (m *capturingLLM) lastMessages() []llmtypes.Message {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.captured
+}
+
+// contentBlocksTestAgent builds an Agent wired to the given LLM with the LLM
+// classifier disabled for deterministic behavior.
+func contentBlocksTestAgent(llm interface {
+	Chat(context.Context, []llmtypes.Message, []shuttle.Tool) (*llmtypes.LLMResponse, error)
+	Name() string
+	Model() string
+}) *Agent {
+	cfg := DefaultConfig()
+	cfg.PatternConfig = DefaultPatternConfig()
+	cfg.PatternConfig.UseLLMClassifier = false
+	return NewAgent(&mockBackend{}, llm, WithConfig(cfg))
+}
+
+// sampleBlocks returns a text + image multimodal turn.
+func sampleBlocks() []ContentBlock {
+	return []ContentBlock{
+		{Type: "text", Text: "What is in this image?"},
+		{
+			Type: "image",
+			Image: &types.ImageContent{
+				Type: "image",
+				Source: types.ImageSource{
+					Type:      "base64",
+					MediaType: "image/png",
+					Data:      "aGVsbG8=", // "hello"
+				},
+			},
+		},
+	}
+}
+
+// findUserMessage returns the first user-role message with the given content.
+func findUserMessage(messages []llmtypes.Message, content string) (llmtypes.Message, bool) {
+	for _, msg := range messages {
+		if msg.Role == "user" && msg.Content == content {
+			return msg, true
+		}
+	}
+	return llmtypes.Message{}, false
+}
+
+// TestAgent_ChatWithContentBlocks_PropagatesBlocksToLLM is the core guarantee of
+// the feature: content blocks attached to the user turn must reach the provider
+// request, not just the plain-text content.
+func TestAgent_ChatWithContentBlocks_PropagatesBlocksToLLM(t *testing.T) {
+	llm := &capturingLLM{response: "I see a picture."}
+	ag := contentBlocksTestAgent(llm)
+
+	blocks := sampleBlocks()
+	resp, err := ag.ChatWithContentBlocks(context.Background(), "blocks_session", "What is in this image?", blocks, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "I see a picture.", resp.Content)
+
+	userMsg, ok := findUserMessage(llm.lastMessages(), "What is in this image?")
+	require.True(t, ok, "user message should be forwarded to the LLM")
+	require.Len(t, userMsg.ContentBlocks, 2, "both content blocks must reach the provider")
+
+	assert.Equal(t, "text", userMsg.ContentBlocks[0].Type)
+	assert.Equal(t, "What is in this image?", userMsg.ContentBlocks[0].Text)
+
+	imgBlock := userMsg.ContentBlocks[1]
+	assert.Equal(t, "image", imgBlock.Type)
+	require.NotNil(t, imgBlock.Image)
+	assert.Equal(t, "image/png", imgBlock.Image.Source.MediaType)
+	assert.Equal(t, "aGVsbG8=", imgBlock.Image.Source.Data)
+}
+
+// TestAgent_ChatWithContentBlocks_PersistsCanonicalText verifies userMessage
+// remains the canonical text on the stored turn while ContentBlocks ride along,
+// and that the assistant response is appended to history.
+func TestAgent_ChatWithContentBlocks_PersistsCanonicalText(t *testing.T) {
+	llm := &capturingLLM{response: "done"}
+	ag := contentBlocksTestAgent(llm)
+
+	const sessionID = "persist_session"
+	_, err := ag.ChatWithContentBlocks(context.Background(), sessionID, "canonical text", sampleBlocks(), nil)
+	require.NoError(t, err)
+
+	session, ok := ag.GetSession(sessionID)
+	require.True(t, ok, "session should exist after the call")
+
+	messages := session.GetMessages()
+	require.GreaterOrEqual(t, len(messages), 2, "expected at least the user turn and assistant reply")
+
+	var userMsg *types.Message
+	var sawAssistant bool
+	for i := range messages {
+		switch messages[i].Role {
+		case "user":
+			if messages[i].Content == "canonical text" {
+				userMsg = &messages[i]
+			}
+		case "assistant":
+			sawAssistant = true
+		}
+	}
+
+	require.NotNil(t, userMsg, "stored user turn should keep the canonical text")
+	assert.Equal(t, "canonical text", userMsg.Content)
+	assert.Len(t, userMsg.ContentBlocks, 2, "content blocks should be stored on the user turn")
+	assert.True(t, sawAssistant, "assistant response should be appended to history")
+}
+
+// TestAgent_ChatWithContentBlocks_NilProgressCallback confirms a nil callback is
+// accepted (the blocks-capable equivalent of plain Chat) and does not panic.
+func TestAgent_ChatWithContentBlocks_NilProgressCallback(t *testing.T) {
+	llm := &capturingLLM{response: "no callback"}
+	ag := contentBlocksTestAgent(llm)
+
+	resp, err := ag.ChatWithContentBlocks(context.Background(), "nil_cb_session", "hello", sampleBlocks(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "no callback", resp.Content)
+}
+
+// TestAgent_ChatWithContentBlocks_EmptyBlocks confirms nil/empty content blocks
+// degrade to an ordinary text turn.
+func TestAgent_ChatWithContentBlocks_EmptyBlocks(t *testing.T) {
+	llm := &capturingLLM{response: "plain"}
+	ag := contentBlocksTestAgent(llm)
+
+	resp, err := ag.ChatWithContentBlocks(context.Background(), "empty_blocks_session", "just text", nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "plain", resp.Content)
+
+	userMsg, ok := findUserMessage(llm.lastMessages(), "just text")
+	require.True(t, ok)
+	assert.Empty(t, userMsg.ContentBlocks, "no blocks supplied means none forwarded")
+}
+
+// TestAgent_ChatWithContentBlocks_ErrorEmitsFailureEvent covers the error path:
+// a failing LLM propagates the error, returns a nil response, and — when a
+// progress callback is supplied — emits a StageFailed event.
+func TestAgent_ChatWithContentBlocks_ErrorEmitsFailureEvent(t *testing.T) {
+	ag := contentBlocksTestAgent(&mockErrorLLM{errorMsg: "boom"})
+
+	var mu sync.Mutex
+	var stages []ExecutionStage
+	cb := func(ev ProgressEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		stages = append(stages, ev.Stage)
+	}
+
+	resp, err := ag.ChatWithContentBlocks(context.Background(), "err_session", "boom please", sampleBlocks(), cb)
+	require.Error(t, err)
+	assert.Nil(t, resp)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Contains(t, stages, StageFailed, "failure should emit a StageFailed progress event")
+}
+
+// TestAgent_ChatWithContentBlocks_ErrorNilCallback ensures the error path does
+// not panic when no progress callback is provided.
+func TestAgent_ChatWithContentBlocks_ErrorNilCallback(t *testing.T) {
+	ag := contentBlocksTestAgent(&mockErrorLLM{errorMsg: "boom"})
+
+	resp, err := ag.ChatWithContentBlocks(context.Background(), "err_nil_cb_session", "boom please", sampleBlocks(), nil)
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// TestContentBlockAlias documents that pkg/agent re-exports the ContentBlock
+// type alias so hosts can build multimodal turns without importing pkg/types.
+func TestContentBlockAlias(t *testing.T) {
+	var block ContentBlock = types.ContentBlock{Type: "text", Text: "hi"}
+	var back types.ContentBlock = block
+	assert.Equal(t, "hi", back.Text)
+}

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -379,6 +379,7 @@ func ValidatePatternConfig(cfg *PatternConfig) error {
 // Type aliases for backward compatibility with code that imports pkg/agent.
 // These types are now defined in pkg/types to break import cycles.
 type Message = types.Message
+type ContentBlock = types.ContentBlock
 type ToolCall = types.ToolCall
 type Usage = types.Usage
 type LLMResponse = types.LLMResponse


### PR DESCRIPTION
## Description

Hosts embedding Loom cannot deliver images to the model: `Agent.Chat` and `Agent.ChatWithProgress` only accept a plain `string`, even though `types.Message.ContentBlocks` and all three provider clients (anthropic, bedrock, openai) already fully support multimodal image content blocks.

This adds `Agent.ChatWithContentBlocks(ctx, sessionID, userMessage, contentBlocks, progressCallback)` — it mirrors `ChatWithProgress` but sets `ContentBlocks` on the user turn. `userMessage` remains the canonical text (persistence, graph-memory extraction, providers without multimodal support); `progressCallback` may be nil, making it also the blocks-capable equivalent of plain `Chat`. Also exports the `ContentBlock` alias from `pkg/agent` alongside the existing `Message` alias.

Motivating use case: loom-cloud (Tera) chat attachments — user-uploaded images resolved from the artifact store and delivered to vision-capable models. Verified end-to-end there against Bedrock Claude Sonnet (model accurately described attached test images).

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Changes Made

- Add `Agent.ChatWithContentBlocks` in `pkg/agent/agent.go`, with `ContentBlocks` set on the user `Message` and a distinct span name `agent.chat_with_content_blocks`.
- Export `type ContentBlock = types.ContentBlock` alias in `pkg/agent/types.go`.
- **Refactor (addresses review):** extract a private `(*Agent).chat(ctx, sessionID, userMessage, chatParams)` helper carrying the shared lifecycle (span setup, persistence, graph-memory kick-off, conversation loop, success/error telemetry). `Chat`, `ChatWithProgress`, and `ChatWithContentBlocks` are now thin wrappers over it — removing ~300 lines of duplication and reconciling with #255: all three now use `truncatePreview` (previously this method still used `truncateString(…,100)`). `chatParams.spanName` plus `reportProgress`/`reportContentBlocks` keep each entry point's span/telemetry byte-identical to before (the sole exception, documented in the commit, is that `ChatWithProgress`'s `has_progress` event field is now `callback != nil` rather than a hardcoded `true`).

## Testing

### Test Checklist

- [x] All new and existing tests pass (`go test -tags fts5 ./pkg/agent/` — ok)
- [x] Race detector shows zero race conditions (`go test -tags fts5 -race ./pkg/agent/` — ok; CI also runs `-race`)
- [x] Code builds successfully (`go build -tags fts5 ./...`)
- [x] All checks pass (CI)

### Test Coverage

- [x] Unit tests added — `pkg/agent/chat_content_blocks_test.go`:
  - **PropagatesBlocksToLLM** — a capturing mock LLM asserts at the provider boundary that text + image blocks actually reach the request (the core guarantee).
  - **PersistsCanonicalText** — `userMessage` stays the canonical text on the stored turn while `ContentBlocks` ride along; assistant reply appended.
  - **NilProgressCallback / EmptyBlocks** — degrade cleanly to a plain text turn.
  - **SuccessWithProgressCallback** — success path with a non-nil callback emits no failure event.
  - **ErrorEmitsFailureEvent / ErrorNilCallback** — failing LLM propagates the error, returns nil, and emits `StageFailed` only when a callback exists.
  - **ContentBlockAlias** — documents the re-exported `pkg/agent.ContentBlock`.

## Proto Changes

- [x] No proto changes in this PR

## Documentation

- [x] Code comments added/updated

## Security

- [x] No security implications

## Performance

- [x] No performance impact

## Deployment Notes

- [x] No special deployment steps needed

## Additional Context

Follow-up (not in this PR): `ContentBlocks` are **not** serialized by either session store — `pkg/agent/session_store.go` (SQLite) and `pkg/storage/postgres/session_store.go` both persist only `Content` and the tool fields — so image blocks are dropped on persistence. A session rehydrated after a restart loses the images and the model sees only the canonical text mid-conversation. Separately, token accounting counts only `msg.Content`, so within a live session images ride in L1 history and are re-sent on every subsequent provider call while the memory manager sees a ~10-token message. Both belong in a tracking issue (block survival across rehydration + image-aware token accounting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
