### PR TITLE
feat(llm): add LiteLLM proxy provider

### DIFF
--- a/cmd/looms/cmd_serve.go
+++ b/cmd/looms/cmd_serve.go
@@ -45,6 +45,7 @@ import (
 	"github.com/teradata-labs/loom/pkg/llm/factory"
 	"github.com/teradata-labs/loom/pkg/llm/gemini"
 	"github.com/teradata-labs/loom/pkg/llm/huggingface"
+	"github.com/teradata-labs/loom/pkg/llm/litellm"
 	"github.com/teradata-labs/loom/pkg/llm/mistral"
 	"github.com/teradata-labs/loom/pkg/llm/ollama"
 	"github.com/teradata-labs/loom/pkg/llm/openai"
@@ -622,6 +623,25 @@ func createProviderWithRateLimit(cfg LLMConfig, logger *zap.Logger) (agent.LLMPr
 			RateLimiterConfig: rlCfg,
 		}), nil
 
+	case "litellm":
+		endpoint := cfg.LiteLLMEndpoint
+		if endpoint == "" {
+			endpoint = os.Getenv("LITELLM_ENDPOINT")
+		}
+		if endpoint == "" {
+			endpoint = os.Getenv("LITELLM_BASE_URL")
+		}
+		key := apiKey(cfg.LiteLLMAPIKey, "LITELLM_API_KEY")
+		return litellm.NewClient(litellm.Config{
+			Endpoint:          endpoint,
+			APIKey:            key,
+			Model:             cfg.LiteLLMModel,
+			MaxTokens:         cfg.MaxTokens,
+			Temperature:       cfg.Temperature,
+			Timeout:           time.Duration(cfg.Timeout) * time.Second,
+			RateLimiterConfig: rlCfg,
+		}), nil
+
 	default:
 		return nil, fmt.Errorf("unsupported LLM provider: %s", cfg.Provider)
 	}
@@ -686,6 +706,11 @@ func getDefaultModelForProvider(cfg *Config) string {
 			return cfg.LLM.HuggingFaceModel
 		}
 		return "meta-llama/Llama-3.1-70B-Instruct"
+	case "litellm":
+		if cfg.LLM.LiteLLMModel != "" {
+			return cfg.LLM.LiteLLMModel
+		}
+		return litellm.DefaultModel
 	default:
 		return ""
 	}
@@ -836,8 +861,22 @@ func createLLMProviderFromProtoConfig(protoConfig *loomv1.LLMConfig, serverConfi
 			Timeout:     timeout,
 		}), nil
 
+	case "litellm":
+		model := protoConfig.Model
+		if model == "" {
+			model = serverConfig.LLM.LiteLLMModel
+		}
+		return litellm.NewClient(litellm.Config{
+			Endpoint:    serverConfig.LLM.LiteLLMEndpoint,
+			APIKey:      serverConfig.LLM.LiteLLMAPIKey,
+			Model:       model,
+			MaxTokens:   maxTokens,
+			Temperature: temperature,
+			Timeout:     timeout,
+		}), nil
+
 	default:
-		return nil, fmt.Errorf("unsupported LLM provider: %s (supported: anthropic, bedrock, ollama, openai, azure-openai, mistral, gemini, huggingface)", protoConfig.Provider)
+		return nil, fmt.Errorf("unsupported LLM provider: %s (supported: anthropic, bedrock, ollama, openai, azure-openai, mistral, gemini, huggingface, litellm)", protoConfig.Provider)
 	}
 }
 
