### PR TITLE
fix(storage): sanitize SQL result table names at every use

### DIFF
--- a/pkg/storage/sql_result_store.go
+++ b/pkg/storage/sql_result_store.go
@@ -212,8 +212,11 @@ func (s *SQLResultStore) Store(_ context.Context, id string, data interface{}) (
 		return nil, fmt.Errorf("no columns found in SQL result")
 	}
 
-	// Create table name
-	tableName := fmt.Sprintf("tool_result_%s", id)
+	// Create table name. Sanitize once here so every downstream use (CREATE,
+	// INSERT, DROP, and the value stored in sql_result_metadata) is a safe SQL
+	// identifier, even when the id embeds external input such as an MCP server
+	// name containing hyphens.
+	tableName := sanitizeIdentifier(fmt.Sprintf("tool_result_%s", id))
 
 	// Create table (REGULAR table, not TEMP - critical fix!)
 	columnDefs := make([]string, len(columns))
@@ -223,7 +226,7 @@ func (s *SQLResultStore) Store(_ context.Context, id string, data interface{}) (
 		columnDefs[i] = fmt.Sprintf("%s TEXT", safeName)
 	}
 
-	createSQL := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (%s)", tableName, strings.Join(columnDefs, ", "))
+	createSQL := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (%s)", tableName, strings.Join(columnDefs, ", ")) // #nosec G201 -- tableName and columns sanitized via sanitizeIdentifier
 	if _, err := s.db.Exec(createSQL); err != nil {
 		return nil, fmt.Errorf("failed to create result table: %w", err)
 	}
@@ -235,8 +238,7 @@ func (s *SQLResultStore) Store(_ context.Context, id string, data interface{}) (
 			placeholders[i] = "?"
 		}
 
-		safeTable := sanitizeIdentifier(tableName)
-		insertSQL := fmt.Sprintf("INSERT INTO %s VALUES (%s)", safeTable, strings.Join(placeholders, ", ")) // #nosec G201 -- tableName sanitized
+		insertSQL := fmt.Sprintf("INSERT INTO %s VALUES (%s)", tableName, strings.Join(placeholders, ", ")) // #nosec G201 -- tableName sanitized via sanitizeIdentifier
 		stmt, err := s.db.Prepare(insertSQL)
 		if err != nil {
 			return nil, fmt.Errorf("failed to prepare insert: %w", err)
@@ -268,7 +270,7 @@ func (s *SQLResultStore) Store(_ context.Context, id string, data interface{}) (
 		now.Unix(), now.Unix(), sizeBytes)
 	if err != nil {
 		// Cleanup table if metadata insert fails
-		_, _ = s.db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName))
+		_, _ = s.db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)) // #nosec G201 -- tableName sanitized via sanitizeIdentifier
 		return nil, fmt.Errorf("failed to store metadata: %w", err)
 	}
 
@@ -397,6 +399,11 @@ func (s *SQLResultStore) GetMetadata(_ context.Context, id string) (*SQLResultMe
 	meta.StoredAt = time.Unix(storedAt, 0)
 	meta.AccessedAt = time.Unix(accessedAt, 0)
 
+	// Defense-in-depth: table names are written sanitized, but re-sanitize the
+	// value read back so a tampered metadata row cannot inject SQL into
+	// consumers that interpolate meta.TableName into queries.
+	meta.TableName = sanitizeIdentifier(meta.TableName)
+
 	// Generate preview data (first 5 + last 5 rows)
 	meta.Preview = s.generatePreview(meta.TableName, meta.Columns, meta.RowCount)
 
@@ -485,8 +492,9 @@ func (s *SQLResultStore) Delete(_ context.Context, id string) error {
 		return fmt.Errorf("failed to get metadata: %w", err)
 	}
 
-	// Drop table
-	dropSQL := fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)
+	// Drop table. Sanitize the name read back from metadata so a tampered row
+	// cannot inject SQL (defense-in-depth; names are stored sanitized).
+	dropSQL := fmt.Sprintf("DROP TABLE IF EXISTS %s", sanitizeIdentifier(tableName)) // #nosec G201 -- identifier sanitized via sanitizeIdentifier
 	if _, err := s.db.Exec(dropSQL); err != nil {
 		return fmt.Errorf("failed to drop table: %w", err)
 	}
