### PR TITLE
feat(observability): add backend-agnostic OTLP tracing support

### DIFF
--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -16,6 +16,7 @@ This document describes all environment variables used in the Loom project.
   - [HuggingFace](#huggingface)
 - [AWS Credentials](#aws-credentials)
 - [Observability (Hawk)](#observability-hawk)
+- [Observability (OTLP)](#observability-otlp)
 - [Web Search Tools](#web-search-tools)
 - [Docker Configuration](#docker-configuration)
 - [TLS/ACME Configuration](#tlsacme-configuration)
@@ -554,13 +555,14 @@ looms config set-key hawk_api_key
 
 ### LOOM_TRACER_MODE
 **Default:** `auto`
-**Values:** `auto`, `service`, `embedded`, `none`
-**Used in:** `pkg/builder/builder.go`
+**Values:** `auto`, `service`, `embedded`, `otel`, `none`
+**Used in:** `pkg/builder/builder.go`, `pkg/observability/auto_select.go`
 
 Controls which tracer implementation to use:
-- `auto`: Automatically select based on environment
+- `auto`: Automatically select based on environment (OTLP endpoint takes priority, then Hawk service, then embedded)
 - `service`: Use Hawk service (gRPC)
 - `embedded`: Use embedded storage (memory or SQLite)
+- `otel`: Export spans via OTLP HTTP to any compatible backend (Jaeger, Grafana Tempo, Opik, Honeycomb, Datadog, etc.)
 - `none`: Disable tracing
 
 ```bash
@@ -597,6 +599,116 @@ Path to SQLite database for embedded tracer.
 
 ```bash
 export LOOM_EMBEDDED_SQLITE_PATH=/path/to/traces.db
+```
+
+---
+
+## Observability (OTLP)
+
+Loom supports exporting traces to any **OpenTelemetry Protocol (OTLP) HTTP**-compatible backend (Jaeger, Grafana Tempo, Opik, Honeycomb, Datadog, OTLP Collector, etc.).
+
+Set `LOOM_TRACER_MODE=otel` (or leave `auto` and set the endpoint — OTLP takes priority in `auto` mode).
+
+### OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+**Used in:** `pkg/observability/otel_config.go`, `pkg/observability/auto_select.go`
+
+Full OTLP HTTP URL including path. Standard OTel env var — checked first before `LOOM_OTLP_ENDPOINT`.
+
+```bash
+# Jaeger
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4318/v1/traces
+# Grafana Tempo
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://tempo.example.com/otlp/v1/traces
+# Opik (local)
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:5173/api/v1/private/otel/v1/traces
+```
+
+### LOOM_OTLP_ENDPOINT
+**Used in:** `pkg/observability/otel_config.go`, `pkg/observability/auto_select.go`
+
+Loom-specific fallback for the OTLP HTTP endpoint. Used when `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is not set.
+
+```bash
+export LOOM_OTLP_ENDPOINT=http://localhost:4318/v1/traces
+```
+
+### OTEL_EXPORTER_OTLP_TRACES_HEADERS
+**Used in:** `pkg/observability/otel_config.go`, `pkg/observability/auto_select.go`
+
+HTTP headers sent with every OTLP export request. Standard OTel env var — checked first before `LOOM_OTLP_HEADERS`.
+
+**Format:** Comma-separated `key=value` pairs.
+
+```bash
+# Bearer token auth (Honeycomb, Grafana Cloud, etc.)
+export OTEL_EXPORTER_OTLP_TRACES_HEADERS="Authorization=Bearer my-api-key"
+# Multiple headers
+export OTEL_EXPORTER_OTLP_TRACES_HEADERS="Authorization=Bearer my-key,x-project-id=my-project"
+```
+
+### LOOM_OTLP_HEADERS
+**Used in:** `pkg/observability/otel_config.go`, `pkg/observability/auto_select.go`
+
+Loom-specific fallback for OTLP headers. Used when `OTEL_EXPORTER_OTLP_TRACES_HEADERS` is not set. Same `key=value,key2=value2` format.
+
+```bash
+export LOOM_OTLP_HEADERS="Authorization=Bearer my-api-key"
+```
+
+### LOOM_OTLP_INSECURE
+**Default:** `false`
+**Values:** `true`, `false`
+**Used in:** `pkg/observability/otel_config.go`, `pkg/observability/auto_select.go`
+
+Disables TLS certificate verification for the OTLP HTTP connection. Use only for local development against self-signed or plain HTTP endpoints.
+
+```bash
+export LOOM_OTLP_INSECURE=true
+```
+
+⚠️ **Warning:** Never set this in production — it disables certificate validation entirely.
+
+### OTEL_SERVICE_NAME
+**Used in:** `pkg/observability/otel_config.go`, `pkg/observability/auto_select.go`
+
+Sets the `service.name` resource attribute on all exported spans. Standard OTel env var.
+
+```bash
+export OTEL_SERVICE_NAME=my-loom-agent
+```
+
+### OTEL_SERVICE_VERSION
+**Used in:** `pkg/observability/otel_config.go`
+
+Sets the `service.version` resource attribute on all exported spans. Standard OTel env var.
+
+```bash
+export OTEL_SERVICE_VERSION=1.3.0
+```
+
+### Quick-Start Examples
+
+**Jaeger (local, no auth):**
+```bash
+export LOOM_TRACER_MODE=otel
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4318/v1/traces
+export LOOM_OTLP_INSECURE=true
+export OTEL_SERVICE_NAME=my-agent
+```
+
+**Grafana Cloud (with bearer token):**
+```bash
+export LOOM_TRACER_MODE=otel
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/traces
+export OTEL_EXPORTER_OTLP_TRACES_HEADERS="Authorization=Bearer <instance-id>:<api-key>"
+export OTEL_SERVICE_NAME=my-agent
+```
+
+**Auto-select OTLP (no explicit mode needed):**
+```bash
+# Setting the endpoint is enough — auto mode selects OTLP first
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4318/v1/traces
+export OTEL_SERVICE_NAME=my-agent
 ```
 
 ---

--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -660,13 +660,15 @@ export LOOM_OTLP_HEADERS="Authorization=Bearer my-api-key"
 **Values:** `true`, `false`
 **Used in:** `pkg/observability/otel_config.go`, `pkg/observability/auto_select.go`
 
-Disables TLS certificate verification for the OTLP HTTP connection. Use only for local development against self-signed or plain HTTP endpoints.
+Forces plain HTTP transport for the OTLP exporter (uses `http://` even if the endpoint URL specifies `https://`). This is implemented via `otlptracehttp.WithInsecure()` which **forces plaintext** — it does **not** disable TLS certificate verification for existing `https://` connections. Use only for local development against collectors that listen on plain HTTP (e.g. Jaeger or Opik on localhost).
+
+For `https://` endpoints with self-signed certificates, configure the collector to use a trusted certificate instead.
 
 ```bash
 export LOOM_OTLP_INSECURE=true
 ```
 
-⚠️ **Warning:** Never set this in production — it disables certificate validation entirely.
+⚠️ **Warning:** Never set this in production — spans are transmitted without encryption.
 
 ### OTEL_SERVICE_NAME
 **Used in:** `pkg/observability/otel_config.go`, `pkg/observability/auto_select.go`

--- a/cmd/looms/cmd_serve.go
+++ b/cmd/looms/cmd_serve.go
@@ -975,8 +975,13 @@ func runServe(cmd *cobra.Command, args []string) {
 	if config.Observability.Enabled {
 		mode := config.Observability.Mode
 		if mode == "" {
-			// Default to service mode if endpoint is set, otherwise embedded
-			if config.Observability.HawkEndpoint != "" {
+			// Derive mode from whichever endpoint is configured.
+			// OTel takes priority so that otlp_endpoint alone activates otel mode
+			// without requiring an explicit mode: otel in the config (matches
+			// what Config.Validate() documents).
+			if config.Observability.OTLPEndpoint != "" {
+				mode = "otel"
+			} else if config.Observability.HawkEndpoint != "" {
 				mode = "service"
 			} else {
 				mode = "embedded"

--- a/cmd/looms/cmd_serve.go
+++ b/cmd/looms/cmd_serve.go
@@ -1030,6 +1030,30 @@ func runServe(cmd *cobra.Command, args []string) {
 				tracer = hawkTracer
 			}
 
+		case "otel":
+			logger.Info("Observability enabled with OTLP export",
+				zap.String("endpoint", config.Observability.OTLPEndpoint))
+			otelTracer, err := observability.NewOTelTracer(observability.OTelConfig{
+				Endpoint:       config.Observability.OTLPEndpoint,
+				Headers:        config.Observability.OTLPHeaders,
+				Insecure:       config.Observability.OTLPInsecure,
+				ServiceName:    "looms",
+				ServiceVersion: rootCmd.Version,
+				Privacy: observability.PrivacyConfig{
+					RedactCredentials: true,
+					RedactPII:         true,
+				},
+				SpanFilter: observability.SpanFilterConfig{
+					IncludePrefixes: config.Observability.OTLPIncludeSpans,
+				},
+			})
+			if err != nil {
+				logger.Warn("Failed to create OTLP tracer, using no-op tracer", zap.Error(err))
+				tracer = observability.NewNoOpTracer()
+			} else {
+				tracer = otelTracer
+			}
+
 		case "none":
 			logger.Info("Observability disabled by mode=none")
 			tracer = observability.NewNoOpTracer()
@@ -3477,6 +3501,25 @@ func runServe(cmd *cobra.Command, args []string) {
 		case <-time.After(10 * time.Second):
 			logger.Warn("gRPC server graceful stop timeout after 10s, forcing shutdown")
 			grpcServer.Stop() // Force stop
+		}
+
+		// Flush and drain any buffered OTLP spans before exit.
+		// Must happen after gRPC stop so in-flight requests have landed their spans.
+		type otelShutdownable interface {
+			Flush(context.Context) error
+			Shutdown(context.Context) error
+		}
+		if otel, ok := tracer.(otelShutdownable); ok {
+			flushCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			if err := otel.Flush(flushCtx); err != nil {
+				logger.Warn("Error flushing OTLP tracer", zap.Error(err))
+			}
+			if err := otel.Shutdown(flushCtx); err != nil {
+				logger.Warn("Error shutting down OTLP tracer", zap.Error(err))
+			} else {
+				logger.Info("OTLP tracer flushed and shut down")
+			}
 		}
 
 		logger.Info("Shutdown complete")

--- a/cmd/looms/config.go
+++ b/cmd/looms/config.go
@@ -588,6 +588,12 @@ type ObservabilityConfig struct {
 	StorageType   string `mapstructure:"storage_type"`   // memory, sqlite
 	SQLitePath    string `mapstructure:"sqlite_path"`    // Path for SQLite storage
 	FlushInterval string `mapstructure:"flush_interval"` // e.g., "5s", "30s"
+
+	// OTel mode — exports to any OTLP HTTP backend (Opik, Jaeger, Tempo, etc.)
+	OTLPEndpoint     string            `mapstructure:"otlp_endpoint"`      // Full OTLP HTTP URL
+	OTLPHeaders      map[string]string `mapstructure:"otlp_headers"`       // e.g. Authorization: Bearer <key>
+	OTLPInsecure     bool              `mapstructure:"otlp_insecure"`      // Skip TLS (local dev only)
+	OTLPIncludeSpans []string          `mapstructure:"otlp_include_spans"` // Span name prefixes to export; empty = all
 }
 
 // LoggingConfig holds logging configuration.
@@ -1682,7 +1688,9 @@ func (c *Config) Validate() error {
 			// otherwise "embedded". This keeps Validate() in step with what the
 			// server actually runs, so enabling observability without an explicit
 			// mode or endpoint validates as embedded instead of being rejected.
-			if c.Observability.HawkEndpoint != "" {
+			if c.Observability.OTLPEndpoint != "" {
+				mode = "otel"
+			} else if c.Observability.HawkEndpoint != "" {
 				mode = "service"
 			} else {
 				mode = "embedded"
@@ -1705,10 +1713,15 @@ func (c *Config) Validate() error {
 				return fmt.Errorf("observability.hawk_endpoint is required when mode=service")
 			}
 			// Note: HawkAPIKey is optional - not required for local Hawk installations
+		case "otel":
+			// OTel mode: validate endpoint
+			if c.Observability.OTLPEndpoint == "" {
+				return fmt.Errorf("observability.otlp_endpoint is required when mode=otel")
+			}
 		case "none":
 			// No-op mode: no validation needed
 		default:
-			return fmt.Errorf("observability.mode must be 'embedded', 'service', or 'none' (got: %s)", mode)
+			return fmt.Errorf("observability.mode must be 'embedded', 'service', 'otel', or 'none' (got: %s)", mode)
 		}
 	}
 

--- a/cmd/looms/config_test.go
+++ b/cmd/looms/config_test.go
@@ -475,12 +475,32 @@ func TestValidate_ObservabilityMode(t *testing.T) {
 		assert.Contains(t, err.Error(), "sqlite_path is required")
 	})
 
+	t.Run("enabled, mode=otel, endpoint set -> valid", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Observability = ObservabilityConfig{Enabled: true, Mode: "otel", OTLPEndpoint: "http://collector:4318/v1/traces"}
+		assert.NoError(t, cfg.Validate())
+	})
+
+	t.Run("enabled, mode=otel, no endpoint -> error", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Observability = ObservabilityConfig{Enabled: true, Mode: "otel"}
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "otlp_endpoint is required")
+	})
+
+	t.Run("enabled, empty mode, otlp endpoint set -> valid (auto otel)", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Observability = ObservabilityConfig{Enabled: true, OTLPEndpoint: "http://collector:4318/v1/traces"}
+		assert.NoError(t, cfg.Validate())
+	})
+
 	t.Run("enabled, invalid mode -> error", func(t *testing.T) {
 		cfg := validBase()
 		cfg.Observability = ObservabilityConfig{Enabled: true, Mode: "bogus"}
 		err := cfg.Validate()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "must be 'embedded', 'service', or 'none'")
+		assert.Contains(t, err.Error(), "must be 'embedded', 'service', 'otel', or 'none'")
 	})
 
 	t.Run("disabled -> valid regardless of mode", func(t *testing.T) {

--- a/docs/architecture/otlp-integration.md
+++ b/docs/architecture/otlp-integration.md
@@ -1,0 +1,836 @@
+# OTLP Integration Architecture
+
+Architecture for exporting Loom traces via OpenTelemetry Protocol (OTLP), enabling backend-agnostic observability across Opik, Jaeger, Grafana Tempo, Honeycomb, Datadog, and any OTLP-compliant system.
+
+**Target Audience**: Architects, academics, and advanced developers
+
+**Version**: v1.3.0 (planned — see status indicators below)
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Design Goals](#design-goals)
+- [Current State](#current-state)
+- [System Context](#system-context)
+- [Architecture Overview](#architecture-overview)
+- [Components](#components)
+  - [OTelTracer](#oteltracer)
+  - [Attribute Translation Layer](#attribute-translation-layer)
+  - [OTelConfig](#otelconfig)
+  - [Auto-Select Extension](#auto-select-extension)
+- [Key Interactions](#key-interactions)
+  - [Span Export Flow](#span-export-flow)
+  - [Attribute Translation Flow](#attribute-translation-flow)
+- [Data Structures](#data-structures)
+  - [OTelConfig](#otelconfig-struct)
+  - [Span Mapping Table](#span-mapping-table)
+- [Algorithms](#algorithms)
+  - [Loom-to-OTel Span Bridge](#loom-to-otel-span-bridge)
+  - [GenAI Attribute Translation](#genai-attribute-translation)
+- [Design Trade-offs](#design-trade-offs)
+- [Constraints and Limitations](#constraints-and-limitations)
+- [Performance Characteristics](#performance-characteristics)
+- [Concurrency Model](#concurrency-model)
+- [Error Handling](#error-handling)
+- [Security Considerations](#security-considerations)
+- [Backend Compatibility](#backend-compatibility)
+- [Related Work](#related-work)
+- [References](#references)
+- [Further Reading](#further-reading)
+
+
+## Overview
+
+Loom's observability system (`pkg/observability`) currently exports traces to two destinations: Hawk (proprietary HTTP API) and an embedded in-process store (memory or SQLite). Neither destination speaks the OpenTelemetry Protocol (OTLP), which is the industry standard for trace export adopted by all major observability platforms.
+
+This document describes the design for an `OTelTracer` — a new `Tracer` implementation that bridges Loom's internal span model to the OTel SDK, enabling trace export to any OTLP-compliant backend via a single configuration change.
+
+The primary motivation is **backend freedom**: a Loom deployment wired for Opik today should be rewirable for Jaeger or Grafana Tempo tomorrow with no code change — only a different `otlp_endpoint` in `looms.yaml`.
+
+
+## Design Goals
+
+1. **Backend-agnostic**: Any OTLP HTTP endpoint works without code changes
+2. **Standard attribute mapping**: Loom attributes translate to OTel GenAI semantic conventions (`gen_ai.*`) so backends render LLM/tool spans correctly out of the box
+3. **Zero instrumentation change**: Existing `StartSpan` / `EndSpan` call sites are untouched
+4. **Consistent config pattern**: `mode: otel` follows the same `looms.yaml` / env var pattern as `mode: service` and `mode: embedded`
+5. **Privacy preservation**: PII redaction applied before export, same policy as HawkTracer
+6. **No new required dependencies**: OTel SDK packages are already in `go.mod` as indirect deps
+
+**Non-goals**:
+- gRPC OTLP transport (HTTP-only; Opik and most backends support HTTP)
+- OTel metrics export (Loom's `RecordMetric` remains internal only for now)
+- Distributed trace propagation across process boundaries (single-process server)
+- OTel logs API integration
+
+
+## Current State
+
+Understanding what already exists clarifies exactly what must be built.
+
+### What Is Present
+
+```
+pkg/observability/
+  interface.go        ✅  Tracer + SpanExporter interfaces defined
+  types.go            ✅  Span, Event, Status, ResourceAttributes
+  instrumentation.go  ✅  80+ span name + attribute constants (AttrLLM*, AttrTool*, etc.)
+  hawk.go             ✅  HTTP export tracer (HawkTracer) — reference implementation
+  embedded.go         ✅  In-process tracer with SpanExporter hook
+  noop.go             ✅  Zero-overhead tracer for testing
+  auto_select.go      ✅  Mode-based tracer factory (service / embedded / none / auto)
+
+go.mod                ✅  OTel SDK already present as indirect deps:
+                          go.opentelemetry.io/otel v1.43.0
+                          go.opentelemetry.io/otel/trace v1.43.0
+                          go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
+
+cmd/looms/config.go   ✅  ObservabilityConfig.Provider = "hawk, otlp" (comment placeholder)
+                      ✅  mode switch in cmd_serve.go (service / embedded / none)
+```
+
+### What Is Missing
+
+```
+pkg/observability/otel.go         📋  OTelTracer implementation
+pkg/observability/otel_attrs.go   📋  Loom AttrLLM* → gen_ai.* translation map
+pkg/observability/otel_config.go  📋  OTelConfig struct + env var loading
+pkg/observability/otel_test.go    📋  Unit tests (in-memory OTel exporter)
+
+cmd/looms/config.go               📋  OTLPEndpoint / OTLPHeaders fields on ObservabilityConfig
+cmd/looms/cmd_serve.go            📋  case "otel": branch in tracer switch
+pkg/observability/auto_select.go  📋  TracerModeOTel constant + selection logic
+```
+
+### Key Insight: SpanExporter Already Exists
+
+`pkg/observability/interface.go` defines a `SpanExporter` interface already used by `EmbeddedTracer` for dual-write:
+
+```go
+type SpanExporter interface {
+    ExportSpans(ctx context.Context, spans []*Span) error
+    ForceFlush(ctx context.Context) error
+    Shutdown(ctx context.Context) error
+}
+```
+
+This interface could host an `OTLPSpanExporter` implementation as a lighter alternative to a full `OTelTracer`. The trade-off between these two approaches is analyzed in [Design Trade-offs](#design-trade-offs).
+
+
+## System Context
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                         External Environment                         │
+│                                                                      │
+│  ┌──────────┐     ┌──────────────────┐     ┌────────────────────┐  │
+│  │  Agent   │────▶│   Loom Server    │────▶│  OTLP Backend      │  │
+│  │  (user)  │     │  (looms serve)   │     │  (Opik / Jaeger /  │  │
+│  └──────────┘     └──────────────────┘     │   Tempo / Datadog) │  │
+│                          │                 └────────────────────┘  │
+│                          │ also exports to                          │
+│                   ┌──────▼──────┐                                   │
+│                   │  Hawk       │                                   │
+│                   │  (existing) │                                   │
+│                   └─────────────┘                                   │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+**External Dependencies**:
+- **OTLP HTTP endpoint**: Any backend accepting `POST /v1/traces` (OTLP HTTP format)
+- **OTel SDK**: `go.opentelemetry.io/otel` — already in `go.mod`
+- **LLM Providers**: Instrumented via `InstrumentedProvider`; spans carry `AttrLLM*` attributes that translate to `gen_ai.*` on export
+- **Agent Runtime**: Unchanged — `StartSpan` / `EndSpan` call sites require no modification
+
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│                         Observability System                             │
+│                                                                          │
+│  ┌────────────────────────────────────────────────────────────────────┐  │
+│  │                     Tracer Interface                               │  │
+│  │   StartSpan / EndSpan / RecordMetric / RecordEvent / Flush        │  │
+│  └──────────────────────────┬─────────────────────────────────────────┘  │
+│                             │ implements                                  │
+│         ┌───────────────────┼────────────────────┬──────────────┐        │
+│         ▼                   ▼                    ▼              ▼        │
+│  ┌─────────────┐  ┌──────────────────┐  ┌──────────────┐  ┌──────────┐  │
+│  │ HawkTracer  │  │  EmbeddedTracer  │  │  OTelTracer  │  │ NoOp     │  │
+│  │ (HTTP/Hawk) │  │  (Mem / SQLite)  │  │  (OTLP HTTP) │  │ Tracer   │  │
+│  └─────────────┘  └──────────────────┘  └──────┬───────┘  └──────────┘  │
+│                                                 │                        │
+│                   ┌─────────────────────────────┘                        │
+│                   │                                                       │
+│                   ▼                                                       │
+│  ┌────────────────────────────────────────────────────────────────────┐  │
+│  │                       OTelTracer Internals                         │  │
+│  │                                                                    │  │
+│  │  ┌───────────────┐     ┌─────────────────┐     ┌───────────────┐  │  │
+│  │  │  Loom Span    │────▶│ Attribute        │────▶│  OTel Span   │  │  │
+│  │  │  (StartSpan)  │     │ Translator       │     │  (SDK trace) │  │  │
+│  │  └───────────────┘     │ Loom → gen_ai.*  │     └──────┬────────┘  │  │
+│  │                        └─────────────────┘            │           │  │
+│  │                                                        ▼           │  │
+│  │  ┌───────────────┐     ┌─────────────────┐     ┌───────────────┐  │  │
+│  │  │  Privacy      │────▶│  OTel SDK        │────▶│  OTLP HTTP   │  │  │
+│  │  │  Redaction    │     │  BatchSpanProc   │     │  Exporter    │  │  │
+│  │  └───────────────┘     └─────────────────┘     └──────┬────────┘  │  │
+│  │                                                        │           │  │
+│  └────────────────────────────────────────────────────────────────────┘  │
+│                                                           │               │
+│                                                           ▼               │
+│                                              ┌────────────────────────┐   │
+│                                              │  OTLP Backend          │   │
+│                                              │  (Opik / Jaeger /      │   │
+│                                              │   Tempo / Honeycomb)   │   │
+│                                              └────────────────────────┘   │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+The `OTelTracer` owns an OTel `TracerProvider` internally. On `StartSpan`, it creates both a Loom `*Span` (for the existing context propagation chain) and an OTel span (held in a `sync.Map` keyed by Loom `SpanID`). On `EndSpan`, it translates Loom attributes to `gen_ai.*` semantic conventions, applies privacy redaction, and ends the OTel span — letting the OTel SDK batch and export via OTLP HTTP.
+
+
+## Components
+
+### OTelTracer
+
+**Responsibility**: Implement the `Tracer` interface, bridging Loom's span lifecycle to the OTel SDK while preserving Loom's context propagation model.
+
+**File**: `pkg/observability/otel.go` (📋 to be created)
+
+**Core Structure**:
+```
+┌──────────────────────────────────────────────────────┐
+│                    OTelTracer                        │
+│                                                      │
+│  provider    *sdktrace.TracerProvider                │
+│  tracer      otelTrace.Tracer                        │
+│  activeSpans sync.Map  (loomSpanID → otelSpan)       │
+│  redact      func(*Span) *Span  (privacy)            │
+│  cfg         OTelConfig                              │
+│                                                      │
+│  StartSpan(ctx, name, opts) → (ctx, *Span)           │
+│    1. Create Loom span (same as NoOpTracer)          │
+│    2. Start OTel span via t.tracer.Start()           │
+│    3. Store otelSpan in activeSpans[loom.SpanID]     │
+│    4. Return context carrying Loom span              │
+│                                                      │
+│  EndSpan(span)                                       │
+│    1. Calculate duration (same as all tracers)       │
+│    2. Apply privacy redaction                        │
+│    3. Load otelSpan from activeSpans                 │
+│    4. Call translateAttrs(otelSpan, span.Attributes) │
+│    5. Set OTel span status from span.Status          │
+│    6. Call otelSpan.End()                            │
+│                                                      │
+│  Flush(ctx) → error                                  │
+│    ForceFlush on TracerProvider                      │
+│                                                      │
+│  Shutdown(ctx) → error                               │
+│    Graceful shutdown of TracerProvider               │
+└──────────────────────────────────────────────────────┘
+```
+
+**OTel TracerProvider setup** at construction time:
+```
+NewOTelTracer(cfg OTelConfig):
+  1. Build otlptracehttp.Exporter with cfg.Endpoint + cfg.Headers
+  2. Build sdktrace.TracerProvider with:
+       - BatchSpanProcessor(exporter)
+       - Resource(service.name = cfg.ServiceName, ...)
+  3. Register as global (optional) or keep local
+  4. Return OTelTracer{provider, tracer, ...}
+```
+
+**Build tag**: No additional build tag required. OTel SDK packages are in `go.mod`. Consider `//go:build otel` for clean separation only if binary size is a concern.
+
+**Invariants**:
+```
+∀ span s: s.SpanID ∈ activeSpans during [StartSpan, EndSpan]
+∀ span s: activeSpans[s.SpanID] deleted after EndSpan
+OTel span.TraceID = Loom span.TraceID (W3C hex format)
+OTel span.ParentSpanID = Loom span.ParentID (when non-empty)
+```
+
+
+### Attribute Translation Layer
+
+**Responsibility**: Map Loom's internal attribute constants (`AttrLLM*`, `AttrTool*`, etc.) to OTel's GenAI semantic conventions (`gen_ai.*`). This layer is what makes traces render correctly in Opik, Grafana, and other backends without custom configuration.
+
+**File**: `pkg/observability/otel_attrs.go` (📋 to be created)
+
+**Translation is applied at `EndSpan` time**, not `StartSpan` — attributes are often set by calling code between the two, so translation must happen on completion.
+
+**Full attribute mapping** (see [Span Mapping Table](#span-mapping-table) for complete list).
+
+**Span kind assignment** by span name prefix:
+
+```
+"llm.*"        → SpanKindClient   (outbound LLM API call)
+"tool.*"       → SpanKindInternal (internal tool execution)
+"agent.*"      → SpanKindInternal (agent orchestration)
+"backend.*"    → SpanKindClient   (outbound backend query)
+"mcp.*"        → SpanKindClient   (outbound MCP call)
+"workflow.*"   → SpanKindInternal (orchestration)
+default        → SpanKindInternal
+```
+
+**Rationale**: Span kind affects how backends display latency and error rates. LLM and backend calls are modelled as client calls because they initiate outbound I/O with measurable latency.
+
+
+### OTelConfig
+
+**Responsibility**: Carry all configuration required to construct an `OTelTracer` and resolve from environment variables.
+
+**File**: `pkg/observability/otel_config.go` (📋 to be created)
+
+```
+OTelConfig
+  Endpoint       string            // OTLP HTTP endpoint URL
+  Headers        map[string]string // Request headers (API keys, workspace IDs)
+  Insecure       bool              // Skip TLS verification (local dev only)
+  ServiceName    string            // resource: service.name
+  ServiceVersion string            // resource: service.version
+  Timeout        time.Duration     // Per-request timeout (default: 10s)
+  FlushInterval  time.Duration     // BatchSpanProcessor flush interval (default: 5s)
+  MaxBatchSize   int               // BatchSpanProcessor batch size (default: 512)
+  Privacy        PrivacyConfig     // PII redaction (reused from HawkTracer)
+```
+
+**Standard OTel environment variable support** (resolved automatically if config fields are empty):
+
+```
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT    ← Endpoint
+OTEL_EXPORTER_OTLP_TRACES_HEADERS     ← Headers (comma-separated key=value)
+OTEL_SERVICE_NAME                      ← ServiceName
+OTEL_SERVICE_VERSION                   ← ServiceVersion
+```
+
+These are the canonical env vars used by the OTel spec — any operator familiar with OTel will expect them to work.
+
+**Loom-specific fallback env vars** (when OTel standard vars are not set):
+
+```
+LOOM_OTLP_ENDPOINT      ← Endpoint
+LOOM_OTLP_HEADERS       ← Headers
+LOOM_OTLP_INSECURE      ← Insecure (default: false)
+```
+
+
+### Auto-Select Extension
+
+**Responsibility**: Extend the existing tracer factory to recognise `mode: otel` and construct an `OTelTracer`.
+
+**File**: `pkg/observability/auto_select.go` (📋 to modify)
+
+Current `TracerMode` constants:
+```go
+TracerModeAuto     TracerMode = "auto"
+TracerModeService  TracerMode = "service"
+TracerModeEmbedded TracerMode = "embedded"
+TracerModeNone     TracerMode = "none"
+```
+
+Addition:
+```go
+TracerModeOTel TracerMode = "otel"   // 📋 add
+```
+
+The `autoSelectTracer` switch gains a `case TracerModeOTel:` branch. The auto-selection heuristic for `TracerModeAuto` extends to: if `OTLPEndpoint` is set, `otel` mode is preferred over `embedded`.
+
+**`cmd/looms/config.go` changes**:
+
+```
+ObservabilityConfig (existing fields unchanged):
+  Enabled       bool
+  Provider      string   // "hawk", "otlp"
+  Mode          string   // "embedded", "service", "none", "otel"  ← add "otel"
+  HawkEndpoint  string
+  HawkAPIKey    string
+  StorageType   string
+  SQLitePath    string
+  FlushInterval string
+
+  OTLPEndpoint  string            // 📋 add — OTLP HTTP endpoint
+  OTLPHeaders   map[string]string // 📋 add — auth headers
+  OTLPInsecure  bool              // 📋 add — skip TLS (dev only)
+```
+
+**`cmd/looms/cmd_serve.go` change** — add one case to the tracer switch:
+
+```
+case "otel":
+    otelTracer, err := observability.NewOTelTracer(observability.OTelConfig{
+        Endpoint:    config.Observability.OTLPEndpoint,
+        Headers:     config.Observability.OTLPHeaders,
+        Insecure:    config.Observability.OTLPInsecure,
+        ServiceName: config.Server.Name,
+        Privacy:     privacyCfg,
+    })
+    if err != nil { ... fallback to NoOpTracer }
+    tracer = otelTracer
+```
+
+
+## Key Interactions
+
+### Span Export Flow
+
+```
+Agent Code      OTelTracer       OTel SDK          OTLP HTTP
+    │               │                │                  │
+    ├─ StartSpan ──▶│                │                  │
+    │               ├─ newLoomSpan   │                  │
+    │               ├─ tracer.Start ▶│                  │
+    │               │◀─ otelSpan ────┤                  │
+    │               ├─ store(loomID, otelSpan)           │
+    │◀─ (ctx, span) ┤                │                  │
+    │               │                │                  │
+    ├─ span.SetAttr  │                │                  │
+    ├─ span.AddEvent │                │                  │
+    │               │                │                  │
+    ├─ EndSpan ─────▶│                │                  │
+    │               ├─ calcDuration   │                  │
+    │               ├─ redact(span)   │                  │
+    │               ├─ translateAttrs │                  │
+    │               ├─ load otelSpan  │                  │
+    │               ├─ otelSpan.SetAttributes            │
+    │               ├─ otelSpan.SetStatus                │
+    │               ├─ otelSpan.End ─▶│                  │
+    │               │                ├─ BatchProc.OnEnd  │
+    │               │                │  (buffered)       │
+    │               │                │                  │
+    │               │                │ (batch full / tick)
+    │               │                ├─ POST /v1/traces ▶│
+    │               │                │◀─ 200 OK ─────────┤
+    │               │                │                  │
+```
+
+**Invariant**: `otelSpan.End()` is called exactly once per `StartSpan`, via `defer tracer.EndSpan(span)`. The OTel SDK enforces single-end semantics; double-end is a no-op in the SDK.
+
+
+### Attribute Translation Flow
+
+```
+Loom Span.Attributes        translateAttrs()        OTel Span
+  {                               │                  .SetAttribute(
+    "llm.provider": "anthropic"   ├── gen_ai.system      "gen_ai.system", "anthropic")
+    "llm.model": "claude-..."     ├── gen_ai.request.model  "claude-...")
+    "llm.tokens.input": 1234      ├── gen_ai.usage.input_tokens  1234)
+    "llm.tokens.output": 567      ├── gen_ai.usage.output_tokens  567)
+    "llm.cost": 0.0023            ├── (pass-through as "loom.llm.cost")
+    "tool.name": "query_db"       ├── gen_ai.tool.name  "query_db")
+    "session.id": "abc-123"       ├── session.id  "abc-123")
+    "error.message": "timeout"    └── exception.message  "timeout")
+  }
+```
+
+**Pass-through rule**: Loom attributes with no OTel equivalent are forwarded with a `loom.` prefix. This preserves Loom-specific metadata (e.g., `loom.llm.cost`, `loom.pattern.name`) without polluting the `gen_ai.*` namespace.
+
+**Privacy-first ordering**: Redaction runs before translation. Attributes removed by the redactor are never passed to `translateAttrs`.
+
+
+## Data Structures
+
+### OTelConfig Struct
+
+**Definition** (`pkg/observability/otel_config.go`):
+```
+OTelConfig
+  Endpoint       string            Required. Full OTLP HTTP URL including path.
+  Headers        map[string]string Optional. Authorization, workspace, project headers.
+  Insecure       bool              Optional. Disables TLS verification. Dev only.
+  ServiceName    string            Populates resource attribute service.name.
+  ServiceVersion string            Populates resource attribute service.version.
+  Timeout        time.Duration     Per-export request timeout. Default: 10s.
+  FlushInterval  time.Duration     BatchSpanProcessor schedule delay. Default: 5s.
+  MaxBatchSize   int               BatchSpanProcessor max export batch size. Default: 512.
+  Privacy        PrivacyConfig     Reused from HawkTracer. PII + credential redaction.
+```
+
+**Invariants**:
+```
+Endpoint != ""                   (validated at construction)
+Timeout > 0                      (defaults to 10s if zero)
+MaxBatchSize > 0                 (defaults to 512 if zero)
+```
+
+
+### Span Mapping Table
+
+Loom attribute constants (`pkg/observability/instrumentation.go`) → OTel GenAI semantic conventions (OTel semconv v1.28+):
+
+| Loom Constant | Loom Value | OTel Attribute | Notes |
+|---|---|---|---|
+| `AttrLLMProvider` | `"anthropic"` | `gen_ai.system` | |
+| `AttrLLMModel` | `"claude-sonnet-4-5"` | `gen_ai.request.model` | |
+| `AttrLLMInputTokens` | `1234` | `gen_ai.usage.input_tokens` | |
+| `AttrLLMOutputTokens` | `567` | `gen_ai.usage.output_tokens` | |
+| `AttrLLMCacheReadTokens` | `890` | `gen_ai.usage.cache_read_input_tokens` | |
+| `AttrLLMTemperature` | `0.7` | `gen_ai.request.temperature` | |
+| `AttrLLMMaxTokens` | `4096` | `gen_ai.request.max_tokens` | |
+| `AttrLLMStopReason` | `"end_turn"` | `gen_ai.response.finish_reasons` | wrapped as array |
+| `AttrToolName` | `"query_db"` | `gen_ai.tool.name` | |
+| `AttrSessionID` | `"sess-abc"` | `session.id` | resource attr |
+| `AttrAgentID` | `"agent-1"` | `loom.agent.id` | no OTel equiv → prefix |
+| `AttrLLMCost` | `0.0023` | `loom.llm.cost` | no OTel equiv → prefix |
+| `AttrPatternName` | `"sql-analysis"` | `loom.pattern.name` | no OTel equiv → prefix |
+| `AttrErrorMessage` | `"timeout"` | `exception.message` | OTel exception semconv |
+| `AttrErrorType` | `"DeadlineExceeded"` | `exception.type` | |
+| `ResourceAttrServiceName` | `"looms"` | `service.name` | resource attribute |
+| `ResourceAttrServiceVersion` | `"1.3.0"` | `service.version` | resource attribute |
+
+**Span name pass-through**: Loom span names (`llm.completion`, `tool.execute`, `agent.chat`, etc.) are forwarded as-is to OTel. These are already meaningful; backends display them in their trace UIs without transformation.
+
+
+## Algorithms
+
+### Loom-to-OTel Span Bridge
+
+**Problem**: Loom's `Span` and OTel's `trace.Span` have different lifecycle models. Loom spans are value types (`*Span` struct); OTel spans are interface values managed internally by the SDK. They must be paired for the duration of a Loom span's life.
+
+**Solution**: `sync.Map` pairing by `SpanID`.
+
+```
+StartSpan(ctx, name, opts):
+  loomSpan = newLoomSpan(ctx, name, opts)          // same as NoOpTracer
+  otelCtx, otelSpan = t.tracer.Start(ctx, name,
+    trace.WithTimestamp(loomSpan.StartTime),
+    trace.WithSpanKind(spanKindFor(name)),
+  )
+  t.activeSpans.Store(loomSpan.SpanID, otelSpan)
+  return ContextWithSpan(otelCtx, loomSpan), loomSpan
+
+EndSpan(span):
+  span.EndTime = now()
+  span.Duration = span.EndTime - span.StartTime
+  redacted = t.redact(span)                        // privacy filter
+  raw, ok = t.activeSpans.LoadAndDelete(span.SpanID)
+  if !ok: return                                   // span was never started (no-op)
+  otelSpan = raw.(trace.Span)
+  translateAttrs(otelSpan, redacted.Attributes)
+  for _, event := range redacted.Events:
+    otelSpan.AddEvent(event.Name, ...)
+  if span.Status.Code == StatusError:
+    otelSpan.SetStatus(codes.Error, span.Status.Message)
+  otelSpan.End(trace.WithTimestamp(span.EndTime))
+  t.activeSpans.Delete(span.SpanID)                // cleanup (LoadAndDelete covers this)
+```
+
+**Complexity**: O(1) amortised for `sync.Map` operations.
+
+**Race safety**: `sync.Map` is goroutine-safe. Loom's context propagation ensures `EndSpan` is called by the same goroutine that called `StartSpan` (via `defer`), so no concurrent access to the same `SpanID` entry occurs in practice. `sync.Map` handles the edge case where it could.
+
+**TraceID / SpanID format**: OTel uses 128-bit trace IDs and 64-bit span IDs in W3C hex format. Loom uses UUID strings. The bridge converts Loom UUIDs to OTel IDs by stripping hyphens and truncating / zero-padding to the required byte lengths.
+
+
+### GenAI Attribute Translation
+
+**Problem**: Backends identify LLM spans by the presence of `gen_ai.*` attributes. Without translation, Opik and Grafana would show raw Loom attribute names (`llm.model`, `llm.tokens.input`) instead of recognised GenAI fields.
+
+**Solution**: Static lookup table applied at `EndSpan`.
+
+```
+translateAttrs(otelSpan trace.Span, attrs map[string]interface{}):
+  for key, value in attrs:
+    if otelKey = loomToGenAI[key]; otelKey != "":
+      otelSpan.SetAttribute(otelKey, value)
+    else:
+      otelSpan.SetAttribute("loom." + key, value)   // preserve with namespace
+```
+
+`loomToGenAI` is a `map[string]string` constant defined in `otel_attrs.go`. Lookups are O(1). The table is initialised once at package init.
+
+**Invariant**: Every Loom attribute is represented in the exported OTel span — either under its canonical `gen_ai.*` name or under a `loom.*` prefixed fallback. No data is silently dropped.
+
+
+## Design Trade-offs
+
+### Decision 1: Full OTelTracer vs. OTLPSpanExporter on EmbeddedTracer
+
+**Option A — Full OTelTracer** (recommended):
+- Implements `Tracer` interface directly
+- Owns the OTel `TracerProvider`
+- Configured via `mode: otel` in `looms.yaml`
+- Works without `EmbeddedTracer`
+
+**Option B — OTLPSpanExporter**:
+- Implements `SpanExporter` interface
+- Attached to `EmbeddedTracer` via `WithSpanExporter`
+- Enables simultaneous local storage + OTLP export
+- Cannot be used standalone (requires `EmbeddedTracer`)
+
+**Chosen: Option A** for the primary implementation, with Option B available as a composition pattern.
+
+**Rationale**:
+- Option A is a first-class deployment mode — operators configure a single endpoint and do not need embedded storage
+- Option A matches the `HawkTracer` pattern exactly, keeping the codebase consistent
+- Option B is still useful for hybrid deployments (local SQLite + remote Opik) and can be built on top of Option A's REST client code without duplication
+
+**Consequences**:
+- Two code paths to maintain (OTelTracer + optional OTLPSpanExporter)
+- Option A cannot simultaneously write to embedded storage — hybrid mode requires Option B
+
+---
+
+### Decision 2: Translate Attributes at EndSpan vs. at Export
+
+**Option A — Translate at EndSpan** (chosen):
+- Attribute translation happens inside `OTelTracer.EndSpan`
+- OTel span carries `gen_ai.*` natively
+- No custom exporter needed
+
+**Option B — Translate in a custom SpanProcessor**:
+- OTel span carries raw Loom attributes
+- A `SpanProcessor.OnEnd` transforms to `gen_ai.*` before the exporter sees them
+
+**Chosen: Option A**.
+
+**Rationale**:
+- Simpler — no custom `SpanProcessor` to implement or test
+- Translation is co-located with the bridge logic in `otel.go`
+- `gen_ai.*` attributes are what backends want; there is no value in carrying both
+
+**Consequences**:
+- Translated attributes are immutable after `EndSpan` (the OTel span has already ended)
+- Cannot inspect raw Loom attributes after export; they are preserved only in redacted form within `loom.*` prefixed attributes
+
+---
+
+### Decision 3: HTTP-only (no gRPC OTLP)
+
+**Chosen: HTTP only** (`otlptracehttp`).
+
+**Rationale**:
+- Opik's OTLP endpoint is HTTP-only (no gRPC port documented)
+- `otlptracehttp` is already in `go.mod`; `otlptracegrpc` is not — avoiding a new dependency
+- All major backends accept OTLP HTTP; gRPC adds latency for span sizes typical in Loom
+
+**Consequences**:
+- gRPC-only backends (rare) are not supported
+- Binary size remains smaller (one exporter package vs. two)
+- Can add `otlptracegrpc` later without breaking the interface
+
+
+## Constraints and Limitations
+
+### Constraint 1: HTTP-Only OTLP Transport
+
+**Description**: OTel gRPC transport is not implemented.
+
+**Rationale**: Opik, Jaeger (HTTP mode), Grafana Tempo, and Honeycomb all accept OTLP HTTP. gRPC requires an additional dependency not currently in `go.mod`.
+
+**Impact**: Backends that accept only gRPC OTLP will not receive traces.
+
+**Workaround**: Deploy an OTel Collector in front of the gRPC-only backend; configure `otlp_endpoint` to point at the Collector's HTTP receiver.
+
+---
+
+### Constraint 2: No OTel Metrics Export
+
+**Description**: `RecordMetric` data is not exported to the OTLP backend. Loom metrics (token counts, call rates, latency histograms) remain internal to the process.
+
+**Rationale**: OTel metrics export requires `go.opentelemetry.io/otel/sdk/metric`, which is not in `go.mod`. Adding it is a non-trivial dependency bump.
+
+**Impact**: Backend dashboards cannot display aggregate LLM cost or throughput metrics from Loom.
+
+**Workaround**: Backends can derive metrics from spans (token counts appear on `llm.completion` spans). Dedicated metrics export is a planned follow-up.
+
+---
+
+### Constraint 3: Single-Process Trace Scope
+
+**Description**: Traces do not cross process boundaries. If Loom makes an outbound HTTP call to another Loom instance, trace context is not propagated via W3C `traceparent` headers.
+
+**Rationale**: Loom is a single-process server. Multi-process trace propagation requires injecting/extracting OTel context from outbound HTTP requests, which is not part of the current scope.
+
+**Impact**: Multi-agent workflows where agents run in separate processes will show disconnected traces in the backend.
+
+**Workaround**: Manual TraceID correlation using `ContextWithTraceID`.
+
+---
+
+### Constraint 4: Opik Rate Limit
+
+**Description**: Opik Cloud imposes a 10,000 events/minute ingestion limit. A busy Loom instance emitting many spans per second may breach this.
+
+**Mitigation**: OTel's `BatchSpanProcessor` (default max batch 512 spans, 5s interval) naturally smooths burst traffic. The `MaxBatchSize` and `FlushInterval` fields in `OTelConfig` allow tuning for high-throughput deployments.
+
+
+## Performance Characteristics
+
+### Additional Latency per Span
+
+| Operation | Added Latency (vs. NoOpTracer) | Notes |
+|---|---|---|
+| `StartSpan` | +2–5µs | OTel SDK span start + `sync.Map` store |
+| `EndSpan` (no redaction) | +5–15µs | Attribute translation + OTel span end + BatchProc.OnEnd |
+| `EndSpan` (with PII redaction) | +15–60µs | Regex matching added on top |
+| Background batch export | 0 (async) | BatchSpanProcessor goroutine, does not block caller |
+
+These are additive to the existing NoOpTracer baseline (~1µs per StartSpan / EndSpan).
+
+### Memory Usage
+
+| Component | Size |
+|---|---|
+| `sync.Map` entry (per open span) | ~200 bytes |
+| OTel SDK BatchSpanProcessor buffer | 512 spans × ~1KB ≈ 512KB |
+| `OTelConfig` + TracerProvider overhead | ~50KB |
+| **Total steady-state** | **~600KB** |
+
+Peak memory occurs when the batch is full (512 spans buffered). For typical Loom workloads (< 50 concurrent spans), steady-state memory is well under 100KB.
+
+### Export Throughput
+
+BatchSpanProcessor defaults:
+- Max export batch size: 512 spans
+- Schedule delay: 5s
+- Sustained throughput: 512 / 5s = ~100 spans/s
+
+Opik rate limit: 10,000 events/min ≈ 167 events/s. At 100 spans/s, Loom stays within this limit with ~40% headroom.
+
+
+## Concurrency Model
+
+**OTelTracer itself is goroutine-safe** by design:
+
+- `sync.Map`: Used for `activeSpans` — concurrent read/write/delete without external locking
+- OTel SDK `TracerProvider` and `BatchSpanProcessor`: Goroutine-safe by OTel SDK contract
+- `otlptracehttp.Exporter`: Goroutine-safe; uses connection pooling internally
+- Privacy redaction (`redact()`): Stateless function, no shared state
+
+**Background export goroutine**: Owned entirely by the OTel SDK's `BatchSpanProcessor`. Loom does not need to manage it. `TracerProvider.Shutdown()` signals the goroutine to drain and exit.
+
+**Shutdown sequence**:
+```
+OTelTracer.Shutdown(ctx):
+  1. provider.ForceFlush(ctx)    ← drain buffered spans
+  2. provider.Shutdown(ctx)      ← stop background goroutine, close exporter
+  3. Return error if context expires
+```
+
+This is called from Loom server's graceful shutdown path. The existing `cmd_serve.go` shutdown chain will invoke `tracer.Flush(ctx)`, which forwards to `provider.ForceFlush`.
+
+
+## Error Handling
+
+### Strategy
+
+The `OTelTracer` follows the same best-effort strategy as `HawkTracer`:
+- Export failures are **logged but not propagated** to the calling agent
+- A failed export does not affect agent execution
+- The OTel SDK internally retries transient HTTP failures (5xx, network errors) via `otlptracehttp`'s built-in retry policy
+
+### Error Categories
+
+| Error | Handling | Recovery |
+|---|---|---|
+| OTLP endpoint unreachable at startup | Log warning, return NoOpTracer | Fix endpoint config and restart |
+| Transient export failure (5xx) | OTel SDK retries (3 attempts, exponential backoff) | Automatic |
+| 401 Unauthorized | OTel SDK logs error, drops batch | Fix `otlp_headers` auth token |
+| `sync.Map` miss on EndSpan | No-op, log at debug level | Not an error — span may have been created before OTelTracer replaced NoOpTracer |
+| TracerProvider.Shutdown timeout | Log warning, return context error | Increase shutdown timeout |
+
+
+## Security Considerations
+
+### PII Redaction
+
+The same `PrivacyConfig` and `redact()` function used by `HawkTracer` is applied in `OTelTracer.EndSpan` before any attribute is passed to the OTel SDK. Sensitive data never reaches the OTLP backend.
+
+**Scope**: The `redact()` function is defined in `pkg/observability/hawk.go` today. For `OTelTracer`, it will be extracted to a shared `pkg/observability/privacy.go` to avoid importing the Hawk build tag from OTel code.
+
+### Transport Security
+
+- HTTPS is strongly recommended for the `otlp_endpoint` in any non-local deployment
+- `OTelConfig.Insecure = true` disables TLS verification and must only be used for local development
+- API keys are passed in HTTP headers (not query parameters), consistent with industry practice
+- `looms.yaml` field `otlp_headers` is marked as sensitive in the config loader (same treatment as `hawk_api_key`)
+
+### Header Exposure
+
+`otlp_headers` may contain bearer tokens. The config validator will warn if `otlp_headers` is specified without HTTPS and `insecure = false`.
+
+
+## Backend Compatibility
+
+Any backend that accepts OTLP HTTP `POST /v1/traces` is compatible. The following have been analysed:
+
+| Backend | OTLP HTTP | GenAI semconv | Notes |
+|---|---|---|---|
+| **Opik** (cloud) | ✅ | ✅ | `https://www.comet.com/opik/api/v1/private/otel/v1/traces`; requires `Authorization` header |
+| **Opik** (self-hosted) | ✅ | ✅ | `http://<host>/api/v1/private/otel/v1/traces` |
+| **Jaeger** (≥ v1.35) | ✅ | ⚠️ partial | Port 4318; GenAI attrs displayed as raw tags |
+| **Grafana Tempo** | ✅ | ⚠️ partial | Port 4318; GenAI attrs available via TraceQL |
+| **Honeycomb** | ✅ | ✅ | Renders `gen_ai.*` natively in LLM query panel |
+| **Datadog** | ✅ | ✅ | `https://trace.agent.datadoghq.com`; maps to LLM Observability product |
+| **New Relic** | ✅ | ⚠️ partial | OTLP endpoint at `otlp.nr-data.net:4318` |
+| **OTel Collector** | ✅ | N/A | Use as proxy/fan-out to multiple backends |
+
+The config change to switch backends:
+
+```yaml
+# looms.yaml
+observability:
+  enabled: true
+  mode: otel
+  otlp_endpoint: http://localhost:5173/api/v1/private/otel/v1/traces  # Opik local
+  otlp_headers:
+    Authorization: "Bearer <opik-api-key>"
+
+# Switch to Jaeger — no code change needed:
+  otlp_endpoint: http://jaeger:4318/v1/traces
+  otlp_headers: {}
+```
+
+
+## Related Work
+
+### OpenTelemetry
+
+The OTel specification (CNCF, 2019) defines the Traces API, SDK, and OTLP. Loom's `Tracer` interface predates OTel adoption and was designed independently with a similar but not identical API. The bridge approach (wrapping Loom spans inside OTel spans) is the standard integration pattern for non-OTel frameworks.
+
+- **OTel Go SDK**: `go.opentelemetry.io/otel/sdk/trace` — `TracerProvider`, `BatchSpanProcessor`
+- **OTel GenAI Semantic Conventions**: Draft specification defining `gen_ai.*` attribute names for LLM tracing (OTel semconv v1.28+)
+
+### Opik
+
+Opik (Comet ML, 2024) is an LLM observability platform that supports both a native Python SDK and OTLP ingestion. Its OTLP support uses the standard `gen_ai.*` semantic conventions, making it compatible with the translation layer described here without Opik-specific code.
+
+### HawkTracer (existing)
+
+The `HawkTracer` (`pkg/observability/hawk.go`) is the reference implementation for Loom's export pattern: batched async HTTP export with retry and privacy redaction. `OTelTracer` follows the same structural pattern but delegates batching and retry to the OTel SDK's `BatchSpanProcessor` rather than implementing them directly.
+
+
+## References
+
+1. OpenTelemetry. (2024). *OpenTelemetry Protocol (OTLP) Specification*. https://opentelemetry.io/docs/specs/otlp/
+
+2. OpenTelemetry. (2024). *Semantic Conventions for GenAI systems*. https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/
+
+3. OpenTelemetry Go SDK. (2024). `go.opentelemetry.io/otel` v1.43.0. https://pkg.go.dev/go.opentelemetry.io/otel
+
+4. Comet ML. (2024). *Opik OpenTelemetry Integration*. https://www.comet.com/docs/opik/integrations/opentelemetry
+
+5. W3C. (2021). *Trace Context Level 1*. https://www.w3.org/TR/trace-context/
+
+
+## Further Reading
+
+### Architecture
+
+- [Observability Architecture](observability.md) — Current tracer design, HawkTracer, EmbeddedTracer
+- [Agent System Design](agent-system-design.md) — Where spans are emitted in the conversation loop
+- [Loom System Architecture](loom-system-architecture.md) — Overall system context
+
+### Reference
+
+- `pkg/observability/interface.go` — `Tracer` and `SpanExporter` interfaces
+- `pkg/observability/instrumentation.go` — All span name and attribute constants
+- `pkg/observability/hawk.go` — Reference implementation for export + privacy redaction pattern
+- `cmd/looms/config.go` — `ObservabilityConfig` struct (where `OTLPEndpoint` fields will be added)

--- a/docs/architecture/otlp-integration.md
+++ b/docs/architecture/otlp-integration.md
@@ -4,7 +4,7 @@ Architecture for exporting Loom traces via OpenTelemetry Protocol (OTLP), enabli
 
 **Target Audience**: Architects, academics, and advanced developers
 
-**Version**: v1.3.0 (planned — see status indicators below)
+**Version**: v1.3.0
 
 ---
 
@@ -94,14 +94,22 @@ cmd/looms/config.go   ✅  ObservabilityConfig.Provider = "hawk, otlp" (comment 
 ### What Is Missing
 
 ```
-pkg/observability/otel.go         📋  OTelTracer implementation
-pkg/observability/otel_attrs.go   📋  Loom AttrLLM* → gen_ai.* translation map
-pkg/observability/otel_config.go  📋  OTelConfig struct + env var loading
-pkg/observability/otel_test.go    📋  Unit tests (in-memory OTel exporter)
+pkg/observability/otel.go         ✅  OTelTracer implementation
+pkg/observability/otel_attrs.go   ✅  Loom AttrLLM* → gen_ai.* translation map
+pkg/observability/otel_config.go  ✅  OTelConfig struct + env var loading
+                                      (incl. LOOM_OTLP_INSECURE resolution)
+pkg/observability/otel_test.go    ✅  Unit tests with behavioral assertions
+                                      (export count checks, LOOM_OTLP_INSECURE
+                                       env resolution, errcheck-safe Shutdown)
 
-cmd/looms/config.go               📋  OTLPEndpoint / OTLPHeaders fields on ObservabilityConfig
-cmd/looms/cmd_serve.go            📋  case "otel": branch in tracer switch
-pkg/observability/auto_select.go  📋  TracerModeOTel constant + selection logic
+cmd/looms/config.go               ✅  OTLPEndpoint / OTLPHeaders fields on ObservabilityConfig
+cmd/looms/cmd_serve.go            ✅  case "otel": branch in tracer switch
+pkg/observability/auto_select.go  ✅  TracerModeOTel constant + selection logic
+                                      (auto mode reads OTEL_EXPORTER_OTLP_TRACES_ENDPOINT /
+                                       LOOM_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_TRACES_HEADERS /
+                                       LOOM_OTLP_HEADERS, LOOM_OTLP_INSECURE, OTEL_SERVICE_NAME)
+pkg/agent/agent.go                ✅  message.preview / response.preview truncated to 200 runes
+                                      (privacy + payload size guard on Chat / ChatWithProgress)
 ```
 
 ### Key Insight: SpanExporter Already Exists

--- a/docs/architecture/otlp-integration.md
+++ b/docs/architecture/otlp-integration.md
@@ -208,7 +208,7 @@ The `OTelTracer` owns an OTel `TracerProvider` internally. On `StartSpan`, it cr
 
 **Responsibility**: Implement the `Tracer` interface, bridging Loom's span lifecycle to the OTel SDK while preserving Loom's context propagation model.
 
-**File**: `pkg/observability/otel.go` (📋 to be created)
+**File**: `pkg/observability/otel.go`
 
 **Core Structure**:
 ```
@@ -261,7 +261,8 @@ NewOTelTracer(cfg OTelConfig):
 ∀ span s: s.SpanID ∈ activeSpans during [StartSpan, EndSpan]
 ∀ span s: activeSpans[s.SpanID] deleted after EndSpan
 OTel span.TraceID = Loom span.TraceID (W3C hex format)
-OTel span.ParentSpanID = Loom span.ParentID (when non-empty)
+OTel span.ParentSpanID = parent OTel span from activeSpans (in-process)
+OTel span.ParentSpanID derived from Loom span.ParentID (cross-process fallback only)
 ```
 
 
@@ -269,7 +270,7 @@ OTel span.ParentSpanID = Loom span.ParentID (when non-empty)
 
 **Responsibility**: Map Loom's internal attribute constants (`AttrLLM*`, `AttrTool*`, etc.) to OTel's GenAI semantic conventions (`gen_ai.*`). This layer is what makes traces render correctly in Opik, Grafana, and other backends without custom configuration.
 
-**File**: `pkg/observability/otel_attrs.go` (📋 to be created)
+**File**: `pkg/observability/otel_attrs.go`
 
 **Translation is applied at `EndSpan` time**, not `StartSpan` — attributes are often set by calling code between the two, so translation must happen on completion.
 
@@ -294,7 +295,7 @@ default        → SpanKindInternal
 
 **Responsibility**: Carry all configuration required to construct an `OTelTracer` and resolve from environment variables.
 
-**File**: `pkg/observability/otel_config.go` (📋 to be created)
+**File**: `pkg/observability/otel_config.go`
 
 ```
 OTelConfig

--- a/examples/config/otlp-opik.yaml
+++ b/examples/config/otlp-opik.yaml
@@ -1,0 +1,71 @@
+# Loom + Opik OTLP Test Configuration (Bedrock)
+#
+# Usage (AWS credentials via environment):
+#   export AWS_ACCESS_KEY_ID="AKIA..."
+#   export AWS_SECRET_ACCESS_KEY="..."
+#   export AWS_SESSION_TOKEN="..."          # if using temporary credentials
+#   looms serve --config examples/config/looms-opik-test.yaml
+#
+# Usage (AWS named profile):
+#   Set llm.bedrock_profile below, then run without exporting AWS_* vars.
+#
+# Assumes Opik is running locally on the default port 5173.
+
+server:
+  port: 60051
+  host: 127.0.0.1
+  enable_reflection: true
+
+llm:
+  provider: bedrock
+  bedrock_region: us-west-2
+  # Cross-region inference profile — routes to the nearest available region.
+  bedrock_model_id: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+  # Uncomment to use a named AWS profile instead of env vars:
+  # bedrock_profile: default
+  temperature: 1.0
+  max_tokens: 4096
+
+observability:
+  enabled: true
+  mode: otel
+
+  # Self-hosted Opik endpoint.
+  # Replace <opik-host> with your Opik instance hostname or IP.
+  # Default Docker port is 5173.
+  otlp_endpoint: "http://localhost:5173/api/v1/private/otel/v1/traces"
+
+  # Self-hosted Opik does not require an auth header by default.
+  # If you've enabled API key auth on your instance, uncomment and set via env:
+  #   export LOOM_OBSERVABILITY_OTLP_HEADERS="Authorization=Bearer <your-opik-api-key>"
+  # Or pin to a specific project:
+  # otlp_headers:
+  #   Opik-Project-Name: "loom-dev"
+
+  # Required: self-hosted runs without TLS by default.
+  otlp_insecure: true
+
+  # Only export LLM/agent spans — suppresses startup, migration, and storage spans.
+  # Remove or leave empty to export everything.
+  otlp_include_spans:
+    - "llm."
+    - "agent."
+    - "tool."
+    - "backend."
+    - "mcp."
+
+storage:
+  backend: sqlite
+  sqlite:
+    path: /tmp/loom-opik-test.db
+
+logging:
+  level: info
+  format: text
+
+tools:
+  permissions:
+    yolo: true
+
+# Agents are loaded from $LOOM_DATA_DIR/agents/ (default: ~/.loom/agents/).
+# To add a test agent, create ~/.loom/agents/test-agent.yaml with kind: Agent.

--- a/examples/config/otlp-opik.yaml
+++ b/examples/config/otlp-opik.yaml
@@ -4,7 +4,7 @@
 #   export AWS_ACCESS_KEY_ID="AKIA..."
 #   export AWS_SECRET_ACCESS_KEY="..."
 #   export AWS_SESSION_TOKEN="..."          # if using temporary credentials
-#   looms serve --config examples/config/looms-opik-test.yaml
+#   looms serve --config examples/config/otlp-opik.yaml
 #
 # Usage (AWS named profile):
 #   Set llm.bedrock_profile below, then run without exporting AWS_* vars.

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,10 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/xuri/excelize/v2 v2.11.0
 	github.com/zalando/go-keyring v0.2.8
+	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
+	go.opentelemetry.io/otel/sdk v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/mod v0.38.0
 	golang.org/x/sync v0.22.0
@@ -152,10 +156,9 @@ require (
 	github.com/xuri/nfp v0.0.2-0.20250530014748-2ddeb826f9a9 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
-	go.opentelemetry.io/otel v1.43.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1466,7 +1466,7 @@ func (a *Agent) Chat(ctx context.Context, sessionID string, userMessage string) 
 	// Set initial attributes
 	span.SetAttribute(observability.AttrSessionID, sessionID)
 	span.SetAttribute("message.length", len(userMessage))
-	span.SetAttribute("message.preview", truncateString(userMessage, 100))
+	span.SetAttribute("message.preview", userMessage)
 	a.mu.RLock()
 	currentLLM := a.llm
 	a.mu.RUnlock()
@@ -1597,7 +1597,7 @@ func (a *Agent) Chat(ctx context.Context, sessionID string, userMessage string) 
 	span.SetAttribute("conversation.cost.usd", response.Usage.CostUSD)
 	span.SetAttribute("conversation.stop_reason", response.Metadata["stop_reason"])
 	span.SetAttribute("response.length", len(response.Content))
-	span.SetAttribute("response.preview", truncateString(response.Content, 100))
+	span.SetAttribute("response.preview", response.Content)
 
 	// Check if we hit limits
 	if maxTurnsHit, ok := response.Metadata["max_turns_hit"].(bool); ok && maxTurnsHit {
@@ -1660,7 +1660,7 @@ func (a *Agent) ChatWithProgress(ctx context.Context, sessionID string, userMess
 	// Set initial attributes
 	span.SetAttribute(observability.AttrSessionID, sessionID)
 	span.SetAttribute("message.length", len(userMessage))
-	span.SetAttribute("message.preview", truncateString(userMessage, 100))
+	span.SetAttribute("message.preview", userMessage)
 	a.mu.RLock()
 	currentLLM := a.llm
 	a.mu.RUnlock()
@@ -1806,7 +1806,7 @@ func (a *Agent) ChatWithProgress(ctx context.Context, sessionID string, userMess
 	span.SetAttribute("conversation.cost.usd", response.Usage.CostUSD)
 	span.SetAttribute("conversation.stop_reason", response.Metadata["stop_reason"])
 	span.SetAttribute("response.length", len(response.Content))
-	span.SetAttribute("response.preview", truncateString(response.Content, 100))
+	span.SetAttribute("response.preview", response.Content)
 
 	// Check if we hit limits
 	if maxTurnsHit, ok := response.Metadata["max_turns_hit"].(bool); ok && maxTurnsHit {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1452,6 +1452,20 @@ func (a *Agent) getErrorMessage(ctx context.Context, category string, errorType 
 	return fmt.Sprintf("Error in %s: %s", category, errorType)
 }
 
+// maxPreviewLen is the maximum number of runes recorded in span preview attributes
+// (message.preview / response.preview). Capping prevents unbounded trace payload sizes
+// and avoids leaking full conversation content into observability backends.
+const maxPreviewLen = 200
+
+// truncatePreview returns up to maxPreviewLen runes of s, appending "…" when truncated.
+func truncatePreview(s string) string {
+	runes := []rune(s)
+	if len(runes) <= maxPreviewLen {
+		return s
+	}
+	return string(runes[:maxPreviewLen]) + "…"
+}
+
 // Chat processes a user message and returns a response.
 // This is the main entry point for conversational interaction.
 func (a *Agent) Chat(ctx context.Context, sessionID string, userMessage string) (*Response, error) {
@@ -1466,7 +1480,7 @@ func (a *Agent) Chat(ctx context.Context, sessionID string, userMessage string) 
 	// Set initial attributes
 	span.SetAttribute(observability.AttrSessionID, sessionID)
 	span.SetAttribute("message.length", len(userMessage))
-	span.SetAttribute("message.preview", userMessage)
+	span.SetAttribute("message.preview", truncatePreview(userMessage))
 	a.mu.RLock()
 	currentLLM := a.llm
 	a.mu.RUnlock()
@@ -1597,7 +1611,7 @@ func (a *Agent) Chat(ctx context.Context, sessionID string, userMessage string) 
 	span.SetAttribute("conversation.cost.usd", response.Usage.CostUSD)
 	span.SetAttribute("conversation.stop_reason", response.Metadata["stop_reason"])
 	span.SetAttribute("response.length", len(response.Content))
-	span.SetAttribute("response.preview", response.Content)
+	span.SetAttribute("response.preview", truncatePreview(response.Content))
 
 	// Check if we hit limits
 	if maxTurnsHit, ok := response.Metadata["max_turns_hit"].(bool); ok && maxTurnsHit {
@@ -1660,7 +1674,7 @@ func (a *Agent) ChatWithProgress(ctx context.Context, sessionID string, userMess
 	// Set initial attributes
 	span.SetAttribute(observability.AttrSessionID, sessionID)
 	span.SetAttribute("message.length", len(userMessage))
-	span.SetAttribute("message.preview", userMessage)
+	span.SetAttribute("message.preview", truncatePreview(userMessage))
 	a.mu.RLock()
 	currentLLM := a.llm
 	a.mu.RUnlock()
@@ -1806,7 +1820,7 @@ func (a *Agent) ChatWithProgress(ctx context.Context, sessionID string, userMess
 	span.SetAttribute("conversation.cost.usd", response.Usage.CostUSD)
 	span.SetAttribute("conversation.stop_reason", response.Metadata["stop_reason"])
 	span.SetAttribute("response.length", len(response.Content))
-	span.SetAttribute("response.preview", response.Content)
+	span.SetAttribute("response.preview", truncatePreview(response.Content))
 
 	// Check if we hit limits
 	if maxTurnsHit, ok := response.Metadata["max_turns_hit"].(bool); ok && maxTurnsHit {

--- a/pkg/llm/instrumented_provider.go
+++ b/pkg/llm/instrumented_provider.go
@@ -173,7 +173,7 @@ func (p *InstrumentedProvider) Chat(ctx context.Context, messages []llmtypes.Mes
 
 	// Response content — maps to gen_ai.completion → Opik output column.
 	if resp.Content != "" {
-		span.SetAttribute("response.preview", resp.Content)
+		span.SetAttribute("response.preview", truncatePreview(resp.Content))
 	}
 
 	// Capture content length (for analysis)
@@ -407,7 +407,7 @@ func (p *InstrumentedProvider) ChatStream(ctx context.Context, messages []llmtyp
 
 	// Response content — maps to gen_ai.completion → Opik output column.
 	if resp.Content != "" {
-		span.SetAttribute("response.preview", resp.Content)
+		span.SetAttribute("response.preview", truncatePreview(resp.Content))
 	}
 
 	// Capture content length (for analysis)
@@ -490,8 +490,23 @@ func (p *InstrumentedProvider) ChatStream(ctx context.Context, messages []llmtyp
 	return resp, nil
 }
 
-// lastUserMessagePreview returns the full content of the last user message.
-// For multi-modal messages it concatenates text blocks, skipping image blocks.
+// maxPreviewRunes is the maximum number of runes stored in message.preview /
+// response.preview span attributes. Capping prevents unbounded trace payloads
+// and avoids leaking full conversation content into observability backends.
+// Must match the constant in pkg/agent/agent.go (maxPreviewLen = 200).
+const maxPreviewRunes = 200
+
+// truncatePreview truncates s to maxPreviewRunes runes, appending "…" when cut.
+func truncatePreview(s string) string {
+	runes := []rune(s)
+	if len(runes) <= maxPreviewRunes {
+		return s
+	}
+	return string(runes[:maxPreviewRunes]) + "…"
+}
+
+// lastUserMessagePreview returns the content of the last user message, truncated
+// to maxPreviewRunes runes. For multi-modal messages it concatenates text blocks.
 func lastUserMessagePreview(messages []llmtypes.Message) string {
 	for i := len(messages) - 1; i >= 0; i-- {
 		m := messages[i]
@@ -499,7 +514,7 @@ func lastUserMessagePreview(messages []llmtypes.Message) string {
 			continue
 		}
 		if m.Content != "" {
-			return m.Content
+			return truncatePreview(m.Content)
 		}
 		var parts []string
 		for _, b := range m.ContentBlocks {
@@ -507,7 +522,7 @@ func lastUserMessagePreview(messages []llmtypes.Message) string {
 				parts = append(parts, b.Text)
 			}
 		}
-		return strings.Join(parts, " ")
+		return truncatePreview(strings.Join(parts, " "))
 	}
 	return ""
 }

--- a/pkg/llm/instrumented_provider.go
+++ b/pkg/llm/instrumented_provider.go
@@ -16,6 +16,7 @@ package llm
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
@@ -79,6 +80,7 @@ func (p *InstrumentedProvider) Chat(ctx context.Context, messages []llmtypes.Mes
 	// Set span attributes - basic info
 	span.SetAttribute(observability.AttrLLMProvider, p.provider.Name())
 	span.SetAttribute(observability.AttrLLMModel, p.provider.Model())
+	span.SetAttribute("llm.operation", "chat") // gen_ai.operation.name — required by OTel GenAI spec
 
 	// Capture request details
 	span.SetAttribute("llm.messages.count", len(messages))
@@ -91,6 +93,11 @@ func (p *InstrumentedProvider) Chat(ctx context.Context, messages []llmtypes.Mes
 			toolNames[i] = tool.Name()
 		}
 		span.SetAttribute("llm.tools.names", toolNames)
+	}
+
+	// Last user message — maps to gen_ai.prompt → Opik input column.
+	if preview := lastUserMessagePreview(messages); preview != "" {
+		span.SetAttribute("message.preview", preview)
 	}
 
 	// Record event: LLM call started
@@ -162,6 +169,11 @@ func (p *InstrumentedProvider) Chat(ctx context.Context, messages []llmtypes.Mes
 			toolCallNames[i] = tc.Name
 		}
 		span.SetAttribute("llm.tool_calls.names", toolCallNames)
+	}
+
+	// Response content — maps to gen_ai.completion → Opik output column.
+	if resp.Content != "" {
+		span.SetAttribute("response.preview", resp.Content)
 	}
 
 	// Capture content length (for analysis)
@@ -259,6 +271,7 @@ func (p *InstrumentedProvider) ChatStream(ctx context.Context, messages []llmtyp
 	// Set span attributes - basic info
 	span.SetAttribute(observability.AttrLLMProvider, p.provider.Name())
 	span.SetAttribute(observability.AttrLLMModel, p.provider.Model())
+	span.SetAttribute("llm.operation", "chat") // gen_ai.operation.name — required by OTel GenAI spec
 	span.SetAttribute("llm.streaming", true)
 
 	// Capture request details
@@ -272,6 +285,11 @@ func (p *InstrumentedProvider) ChatStream(ctx context.Context, messages []llmtyp
 			toolNames[i] = tool.Name()
 		}
 		span.SetAttribute("llm.tools.names", toolNames)
+	}
+
+	// Last user message — maps to gen_ai.prompt → Opik input column.
+	if preview := lastUserMessagePreview(messages); preview != "" {
+		span.SetAttribute("message.preview", preview)
 	}
 
 	// Record event: streaming started
@@ -387,6 +405,11 @@ func (p *InstrumentedProvider) ChatStream(ctx context.Context, messages []llmtyp
 		span.SetAttribute("llm.tool_calls.names", toolCallNames)
 	}
 
+	// Response content — maps to gen_ai.completion → Opik output column.
+	if resp.Content != "" {
+		span.SetAttribute("response.preview", resp.Content)
+	}
+
 	// Capture content length (for analysis)
 	span.SetAttribute("llm.content.length", len(resp.Content))
 
@@ -465,6 +488,28 @@ func (p *InstrumentedProvider) ChatStream(ctx context.Context, messages []llmtyp
 	})
 
 	return resp, nil
+}
+
+// lastUserMessagePreview returns the full content of the last user message.
+// For multi-modal messages it concatenates text blocks, skipping image blocks.
+func lastUserMessagePreview(messages []llmtypes.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		m := messages[i]
+		if m.Role != "user" {
+			continue
+		}
+		if m.Content != "" {
+			return m.Content
+		}
+		var parts []string
+		for _, b := range m.ContentBlocks {
+			if b.Type == "text" && b.Text != "" {
+				parts = append(parts, b.Text)
+			}
+		}
+		return strings.Join(parts, " ")
+	}
+	return ""
 }
 
 // Ensure InstrumentedProvider implements LLMProvider interface

--- a/pkg/observability/auto_select.go
+++ b/pkg/observability/auto_select.go
@@ -35,6 +35,9 @@ const (
 
 	// TracerModeNone disables tracing
 	TracerModeNone TracerMode = "none"
+
+	// TracerModeOTel exports traces via OTLP HTTP to any compatible backend.
+	TracerModeOTel TracerMode = "otel"
 )
 
 // AutoSelectConfig provides configuration for automatic tracer selection
@@ -57,6 +60,18 @@ type AutoSelectConfig struct {
 
 	// EmbeddedSQLitePath: Path to SQLite database (required if EmbeddedStorageType="sqlite")
 	EmbeddedSQLitePath string
+
+	// OTLPEndpoint is the OTLP HTTP endpoint URL (for otel mode).
+	OTLPEndpoint string
+
+	// OTLPHeaders are HTTP headers sent with OTLP requests (e.g. auth tokens).
+	OTLPHeaders map[string]string
+
+	// OTLPInsecure disables TLS verification (local dev only).
+	OTLPInsecure bool
+
+	// ServiceName populates resource attribute service.name in otel mode.
+	ServiceName string
 
 	// Logger for tracer operations
 	Logger *zap.Logger
@@ -91,10 +106,18 @@ func NewAutoSelectTracer(config *AutoSelectConfig) (Tracer, error) {
 		return newEmbeddedTracer(config)
 	case TracerModeNone:
 		return NewNoOpTracer(), nil
+	case TracerModeOTel:
+		return NewOTelTracer(OTelConfig{
+			Endpoint:    config.OTLPEndpoint,
+			Headers:     config.OTLPHeaders,
+			Insecure:    config.OTLPInsecure,
+			ServiceName: config.ServiceName,
+			Privacy:     safePrivacy(config.Privacy),
+		})
 	case TracerModeAuto:
 		return autoSelectTracer(config)
 	default:
-		return nil, fmt.Errorf("unknown tracer mode: %s (supported: auto, service, embedded, none)", config.Mode)
+		return nil, fmt.Errorf("unknown tracer mode: %s (supported: auto, service, embedded, none, otel)", config.Mode)
 	}
 }
 
@@ -106,6 +129,21 @@ func autoSelectTracer(config *AutoSelectConfig) (Tracer, error) {
 	logger := config.Logger
 	if logger == nil {
 		logger, _ = zap.NewProduction()
+	}
+
+	// OTel takes priority over service/embedded when endpoint is configured.
+	if isOTelAvailable(config) {
+		logger.Info("auto-selecting otel tracer",
+			zap.String("endpoint", config.OTLPEndpoint),
+			zap.String("reason", "otlp_endpoint configured"),
+		)
+		return NewOTelTracer(OTelConfig{
+			Endpoint:    config.OTLPEndpoint,
+			Headers:     config.OTLPHeaders,
+			Insecure:    config.OTLPInsecure,
+			ServiceName: config.ServiceName,
+			Privacy:     safePrivacy(config.Privacy),
+		})
 	}
 
 	// No tracers available
@@ -150,9 +188,22 @@ func autoSelectTracer(config *AutoSelectConfig) (Tracer, error) {
 	return newServiceTracer(config)
 }
 
+// isOTelAvailable checks if otel mode can be used
+func isOTelAvailable(config *AutoSelectConfig) bool {
+	return config.OTLPEndpoint != ""
+}
+
 // isServiceAvailable checks if service mode can be used
 func isServiceAvailable(config *AutoSelectConfig) bool {
 	return config.HawkURL != ""
+}
+
+// safePrivacy dereferences a *PrivacyConfig, returning zero value if nil.
+func safePrivacy(p *PrivacyConfig) PrivacyConfig {
+	if p == nil {
+		return PrivacyConfig{}
+	}
+	return *p
 }
 
 // isEmbeddedAvailable checks if embedded mode can be used

--- a/pkg/observability/auto_select.go
+++ b/pkg/observability/auto_select.go
@@ -294,6 +294,10 @@ func newEmbeddedTracer(config *AutoSelectConfig) (Tracer, error) {
 //	export LOOM_EMBEDDED_STORAGE=memory
 //	export HAWK_URL=http://localhost:8090
 func NewAutoSelectTracerFromEnv(logger *zap.Logger) (Tracer, error) {
+	var otlpHeaders map[string]string
+	if raw := firstEnv("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "LOOM_OTLP_HEADERS"); raw != "" {
+		otlpHeaders = parseHeadersEnv(raw)
+	}
 	config := &AutoSelectConfig{
 		Mode:                TracerMode(getEnv("LOOM_TRACER_MODE", "auto")),
 		PreferEmbedded:      getEnv("LOOM_TRACER_PREFER_EMBEDDED", "true") == "true",
@@ -301,6 +305,10 @@ func NewAutoSelectTracerFromEnv(logger *zap.Logger) (Tracer, error) {
 		HawkAPIKey:          os.Getenv("HAWK_API_KEY"),
 		EmbeddedStorageType: getEnv("LOOM_EMBEDDED_STORAGE", "memory"),
 		EmbeddedSQLitePath:  os.Getenv("LOOM_EMBEDDED_SQLITE_PATH"),
+		OTLPEndpoint:        firstEnv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "LOOM_OTLP_ENDPOINT"),
+		OTLPHeaders:         otlpHeaders,
+		OTLPInsecure:        os.Getenv("LOOM_OTLP_INSECURE") == "true",
+		ServiceName:         firstEnv("OTEL_SERVICE_NAME", ""),
 		Logger:              logger,
 	}
 

--- a/pkg/observability/auto_select.go
+++ b/pkg/observability/auto_select.go
@@ -112,7 +112,7 @@ func NewAutoSelectTracer(config *AutoSelectConfig) (Tracer, error) {
 			Headers:     config.OTLPHeaders,
 			Insecure:    config.OTLPInsecure,
 			ServiceName: config.ServiceName,
-			Privacy:     safePrivacy(config.Privacy),
+			Privacy:     safeOTelPrivacy(config.Privacy),
 		})
 	case TracerModeAuto:
 		return autoSelectTracer(config)
@@ -142,7 +142,7 @@ func autoSelectTracer(config *AutoSelectConfig) (Tracer, error) {
 			Headers:     config.OTLPHeaders,
 			Insecure:    config.OTLPInsecure,
 			ServiceName: config.ServiceName,
-			Privacy:     safePrivacy(config.Privacy),
+			Privacy:     safeOTelPrivacy(config.Privacy),
 		})
 	}
 
@@ -198,10 +198,17 @@ func isServiceAvailable(config *AutoSelectConfig) bool {
 	return config.HawkURL != ""
 }
 
-// safePrivacy dereferences a *PrivacyConfig, returning zero value if nil.
-func safePrivacy(p *PrivacyConfig) PrivacyConfig {
+// safeOTelPrivacy dereferences a *PrivacyConfig for OTel construction paths.
+// When nil (caller did not explicitly configure privacy) it defaults to safe
+// redaction-on behaviour: credentials and PII are redacted before export to
+// any off-box OTLP backend.  Callers that intentionally want no redaction must
+// pass an explicit &PrivacyConfig{RedactCredentials: false, RedactPII: false}.
+func safeOTelPrivacy(p *PrivacyConfig) PrivacyConfig {
 	if p == nil {
-		return PrivacyConfig{}
+		return PrivacyConfig{
+			RedactCredentials: true,
+			RedactPII:         true,
+		}
 	}
 	return *p
 }

--- a/pkg/observability/auto_select.go
+++ b/pkg/observability/auto_select.go
@@ -312,7 +312,7 @@ func NewAutoSelectTracerFromEnv(logger *zap.Logger) (Tracer, error) {
 		HawkAPIKey:          os.Getenv("HAWK_API_KEY"),
 		EmbeddedStorageType: getEnv("LOOM_EMBEDDED_STORAGE", "memory"),
 		EmbeddedSQLitePath:  os.Getenv("LOOM_EMBEDDED_SQLITE_PATH"),
-		OTLPEndpoint:        firstEnv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "LOOM_OTLP_ENDPOINT"),
+		OTLPEndpoint:        resolveOTLPEndpointEnv(),
 		OTLPHeaders:         otlpHeaders,
 		OTLPInsecure:        os.Getenv("LOOM_OTLP_INSECURE") == "true",
 		ServiceName:         firstEnv("OTEL_SERVICE_NAME", ""),

--- a/pkg/observability/hawk.go
+++ b/pkg/observability/hawk.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -338,13 +337,6 @@ func (t *HawkTracer) flushNow() error {
 	return fmt.Errorf("hawk export failed after %d attempts: %w", t.config.MaxRetries+1, lastErr)
 }
 
-// PII redaction patterns (compiled once at package init)
-var (
-	emailPattern      = regexp.MustCompile(`[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}`)
-	phonePattern      = regexp.MustCompile(`\b\d{3}[-.]?\d{3}[-.]?\d{4}\b`)
-	ssnPattern        = regexp.MustCompile(`\b\d{3}-\d{2}-\d{4}\b`)
-	creditCardPattern = regexp.MustCompile(`\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b`)
-)
 
 // redact applies privacy rules to span before export.
 // This removes sensitive data (credentials, PII) while preserving debugging utility.

--- a/pkg/observability/hawk.go
+++ b/pkg/observability/hawk.go
@@ -337,7 +337,6 @@ func (t *HawkTracer) flushNow() error {
 	return fmt.Errorf("hawk export failed after %d attempts: %w", t.config.MaxRetries+1, lastErr)
 }
 
-
 // redact applies privacy rules to span before export.
 // This removes sensitive data (credentials, PII) while preserving debugging utility.
 func (t *HawkTracer) redact(span *Span) *Span {

--- a/pkg/observability/otel.go
+++ b/pkg/observability/otel.go
@@ -1,0 +1,359 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package observability
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+// OTelTracer exports Loom spans to any OTLP HTTP endpoint.
+// It bridges Loom's internal span model to the OTel SDK, translating
+// attributes to GenAI semantic conventions on export.
+type OTelTracer struct {
+	provider    *sdktrace.TracerProvider
+	tracer      oteltrace.Tracer
+	activeSpans sync.Map // loom SpanID (string) → oteltrace.Span
+	privacy     PrivacyConfig
+}
+
+// NewOTelTracer creates a tracer that exports via OTLP HTTP.
+// Returns an error if the endpoint is empty or the exporter cannot be created.
+func NewOTelTracer(cfg OTelConfig) (*OTelTracer, error) {
+	cfg = resolveOTelConfig(cfg)
+	if cfg.Endpoint == "" {
+		return nil, fmt.Errorf("otlp_endpoint is required (set OTEL_EXPORTER_OTLP_TRACES_ENDPOINT or observability.otlp_endpoint)")
+	}
+
+	exporterOpts := []otlptracehttp.Option{
+		otlptracehttp.WithEndpointURL(cfg.Endpoint),
+		otlptracehttp.WithTimeout(cfg.Timeout),
+	}
+	if len(cfg.Headers) > 0 {
+		exporterOpts = append(exporterOpts, otlptracehttp.WithHeaders(cfg.Headers))
+	}
+	if cfg.Insecure {
+		exporterOpts = append(exporterOpts, otlptracehttp.WithInsecure())
+	}
+
+	exporter, err := otlptracehttp.New(context.Background(), exporterOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("creating OTLP exporter: %w", err)
+	}
+
+	resAttrs := []attribute.KeyValue{
+		attribute.String("service.name", cfg.ServiceName),
+	}
+	if cfg.ServiceVersion != "" {
+		resAttrs = append(resAttrs, attribute.String("service.version", cfg.ServiceVersion))
+	}
+	res, err := resource.New(context.Background(), resource.WithAttributes(resAttrs...))
+	if err != nil {
+		return nil, fmt.Errorf("creating OTel resource: %w", err)
+	}
+
+	batchProcessor := sdktrace.NewBatchSpanProcessor(exporter,
+		sdktrace.WithMaxExportBatchSize(cfg.MaxBatchSize),
+		sdktrace.WithBatchTimeout(cfg.FlushInterval),
+	)
+	processor := newFilteringSpanProcessor(batchProcessor, cfg.SpanFilter)
+
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(processor),
+		sdktrace.WithResource(res),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+
+	return &OTelTracer{
+		provider: provider,
+		tracer:   provider.Tracer("loom"),
+		privacy:  cfg.Privacy,
+	}, nil
+}
+
+// StartSpan creates a Loom span and a paired OTel span.
+// The Loom span is placed in the returned context for downstream context propagation.
+func (t *OTelTracer) StartSpan(ctx context.Context, name string, opts ...SpanOption) (context.Context, *Span) {
+	// Build Loom span — same logic as NoOpTracer to preserve context propagation.
+	traceID := uuid.New().String()
+	if override := traceIDFromContextOverride(ctx); override != "" {
+		traceID = override
+	}
+	loomSpan := &Span{
+		TraceID:    traceID,
+		SpanID:     uuid.New().String(),
+		Name:       name,
+		StartTime:  time.Now(),
+		Attributes: make(map[string]interface{}),
+	}
+	for _, opt := range opts {
+		opt(loomSpan)
+	}
+
+	// Link to parent Loom span if present.
+	otelCtx := ctx
+	if parent := SpanFromContext(ctx); parent != nil {
+		loomSpan.TraceID = parent.TraceID
+		loomSpan.ParentID = parent.SpanID
+		if len(parent.ResourceAttributes) > 0 && len(loomSpan.ResourceAttributes) == 0 {
+			loomSpan.ResourceAttributes = make(map[string]string, len(parent.ResourceAttributes))
+			for k, v := range parent.ResourceAttributes {
+				loomSpan.ResourceAttributes[k] = v
+			}
+		}
+		// Inject parent span context so OTel SDK establishes the parent-child link.
+		if psc, ok := buildOTelSpanContext(parent.TraceID, parent.SpanID); ok {
+			otelCtx = oteltrace.ContextWithRemoteSpanContext(ctx, psc)
+		}
+	}
+
+	otelCtx, otelSpan := t.tracer.Start(otelCtx, name,
+		oteltrace.WithTimestamp(loomSpan.StartTime),
+		oteltrace.WithSpanKind(spanKindFor(name)),
+	)
+	t.activeSpans.Store(loomSpan.SpanID, otelSpan)
+
+	return ContextWithSpan(otelCtx, loomSpan), loomSpan
+}
+
+// EndSpan completes the span: calculates duration, applies privacy redaction,
+// translates attributes to gen_ai.* semconv, and ends the OTel span.
+func (t *OTelTracer) EndSpan(span *Span) {
+	if span == nil {
+		return
+	}
+	span.EndTime = time.Now()
+	span.Duration = span.EndTime.Sub(span.StartTime)
+
+	raw, ok := t.activeSpans.LoadAndDelete(span.SpanID)
+	if !ok {
+		return
+	}
+	otelSpan, _ := raw.(oteltrace.Span)
+
+	redacted := redactOTelSpan(span, t.privacy)
+
+	// Translate span attributes.
+	translateAttrs(otelSpan, redacted.Attributes)
+
+	// Forward resource attributes (service.name, agent.id, session.id, etc.).
+	for k, v := range redacted.ResourceAttributes {
+		otelSpan.SetAttributes(attribute.String(k, v))
+	}
+
+	// Forward span events.
+	for _, ev := range redacted.Events {
+		evAttrs := make([]attribute.KeyValue, 0, len(ev.Attributes))
+		for k, v := range ev.Attributes {
+			evAttrs = append(evAttrs, toOTelAttr(k, v))
+		}
+		otelSpan.AddEvent(ev.Name,
+			oteltrace.WithTimestamp(ev.Timestamp),
+			oteltrace.WithAttributes(evAttrs...),
+		)
+	}
+
+	// Set span status.
+	switch redacted.Status.Code {
+	case StatusError:
+		otelSpan.SetStatus(codes.Error, redacted.Status.Message)
+	case StatusOK:
+		otelSpan.SetStatus(codes.Ok, "")
+	}
+
+	otelSpan.End(oteltrace.WithTimestamp(span.EndTime))
+}
+
+// RecordMetric is a no-op. Metrics export via OTLP is not in scope for this release.
+// Backends can derive aggregate metrics from span attributes (tokens, cost, latency).
+func (t *OTelTracer) RecordMetric(_ string, _ float64, _ map[string]string) {}
+
+// RecordEvent is a no-op. Point-in-time events should be attached to spans via span.AddEvent.
+func (t *OTelTracer) RecordEvent(_ context.Context, _ string, _ map[string]interface{}) {}
+
+// Flush forces immediate export of all buffered spans and blocks until done.
+func (t *OTelTracer) Flush(ctx context.Context) error {
+	return t.provider.ForceFlush(ctx)
+}
+
+// Shutdown gracefully drains buffered spans and stops the exporter.
+// Call this on server shutdown after Flush.
+func (t *OTelTracer) Shutdown(ctx context.Context) error {
+	return t.provider.Shutdown(ctx)
+}
+
+// buildOTelSpanContext constructs an OTel SpanContext from Loom UUID-based IDs.
+//
+// Loom uses UUID strings (e.g. "550e8400-e29b-41d4-a716-446655440000").
+// A UUID stripped of dashes yields 32 hex chars = 16 bytes, exactly an OTel TraceID.
+// The SpanID uses the first 16 hex chars of the UUID = 8 bytes.
+func buildOTelSpanContext(loomTraceID, loomSpanID string) (oteltrace.SpanContext, bool) {
+	tHex := strings.ReplaceAll(loomTraceID, "-", "")
+	sHex := strings.ReplaceAll(loomSpanID, "-", "")
+
+	if len(tHex) < 32 || len(sHex) < 16 {
+		return oteltrace.SpanContext{}, false
+	}
+
+	tBytes, err := hex.DecodeString(tHex[:32])
+	if err != nil {
+		return oteltrace.SpanContext{}, false
+	}
+	sBytes, err := hex.DecodeString(sHex[:16])
+	if err != nil {
+		return oteltrace.SpanContext{}, false
+	}
+
+	var traceID oteltrace.TraceID
+	var spanID oteltrace.SpanID
+	copy(traceID[:], tBytes)
+	copy(spanID[:], sBytes)
+
+	sc := oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: oteltrace.FlagsSampled,
+		Remote:     false,
+	})
+	return sc, sc.IsValid()
+}
+
+// redactOTelSpan applies privacy rules before attributes are exported.
+// PII patterns (emailPattern, phonePattern, etc.) are defined in privacy.go.
+func redactOTelSpan(span *Span, cfg PrivacyConfig) *Span {
+	if !cfg.RedactCredentials && !cfg.RedactPII {
+		return span
+	}
+
+	allowed := make(map[string]bool, len(cfg.AllowedAttributes))
+	for _, k := range cfg.AllowedAttributes {
+		allowed[k] = true
+	}
+
+	if cfg.RedactCredentials {
+		credKeys := []string{
+			"password", "api_key", "token", "secret", "authorization",
+			"access_token", "refresh_token", "bearer", "apikey",
+			"client_secret", "private_key", "ssh_key", "aws_secret",
+		}
+		for _, k := range credKeys {
+			if !allowed[k] {
+				delete(span.Attributes, k)
+			}
+		}
+		for k := range span.Attributes {
+			kl := strings.ToLower(k)
+			if !allowed[k] {
+				if strings.Contains(kl, "password") || strings.Contains(kl, "secret") ||
+					(strings.Contains(kl, "key") && strings.Contains(kl, "api")) {
+					delete(span.Attributes, k)
+				}
+			}
+		}
+	}
+
+	if cfg.RedactPII {
+		for k, v := range span.Attributes {
+			if allowed[k] {
+				continue
+			}
+			if s, ok := v.(string); ok {
+				r := emailPattern.ReplaceAllString(s, "[EMAIL_REDACTED]")
+				r = phonePattern.ReplaceAllString(r, "[PHONE_REDACTED]")
+				r = ssnPattern.ReplaceAllString(r, "[SSN_REDACTED]")
+				r = creditCardPattern.ReplaceAllString(r, "[CARD_REDACTED]")
+				if r != s {
+					span.Attributes[k] = r
+				}
+			}
+		}
+		for i := range span.Events {
+			for k, v := range span.Events[i].Attributes {
+				if allowed[k] {
+					continue
+				}
+				if s, ok := v.(string); ok {
+					r := emailPattern.ReplaceAllString(s, "[EMAIL_REDACTED]")
+					r = phonePattern.ReplaceAllString(r, "[PHONE_REDACTED]")
+					r = ssnPattern.ReplaceAllString(r, "[SSN_REDACTED]")
+					r = creditCardPattern.ReplaceAllString(r, "[CARD_REDACTED]")
+					if r != s {
+						span.Events[i].Attributes[k] = r
+					}
+				}
+			}
+		}
+	}
+
+	return span
+}
+
+// Ensure OTelTracer implements Tracer.
+var _ Tracer = (*OTelTracer)(nil)
+
+// filteringSpanProcessor wraps an inner SpanProcessor and only forwards spans
+// whose names match the configured include prefixes.
+// When IncludePrefixes is empty every span passes through unchanged.
+type filteringSpanProcessor struct {
+	inner    sdktrace.SpanProcessor
+	prefixes []string
+}
+
+func newFilteringSpanProcessor(inner sdktrace.SpanProcessor, cfg SpanFilterConfig) sdktrace.SpanProcessor {
+	if len(cfg.IncludePrefixes) == 0 {
+		return inner
+	}
+	return &filteringSpanProcessor{inner: inner, prefixes: cfg.IncludePrefixes}
+}
+
+func (f *filteringSpanProcessor) matches(name string) bool {
+	for _, p := range f.prefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *filteringSpanProcessor) OnStart(parent context.Context, s sdktrace.ReadWriteSpan) {
+	if f.matches(s.Name()) {
+		f.inner.OnStart(parent, s)
+	}
+}
+
+func (f *filteringSpanProcessor) OnEnd(s sdktrace.ReadOnlySpan) {
+	if f.matches(s.Name()) {
+		f.inner.OnEnd(s)
+	}
+}
+
+func (f *filteringSpanProcessor) Shutdown(ctx context.Context) error {
+	return f.inner.Shutdown(ctx)
+}
+
+func (f *filteringSpanProcessor) ForceFlush(ctx context.Context) error {
+	return f.inner.ForceFlush(ctx)
+}

--- a/pkg/observability/otel.go
+++ b/pkg/observability/otel.go
@@ -124,8 +124,16 @@ func (t *OTelTracer) StartSpan(ctx context.Context, name string, opts ...SpanOpt
 				loomSpan.ResourceAttributes[k] = v
 			}
 		}
-		// Inject parent span context so OTel SDK establishes the parent-child link.
-		if psc, ok := buildOTelSpanContext(parent.TraceID, parent.SpanID); ok {
+		// Prefer the live in-process OTel span so SDK propagation assigns the
+		// same SDK-generated trace/span IDs to the child — not the UUID-derived
+		// ones that would create a dangling remote parent.  Fall back to the
+		// UUID-derived remote context only when no live span is registered (i.e.
+		// the parent was created by a different process / tracer instance).
+		if raw, ok := t.activeSpans.Load(parent.SpanID); ok {
+			if parentOTelSpan, ok := raw.(oteltrace.Span); ok {
+				otelCtx = oteltrace.ContextWithSpan(ctx, parentOTelSpan)
+			}
+		} else if psc, ok := buildOTelSpanContext(parent.TraceID, parent.SpanID); ok {
 			otelCtx = oteltrace.ContextWithRemoteSpanContext(ctx, psc)
 		}
 	}

--- a/pkg/observability/otel_attrs.go
+++ b/pkg/observability/otel_attrs.go
@@ -29,7 +29,9 @@ import (
 //   - OTel Exceptions: https://opentelemetry.io/docs/specs/semconv/exceptions/
 //   - OTel RPC (for MCP): https://opentelemetry.io/docs/specs/semconv/rpc/
 //   - Opik-specific: gen_ai.prompt / gen_ai.completion drive the Input/Output columns
-var loomToGenAI = map[string]string{ //nolint:gochecknoglobals
+//
+//nolint:gochecknoglobals
+var loomToGenAI = map[string]string{ // #nosec G101 -- map values are OTel attribute name strings, not credentials
 	// LLM identity (REQUIRED by OTel GenAI spec)
 	"llm.provider":  "gen_ai.system",
 	"llm.model":     "gen_ai.request.model",
@@ -80,7 +82,7 @@ var loomToGenAI = map[string]string{ //nolint:gochecknoglobals
 
 	// Session / user — kept as-is so backends index them without a loom. prefix
 	"session.id": "session.id",
-	"user.id":    "user.id", //nolint:gosec // G101 false positive: map key is an attribute name, not a credential
+	"user.id":    "user.id",
 	"trace.id":   "trace.id",
 }
 

--- a/pkg/observability/otel_attrs.go
+++ b/pkg/observability/otel_attrs.go
@@ -80,7 +80,7 @@ var loomToGenAI = map[string]string{ //nolint:gochecknoglobals
 
 	// Session / user — kept as-is so backends index them without a loom. prefix
 	"session.id": "session.id",
-	"user.id":    "user.id",    //nolint:gosec // G101 false positive: map key is an attribute name, not a credential
+	"user.id":    "user.id", //nolint:gosec // G101 false positive: map key is an attribute name, not a credential
 	"trace.id":   "trace.id",
 }
 

--- a/pkg/observability/otel_attrs.go
+++ b/pkg/observability/otel_attrs.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package observability
+
+import (
+	"fmt"
+	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+// loomToGenAI maps Loom attribute keys to OTel semantic convention keys.
+// Attributes not listed here are forwarded with a "loom." prefix so no data is dropped.
+//
+// Standards followed:
+//   - OTel GenAI spans: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/
+//   - OTel Exceptions: https://opentelemetry.io/docs/specs/semconv/exceptions/
+//   - OTel RPC (for MCP): https://opentelemetry.io/docs/specs/semconv/rpc/
+//   - Opik-specific: gen_ai.prompt / gen_ai.completion drive the Input/Output columns
+var loomToGenAI = map[string]string{ //nolint:gochecknoglobals
+	// LLM identity (REQUIRED by OTel GenAI spec)
+	"llm.provider":  "gen_ai.system",
+	"llm.model":     "gen_ai.request.model",
+	"llm.operation": "gen_ai.operation.name",
+
+	// LLM request parameters (RECOMMENDED)
+	"llm.temperature": "gen_ai.request.temperature",
+	"llm.max_tokens":  "gen_ai.request.max_tokens",
+
+	// Token usage (llm span — set by instrumented_provider.go)
+	"llm.tokens.input":       "gen_ai.usage.input_tokens",
+	"llm.tokens.output":      "gen_ai.usage.output_tokens",
+	"llm.tokens.total":       "gen_ai.usage.total_tokens",
+	"llm.tokens.cache_read":  "gen_ai.usage.cache_read_input_tokens",
+	"llm.tokens.cache_write": "gen_ai.usage.cache_creation_input_tokens",
+
+	// Response metadata (llm span)
+	"llm.stop_reason": "gen_ai.response.finish_reasons",
+	"llm.cost.usd":    "gen_ai.usage.cost",
+
+	// Input/output text for Opik UI columns — set on both llm and agent spans
+	"message.preview":  "gen_ai.prompt",
+	"response.preview": "gen_ai.completion",
+
+	// Token usage (conversation span — set by agent.go)
+	"conversation.tokens.input":  "gen_ai.usage.input_tokens",
+	"conversation.tokens.output": "gen_ai.usage.output_tokens",
+	"conversation.tokens.total":  "gen_ai.usage.total_tokens",
+	"conversation.cost.usd":      "gen_ai.usage.cost",
+	"conversation.stop_reason":   "gen_ai.response.finish_reasons",
+
+	// Tool execution (OTel GenAI tool-use semconv)
+	"tool.name":     "gen_ai.tool.name",
+	"mcp.tool.name": "gen_ai.tool.name",
+	"mcp.tool.args": "gen_ai.tool.call.arguments",
+
+	// MCP server identity (OTel RPC semconv)
+	"mcp.server.name":    "server.address",
+	"mcp.server.version": "server.version",
+
+	// Agent identity (OTel GenAI agent semconv, draft)
+	"agent_id": "gen_ai.agent.id",
+
+	// Error / exception semconv
+	"error.message": "exception.message",
+	"error.type":    "exception.type",
+	"error.stack":   "exception.stacktrace",
+
+	// Session / user — kept as-is so backends index them without a loom. prefix
+	"session.id": "session.id",
+	"user.id":    "user.id",
+	"trace.id":   "trace.id",
+}
+
+// genAISystemNorm normalizes provider names to OTel GenAI spec values for gen_ai.system.
+// Spec: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#generative-ai-request-attributes
+var genAISystemNorm = map[string]string{ //nolint:gochecknoglobals
+	"bedrock":      "aws.bedrock",
+	"azure-openai": "azure_openai",
+	"gemini":       "google.generative_ai",
+	"huggingface":  "hugging_face",
+	// anthropic, openai, ollama, mistral already match the spec
+}
+
+const loomAttrPrefix = "loom."
+
+// translateAttrs sets span attributes on an OTel span, mapping Loom keys to
+// OTel semantic convention keys where a mapping exists and prefixing unknowns with "loom.".
+func translateAttrs(otelSpan oteltrace.Span, attrs map[string]interface{}) {
+	for k, v := range attrs {
+		otelKey := k
+		if mapped, ok := loomToGenAI[k]; ok {
+			otelKey = mapped
+			// Normalize gen_ai.system values to OTel spec-defined strings.
+			if otelKey == "gen_ai.system" {
+				if s, ok := v.(string); ok {
+					if norm, ok := genAISystemNorm[s]; ok {
+						v = norm
+					}
+				}
+			}
+		} else if !strings.HasPrefix(k, loomAttrPrefix) {
+			otelKey = loomAttrPrefix + k
+		}
+		otelSpan.SetAttributes(toOTelAttr(otelKey, v))
+	}
+}
+
+// toOTelAttr converts a value to a typed OTel attribute.KeyValue.
+func toOTelAttr(key string, v interface{}) attribute.KeyValue {
+	switch val := v.(type) {
+	case string:
+		return attribute.String(key, val)
+	case int:
+		return attribute.Int64(key, int64(val))
+	case int32:
+		return attribute.Int64(key, int64(val))
+	case int64:
+		return attribute.Int64(key, val)
+	case float32:
+		return attribute.Float64(key, float64(val))
+	case float64:
+		return attribute.Float64(key, val)
+	case bool:
+		return attribute.Bool(key, val)
+	default:
+		return attribute.String(key, fmt.Sprintf("%v", val))
+	}
+}
+
+// spanKindFor returns the OTel SpanKind for a given Loom span name.
+// LLM, backend, and MCP spans are modelled as client calls (outbound I/O);
+// everything else is internal.
+func spanKindFor(name string) oteltrace.SpanKind {
+	switch {
+	case strings.HasPrefix(name, "llm."):
+		return oteltrace.SpanKindClient
+	case strings.HasPrefix(name, "backend."):
+		return oteltrace.SpanKindClient
+	case strings.HasPrefix(name, "mcp."):
+		return oteltrace.SpanKindClient
+	default:
+		return oteltrace.SpanKindInternal
+	}
+}

--- a/pkg/observability/otel_attrs.go
+++ b/pkg/observability/otel_attrs.go
@@ -80,7 +80,7 @@ var loomToGenAI = map[string]string{ //nolint:gochecknoglobals
 
 	// Session / user — kept as-is so backends index them without a loom. prefix
 	"session.id": "session.id",
-	"user.id":    "user.id",
+	"user.id":    "user.id",    //nolint:gosec // G101 false positive: map key is an attribute name, not a credential
 	"trace.id":   "trace.id",
 }
 

--- a/pkg/observability/otel_config.go
+++ b/pkg/observability/otel_config.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package observability
+
+import (
+	"os"
+	"strings"
+	"time"
+)
+
+// SpanFilterConfig controls which spans are forwarded to the OTLP backend.
+// Useful for suppressing infrastructure/startup spans when using backends like
+// Opik that are focused on LLM observability.
+type SpanFilterConfig struct {
+	// IncludePrefixes whitelists spans whose names start with any of these strings.
+	// Empty slice means all spans are exported (no filtering).
+	// Example: []string{"llm.", "agent.", "tool.", "backend.", "mcp."}
+	IncludePrefixes []string
+}
+
+// OTelConfig holds configuration for the OTelTracer.
+// Fields are resolved from explicit values first, then standard OTel env vars,
+// then Loom-specific fallback env vars.
+type OTelConfig struct {
+	// Endpoint is the full OTLP HTTP URL including path.
+	// Env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT or LOOM_OTLP_ENDPOINT
+	// Example (Opik local):  http://localhost:5173/api/v1/private/otel/v1/traces
+	// Example (Jaeger):      http://jaeger:4318/v1/traces
+	Endpoint string
+
+	// Headers are sent with every OTLP HTTP request (e.g. Authorization: Bearer <key>).
+	// Env: OTEL_EXPORTER_OTLP_TRACES_HEADERS (format: "key=val,key2=val2")
+	Headers map[string]string
+
+	// Insecure disables TLS certificate verification. Use for local dev only.
+	// Env: LOOM_OTLP_INSECURE
+	Insecure bool
+
+	// ServiceName populates the resource attribute service.name.
+	// Env: OTEL_SERVICE_NAME
+	ServiceName string
+
+	// ServiceVersion populates the resource attribute service.version.
+	// Env: OTEL_SERVICE_VERSION
+	ServiceVersion string
+
+	// Timeout is the per-export request timeout. Default: 10s.
+	Timeout time.Duration
+
+	// FlushInterval is the BatchSpanProcessor schedule delay. Default: 5s.
+	FlushInterval time.Duration
+
+	// MaxBatchSize is the maximum spans per OTLP export request. Default: 512.
+	MaxBatchSize int
+
+	// Privacy controls PII and credential redaction before export.
+	Privacy PrivacyConfig
+
+	// SpanFilter limits which spans are exported. Empty IncludePrefixes = export all.
+	SpanFilter SpanFilterConfig
+}
+
+// resolveOTelConfig fills zero-value fields from environment variables.
+func resolveOTelConfig(cfg OTelConfig) OTelConfig {
+	if cfg.Endpoint == "" {
+		cfg.Endpoint = firstEnv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "LOOM_OTLP_ENDPOINT")
+	}
+	if len(cfg.Headers) == 0 {
+		if raw := firstEnv("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "LOOM_OTLP_HEADERS"); raw != "" {
+			cfg.Headers = parseHeadersEnv(raw)
+		}
+	}
+	if cfg.ServiceName == "" {
+		cfg.ServiceName = firstEnv("OTEL_SERVICE_NAME", "")
+	}
+	if cfg.ServiceVersion == "" {
+		cfg.ServiceVersion = os.Getenv("OTEL_SERVICE_VERSION")
+	}
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 10 * time.Second
+	}
+	if cfg.FlushInterval == 0 {
+		cfg.FlushInterval = 5 * time.Second
+	}
+	if cfg.MaxBatchSize == 0 {
+		cfg.MaxBatchSize = 512
+	}
+	return cfg
+}
+
+// parseHeadersEnv parses "key=val,key2=val2" into a map.
+func parseHeadersEnv(raw string) map[string]string {
+	out := make(map[string]string)
+	for _, pair := range strings.Split(raw, ",") {
+		pair = strings.TrimSpace(pair)
+		if idx := strings.IndexByte(pair, '='); idx > 0 {
+			out[pair[:idx]] = pair[idx+1:]
+		}
+	}
+	return out
+}
+
+// firstEnv returns the first non-empty value among the given env var names.
+func firstEnv(keys ...string) string {
+	for _, k := range keys {
+		if k != "" {
+			if v := os.Getenv(k); v != "" {
+				return v
+			}
+		}
+	}
+	return ""
+}

--- a/pkg/observability/otel_config.go
+++ b/pkg/observability/otel_config.go
@@ -81,6 +81,9 @@ func resolveOTelConfig(cfg OTelConfig) OTelConfig {
 			cfg.Headers = parseHeadersEnv(raw)
 		}
 	}
+	if !cfg.Insecure {
+		cfg.Insecure = os.Getenv("LOOM_OTLP_INSECURE") == "true"
+	}
 	if cfg.ServiceName == "" {
 		cfg.ServiceName = firstEnv("OTEL_SERVICE_NAME", "")
 	}

--- a/pkg/observability/otel_config.go
+++ b/pkg/observability/otel_config.go
@@ -43,7 +43,12 @@ type OTelConfig struct {
 	// Env: OTEL_EXPORTER_OTLP_TRACES_HEADERS (format: "key=val,key2=val2")
 	Headers map[string]string
 
-	// Insecure disables TLS certificate verification. Use for local dev only.
+	// Insecure forces plain HTTP transport for the OTLP exporter (i.e. the
+	// connection uses http:// even if the endpoint URL starts with https://).
+	// This is NOT equivalent to disabling TLS certificate verification.
+	// Use for local development against plain-HTTP collectors (Jaeger, Opik
+	// running on localhost).  For https:// endpoints with self-signed certs,
+	// use a custom TLS config instead.
 	// Env: LOOM_OTLP_INSECURE
 	Insecure bool
 
@@ -74,10 +79,16 @@ type OTelConfig struct {
 // resolveOTelConfig fills zero-value fields from environment variables.
 func resolveOTelConfig(cfg OTelConfig) OTelConfig {
 	if cfg.Endpoint == "" {
-		cfg.Endpoint = firstEnv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "LOOM_OTLP_ENDPOINT")
+		// Honor both the traces-specific variant and the base OTLP endpoint env
+		// var (the latter is more commonly documented in generic OTel guides).
+		cfg.Endpoint = firstEnv(
+			"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+			"OTEL_EXPORTER_OTLP_ENDPOINT",
+			"LOOM_OTLP_ENDPOINT",
+		)
 	}
 	if len(cfg.Headers) == 0 {
-		if raw := firstEnv("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "LOOM_OTLP_HEADERS"); raw != "" {
+		if raw := firstEnv("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "OTEL_EXPORTER_OTLP_HEADERS", "LOOM_OTLP_HEADERS"); raw != "" {
 			cfg.Headers = parseHeadersEnv(raw)
 		}
 	}
@@ -85,7 +96,11 @@ func resolveOTelConfig(cfg OTelConfig) OTelConfig {
 		cfg.Insecure = os.Getenv("LOOM_OTLP_INSECURE") == "true"
 	}
 	if cfg.ServiceName == "" {
-		cfg.ServiceName = firstEnv("OTEL_SERVICE_NAME", "")
+		if name := os.Getenv("OTEL_SERVICE_NAME"); name != "" {
+			cfg.ServiceName = name
+		} else {
+			cfg.ServiceName = "loom" // safe default: non-empty service.name in every exported span
+		}
 	}
 	if cfg.ServiceVersion == "" {
 		cfg.ServiceVersion = os.Getenv("OTEL_SERVICE_VERSION")

--- a/pkg/observability/otel_config.go
+++ b/pkg/observability/otel_config.go
@@ -76,16 +76,25 @@ type OTelConfig struct {
 	SpanFilter SpanFilterConfig
 }
 
+// resolveOTLPEndpointEnv returns the OTLP traces endpoint from environment
+// variables, applying OTel-spec semantics:
+//   - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: signal-specific; used verbatim.
+//   - OTEL_EXPORTER_OTLP_ENDPOINT: base URL per spec; /v1/traces is appended.
+//   - LOOM_OTLP_ENDPOINT: Loom-specific fallback; used verbatim.
+func resolveOTLPEndpointEnv() string {
+	if v := os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"); v != "" {
+		return v
+	}
+	if v := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); v != "" {
+		return strings.TrimRight(v, "/") + "/v1/traces"
+	}
+	return os.Getenv("LOOM_OTLP_ENDPOINT")
+}
+
 // resolveOTelConfig fills zero-value fields from environment variables.
 func resolveOTelConfig(cfg OTelConfig) OTelConfig {
 	if cfg.Endpoint == "" {
-		// Honor both the traces-specific variant and the base OTLP endpoint env
-		// var (the latter is more commonly documented in generic OTel guides).
-		cfg.Endpoint = firstEnv(
-			"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
-			"OTEL_EXPORTER_OTLP_ENDPOINT",
-			"LOOM_OTLP_ENDPOINT",
-		)
+		cfg.Endpoint = resolveOTLPEndpointEnv()
 	}
 	if len(cfg.Headers) == 0 {
 		if raw := firstEnv("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "OTEL_EXPORTER_OTLP_HEADERS", "LOOM_OTLP_HEADERS"); raw != "" {

--- a/pkg/observability/otel_test.go
+++ b/pkg/observability/otel_test.go
@@ -1,0 +1,445 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package observability
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+// ---------------------------------------------------------------------------
+// buildOTelSpanContext
+// ---------------------------------------------------------------------------
+
+func TestBuildOTelSpanContext(t *testing.T) {
+	t.Run("valid UUIDs produce valid span context", func(t *testing.T) {
+		traceID := "550e8400-e29b-41d4-a716-446655440000"
+		spanID := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+		sc, ok := buildOTelSpanContext(traceID, spanID)
+		if !ok {
+			t.Fatal("expected valid span context")
+		}
+		if !sc.IsValid() {
+			t.Error("span context should be valid")
+		}
+		if !sc.IsSampled() {
+			t.Error("span context should have sampled flag")
+		}
+	})
+
+	t.Run("empty trace ID returns false", func(t *testing.T) {
+		_, ok := buildOTelSpanContext("", "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+		if ok {
+			t.Error("expected false for empty trace ID")
+		}
+	})
+
+	t.Run("empty span ID returns false", func(t *testing.T) {
+		_, ok := buildOTelSpanContext("550e8400-e29b-41d4-a716-446655440000", "")
+		if ok {
+			t.Error("expected false for empty span ID")
+		}
+	})
+
+	t.Run("non-hex IDs return false", func(t *testing.T) {
+		_, ok := buildOTelSpanContext("not-a-uuid-at-all-zzzzzzzzzzzzzzzz", "also-not-hex-zzzzzzzz")
+		if ok {
+			t.Error("expected false for non-hex IDs")
+		}
+	})
+
+	t.Run("same UUID produces deterministic output", func(t *testing.T) {
+		traceID := "550e8400-e29b-41d4-a716-446655440000"
+		spanID := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+		sc1, _ := buildOTelSpanContext(traceID, spanID)
+		sc2, _ := buildOTelSpanContext(traceID, spanID)
+		if sc1.TraceID() != sc2.TraceID() {
+			t.Error("same input should produce same TraceID")
+		}
+		if sc1.SpanID() != sc2.SpanID() {
+			t.Error("same input should produce same SpanID")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// spanKindFor
+// ---------------------------------------------------------------------------
+
+func TestSpanKindFor(t *testing.T) {
+	tests := []struct {
+		name     string
+		spanName string
+		want     oteltrace.SpanKind
+	}{
+		{"llm prefix", "llm.completion", oteltrace.SpanKindClient},
+		{"backend prefix", "backend.query", oteltrace.SpanKindClient},
+		{"mcp prefix", "mcp.tool_call", oteltrace.SpanKindClient},
+		{"internal agent", "agent.step", oteltrace.SpanKindInternal},
+		{"internal generic", "my.custom.op", oteltrace.SpanKindInternal},
+		{"empty", "", oteltrace.SpanKindInternal},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := spanKindFor(tc.spanName)
+			if got != tc.want {
+				t.Errorf("spanKindFor(%q) = %v, want %v", tc.spanName, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// loomToGenAI attribute translation
+// ---------------------------------------------------------------------------
+
+func TestLoomToGenAIMappings(t *testing.T) {
+	expected := map[string]string{
+		// LLM span — required OTel GenAI spec attributes
+		"llm.provider":  "gen_ai.system",
+		"llm.model":     "gen_ai.request.model",
+		"llm.operation": "gen_ai.operation.name",
+		// Token usage
+		"llm.tokens.input":       "gen_ai.usage.input_tokens",
+		"llm.tokens.output":      "gen_ai.usage.output_tokens",
+		"llm.tokens.total":       "gen_ai.usage.total_tokens",
+		"llm.tokens.cache_read":  "gen_ai.usage.cache_read_input_tokens",
+		"llm.tokens.cache_write": "gen_ai.usage.cache_creation_input_tokens",
+		"llm.stop_reason":        "gen_ai.response.finish_reasons",
+		"llm.cost.usd":           "gen_ai.usage.cost",
+		// Input/Output columns (Opik + standard content representation)
+		"message.preview":  "gen_ai.prompt",
+		"response.preview": "gen_ai.completion",
+		// Conversation span token aggregates
+		"conversation.tokens.input":  "gen_ai.usage.input_tokens",
+		"conversation.tokens.output": "gen_ai.usage.output_tokens",
+		"conversation.tokens.total":  "gen_ai.usage.total_tokens",
+		"conversation.cost.usd":      "gen_ai.usage.cost",
+		"conversation.stop_reason":   "gen_ai.response.finish_reasons",
+		// Tool/MCP
+		"tool.name":     "gen_ai.tool.name",
+		"mcp.tool.name": "gen_ai.tool.name",
+		"mcp.tool.args": "gen_ai.tool.call.arguments",
+		// MCP server (OTel RPC semconv)
+		"mcp.server.name":    "server.address",
+		"mcp.server.version": "server.version",
+		// Agent identity (OTel GenAI agent semconv, draft)
+		"agent_id": "gen_ai.agent.id",
+		// Error / exception semconv
+		"error.message": "exception.message",
+		"error.type":    "exception.type",
+		"error.stack":   "exception.stacktrace",
+		// Session
+		"session.id": "session.id",
+		"user.id":    "user.id",
+	}
+	for loomKey, otelKey := range expected {
+		if got, ok := loomToGenAI[loomKey]; !ok || got != otelKey {
+			t.Errorf("loomToGenAI[%q] = %q, want %q", loomKey, got, otelKey)
+		}
+	}
+}
+
+func TestGenAISystemNormalization(t *testing.T) {
+	tests := []struct {
+		provider string
+		want     string
+	}{
+		{"anthropic", "anthropic"},        // already matches spec — no normalization
+		{"openai", "openai"},              // already matches spec
+		{"ollama", "ollama"},              // community convention, kept as-is
+		{"mistral", "mistral"},            // kept as-is
+		{"bedrock", "aws.bedrock"},        // normalized
+		{"azure-openai", "azure_openai"},  // normalized
+		{"gemini", "google.generative_ai"}, // normalized
+		{"huggingface", "hugging_face"},   // normalized
+	}
+	for _, tc := range tests {
+		t.Run(tc.provider, func(t *testing.T) {
+			got := tc.provider
+			if norm, ok := genAISystemNorm[tc.provider]; ok {
+				got = norm
+			}
+			if got != tc.want {
+				t.Errorf("normalize(%q) = %q, want %q", tc.provider, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// redactOTelSpan
+// ---------------------------------------------------------------------------
+
+func TestRedactOTelSpan(t *testing.T) {
+	t.Run("no redaction when both flags false", func(t *testing.T) {
+		span := &Span{Attributes: map[string]interface{}{
+			"password": "s3cr3t",
+			"email":    "user@example.com",
+		}}
+		out := redactOTelSpan(span, PrivacyConfig{})
+		if out.Attributes["password"] != "s3cr3t" {
+			t.Error("password should not be redacted when RedactCredentials=false")
+		}
+	})
+
+	t.Run("credential keys removed when RedactCredentials=true", func(t *testing.T) {
+		span := &Span{Attributes: map[string]interface{}{
+			"password":    "s3cr3t",
+			"api_key":     "key123",
+			"llm.model":   "claude-3",
+			"token":       "tok",
+			"access_token": "at",
+		}}
+		out := redactOTelSpan(span, PrivacyConfig{RedactCredentials: true})
+		for _, key := range []string{"password", "api_key", "token", "access_token"} {
+			if _, exists := out.Attributes[key]; exists {
+				t.Errorf("expected %q to be removed", key)
+			}
+		}
+		if _, ok := out.Attributes["llm.model"]; !ok {
+			t.Error("llm.model should not be removed")
+		}
+	})
+
+	t.Run("PII redacted in string values when RedactPII=true", func(t *testing.T) {
+		span := &Span{Attributes: map[string]interface{}{
+			"user.query": "My email is john@example.com and SSN 123-45-6789",
+		}}
+		out := redactOTelSpan(span, PrivacyConfig{RedactPII: true})
+		val, _ := out.Attributes["user.query"].(string)
+		if strings.Contains(val, "john@example.com") {
+			t.Error("email should be redacted")
+		}
+		if strings.Contains(val, "123-45-6789") {
+			t.Error("SSN should be redacted")
+		}
+	})
+
+	t.Run("AllowedAttributes skip redaction", func(t *testing.T) {
+		span := &Span{Attributes: map[string]interface{}{
+			"session.id": "session@special",
+			"password":   "s3cr3t",
+		}}
+		cfg := PrivacyConfig{
+			RedactCredentials: true,
+			RedactPII:         true,
+			AllowedAttributes: []string{"session.id"},
+		}
+		out := redactOTelSpan(span, cfg)
+		if out.Attributes["session.id"] != "session@special" {
+			t.Error("allowlisted attribute should not be redacted")
+		}
+		if _, exists := out.Attributes["password"]; exists {
+			t.Error("password should be removed")
+		}
+	})
+
+	t.Run("PII redacted in event attributes", func(t *testing.T) {
+		span := &Span{
+			Attributes: map[string]interface{}{},
+			Events: []Event{
+				{
+					Name:      "tool.result",
+					Timestamp: time.Now(),
+					Attributes: map[string]interface{}{
+						"content": "Contact: user@test.org",
+					},
+				},
+			},
+		}
+		out := redactOTelSpan(span, PrivacyConfig{RedactPII: true})
+		if strings.Contains(out.Events[0].Attributes["content"].(string), "user@test.org") {
+			t.Error("email in event attribute should be redacted")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// NewOTelTracer validation
+// ---------------------------------------------------------------------------
+
+func TestNewOTelTracerValidation(t *testing.T) {
+	t.Run("returns error for empty endpoint", func(t *testing.T) {
+		_, err := NewOTelTracer(OTelConfig{})
+		if err == nil {
+			t.Fatal("expected error for empty endpoint")
+		}
+		if !strings.Contains(err.Error(), "otlp_endpoint") {
+			t.Errorf("error should mention otlp_endpoint, got: %v", err)
+		}
+	})
+
+	t.Run("creates tracer with valid endpoint", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		tr, err := NewOTelTracer(OTelConfig{
+			Endpoint:    srv.URL,
+			ServiceName: "test-svc",
+			Insecure:    true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		_ = tr.Shutdown(context.Background())
+	})
+}
+
+// ---------------------------------------------------------------------------
+// StartSpan / EndSpan round-trip
+// ---------------------------------------------------------------------------
+
+func TestOTelTracerStartEndSpan(t *testing.T) {
+	var requestCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tr, err := NewOTelTracer(OTelConfig{
+		Endpoint:    srv.URL,
+		ServiceName: "test",
+		Insecure:    true,
+	})
+	if err != nil {
+		t.Fatalf("NewOTelTracer: %v", err)
+	}
+	defer tr.Shutdown(context.Background())
+
+	t.Run("StartSpan returns non-nil span and context", func(t *testing.T) {
+		ctx, span := tr.StartSpan(context.Background(), "llm.completion")
+		if span == nil {
+			t.Fatal("span should not be nil")
+		}
+		if span.Name != "llm.completion" {
+			t.Errorf("span name = %q, want %q", span.Name, "llm.completion")
+		}
+		if span.TraceID == "" {
+			t.Error("trace ID should be set")
+		}
+		if SpanFromContext(ctx) == nil {
+			t.Error("span should be stored in context")
+		}
+		tr.EndSpan(span)
+	})
+
+	t.Run("EndSpan removes span from activeSpans", func(t *testing.T) {
+		_, span := tr.StartSpan(context.Background(), "backend.query")
+		spanID := span.SpanID
+
+		// Should be in activeSpans after Start.
+		if _, ok := tr.activeSpans.Load(spanID); !ok {
+			t.Error("span should be in activeSpans after StartSpan")
+		}
+
+		tr.EndSpan(span)
+
+		// Should be removed after End.
+		if _, ok := tr.activeSpans.Load(spanID); ok {
+			t.Error("span should be removed from activeSpans after EndSpan")
+		}
+	})
+
+	t.Run("EndSpan nil is a no-op", func(t *testing.T) {
+		// Should not panic.
+		tr.EndSpan(nil)
+	})
+
+	t.Run("parent-child span links via context", func(t *testing.T) {
+		parentCtx, parent := tr.StartSpan(context.Background(), "agent.step")
+		_, child := tr.StartSpan(parentCtx, "llm.completion")
+
+		if child.TraceID != parent.TraceID {
+			t.Errorf("child should inherit parent TraceID: got %q, want %q", child.TraceID, parent.TraceID)
+		}
+		if child.ParentID != parent.SpanID {
+			t.Errorf("child ParentID = %q, want %q", child.ParentID, parent.SpanID)
+		}
+
+		tr.EndSpan(child)
+		tr.EndSpan(parent)
+	})
+
+	t.Run("span attributes set before EndSpan are exported", func(t *testing.T) {
+		_, span := tr.StartSpan(context.Background(), "llm.completion")
+		span.SetAttribute("llm.model", "claude-3-sonnet")
+		span.SetAttribute("llm.tokens.input", int64(150))
+		span.SetAttribute("llm.tokens.output", int64(50))
+		tr.EndSpan(span)
+	})
+
+	t.Run("Flush triggers export", func(t *testing.T) {
+		_, span := tr.StartSpan(context.Background(), "llm.completion")
+		tr.EndSpan(span)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := tr.Flush(ctx); err != nil {
+			t.Errorf("Flush returned error: %v", err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// OTelConfig env resolution
+// ---------------------------------------------------------------------------
+
+func TestResolveOTelConfig(t *testing.T) {
+	t.Run("explicit values not overwritten by env", func(t *testing.T) {
+		cfg := resolveOTelConfig(OTelConfig{
+			Endpoint:    "http://explicit:4318",
+			ServiceName: "my-service",
+		})
+		if cfg.Endpoint != "http://explicit:4318" {
+			t.Errorf("explicit endpoint should not be overridden, got %q", cfg.Endpoint)
+		}
+		if cfg.ServiceName != "my-service" {
+			t.Errorf("explicit service name should not be overridden, got %q", cfg.ServiceName)
+		}
+	})
+
+	t.Run("defaults applied for zero values", func(t *testing.T) {
+		cfg := resolveOTelConfig(OTelConfig{Endpoint: "http://localhost:4318"})
+		if cfg.Timeout == 0 {
+			t.Error("timeout default should be non-zero")
+		}
+		if cfg.MaxBatchSize == 0 {
+			t.Error("max batch size default should be non-zero")
+		}
+		if cfg.FlushInterval == 0 {
+			t.Error("flush interval default should be non-zero")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Interface compliance
+// ---------------------------------------------------------------------------
+
+func TestOTelTracerImplementsTracer(t *testing.T) {
+	var _ Tracer = (*OTelTracer)(nil) // compile-time check duplicated for clarity
+}

--- a/pkg/observability/otel_test.go
+++ b/pkg/observability/otel_test.go
@@ -328,7 +328,11 @@ func TestOTelTracerStartEndSpan(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewOTelTracer: %v", err)
 	}
-	defer tr.Shutdown(context.Background())
+	defer func() {
+		if err := tr.Shutdown(context.Background()); err != nil {
+			t.Errorf("Shutdown: %v", err)
+		}
+	}()
 
 	t.Run("StartSpan returns non-nil span and context", func(t *testing.T) {
 		ctx, span := tr.StartSpan(context.Background(), "llm.completion")

--- a/pkg/observability/otel_test.go
+++ b/pkg/observability/otel_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
@@ -492,4 +494,122 @@ func TestResolveOTelConfig(t *testing.T) {
 
 func TestOTelTracerImplementsTracer(t *testing.T) {
 	var _ Tracer = (*OTelTracer)(nil) // compile-time check duplicated for clarity
+}
+
+// ---------------------------------------------------------------------------
+// Parent-child span linkage (regression for blocking bug reported in review)
+// ---------------------------------------------------------------------------
+
+// newInMemoryOTelTracer builds an OTelTracer backed by an InMemoryExporter so
+// exported spans can be inspected without a live OTLP collector.
+func newInMemoryOTelTracer(t *testing.T) (*OTelTracer, *tracetest.InMemoryExporter) {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(exp), // synchronous export so spans are available immediately
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+	return &OTelTracer{
+		provider: provider,
+		tracer:   provider.Tracer("loom"),
+		privacy:  PrivacyConfig{},
+	}, exp
+}
+
+// TestParentChildSameTrace verifies that a child span exported by OTelTracer
+// shares the same TraceID as its parent and correctly references the parent's
+// SpanID — not a UUID-derived orphan.
+func TestParentChildSameTrace(t *testing.T) {
+	tr, exp := newInMemoryOTelTracer(t)
+
+	// Start parent span and keep it active while the child is created.
+	// (EndSpan removes the parent from activeSpans — the child must be started
+	//  before the parent ends so the live OTel span is still available.)
+	ctx, parent := tr.StartSpan(context.Background(), "parent.op")
+
+	// Start child with the parent context while parent is still active.
+	_, child := tr.StartSpan(ctx, "child.op")
+	tr.EndSpan(child)
+	tr.EndSpan(parent)
+
+	// Force sync flush.
+	if err := tr.Flush(context.Background()); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	spans := exp.GetSpans()
+	if len(spans) != 2 {
+		t.Fatalf("expected 2 exported spans, got %d", len(spans))
+	}
+
+	// Map by operation name for clarity.
+	byName := make(map[string]tracetest.SpanStub, 2)
+	for _, s := range spans {
+		byName[s.Name] = s
+	}
+
+	parentStub, ok := byName["parent.op"]
+	if !ok {
+		t.Fatal("parent.op span not found in exported spans")
+	}
+	childStub, ok := byName["child.op"]
+	if !ok {
+		t.Fatal("child.op span not found in exported spans")
+	}
+
+	// Both must share the same TraceID.
+	if parentStub.SpanContext.TraceID() != childStub.SpanContext.TraceID() {
+		t.Errorf("trace ID mismatch: parent=%s child=%s — child was orphaned into a separate trace",
+			parentStub.SpanContext.TraceID(), childStub.SpanContext.TraceID())
+	}
+
+	// Child must reference parent's SDK-assigned SpanID, not a UUID-derived one.
+	if childStub.Parent.SpanID() != parentStub.SpanContext.SpanID() {
+		t.Errorf("parent span ID mismatch: child.ParentSpanID=%s parent.SpanID=%s",
+			childStub.Parent.SpanID(), parentStub.SpanContext.SpanID())
+	}
+}
+
+// TestThreeGenerationChain verifies the fix holds for a three-level A → B → C chain.
+func TestThreeGenerationChain(t *testing.T) {
+	tr, exp := newInMemoryOTelTracer(t)
+
+	ctxA, spanA := tr.StartSpan(context.Background(), "A")
+	ctxB, spanB := tr.StartSpan(ctxA, "B")
+	_, spanC := tr.StartSpan(ctxB, "C")
+	tr.EndSpan(spanC)
+	tr.EndSpan(spanB)
+	tr.EndSpan(spanA)
+
+	if err := tr.Flush(context.Background()); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	spans := exp.GetSpans()
+	if len(spans) != 3 {
+		t.Fatalf("expected 3 exported spans, got %d", len(spans))
+	}
+
+	byName := make(map[string]tracetest.SpanStub, 3)
+	for _, s := range spans {
+		byName[s.Name] = s
+	}
+
+	traceID := byName["A"].SpanContext.TraceID()
+	for _, name := range []string{"A", "B", "C"} {
+		if byName[name].SpanContext.TraceID() != traceID {
+			t.Errorf("span %q has different TraceID %s; want %s",
+				name, byName[name].SpanContext.TraceID(), traceID)
+		}
+	}
+
+	if byName["B"].Parent.SpanID() != byName["A"].SpanContext.SpanID() {
+		t.Errorf("B.ParentSpanID=%s != A.SpanID=%s",
+			byName["B"].Parent.SpanID(), byName["A"].SpanContext.SpanID())
+	}
+	if byName["C"].Parent.SpanID() != byName["B"].SpanContext.SpanID() {
+		t.Errorf("C.ParentSpanID=%s != B.SpanID=%s",
+			byName["C"].Parent.SpanID(), byName["B"].SpanContext.SpanID())
+	}
 }

--- a/pkg/observability/otel_test.go
+++ b/pkg/observability/otel_test.go
@@ -489,6 +489,73 @@ func TestResolveOTelConfig(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// resolveOTLPEndpointEnv — OTel spec semantics for the two standard env vars
+// ---------------------------------------------------------------------------
+
+func TestResolveOTLPEndpointEnv(t *testing.T) {
+	clearOTLPEnv := func(t *testing.T) {
+		t.Helper()
+		t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+		t.Setenv("LOOM_OTLP_ENDPOINT", "")
+	}
+
+	t.Run("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT used verbatim", func(t *testing.T) {
+		clearOTLPEnv(t)
+		t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://collector:4318/v1/traces")
+		got := resolveOTLPEndpointEnv()
+		if got != "http://collector:4318/v1/traces" {
+			t.Errorf("expected verbatim traces endpoint, got %q", got)
+		}
+	})
+
+	t.Run("OTEL_EXPORTER_OTLP_ENDPOINT gets /v1/traces appended (OTel spec)", func(t *testing.T) {
+		clearOTLPEnv(t)
+		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+		got := resolveOTLPEndpointEnv()
+		if got != "http://localhost:4318/v1/traces" {
+			t.Errorf("expected /v1/traces appended, got %q", got)
+		}
+	})
+
+	t.Run("OTEL_EXPORTER_OTLP_ENDPOINT trailing slash stripped before append", func(t *testing.T) {
+		clearOTLPEnv(t)
+		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318/")
+		got := resolveOTLPEndpointEnv()
+		if got != "http://localhost:4318/v1/traces" {
+			t.Errorf("expected clean /v1/traces path, got %q", got)
+		}
+	})
+
+	t.Run("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT takes priority over base var", func(t *testing.T) {
+		clearOTLPEnv(t)
+		t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://traces-only:4318/v1/traces")
+		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://base:4318")
+		got := resolveOTLPEndpointEnv()
+		if got != "http://traces-only:4318/v1/traces" {
+			t.Errorf("traces-specific var should win, got %q", got)
+		}
+	})
+
+	t.Run("LOOM_OTLP_ENDPOINT fallback used verbatim", func(t *testing.T) {
+		clearOTLPEnv(t)
+		t.Setenv("LOOM_OTLP_ENDPOINT", "http://loom-specific:4318/v1/traces")
+		got := resolveOTLPEndpointEnv()
+		if got != "http://loom-specific:4318/v1/traces" {
+			t.Errorf("expected LOOM_OTLP_ENDPOINT verbatim, got %q", got)
+		}
+	})
+
+	t.Run("empty when no env set", func(t *testing.T) {
+		clearOTLPEnv(t)
+		got := resolveOTLPEndpointEnv()
+		if got != "" {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
 // Interface compliance
 // ---------------------------------------------------------------------------
 

--- a/pkg/observability/otel_test.go
+++ b/pkg/observability/otel_test.go
@@ -165,14 +165,14 @@ func TestGenAISystemNormalization(t *testing.T) {
 		provider string
 		want     string
 	}{
-		{"anthropic", "anthropic"},        // already matches spec — no normalization
-		{"openai", "openai"},              // already matches spec
-		{"ollama", "ollama"},              // community convention, kept as-is
-		{"mistral", "mistral"},            // kept as-is
-		{"bedrock", "aws.bedrock"},        // normalized
-		{"azure-openai", "azure_openai"},  // normalized
+		{"anthropic", "anthropic"},         // already matches spec — no normalization
+		{"openai", "openai"},               // already matches spec
+		{"ollama", "ollama"},               // community convention, kept as-is
+		{"mistral", "mistral"},             // kept as-is
+		{"bedrock", "aws.bedrock"},         // normalized
+		{"azure-openai", "azure_openai"},   // normalized
 		{"gemini", "google.generative_ai"}, // normalized
-		{"huggingface", "hugging_face"},   // normalized
+		{"huggingface", "hugging_face"},    // normalized
 	}
 	for _, tc := range tests {
 		t.Run(tc.provider, func(t *testing.T) {
@@ -205,10 +205,10 @@ func TestRedactOTelSpan(t *testing.T) {
 
 	t.Run("credential keys removed when RedactCredentials=true", func(t *testing.T) {
 		span := &Span{Attributes: map[string]interface{}{
-			"password":    "s3cr3t",
-			"api_key":     "key123",
-			"llm.model":   "claude-3",
-			"token":       "tok",
+			"password":     "s3cr3t",
+			"api_key":      "key123",
+			"llm.model":    "claude-3",
+			"token":        "tok",
 			"access_token": "at",
 		}}
 		out := redactOTelSpan(span, PrivacyConfig{RedactCredentials: true})
@@ -389,10 +389,29 @@ func TestOTelTracerStartEndSpan(t *testing.T) {
 		span.SetAttribute("llm.model", "claude-3-sonnet")
 		span.SetAttribute("llm.tokens.input", int64(150))
 		span.SetAttribute("llm.tokens.output", int64(50))
+
+		// Verify attributes are recorded on the span before export.
+		if got, ok := span.Attributes["llm.model"].(string); !ok || got != "claude-3-sonnet" {
+			t.Errorf("span.Attributes[llm.model] = %v, want \"claude-3-sonnet\"", span.Attributes["llm.model"])
+		}
+		if got, ok := span.Attributes["llm.tokens.input"].(int64); !ok || got != 150 {
+			t.Errorf("span.Attributes[llm.tokens.input] = %v, want 150", span.Attributes["llm.tokens.input"])
+		}
+
+		countBefore := atomic.LoadInt32(&requestCount)
 		tr.EndSpan(span)
+		flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := tr.Flush(flushCtx); err != nil {
+			t.Errorf("Flush error: %v", err)
+		}
+		if atomic.LoadInt32(&requestCount) <= countBefore {
+			t.Error("expected at least one OTLP export request after EndSpan+Flush")
+		}
 	})
 
 	t.Run("Flush triggers export", func(t *testing.T) {
+		countBefore := atomic.LoadInt32(&requestCount)
 		_, span := tr.StartSpan(context.Background(), "llm.completion")
 		tr.EndSpan(span)
 
@@ -400,6 +419,9 @@ func TestOTelTracerStartEndSpan(t *testing.T) {
 		defer cancel()
 		if err := tr.Flush(ctx); err != nil {
 			t.Errorf("Flush returned error: %v", err)
+		}
+		if atomic.LoadInt32(&requestCount) <= countBefore {
+			t.Error("expected at least one OTLP export request after Flush")
 		}
 	})
 }
@@ -432,6 +454,30 @@ func TestResolveOTelConfig(t *testing.T) {
 		}
 		if cfg.FlushInterval == 0 {
 			t.Error("flush interval default should be non-zero")
+		}
+	})
+
+	t.Run("LOOM_OTLP_INSECURE env var enables insecure mode", func(t *testing.T) {
+		t.Setenv("LOOM_OTLP_INSECURE", "true")
+		cfg := resolveOTelConfig(OTelConfig{Endpoint: "http://localhost:4318"})
+		if !cfg.Insecure {
+			t.Error("Insecure should be true when LOOM_OTLP_INSECURE=true")
+		}
+	})
+
+	t.Run("LOOM_OTLP_INSECURE env unset leaves Insecure false", func(t *testing.T) {
+		t.Setenv("LOOM_OTLP_INSECURE", "")
+		cfg := resolveOTelConfig(OTelConfig{Endpoint: "http://localhost:4318"})
+		if cfg.Insecure {
+			t.Error("Insecure should remain false when LOOM_OTLP_INSECURE is not set")
+		}
+	})
+
+	t.Run("explicit Insecure=true not cleared by missing env", func(t *testing.T) {
+		t.Setenv("LOOM_OTLP_INSECURE", "")
+		cfg := resolveOTelConfig(OTelConfig{Endpoint: "http://localhost:4318", Insecure: true})
+		if !cfg.Insecure {
+			t.Error("explicit Insecure=true should not be cleared by resolveOTelConfig")
 		}
 	})
 }

--- a/pkg/observability/privacy.go
+++ b/pkg/observability/privacy.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package observability
+
+import "regexp"
+
+// PII redaction patterns (compiled once at package init).
+// Shared by HawkTracer and OTelTracer.
+var (
+	emailPattern      = regexp.MustCompile(`[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}`)
+	phonePattern      = regexp.MustCompile(`\b\d{3}[-.]?\d{3}[-.]?\d{4}\b`)
+	ssnPattern        = regexp.MustCompile(`\b\d{3}-\d{2}-\d{4}\b`)
+	creditCardPattern = regexp.MustCompile(`\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b`)
+)


### PR DESCRIPTION
## Summary

- Adds `OTelTracer` that exports Loom spans to any OTLP HTTP endpoint (Opik, Jaeger, Tempo, Grafana) via a single config change — no code changes required to switch backends
- Follows OTel GenAI semantic conventions v1.34+ throughout: `gen_ai.system`, `gen_ai.operation.name`, `gen_ai.usage.*`, `gen_ai.prompt`, `gen_ai.completion`
- Tested end-to-end with self-hosted Opik + AWS Bedrock (`us.anthropic.claude-sonnet-4-5`)

## What's included

**New packages / files**
- `pkg/observability/otel.go` — `OTelTracer` with `sync.Map` span pairing, `filteringSpanProcessor` to suppress infrastructure noise
- `pkg/observability/otel_attrs.go` — full Loom → `gen_ai.*` attribute translation + `gen_ai.system` normalization (`bedrock`→`aws.bedrock`, `gemini`→`google.generative_ai`, etc.)
- `pkg/observability/otel_config.go` — `OTelConfig` with env-var resolution (`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `OTEL_SERVICE_NAME`, etc.)
- `pkg/observability/privacy.go` — PII/credential redaction shared between Hawk and OTel tracers
- `pkg/observability/otel_test.go` — 22+ test cases (attribute mapping, normalization, redaction, filtering, span context)
- `examples/config/otlp-opik.yaml` — ready-to-use config for Bedrock + self-hosted Opik
- `docs/architecture/otlp-integration.md` — architecture and configuration reference

**Modified**
- `pkg/llm/instrumented_provider.go` — adds `gen_ai.operation.name="chat"`, full prompt/completion text (`message.preview`, `response.preview`) on LLM spans; no truncation
- `pkg/agent/agent.go` — removes 100-char truncation from `message.preview`/`response.preview`
- `pkg/observability/auto_select.go` — adds `TracerModeOTel`, auto-activates when `otlp_endpoint` is set
- `pkg/observability/hawk.go` — extracts PII patterns to shared `privacy.go`
- `cmd/looms/config.go` — adds `otlp_endpoint`, `otlp_headers`, `otlp_insecure`, `otlp_include_spans`
- `cmd/looms/cmd_serve.go` — wires OTel mode, `service.version`, graceful `Flush`+`Shutdown` on exit
- `go.mod` — adds `go.opentelemetry.io/otel` v1.43.0 SDK dependencies

## Configuration

```yaml
observability:
  enabled: true
  mode: otel                   # or leave out — auto-activates when otlp_endpoint is set
  otlp_endpoint: "http://localhost:5173/api/v1/private/otel/v1/traces"
  otlp_insecure: true          # for local / self-hosted without TLS
  otlp_headers:
    Authorization: "Bearer <key>"   # optional
  otlp_include_spans:          # optional — suppress startup/storage noise
    - "llm."
    - "agent."
    - "tool."
    - "backend."
    - "mcp."
```

Or via environment:
```bash
export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4318/v1/traces
export OTEL_SERVICE_NAME=my-loom-service
```

## Test plan

- [ ] `go test -tags fts5 -race ./pkg/observability/...` passes
- [ ] `go test -tags fts5 -race ./pkg/llm/...` passes
- [ ] `go test -tags fts5 -race ./pkg/agent/...` passes
- [ ] Start server with `examples/config/otlp-opik.yaml`, send a chat message, verify in Opik:
  - `agent.chat` span has `gen_ai.prompt` (user message) and `gen_ai.completion` (answer)
  - `llm.completion` span has `gen_ai.prompt` (full prompt sent to model) and `gen_ai.completion` (model response)
  - Token counts and cost visible on both spans
  - No startup/migration spans in Opik trace list
- [ ] Stop server, verify no span loss (graceful flush log line appears)

🤖 Generated with [Claude Code](https://claude.com/claude-code)