@@ -1415,6 +1454,11 @@ func runServe(cmd *cobra.Command, args []string) {
 		// HuggingFace
 		HuggingFaceToken: config.LLM.HuggingFaceToken,
 		HuggingFaceModel: config.LLM.HuggingFaceModel,
+
+		// LiteLLM
+		LiteLLMEndpoint: config.LLM.LiteLLMEndpoint,
+		LiteLLMAPIKey:   config.LLM.LiteLLMAPIKey,
+		LiteLLMModel:    config.LLM.LiteLLMModel,
 
 		// Common settings
 		MaxTokens:       config.LLM.MaxTokens,

--- a/cmd/looms/config.go
+++ b/cmd/looms/config.go
@@ -339,6 +339,11 @@ type LLMConfig struct {
 	HuggingFaceToken string `mapstructure:"huggingface_token"` // From CLI/env/keyring only
 	HuggingFaceModel string `mapstructure:"huggingface_model"`
 
+	// LiteLLM-specific
+	LiteLLMEndpoint string `mapstructure:"litellm_endpoint"`
+	LiteLLMAPIKey   string `mapstructure:"litellm_api_key"` // From CLI/env/keyring only
+	LiteLLMModel    string `mapstructure:"litellm_model"`
+
 	// Common generation parameters
 	Temperature float64 `mapstructure:"temperature"`
 	MaxTokens   int     `mapstructure:"max_tokens"`
@@ -1630,8 +1635,11 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("huggingface token is required (set LOOM_LLM_HUGGINGFACE_TOKEN, HUGGINGFACE_API_KEY, or save to keyring with 'looms config set-key huggingface_token')")
 		}
 
+	case "litellm":
+		// endpoint and API key are optional — defaults apply
+
 	default:
-		return fmt.Errorf("unsupported LLM provider: %s (must be anthropic, bedrock, ollama, openai, azure-openai, mistral, gemini, or huggingface)", c.LLM.Provider)
+		return fmt.Errorf("unsupported LLM provider: %s (must be anthropic, bedrock, ollama, openai, azure-openai, mistral, gemini, huggingface, or litellm)", c.LLM.Provider)
 	}
 
 	// Validate storage config
@@ -1838,6 +1846,11 @@ llm:
   # HuggingFace configuration
   huggingface_model: meta-llama/Meta-Llama-3.1-70B-Instruct
   # huggingface_token: set via keyring (looms config set-key huggingface_token)
+
+  # LiteLLM proxy configuration
+  # litellm_endpoint: http://litellm:4000/v1/chat/completions
+  # litellm_model: anthropic/claude-sonnet-4-5-20250929
+  # litellm_api_key: set via keyring (looms config set-key litellm_api_key)
 
   # Common generation parameters (apply to all providers)
   temperature: 1.0

--- a/pkg/llm/factory/factory.go
+++ b/pkg/llm/factory/factory.go
@@ -24,6 +24,7 @@ import (
 	"github.com/teradata-labs/loom/pkg/llm/catalog"
 	"github.com/teradata-labs/loom/pkg/llm/gemini"
 	"github.com/teradata-labs/loom/pkg/llm/huggingface"
+	"github.com/teradata-labs/loom/pkg/llm/litellm"
 	"github.com/teradata-labs/loom/pkg/llm/mistral"
 	"github.com/teradata-labs/loom/pkg/llm/ollama"
 	"github.com/teradata-labs/loom/pkg/llm/openai"
@@ -84,6 +85,11 @@ type FactoryConfig struct {
 	// HuggingFace configuration
 	HuggingFaceToken string
 	HuggingFaceModel string
+
+	// LiteLLM configuration
+	LiteLLMEndpoint string
+	LiteLLMAPIKey   string
+	LiteLLMModel    string
 
 	// Common settings
 	MaxTokens       int
@@ -151,6 +157,8 @@ func (f *ProviderFactory) CreateProvider(provider, model string) (interface{}, e
 		return f.createGeminiProvider(model)
 	case "huggingface":
 		return f.createHuggingFaceProvider(model)
+	case "litellm":
+		return f.createLiteLLMProvider(model)
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", provider)
 	}
@@ -384,6 +392,34 @@ func (f *ProviderFactory) createHuggingFaceProvider(model string) (interface{}, 
 		Token:       token,
 		Model:       model,
 		MaxTokens:   f.resolveMaxOutput("huggingface", model),
+		Temperature: f.config.Temperature,
+		Timeout:     time.Duration(f.config.Timeout) * time.Second,
+	}), nil
+}
+
+func (f *ProviderFactory) createLiteLLMProvider(model string) (interface{}, error) {
+	endpoint := f.config.LiteLLMEndpoint
+	if endpoint == "" {
+		endpoint = os.Getenv("LITELLM_ENDPOINT")
+	}
+	if endpoint == "" {
+		endpoint = os.Getenv("LITELLM_BASE_URL")
+	}
+
+	apiKey := f.config.LiteLLMAPIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("LITELLM_API_KEY")
+	}
+
+	if model == "" {
+		model = f.config.LiteLLMModel
+	}
+
+	return litellm.NewClient(litellm.Config{
+		Endpoint:    endpoint,
+		APIKey:      apiKey,
+		Model:       model,
+		MaxTokens:   f.resolveMaxOutput("litellm", model),
 		Temperature: f.config.Temperature,
 		Timeout:     time.Duration(f.config.Timeout) * time.Second,
 	}), nil

