### PR TITLE
fix(agent): never compress the active user message out of L1

### DIFF
--- a/pkg/agent/memory_compressor.go
+++ b/pkg/agent/memory_compressor.go
@@ -88,12 +88,9 @@ func (c *LLMCompressor) simpleCompress(messages []Message) string {
 	for _, msg := range messages {
 		switch msg.Role {
 		case "user":
-			// Extract key terms from user queries
-			content := msg.Content
-			if len(content) > 60 {
-				content = content[:60] + "..."
-			}
-			parts = append(parts, fmt.Sprintf("User: %s", content))
+			// Preserve the user's question — truncating it loses the
+			// objective (issue #262).
+			parts = append(parts, fmt.Sprintf("User: %s", truncateForSummary(msg.Content, maxSummaryUserQueryChars)))
 		case "assistant":
 			// Assistant responses - extract tool usage or key facts
 			if c.containsToolCall(msg) {
@@ -156,11 +153,9 @@ func (c *SimpleCompressor) CompressMessages(ctx context.Context, messages []Mess
 	for _, msg := range messages {
 		switch msg.Role {
 		case "user":
-			content := msg.Content
-			if len(content) > 60 {
-				content = content[:60] + "..."
-			}
-			parts = append(parts, fmt.Sprintf("User: %s", content))
+			// Preserve the user's question — truncating it loses the
+			// objective (issue #262).
+			parts = append(parts, fmt.Sprintf("User: %s", truncateForSummary(msg.Content, maxSummaryUserQueryChars)))
 		case "assistant":
 			if len(msg.ToolCalls) > 0 {
 				parts = append(parts, "Agent executed tools")

--- a/pkg/agent/memory_compressor_test.go
+++ b/pkg/agent/memory_compressor_test.go
@@ -162,7 +162,9 @@ func TestLLMCompressor_SimpleCompress(t *testing.T) {
 		{
 			name: "long user message truncated",
 			messages: []Message{
-				{Role: "user", Content: strings.Repeat("This is a very long message that should be truncated. ", 5)},
+				// Must exceed maxSummaryUserQueryChars — user content below the
+				// cap is preserved verbatim (issue #262).
+				{Role: "user", Content: strings.Repeat("This is a very long message that should be truncated. ", 10)},
 			},
 			expected: []string{"User:", "..."},
 		},

--- a/pkg/agent/segmented_memory.go
+++ b/pkg/agent/segmented_memory.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
 	"github.com/teradata-labs/loom/pkg/observability"
@@ -366,28 +367,25 @@ func (sm *SegmentedMemory) AddMessage(ctx context.Context, msg Message) {
 		}
 
 		if toCompressCount > 0 {
-			// CRITICAL: Ensure tool_use/tool_result pairs stay together
-			// If compression boundary splits a tool pair, adjust to keep them together
-			toCompressCount = sm.adjustCompressionBoundary(toCompressCount)
-
 			// Track token count before compression
 			tokensBefore := sm.tokenCount
 
-			// Compress oldest messages to L2
-			toCompress := sm.l1Messages[:toCompressCount]
-			sm.l1Messages = sm.l1Messages[toCompressCount:]
+			// Compress oldest messages to L2, keeping the active user message
+			// pinned (evictL1Prefix also pair-adjusts the boundary).
+			toCompress := sm.evictL1Prefix(toCompressCount)
+			if len(toCompress) > 0 {
+				sm.compressToL2(ctx, toCompress)
+				// Recount only the layers that changed: L1 (shrunk) and L2 (grew)
+				sm.cachedL1Tokens = sm.tokenCounter.EstimateMessagesTokens(sm.l1Messages)
+				sm.cachedL2Tokens = sm.tokenCounter.CountTokens(sm.l2Summary)
+				sm.l1Dirty = false
+				sm.updateTokenCount()
+				sm.tokenCountDirty = false
 
-			sm.compressToL2(ctx, toCompress)
-			// Recount only the layers that changed: L1 (shrunk) and L2 (grew)
-			sm.cachedL1Tokens = sm.tokenCounter.EstimateMessagesTokens(sm.l1Messages)
-			sm.cachedL2Tokens = sm.tokenCounter.CountTokens(sm.l2Summary)
-			sm.l1Dirty = false
-			sm.updateTokenCount()
-			sm.tokenCountDirty = false
-
-			// Log compression event with token savings
-			tokensSaved := tokensBefore - sm.tokenCount
-			sm.logCompressionEvent(len(toCompress), tokensSaved)
+				// Log compression event with token savings
+				tokensSaved := tokensBefore - sm.tokenCount
+				sm.logCompressionEvent(len(toCompress), tokensSaved)
+			}
 		}
 	}
 }
@@ -398,6 +396,67 @@ func min(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// evictL1Prefix removes roughly the first toCompressCount messages from L1
+// and returns them for compression — except the most recent user message,
+// which is never evicted. That message is the active objective the agent is
+// still executing; compressing it mid-turn replaces the question with a short
+// summary and the agent loses the tail of its own task (issue #262). If the
+// pinned message falls inside the eviction window, the window widens by one
+// (so pinning never shrinks the batch) and the pinned message is spliced out
+// and kept at the head of L1, preserving the relative order of the remaining
+// messages. Splicing a user message out of the prefix cannot split a
+// tool_use/tool_result group; the boundary is pair-adjusted here via
+// adjustCompressionBoundary, so callers must not pre-adjust.
+// Returns nil when nothing can safely be evicted. Must hold lock.
+func (sm *SegmentedMemory) evictL1Prefix(toCompressCount int) []Message {
+	if toCompressCount <= 0 || len(sm.l1Messages) == 0 {
+		return nil
+	}
+	if toCompressCount > len(sm.l1Messages) {
+		toCompressCount = len(sm.l1Messages)
+	}
+
+	pinnedIdx := -1
+	for i := len(sm.l1Messages) - 1; i >= 0; i-- {
+		if sm.l1Messages[i].Role == "user" {
+			pinnedIdx = i
+			break
+		}
+	}
+
+	// The pinned message doesn't count toward the eviction batch — widen the
+	// window by one so pinning can't shrink the batch to nothing.
+	if pinnedIdx >= 0 && pinnedIdx < toCompressCount && toCompressCount < len(sm.l1Messages) {
+		toCompressCount++
+	}
+
+	// CRITICAL: Ensure tool_use/tool_result pairs stay together.
+	// If the eviction boundary splits a tool pair, adjust to keep them together.
+	toCompressCount = sm.adjustCompressionBoundary(toCompressCount)
+	if toCompressCount <= 0 {
+		return nil
+	}
+
+	if pinnedIdx < 0 || pinnedIdx >= toCompressCount {
+		// No user message, or the most recent one is outside the evicted
+		// prefix (an older user turn may still compress) — plain eviction.
+		toCompress := sm.l1Messages[:toCompressCount]
+		sm.l1Messages = sm.l1Messages[toCompressCount:]
+		return toCompress
+	}
+
+	// Splice the pinned message out of the prefix and keep it at the head of L1.
+	toCompress := make([]Message, 0, toCompressCount-1)
+	toCompress = append(toCompress, sm.l1Messages[:pinnedIdx]...)
+	toCompress = append(toCompress, sm.l1Messages[pinnedIdx+1:toCompressCount]...)
+
+	rest := make([]Message, 0, len(sm.l1Messages)-toCompressCount+1)
+	rest = append(rest, sm.l1Messages[pinnedIdx])
+	rest = append(rest, sm.l1Messages[toCompressCount:]...)
+	sm.l1Messages = rest
+	return toCompress
 }
 
 // adjustCompressionBoundary ensures tool_use/tool_result pairs stay together.
@@ -566,14 +625,11 @@ func (sm *SegmentedMemory) ReplayMessages(ctx context.Context, messages []Messag
 				break
 			}
 
-			toCompressCount = sm.adjustCompressionBoundary(toCompressCount)
-			if toCompressCount <= 0 {
-				break // adjustCompressionBoundary reduced to 0 — nothing safe to compress
-			}
-
 			tokensBefore := sm.tokenCount
-			toCompress := sm.l1Messages[:toCompressCount]
-			sm.l1Messages = sm.l1Messages[toCompressCount:]
+			toCompress := sm.evictL1Prefix(toCompressCount)
+			if len(toCompress) == 0 {
+				break // nothing safe to compress (pair boundary or pinned user message)
+			}
 			sm.compressToL2(ctx, toCompress)
 			sm.updateTokenCount()
 			sm.tokenCountDirty = false
@@ -918,8 +974,10 @@ func (sm *SegmentedMemory) summarizeMessages(messages []Message) string {
 		// Extract key information
 		switch msg.Role {
 		case "user":
-			// User queries
-			parts = append(parts, fmt.Sprintf("User asked about: %s", sm.extractKeywords(msg.Content)))
+			// User queries — preserve the question itself. The user's request is
+			// the highest-value, lowest-cost string in the context; reducing it
+			// to a keyword stub destroys the agent's objective (issue #262).
+			parts = append(parts, fmt.Sprintf("User asked about: %s", truncateForSummary(msg.Content, maxSummaryUserQueryChars)))
 		case "assistant":
 			// Assistant actions
 			if sm.containsToolCall(msg) {
@@ -943,13 +1001,25 @@ func (sm *SegmentedMemory) summarizeMessages(messages []Message) string {
 	return strings.Join(parts, "; ")
 }
 
-// extractKeywords pulls out key terms from text (simple heuristic)
-func (sm *SegmentedMemory) extractKeywords(text string) string {
-	// Simple keyword extraction - just take first 50 chars
-	if len(text) > 50 {
-		return text[:50] + "..."
+// maxSummaryUserQueryChars caps user message content preserved in compression
+// summaries. Generous on purpose: user questions are small, and losing their
+// tail loses the objective (issue #262 — a question truncated at 50 chars cut
+// `demo_user.telecocustomer` down to a table named "t"). Assistant/tool
+// content stays aggressively summarized — it is derivable from tool traces,
+// unlike the user's intent.
+const maxSummaryUserQueryChars = 500
+
+// truncateForSummary caps text at max bytes without splitting a UTF-8 rune,
+// appending "..." when truncated.
+func truncateForSummary(text string, max int) string {
+	if len(text) <= max {
+		return text
 	}
-	return text
+	cut := text[:max]
+	for len(cut) > 0 && !utf8.ValidString(cut) {
+		cut = cut[:len(cut)-1]
+	}
+	return cut + "..."
 }
 
 // containsToolCall checks if message contains tool execution.

--- a/pkg/agent/segmented_memory_pin_test.go
+++ b/pkg/agent/segmented_memory_pin_test.go
@@ -1,0 +1,218 @@
+// Copyright © 2026 Teradata Corporation - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+)
+
+// ter320Question mirrors the live failure from issue #262: byte 50 lands one
+// character into the table name, so the old 50-char summary stub reduced
+// `demo_user.telecocustomer` to a table named "t".
+const ter320Question = "/td-data-profile How many columns does demo_user.telecocustomer have and what are the data types?"
+
+// bigToolExchange builds an assistant tool_use + tool_result pair whose result
+// is large enough to drive L1 over its token budget within a few exchanges.
+func bigToolExchange(id string, repeats int) []Message {
+	return []Message{
+		{Role: "assistant", ToolCalls: []ToolCall{{ID: id, Name: "teradata_tool_call"}}},
+		{Role: "tool", ToolUseID: id, Content: strings.Repeat("row data ", repeats)},
+	}
+}
+
+// l1ContainsUserMessage reports whether L1 still holds the exact user message.
+func l1ContainsUserMessage(sm *SegmentedMemory, content string) bool {
+	for _, m := range sm.l1Messages {
+		if m.Role == "user" && m.Content == content {
+			return true
+		}
+	}
+	return false
+}
+
+// TestAddMessage_PinsActiveUserMessage is the issue #262 regression: a single
+// user question followed by large tool results must survive mid-turn L1
+// compression verbatim. No compressor is set, matching the production path
+// that fell back to summarizeMessages and destroyed the question.
+func TestAddMessage_PinsActiveUserMessage(t *testing.T) {
+	profile := ProfileDefaults[loomv1.WorkloadProfile_WORKLOAD_PROFILE_DATA_INTENSIVE]
+	sm := NewSegmentedMemoryWithCompression("rom", 10000, 1000, profile)
+	ctx := context.Background()
+
+	sm.AddMessage(ctx, Message{Role: "user", Content: ter320Question})
+	totalAdded := 1
+	for i := 0; i < 6; i++ {
+		for _, m := range bigToolExchange(fmt.Sprintf("tool_%d", i), 400) {
+			sm.AddMessage(ctx, m)
+			totalAdded++
+		}
+	}
+
+	require.NotEmpty(t, sm.l2Summary, "test setup must drive L1 compression")
+	require.Less(t, len(sm.l1Messages), totalAdded, "test setup must evict messages from L1")
+
+	assert.True(t, l1ContainsUserMessage(sm, ter320Question),
+		"the active user question must never be evicted from L1")
+	assert.NotContains(t, sm.l2Summary, "User asked about",
+		"the only user message was pinned, so no user stub should reach L2")
+}
+
+// TestReplayMessages_PinsActiveUserMessage covers the session-restore path.
+func TestReplayMessages_PinsActiveUserMessage(t *testing.T) {
+	profile := ProfileDefaults[loomv1.WorkloadProfile_WORKLOAD_PROFILE_DATA_INTENSIVE]
+	sm := NewSegmentedMemoryWithCompression("rom", 10000, 1000, profile)
+
+	msgs := []Message{{Role: "user", Content: ter320Question}}
+	for i := 0; i < 6; i++ {
+		msgs = append(msgs, bigToolExchange(fmt.Sprintf("tool_%d", i), 400)...)
+	}
+	sm.ReplayMessages(context.Background(), msgs)
+
+	require.Less(t, len(sm.l1Messages), len(msgs), "test setup must drive replay compression")
+	assert.True(t, l1ContainsUserMessage(sm, ter320Question),
+		"the active user question must survive replay compression")
+}
+
+// TestReplayMessages_TerminatesWhenPinnedMessageHeadsL1 guards the compression
+// loop against spinning forever when the eviction window lands on the pinned
+// user message: the window widens past it, evicts the next message instead,
+// and the loop terminates at minL1Messages with the question intact.
+func TestReplayMessages_TerminatesWhenPinnedMessageHeadsL1(t *testing.T) {
+	profile := ProfileDefaults[loomv1.WorkloadProfile_WORKLOAD_PROFILE_DATA_INTENSIVE]
+	sm := NewSegmentedMemoryWithCompression("rom", 10000, 1000, profile)
+
+	// One huge user message pushes L1 over budget; the nominal batch is only
+	// the pinned message (len - minL1Messages = 1).
+	msgs := []Message{
+		{Role: "user", Content: strings.Repeat("describe my data ", 1500)},
+		{Role: "assistant", Content: "a"},
+		{Role: "assistant", Content: "b"},
+		{Role: "assistant", Content: "c"},
+	}
+	sm.ReplayMessages(context.Background(), msgs) // must not hang
+
+	assert.Equal(t, msgs[0].Content, sm.l1Messages[0].Content,
+		"the pinned user message must stay at the head of L1")
+	assert.GreaterOrEqual(t, len(sm.l1Messages), sm.minL1Messages,
+		"compression must respect the L1 floor")
+}
+
+func TestEvictL1Prefix(t *testing.T) {
+	newSM := func(msgs ...Message) *SegmentedMemory {
+		sm := NewSegmentedMemory("rom", 200000, 20000)
+		sm.l1Messages = msgs
+		return sm
+	}
+	user := func(c string) Message { return Message{Role: "user", Content: c} }
+	asst := func(c string) Message { return Message{Role: "assistant", Content: c} }
+
+	t.Run("pinned message inside window is spliced out and kept at L1 head", func(t *testing.T) {
+		sm := newSM(user("Q"), asst("a1"), asst("a2"), asst("a3"))
+		evicted := sm.evictL1Prefix(3)
+
+		// Window widens by one to compensate for the pinned message.
+		require.Len(t, evicted, 3)
+		assert.Equal(t, "a1", evicted[0].Content)
+		assert.Equal(t, "a3", evicted[2].Content)
+		require.Len(t, sm.l1Messages, 1)
+		assert.Equal(t, "Q", sm.l1Messages[0].Content)
+	})
+
+	t.Run("window covering only the pinned message widens past it", func(t *testing.T) {
+		sm := newSM(user("Q"), asst("a1"), asst("a2"))
+		evicted := sm.evictL1Prefix(1)
+
+		require.Len(t, evicted, 1)
+		assert.Equal(t, "a1", evicted[0].Content)
+		require.Len(t, sm.l1Messages, 2)
+		assert.Equal(t, "Q", sm.l1Messages[0].Content)
+		assert.Equal(t, "a2", sm.l1Messages[1].Content)
+	})
+
+	t.Run("older user turns still compress when a newer one exists", func(t *testing.T) {
+		sm := newSM(user("old question"), asst("a1"), user("new question"), asst("a2"))
+		evicted := sm.evictL1Prefix(2)
+
+		require.Len(t, evicted, 2)
+		assert.Equal(t, "old question", evicted[0].Content)
+		require.Len(t, sm.l1Messages, 2)
+		assert.Equal(t, "new question", sm.l1Messages[0].Content)
+	})
+
+	t.Run("no user message falls back to plain prefix eviction", func(t *testing.T) {
+		sm := newSM(asst("a1"), asst("a2"), asst("a3"))
+		evicted := sm.evictL1Prefix(2)
+
+		require.Len(t, evicted, 2)
+		require.Len(t, sm.l1Messages, 1)
+		assert.Equal(t, "a3", sm.l1Messages[0].Content)
+	})
+
+	t.Run("count larger than L1 is clamped", func(t *testing.T) {
+		sm := newSM(asst("a1"), user("Q"))
+		evicted := sm.evictL1Prefix(10)
+
+		require.Len(t, evicted, 1)
+		assert.Equal(t, "a1", evicted[0].Content)
+		require.Len(t, sm.l1Messages, 1)
+		assert.Equal(t, "Q", sm.l1Messages[0].Content)
+	})
+}
+
+func TestSummarizeMessages_PreservesUserQuery(t *testing.T) {
+	sm := NewSegmentedMemory("rom", 200000, 20000)
+
+	summary := sm.summarizeMessages([]Message{
+		{Role: "user", Content: ter320Question},
+		{Role: "assistant", ToolCalls: []ToolCall{{ID: "t1", Name: "base_tableList"}}},
+		{Role: "tool", ToolUseID: "t1", Content: "tables..."},
+	})
+
+	assert.Contains(t, summary, ter320Question,
+		"a summarized user turn must carry the full question, not a 50-char stub")
+}
+
+func TestSummarizeMessages_CapsVeryLongUserQuery(t *testing.T) {
+	sm := NewSegmentedMemory("rom", 200000, 20000)
+	long := strings.Repeat("x", maxSummaryUserQueryChars+100)
+
+	summary := sm.summarizeMessages([]Message{{Role: "user", Content: long}})
+
+	assert.Contains(t, summary, long[:maxSummaryUserQueryChars]+"...")
+	assert.NotContains(t, summary, long)
+}
+
+func TestSimpleCompressorFallbacks_PreserveUserQuery(t *testing.T) {
+	msgs := []Message{
+		{Role: "user", Content: ter320Question},
+		{Role: "assistant", Content: "Let me check that table for you right away."},
+	}
+
+	llmFallback := (&LLMCompressor{}).simpleCompress(msgs)
+	assert.Contains(t, llmFallback, ter320Question)
+
+	simple, err := NewSimpleCompressor().CompressMessages(context.Background(), msgs)
+	require.NoError(t, err)
+	assert.Contains(t, simple, ter320Question)
+}
+
+func TestTruncateForSummary_UTF8Safe(t *testing.T) {
+	assert.Equal(t, "short", truncateForSummary("short", 500), "short text passes through")
+
+	multibyte := strings.Repeat("€", 200) // 600 bytes; byte 500 splits a rune
+	got := truncateForSummary(multibyte, 500)
+	assert.True(t, utf8.ValidString(got), "truncation must not split a rune")
+	assert.True(t, strings.HasSuffix(got, "..."))
+	assert.LessOrEqual(t, len(got), 500+len("..."))
+}


### PR DESCRIPTION
Fixes #262.

## What

Two changes to `SegmentedMemory` compression so the agent can never lose its own objective mid-turn:

1. **Pin the most recent user message.** `evictL1Prefix` (new helper shared by `AddMessage` and `ReplayMessages`) never evicts the latest user-role message. If it falls inside the eviction window, the window widens by one (so pinning never shrinks the batch) and the pinned message is spliced out and kept at the head of L1, preserving relative order. Tool_use/tool_result pair adjustment (`adjustCompressionBoundary`) moved inside the helper so both call sites share one safe sequence; the replay loop breaks when nothing can safely be evicted (no-spin guard).
2. **Preserve user content in summaries.** `summarizeMessages` and both fallback compressors (`LLMCompressor.simpleCompress`, `SimpleCompressor.CompressMessages`) keep user turns verbatim up to `maxSummaryUserQueryChars = 500` (UTF-8 rune-safe truncation) instead of 50/60-char stubs. Assistant/tool content stays aggressively summarized — it's derivable from tool traces; the user's intent is not.

## Why

See #262: a skill body plus a few large tool results push the token budget over the warning threshold on the *first* turn; compression evicts from the oldest end of L1 — the current question — and rewrites it as `User asked about: <first 50 chars>...`. Every subsequent LLM iteration in the same turn sees only the stub. Observed live (Tera Cloud, JIRA TER-320): `demo_user.telecocustomer` cut at byte 50 became a table named `"t"`, and the agent asked the user to re-supply the name while its own tool result listed the table.

## Tests

- `TestAddMessage_PinsActiveUserMessage` — end-to-end TER-320 repro through the public `AddMessage` path (no compressor set, matching the production fallback): compression fires, question survives verbatim in L1, no user stub reaches L2.
- `TestReplayMessages_PinsActiveUserMessage` — session-restore path.
- `TestReplayMessages_TerminatesWhenPinnedMessageHeadsL1` — loop termination with the widened window.
- `TestEvictL1Prefix` — table-driven: splice, widen-past-pinned, older-user-turns-still-compress, no-user fallback, clamp.
- `TestSummarizeMessages_PreservesUserQuery` / `_CapsVeryLongUserQuery`, `TestSimpleCompressorFallbacks_PreserveUserQuery`, `TestTruncateForSummary_UTF8Safe`.
- Updated `TestLLMCompressor_SimpleCompress/long_user_message_truncated` fixture to exceed the new 500-char cap (its intent — very long user messages still truncate — is preserved).

`GOWORK=off go test -tags fts5 -race -short ./...` — entire repo green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)