@@ -540,9 +548,9 @@ func (s *SQLResultStore) cleanupExpired() {
 
 	// Delete expired results
 	for _, result := range toDelete {
-		// Drop table
-		dropSQL := fmt.Sprintf("DROP TABLE IF EXISTS %s", result.tableName)
-		_, _ = s.db.Exec(dropSQL) // Ignore errors
+		// Drop table. Sanitize the name read back from metadata (defense-in-depth).
+		dropSQL := fmt.Sprintf("DROP TABLE IF EXISTS %s", sanitizeIdentifier(result.tableName)) // #nosec G201 -- identifier sanitized via sanitizeIdentifier
+		_, _ = s.db.Exec(dropSQL)                                                               // Ignore errors
 
 		// Delete metadata
 		_, _ = s.db.Exec(`DELETE FROM sql_result_metadata WHERE id = ?`, result.id)

--- a/pkg/storage/sql_result_store_test.go
+++ b/pkg/storage/sql_result_store_test.go
@@ -1,0 +1,178 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestSQLResultStore(t *testing.T) *SQLResultStore {
+	t.Helper()
+
+	store, err := NewSQLResultStore(&SQLResultStoreConfig{
+		DBPath: filepath.Join(t.TempDir(), "test.db"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func testSQLResultData() map[string]interface{} {
+	return map[string]interface{}{
+		"columns": []interface{}{"name", "value"},
+		"rows": []interface{}{
+			[]interface{}{"alpha", "1"},
+			[]interface{}{"beta", "2"},
+		},
+	}
+}
+
+// tableExists reports whether a table is present in sqlite_master.
+func tableExists(t *testing.T, store *SQLResultStore, tableName string) bool {
+	t.Helper()
+
+	var count int
+	err := store.db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?`, tableName,
+	).Scan(&count)
+	require.NoError(t, err)
+	return count > 0
+}
+
+// Regression test: MCP tool results use IDs like "mcp_<serverName>_<ts>" where
+// the server name may contain hyphens. Before sanitizing at creation time, the
+// raw table name "tool_result_mcp_my-server_..." broke CREATE TABLE (hyphen is
+// invalid in an unquoted SQLite identifier), so storing the result failed.
+func TestSQLResultStore_HyphenatedMCPServerName(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSQLResultStore(t)
+	ctx := context.Background()
+
+	id := "mcp_my-server_1234567890"
+	ref, err := store.Store(ctx, id, testSQLResultData())
+	require.NoError(t, err, "Store must handle IDs containing hyphens")
+	require.NotNil(t, ref)
+	assert.Equal(t, id, ref.Id)
+
+	meta, err := store.GetMetadata(ctx, id)
+	require.NoError(t, err)
+	assert.NotContains(t, meta.TableName, "-", "stored table name must be a sanitized identifier")
+	assert.Equal(t, "tool_result_mcp_my_server_1234567890", meta.TableName)
+	assert.True(t, tableExists(t, store, meta.TableName), "sanitized table must exist")
+
+	// The query_tool_result builtin interpolates meta.TableName into SQL;
+	// verify that round-trip works.
+	rows, err := store.Query(ctx, id, fmt.Sprintf("SELECT * FROM %s LIMIT 100", meta.TableName))
+	require.NoError(t, err)
+	require.NotNil(t, rows)
+
+	// Delete must drop the sanitized table, not a divergent raw name.
+	require.NoError(t, store.Delete(ctx, id))
+	assert.False(t, tableExists(t, store, meta.TableName), "Delete must drop the result table")
+}
+
+// A crafted ID with SQL metacharacters must not escape the identifier position.
+func TestSQLResultStore_MaliciousIDSanitized(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSQLResultStore(t)
+	ctx := context.Background()
+
+	id := `x"; DROP TABLE sql_result_metadata;--`
+	_, err := store.Store(ctx, id, testSQLResultData())
+	require.NoError(t, err)
+
+	assert.True(t, tableExists(t, store, "sql_result_metadata"),
+		"metadata table must survive a crafted ID")
+
+	meta, err := store.GetMetadata(ctx, id)
+	require.NoError(t, err)
+	for _, c := range meta.TableName {
+		validChar := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
+		assert.True(t, validChar, "table name char %q must be sanitized", c)
+	}
+	assert.True(t, tableExists(t, store, meta.TableName))
+
+	require.NoError(t, store.Delete(ctx, id))
+	assert.False(t, tableExists(t, store, meta.TableName))
+	assert.True(t, tableExists(t, store, "sql_result_metadata"))
+}
+
+// Defense-in-depth: a tampered table_name in the metadata table must not reach
+// GetMetadata consumers or the DROP TABLE statements unsanitized.
+func TestSQLResultStore_TamperedMetadataTableName(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSQLResultStore(t)
+	ctx := context.Background()
+
+	id := "tampered"
+	_, err := store.Store(ctx, id, testSQLResultData())
+	require.NoError(t, err)
+
+	injected := `tool_result_x; DROP TABLE sql_result_metadata;--`
+	_, err = store.db.Exec(`UPDATE sql_result_metadata SET table_name = ? WHERE id = ?`, injected, id)
+	require.NoError(t, err)
+
+	meta, err := store.GetMetadata(ctx, id)
+	require.NoError(t, err)
+	assert.NotContains(t, meta.TableName, ";", "GetMetadata must return a sanitized table name")
+	assert.NotContains(t, meta.TableName, " ")
+
+	require.NoError(t, store.Delete(ctx, id))
+	assert.True(t, tableExists(t, store, "sql_result_metadata"),
+		"metadata table must survive a tampered table_name")
+}
+
+func TestSanitizeIdentifier(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "clean identifier unchanged", input: "tool_result_abc123", want: "tool_result_abc123"},
+		{name: "hyphens replaced", input: "tool_result_mcp_my-server_1", want: "tool_result_mcp_my_server_1"},
+		{name: "sql metacharacters replaced", input: `x"; DROP TABLE y;--`, want: "x___DROP_TABLE_y___"},
+		{name: "spaces replaced", input: "a b c", want: "a_b_c"},
+		{name: "leading digit prefixed", input: "1abc", want: "col_1abc"},
+		{name: "empty becomes col", input: "", want: "col"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := sanitizeIdentifier(tt.input)
+			assert.Equal(t, tt.want, got)
+
+			// Result must always be a safe SQL identifier.
+			assert.NotEmpty(t, got)
+			for _, c := range got {
+				validChar := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
+				assert.True(t, validChar, "char %q in %q", c, got)
+			}
+			assert.False(t, strings.ContainsAny(got, `"';- `))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Triage of an ArmorCode/Snyk SQL injection finding on `pkg/storage/sql_result_store.go:434` (tainted `table_name` from `sql_result_metadata` flowing into `Query`). The flagged sink was already sanitized via `sanitizeIdentifier()`, but the same tainted value reached other sinks in the file **unsanitized**:

- `CREATE TABLE` in `Store`
- `DROP TABLE` in `Store`'s error cleanup path
- `DROP TABLE` in `Delete` and `cleanupExpired` (both read `table_name` back from the metadata table — the exact taint flow Snyk tracks)

## Changes

- **`Store`**: sanitize the table name once at creation, so `CREATE TABLE`, `INSERT`, the error-path `DROP TABLE`, and the value persisted in `sql_result_metadata` are all guaranteed-safe identifiers. Removed the now-redundant second sanitization in the insert path.
- **`GetMetadata`**: re-sanitize `meta.TableName` after reading it back (defense-in-depth against tampered metadata rows). This also covers the builtin `query_tool_result` tool (`pkg/agent/builtin_tools.go`), which interpolates `meta.TableName` into SQL.
- **`Delete` / `cleanupExpired`**: sanitize the table name read back from metadata before `DROP TABLE`.

## Bug fixed

MCP result IDs embed the server name (`mcp_<serverName>_<ts>`). A hyphenated MCP server name (e.g. `my-server`) previously produced an invalid unquoted SQLite identifier, so `CREATE TABLE` failed and result storage broke for that server. Sanitizing at creation fixes this.

## Codebase sweep

Audited every `fmt.Sprintf`-built SQL statement in the repo for the same pattern:

| Location | Verdict |
|---|---|
| `pkg/storage/postgres/result_store.go` | Already safe — `pgx.Identifier{}.Sanitize()` + regex validation |
| `pkg/storage/postgres/task_store.go`, `pkg/storage/sqlite/task_store.go` | Safe — only `$N`/`?` placeholders interpolated |
| `pkg/storage/{sqlite,postgres}/graph_memory_store.go` | Safe — placeholder lists only |
| `pkg/agent/session_store.go` | Safe — identifiers regex-validated |
| `pkg/agent/builtin_tools.go` | Was exposed to tainted `meta.TableName`; now covered via `GetMetadata` sanitization |
| `pkg/shuttle/builtin/document_parse_enhanced.go` | Not a sink — generates DDL as text output, never executes it |

The companion XSS finding on `pkg/server/http.go:481` was triaged as a false positive: the URL-derived app name is allowlist-validated, used only as a registry lookup key, and never echoed into the response.

## Tests

New `pkg/storage/sql_result_store_test.go`:
- Hyphenated MCP server name regression (store → metadata → query → delete round-trip)
- Crafted ID with SQL metacharacters (metadata table survives)
- Tampered `table_name` metadata row (no injection through `GetMetadata`/`Delete`)
- Table-driven `sanitizeIdentifier` cases

Verified: `gofmt` clean, `golangci-lint` 0 issues, `go test -tags fts5 -race` passes for `pkg/storage/...`, `pkg/agent/...`, `pkg/mcp/...`, `pkg/shuttle/...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)