--- a/pkg/llm/factory/factory_litellm_test.go
+++ b/pkg/llm/factory/factory_litellm_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package factory
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/teradata-labs/loom/pkg/llm/litellm"
+)
+
+// TestCreateLiteLLMProvider_FromConfig verifies that explicit config values are
+// used to construct the client and that the provider is always available (no
+// required credentials unlike Anthropic/OpenAI).
+func TestCreateLiteLLMProvider_FromConfig(t *testing.T) {
+	f := NewProviderFactory(FactoryConfig{
+		LiteLLMEndpoint: "http://litellm:4000",
+		LiteLLMAPIKey:   "sk-test",
+		LiteLLMModel:    "anthropic/claude-sonnet-4-5-20250929",
+		Temperature:     1.0,
+	})
+
+	raw, err := f.createLiteLLMProvider("anthropic/claude-sonnet-4-5-20250929")
+	require.NoError(t, err)
+
+	client, ok := raw.(*litellm.Client)
+	require.True(t, ok, "expected *litellm.Client")
+	assert.Equal(t, "litellm", client.Name())
+	assert.Equal(t, "anthropic/claude-sonnet-4-5-20250929", client.Model())
+}
+
+// TestCreateLiteLLMProvider_DefaultModel verifies that the default model is
+// applied when no model is specified.
+func TestCreateLiteLLMProvider_DefaultModel(t *testing.T) {
+	f := NewProviderFactory(FactoryConfig{
+		LiteLLMEndpoint: "http://litellm:4000",
+	})
+
+	raw, err := f.createLiteLLMProvider("")
+	require.NoError(t, err)
+
+	client, ok := raw.(*litellm.Client)
+	require.True(t, ok)
+	assert.Equal(t, litellm.DefaultModel, client.Model())
+}
+
+// TestCreateLiteLLMProvider_FromEnv verifies that the LITELLM_ENDPOINT and
+// LITELLM_API_KEY environment variables are used as fallbacks.
+func TestCreateLiteLLMProvider_FromEnv(t *testing.T) {
+	t.Setenv("LITELLM_ENDPOINT", "http://env-litellm:4000")
+	t.Setenv("LITELLM_API_KEY", "sk-env")
+
+	f := NewProviderFactory(FactoryConfig{})
+
+	raw, err := f.createLiteLLMProvider("azure/gpt-4o")
+	require.NoError(t, err)
+
+	client, ok := raw.(*litellm.Client)
+	require.True(t, ok)
+	assert.Equal(t, "azure/gpt-4o", client.Model())
+}
+
+// TestCreateLiteLLMProvider_BaseURLEnvFallback verifies LITELLM_BASE_URL is
+// used when LITELLM_ENDPOINT is not set.
+func TestCreateLiteLLMProvider_BaseURLEnvFallback(t *testing.T) {
+	os.Unsetenv("LITELLM_ENDPOINT")
+	t.Setenv("LITELLM_BASE_URL", "http://base-url-litellm:4000")
+	defer os.Unsetenv("LITELLM_BASE_URL")
+
+	f := NewProviderFactory(FactoryConfig{})
+
+	raw, err := f.createLiteLLMProvider("")
+	require.NoError(t, err)
+	assert.NotNil(t, raw)
+}
+
+// TestCreateProvider_LiteLLM verifies that the generic CreateProvider dispatcher
+// routes to the litellm factory correctly.
+func TestCreateProvider_LiteLLM(t *testing.T) {
+	f := NewProviderFactory(FactoryConfig{
+		LiteLLMEndpoint: "http://litellm:4000",
+		LiteLLMModel:    "ollama/llama3.2",
+	})
+
+	raw, err := f.CreateProvider("litellm", "ollama/llama3.2")
+	require.NoError(t, err)
+
+	client, ok := raw.(*litellm.Client)
+	require.True(t, ok)
+	assert.Equal(t, "ollama/llama3.2", client.Model())
+}
+
+// TestIsProviderAvailable_LiteLLM verifies that IsProviderAvailable returns
+// true for litellm (no mandatory credentials).
+func TestIsProviderAvailable_LiteLLM(t *testing.T) {
+	f := NewProviderFactory(FactoryConfig{})
+	assert.True(t, f.IsProviderAvailable("litellm"))
+}
+
+// TestCreateLiteLLMProvider_MaxTokensOverride verifies that an explicit MaxTokens
+// value in the config overrides the catalog default.
+func TestCreateLiteLLMProvider_MaxTokensOverride(t *testing.T) {
+	f := NewProviderFactory(FactoryConfig{
+		LiteLLMEndpoint: "http://litellm:4000",
+		MaxTokens:       512,
+	})
+
+	raw, err := f.createLiteLLMProvider("")
+	require.NoError(t, err)
+	require.NotNil(t, raw)
+	// We can only assert it doesn't error; the inner token value is encapsulated
+	// inside the openai.Client delegate and not exposed publicly.
+}

--- a/pkg/llm/factory/factory_litellm_test.go
+++ b/pkg/llm/factory/factory_litellm_test.go
@@ -14,7 +14,6 @@
 package factory
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -76,9 +75,8 @@ func TestCreateLiteLLMProvider_FromEnv(t *testing.T) {
 // TestCreateLiteLLMProvider_BaseURLEnvFallback verifies LITELLM_BASE_URL is
 // used when LITELLM_ENDPOINT is not set.
 func TestCreateLiteLLMProvider_BaseURLEnvFallback(t *testing.T) {
-	os.Unsetenv("LITELLM_ENDPOINT")
+	t.Setenv("LITELLM_ENDPOINT", "") // ensure LITELLM_ENDPOINT is unset for this test
 	t.Setenv("LITELLM_BASE_URL", "http://base-url-litellm:4000")
-	defer os.Unsetenv("LITELLM_BASE_URL")
 
 	f := NewProviderFactory(FactoryConfig{})
 

--- a/pkg/llm/litellm/client.go
+++ b/pkg/llm/litellm/client.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package litellm provides an LLM provider that routes requests through a
+// LiteLLM proxy (https://litellm.ai). The proxy exposes an OpenAI-compatible
+// /chat/completions endpoint and forwards requests to any upstream provider
+// (Anthropic, Bedrock, Azure, Gemini, Ollama, …) based on the model name.
+//
+// Configuration example (looms.yaml):
+//
+//	llm:
+//	  provider: litellm
+//	  litellm_endpoint: http://litellm:4000/v1/chat/completions
+//	  litellm_model: anthropic/claude-sonnet-4-5-20250929
+//	  litellm_api_key: sk-...   # optional – set via LITELLM_API_KEY env var
+package litellm
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/teradata-labs/loom/pkg/llm"
+	"github.com/teradata-labs/loom/pkg/llm/openai"
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+	"github.com/teradata-labs/loom/pkg/types"
+)
+
+const (
+	// DefaultEndpoint is the default LiteLLM proxy address when running
+	// in-cluster via the standard Kubernetes service name.
+	DefaultEndpoint    = "http://litellm:4000/v1/chat/completions"
+	DefaultModel       = "anthropic/claude-sonnet-4-5-20250929"
+	DefaultTimeout     = 120 * time.Second
+	DefaultMaxTokens   = 4096
+	DefaultTemperature = 1.0
+)
+
+// Config holds configuration for the LiteLLM client.
+type Config struct {
+	// Endpoint is the full URL of the LiteLLM proxy chat-completions endpoint.
+	// Defaults to http://litellm:4000/v1/chat/completions.
+	Endpoint string
+
+	// APIKey is the LiteLLM virtual key (LITELLM_API_KEY). Optional when the
+	// proxy is configured to allow unauthenticated requests.
+	APIKey string
+
+	// Model is the LiteLLM model routing string, e.g.
+	//   "anthropic/claude-sonnet-4-5-20250929"
+	//   "azure/gpt-4o-deployment"
+	//   "bedrock/anthropic.claude-3-5-sonnet"
+	//   "ollama/llama3.2"
+	Model string
+
+	MaxTokens   int
+	Temperature float64
+	Timeout     time.Duration
+
+	RateLimiterConfig llm.RateLimiterConfig
+}
+
+// Client implements types.LLMProvider and types.StreamingLLMProvider by
+// delegating to an openai.Client pointed at the LiteLLM proxy endpoint.
+type Client struct {
+	inner *openai.Client
+	model string
+}
+
+// NewClient creates a new LiteLLM client.
+//
+// The Endpoint may be either a full chat-completions URL
+// (http://host:4000/v1/chat/completions) or a bare base URL
+// (http://host:4000 / http://host:4000/v1). The latter is what
+// avmo-tera-cloud injects via LOOM_LLM_LITELLM_ENDPOINT — this function
+// normalises it to the full path automatically.
+func NewClient(cfg Config) *Client {
+	if cfg.Endpoint == "" {
+		cfg.Endpoint = DefaultEndpoint
+	} else {
+		cfg.Endpoint = normalizeEndpoint(cfg.Endpoint)
+	}
+	if cfg.Model == "" {
+		cfg.Model = DefaultModel
+	}
+	if cfg.Timeout == 0 {
+		cfg.Timeout = DefaultTimeout
+	}
+	if cfg.MaxTokens == 0 {
+		cfg.MaxTokens = DefaultMaxTokens
+	}
+	if cfg.Temperature == 0 {
+		cfg.Temperature = DefaultTemperature
+	}
+
+	inner := openai.NewClient(openai.Config{
+		APIKey:            cfg.APIKey,
+		Model:             cfg.Model,
+		Endpoint:          cfg.Endpoint,
+		Timeout:           cfg.Timeout,
+		MaxTokens:         cfg.MaxTokens,
+		Temperature:       cfg.Temperature,
+		RateLimiterConfig: cfg.RateLimiterConfig,
+	})
+
+	return &Client{inner: inner, model: cfg.Model}
+}
+
+// Name returns the provider identifier.
+func (c *Client) Name() string { return "litellm" }
+
+// Model returns the configured model routing string.
+func (c *Client) Model() string { return c.model }
+
+// Chat sends a conversation to the LiteLLM proxy and returns the response.
+func (c *Client) Chat(ctx context.Context, messages []types.Message, tools []shuttle.Tool) (*types.LLMResponse, error) {
+	return c.inner.Chat(ctx, messages, tools)
+}
+
+// ChatStream streams tokens from the LiteLLM proxy as they are generated.
+func (c *Client) ChatStream(ctx context.Context, messages []types.Message, tools []shuttle.Tool, tokenCallback llmtypes.TokenCallback) (*types.LLMResponse, error) {
+	return c.inner.ChatStream(ctx, messages, tools, tokenCallback)
+}
+
+// HealthCheck verifies the proxy is reachable via a minimal OPTIONS/GET probe.
+// Delegates to the inner openai.Client health check.
+func (c *Client) HealthCheck(ctx context.Context) error {
+	if hc, ok := any(c.inner).(interface {
+		HealthCheck(context.Context) error
+	}); ok {
+		return hc.HealthCheck(ctx)
+	}
+	return nil
+}
+
+// normalizeEndpoint ensures the endpoint is the full chat-completions path.
+// avmo-tera-cloud injects LOOM_LLM_LITELLM_ENDPOINT as a bare base URL
+// (e.g. "http://litellm:4000"), so we append the standard path when it is absent.
+func normalizeEndpoint(endpoint string) string {
+	endpoint = strings.TrimRight(endpoint, "/")
+	if strings.HasSuffix(endpoint, "/chat/completions") {
+		return endpoint
+	}
+	if strings.HasSuffix(endpoint, "/v1") {
+		return endpoint + "/chat/completions"
+	}
+	return endpoint + "/v1/chat/completions"
+}

--- a/pkg/llm/litellm/client_test.go
+++ b/pkg/llm/litellm/client_test.go
@@ -1,0 +1,248 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package litellm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+	"github.com/teradata-labs/loom/pkg/types"
+)
+
+// openAIChatResponse mirrors the subset of the OpenAI chat-completions response
+// that the inner openai.Client parses, sufficient for test assertions.
+type openAIChatResponse struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	Model   string `json:"model"`
+	Choices []struct {
+		Index   int `json:"index"`
+		Message struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"message"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+func writeChatResponse(w http.ResponseWriter, content string, inputTokens, outputTokens int) {
+	resp := openAIChatResponse{
+		ID:      "chatcmpl-test",
+		Object:  "chat.completion",
+		Created: 1700000000,
+		Model:   DefaultModel,
+	}
+	resp.Choices = []struct {
+		Index   int `json:"index"`
+		Message struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"message"`
+		FinishReason string `json:"finish_reason"`
+	}{
+		{
+			Index: 0,
+			Message: struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			}{Role: "assistant", Content: content},
+			FinishReason: "stop",
+		},
+	}
+	resp.Usage.PromptTokens = inputTokens
+	resp.Usage.CompletionTokens = outputTokens
+	resp.Usage.TotalTokens = inputTokens + outputTokens
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// newTestServer starts an httptest server that returns a fixed assistant message
+// for POST /v1/chat/completions requests.
+func newTestServer(t *testing.T, content string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/chat/completions", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+		writeChatResponse(w, content, 10, 5)
+	}))
+}
+
+// TestNormalizeEndpoint covers all URL normalisation branches.
+func TestNormalizeEndpoint(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"http://litellm:4000", "http://litellm:4000/v1/chat/completions"},
+		{"http://litellm:4000/", "http://litellm:4000/v1/chat/completions"},
+		{"http://litellm:4000/v1", "http://litellm:4000/v1/chat/completions"},
+		{"http://litellm:4000/v1/", "http://litellm:4000/v1/chat/completions"},
+		{"http://litellm:4000/v1/chat/completions", "http://litellm:4000/v1/chat/completions"},
+		{"http://litellm:4000/v1/chat/completions/", "http://litellm:4000/v1/chat/completions"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, normalizeEndpoint(tt.input))
+		})
+	}
+}
+
+// TestNewClient_Defaults verifies that zero-value Config fields get sensible defaults.
+func TestNewClient_Defaults(t *testing.T) {
+	c := NewClient(Config{})
+	assert.Equal(t, "litellm", c.Name())
+	assert.Equal(t, DefaultModel, c.Model())
+	assert.NotNil(t, c.inner)
+}
+
+// TestNewClient_CustomConfig verifies that explicit config values are respected.
+func TestNewClient_CustomConfig(t *testing.T) {
+	cfg := Config{
+		Endpoint:    "http://proxy:8080/v1",
+		APIKey:      "sk-test",
+		Model:       "ollama/llama3.2",
+		MaxTokens:   1024,
+		Temperature: 0.7,
+		Timeout:     30 * time.Second,
+	}
+	c := NewClient(cfg)
+	assert.Equal(t, "ollama/llama3.2", c.Model())
+	assert.Equal(t, "litellm", c.Name())
+}
+
+// TestClient_Chat_SimpleText verifies a successful round-trip for a plain text response.
+func TestClient_Chat_SimpleText(t *testing.T) {
+	srv := newTestServer(t, "Hello from LiteLLM!")
+	defer srv.Close()
+
+	c := NewClient(Config{
+		Endpoint: srv.URL,
+		Model:    DefaultModel,
+	})
+
+	resp, err := c.Chat(context.Background(), []types.Message{
+		{Role: "user", Content: "Hi"},
+	}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "Hello from LiteLLM!", resp.Content)
+	assert.NotEmpty(t, resp.StopReason)
+	assert.Equal(t, 10, resp.Usage.InputTokens)
+	assert.Equal(t, 5, resp.Usage.OutputTokens)
+	assert.Equal(t, 15, resp.Usage.TotalTokens)
+}
+
+// TestClient_Chat_MultiTurn verifies that multi-turn conversations are forwarded correctly.
+func TestClient_Chat_MultiTurn(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var reqBody struct {
+			Messages []struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"messages"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&reqBody))
+		assert.Len(t, reqBody.Messages, 3)
+		writeChatResponse(w, "Sure!", 20, 3)
+	}))
+	defer srv.Close()
+
+	c := NewClient(Config{Endpoint: srv.URL})
+	resp, err := c.Chat(context.Background(), []types.Message{
+		{Role: "user", Content: "What is 2+2?"},
+		{Role: "assistant", Content: "4"},
+		{Role: "user", Content: "And 3+3?"},
+	}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "Sure!", resp.Content)
+}
+
+// TestClient_Chat_ErrorResponse verifies that HTTP error status codes surface as errors.
+func TestClient_Chat_ErrorResponse(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{"bad request", http.StatusBadRequest},
+		{"unauthorized", http.StatusUnauthorized},
+		{"server error", http.StatusInternalServerError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(`{"error": "something went wrong"}`))
+			}))
+			defer srv.Close()
+
+			c := NewClient(Config{Endpoint: srv.URL})
+			_, err := c.Chat(context.Background(), []types.Message{{Role: "user", Content: "ping"}}, nil)
+			assert.Error(t, err)
+		})
+	}
+}
+
+// TestClient_HealthCheck_NoHealthChecker verifies that HealthCheck returns nil when the
+// inner client does not implement the optional interface (should not panic).
+func TestClient_HealthCheck_NoHealthChecker(t *testing.T) {
+	c := NewClient(Config{Endpoint: "http://localhost:4000"})
+	// HealthCheck either delegates or returns nil — must not panic.
+	_ = c.HealthCheck(context.Background())
+}
+
+// TestClient_ChatStream_SimpleText verifies streaming returns a valid response.
+func TestClient_ChatStream_SimpleText(t *testing.T) {
+	// The inner openai.Client streaming uses SSE; we return a non-streamed
+	// completion so the client falls back to the body, which is acceptable for
+	// unit-level coverage.
+	streamResp := `data: {"id":"x","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":null}]}` + "\n\n" +
+		`data: {"id":"x","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n" +
+		"data: [DONE]\n\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		_, _ = w.Write([]byte(streamResp))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Config{Endpoint: srv.URL, Model: DefaultModel})
+
+	var tokens []string
+	resp, err := c.ChatStream(context.Background(), []types.Message{
+		{Role: "user", Content: "Hi"},
+	}, nil, func(token string) {
+		tokens = append(tokens, token)
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Contains(t, resp.Content, "Hi")
+}
+
+// TestClient_ImplementsLLMProvider is a compile-time interface assertion.
+func TestClient_ImplementsLLMProvider(t *testing.T) {
+	var _ llmtypes.LLMProvider = (*Client)(nil)
+}


### PR DESCRIPTION
## Summary

- Adds a new `litellm` LLM provider that routes requests through a [LiteLLM proxy](https://litellm.ai) (OpenAI-compatible `/chat/completions` endpoint)
- Provider delegates to the existing `openai.Client` — streaming, tool-use, and rate-limiting all inherited with no duplication
- Endpoint auto-normalizes from bare base URL (`http://litellm:4000`) to full path (`/v1/chat/completions`), matching what avmo-tera-cloud injects via `LOOM_LLM_LITELLM_ENDPOINT`

## Configuration

```yaml
llm:
  provider: litellm
  litellm_endpoint: http://litellm:4000   # optional, defaults to http://litellm:4000/v1/chat/completions
  litellm_model: anthropic/claude-sonnet-4-5-20250929  # any LiteLLM routing string
  # litellm_api_key: set via LITELLM_API_KEY env var or keyring
```

## Files changed

| File | Change |
|---|---|
| `pkg/llm/litellm/client.go` | New provider wrapping `openai.Client` |
| `pkg/llm/factory/factory.go` | Register `litellm` in `ProviderFactory` |
| `cmd/looms/config.go` | `LiteLLMEndpoint/APIKey/Model` fields, validation, config template |
| `cmd/looms/cmd_serve.go` | Wire into `createProviderWithRateLimit`, model-defaulting, `createLLMProviderFromProtoConfig`, factory init |

## Test plan

- [x] `just build` — clean build
- [x] `looms serve` with `provider: litellm` starts up, all agents initialized with `provider=litellm` in preflight log
- [x] `POST /v1/weave:stream` completes full round-trip through mock LiteLLM proxy; response cost block confirms `"provider":"litellm"`
- [x] Bare base URL (`http://host:4000`) normalizes to `/v1/chat/completions` correctly
- [x] `LITELLM_BASE_URL` env var picked up as endpoint fallback
- [ ] Integration test against real LiteLLM proxy (requires running proxy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)