### PR TITLE
feat(orchestration): HITL approval gates with durable checkpoint/resume

### DIFF
--- a/cmd/looms/cmd_workflow.go
+++ b/cmd/looms/cmd_workflow.go
@@ -14,7 +14,9 @@
 package main
 
 import (
+	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -40,14 +42,19 @@ import (
 	"github.com/teradata-labs/loom/pkg/shuttle/builtin"
 	"github.com/teradata-labs/loom/pkg/visualization"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v3"
 )
 
 var (
-	workflowDir     string
-	workflowAgents  []string
-	workflowDryRun  bool
-	workflowTimeout int
+	workflowDir       string
+	workflowAgents    []string
+	workflowDryRun    bool
+	workflowTimeout   int
+	workflowSuspendTo string
+	resumeApprove     bool
+	resumeReject      bool
+	resumeRevise      string
 )
 
 // workflowCmd represents the workflow command
@@ -126,6 +133,32 @@ Examples:
 	Run:  runWorkflow,
 }
 
+// resumeCmd resumes a workflow suspended at a HITL gate
+var resumeCmd = &cobra.Command{
+	Use:   "resume <workflow-file> <checkpoint-file>",
+	Short: "Resume a workflow suspended at a HITL gate",
+	Long: `Resume a workflow that suspended at a human-in-the-loop gate.
+
+When a stage declares a hitl_gate and no interactive prompt is available,
+'looms workflow run' writes a durable checkpoint file and exits. Review the
+gated output, then resume with exactly one decision flag:
+
+  --approve            continue to the next stage
+  --revise "feedback"  restart the gate's revise target stage with feedback
+  --reject             end the workflow without executing later stages
+
+The workflow file must be IDENTICAL to the one the run started with — the
+checkpoint records a fingerprint of the definition and refuses to resume a
+changed workflow.
+
+Examples:
+  looms workflow resume create-table.yaml create-table.checkpoint.pb --approve
+  looms workflow resume create-table.yaml create-table.checkpoint.pb --revise "Use MULTISET and add COMPRESS"
+  looms workflow resume create-table.yaml create-table.checkpoint.pb --reject`,
+	Args: cobra.ExactArgs(2),
+	Run:  runResume,
+}
+
 // listCmd lists available workflow files
 var listCmd = &cobra.Command{
 	Use:   "list [directory]",
@@ -160,12 +193,21 @@ func init() {
 	// Add subcommands
 	workflowCmd.AddCommand(validateCmd)
 	workflowCmd.AddCommand(runCmd)
+	workflowCmd.AddCommand(resumeCmd)
 	workflowCmd.AddCommand(listCmd)
 
 	// Flags for run command
 	runCmd.Flags().StringSliceVar(&workflowAgents, "threads", []string{}, "Comma-separated thread IDs to register")
 	runCmd.Flags().BoolVar(&workflowDryRun, "dry-run", false, "Validate without executing")
 	runCmd.Flags().IntVar(&workflowTimeout, "timeout", 3600, "Execution timeout in seconds")
+	runCmd.Flags().StringVar(&workflowSuspendTo, "suspend-to", "", "Write the HITL gate checkpoint to this file on suspension (default: <workflow>.checkpoint.pb; also disables interactive gate prompts)")
+
+	// Flags for resume command
+	resumeCmd.Flags().BoolVar(&resumeApprove, "approve", false, "Approve the pending gate and continue")
+	resumeCmd.Flags().BoolVar(&resumeReject, "reject", false, "Reject the pending gate and end the workflow")
+	resumeCmd.Flags().StringVar(&resumeRevise, "revise", "", "Request a revision with this feedback")
+	resumeCmd.Flags().IntVar(&workflowTimeout, "timeout", 3600, "Execution timeout in seconds")
+	resumeCmd.Flags().StringVar(&workflowSuspendTo, "suspend-to", "", "Write the next HITL gate checkpoint to this file if the run suspends again")
 
 	// Flags for list command
 	listCmd.Flags().StringVarP(&workflowDir, "dir", "d", "", "Directory to search (default: auto-detect)")
@@ -210,6 +252,286 @@ func runWorkflow(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	// Interactive gate prompting only makes sense on a TTY without an
+	// explicit suspend target; otherwise HITL gates suspend to a checkpoint.
+	rt, err := setupWorkflowRuntime(pattern, workflowSuspendTo == "" && stdinIsTTY())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "❌ %v\n", err)
+		os.Exit(1)
+	}
+	defer rt.Close()
+
+	// Execute workflow
+	fmt.Println("\n⚡ Executing workflow...")
+	startTime := time.Now()
+
+	ctx := context.Background()
+	if workflowTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(workflowTimeout)*time.Second)
+		defer cancel()
+	}
+
+	result, err := rt.orchestrator.ExecutePattern(ctx, pattern)
+	handleWorkflowOutcome(filePath, result, err, time.Since(startTime))
+}
+
+// runResume resumes a workflow suspended at a HITL gate.
+func runResume(cmd *cobra.Command, args []string) {
+	workflowPath, checkpointPath := args[0], args[1]
+
+	decision, err := buildResumeDecision()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "❌ %v\n", err)
+		os.Exit(1)
+	}
+
+	pattern, err := orchestration.LoadWorkflowFromYAML(workflowPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "❌ Failed to load workflow: %v\n", err)
+		os.Exit(1)
+	}
+
+	ckptData, err := os.ReadFile(filepath.Clean(checkpointPath))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "❌ Failed to read checkpoint: %v\n", err)
+		os.Exit(1)
+	}
+	ckpt := &loomv1.WorkflowCheckpoint{}
+	if err := proto.Unmarshal(ckptData, ckpt); err != nil {
+		fmt.Fprintf(os.Stderr, "❌ Invalid checkpoint file: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("📄 Resuming workflow: %s\n", workflowPath)
+	printPatternSummary(pattern)
+	gate := ckpt.GetPendingGate()
+	fmt.Printf("   Pending gate: stage %d (%s), decision: %s\n",
+		gate.GetStageNumber(), gate.GetStageAgentId(), decision.Action.String())
+
+	// A rejection needs no agents or LLM — short-circuit before runtime setup.
+	if decision.Action == loomv1.GateAction_GATE_ACTION_REJECT {
+		fmt.Printf("\n🛑 Workflow rejected at gate on stage %s. No further stages executed.\n", gate.GetStageAgentId())
+		return
+	}
+
+	rt, err := setupWorkflowRuntime(pattern, false)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "❌ %v\n", err)
+		os.Exit(1)
+	}
+	defer rt.Close()
+
+	fmt.Println("\n⚡ Resuming workflow...")
+	startTime := time.Now()
+
+	ctx := context.Background()
+	if workflowTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(workflowTimeout)*time.Second)
+		defer cancel()
+	}
+
+	result, err := rt.orchestrator.ResumeWorkflow(ctx, pattern, ckpt, decision)
+	handleWorkflowOutcome(workflowPath, result, err, time.Since(startTime))
+}
+
+// buildResumeDecision maps the resume flags to a GateDecision, requiring
+// exactly one of --approve / --revise / --reject.
+func buildResumeDecision() (*loomv1.GateDecision, error) {
+	set := 0
+	if resumeApprove {
+		set++
+	}
+	if resumeReject {
+		set++
+	}
+	if resumeRevise != "" {
+		set++
+	}
+	if set != 1 {
+		return nil, fmt.Errorf("exactly one of --approve, --revise \"feedback\", or --reject is required")
+	}
+	switch {
+	case resumeApprove:
+		return &loomv1.GateDecision{Action: loomv1.GateAction_GATE_ACTION_APPROVE}, nil
+	case resumeReject:
+		return &loomv1.GateDecision{Action: loomv1.GateAction_GATE_ACTION_REJECT}, nil
+	default:
+		return &loomv1.GateDecision{Action: loomv1.GateAction_GATE_ACTION_REVISE, Feedback: resumeRevise}, nil
+	}
+}
+
+// handleWorkflowOutcome prints the result of a run/resume, handling HITL
+// suspension (write checkpoint + resume instructions) and rejection.
+func handleWorkflowOutcome(workflowPath string, result *loomv1.WorkflowResult, err error, duration time.Duration) {
+	var suspended *orchestration.WorkflowSuspended
+	if errors.As(err, &suspended) {
+		writeCheckpointAndPrintGate(workflowPath, suspended.Checkpoint)
+		return
+	}
+	var rejected *orchestration.GateRejected
+	if errors.As(err, &rejected) {
+		fmt.Printf("\n🛑 Workflow rejected at gate on stage %s.\n", rejected.StageAgentID)
+		if rejected.Feedback != "" {
+			fmt.Printf("   Feedback: %s\n", rejected.Feedback)
+		}
+		return
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\n❌ Execution failed: %v\n", err)
+		os.Exit(1)
+	}
+	printWorkflowResult(result, duration)
+}
+
+// writeCheckpointAndPrintGate persists a suspension checkpoint and prints the
+// pending gate with resume instructions.
+func writeCheckpointAndPrintGate(workflowPath string, ckpt *loomv1.WorkflowCheckpoint) {
+	path := workflowSuspendTo
+	if path == "" {
+		base := strings.TrimSuffix(filepath.Base(workflowPath), filepath.Ext(workflowPath))
+		path = base + ".checkpoint.pb"
+	}
+	data, err := proto.Marshal(ckpt)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "❌ Failed to marshal checkpoint: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		fmt.Fprintf(os.Stderr, "❌ Failed to write checkpoint %s: %v\n", path, err)
+		os.Exit(1)
+	}
+
+	gate := ckpt.GetPendingGate()
+	fmt.Println("\n" + strings.Repeat("=", 80))
+	fmt.Println("⏸  WORKFLOW SUSPENDED — HUMAN REVIEW REQUIRED")
+	fmt.Println(strings.Repeat("=", 80))
+	fmt.Printf("\nStage %d (%s) asks:\n\n%s\n", gate.GetStageNumber(), gate.GetStageAgentId(), gate.GetQuestion())
+	output := gate.GetStageOutput()
+	if len(output) > 4000 {
+		output = output[:4000] + "\n... (truncated — full output is in the checkpoint)"
+	}
+	fmt.Println("\n--- Output under review " + strings.Repeat("-", 55))
+	fmt.Println(output)
+	fmt.Println(strings.Repeat("-", 80))
+	fmt.Printf("\n💾 Checkpoint written: %s\n", path)
+	fmt.Println("\nResume with one of:")
+	fmt.Printf("  looms workflow resume %s %s --approve\n", workflowPath, path)
+	fmt.Printf("  looms workflow resume %s %s --revise \"<feedback>\"\n", workflowPath, path)
+	fmt.Printf("  looms workflow resume %s %s --reject\n", workflowPath, path)
+}
+
+// printWorkflowResult prints a completed workflow's results (shared by run
+// and resume).
+func printWorkflowResult(result *loomv1.WorkflowResult, duration time.Duration) {
+	fmt.Println("\n" + strings.Repeat("=", 80))
+	fmt.Println("✅ WORKFLOW COMPLETED")
+	fmt.Println(strings.Repeat("=", 80))
+	fmt.Printf("\nDuration: %.2fs\n", duration.Seconds())
+	fmt.Printf("Total cost: $%.4f\n", result.Cost.TotalCostUsd)
+	fmt.Printf("Total tokens: %d\n", result.Cost.TotalTokens)
+	fmt.Printf("LLM calls: %d\n\n", result.Cost.LlmCalls)
+
+	// Print detailed results based on pattern type
+	if debateResult := result.GetDebateResult(); debateResult != nil {
+		printDebateResults(result, debateResult)
+	} else {
+		// Print merged output for non-debate patterns
+		fmt.Println("📊 Result:")
+		fmt.Println(strings.Repeat("-", 80))
+		fmt.Println(result.MergedOutput)
+		fmt.Println(strings.Repeat("-", 80))
+	}
+}
+
+// stdinIsTTY reports whether stdin is an interactive terminal.
+func stdinIsTTY() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}
+
+// terminalGateHandler decides HITL gates interactively on the terminal.
+type terminalGateHandler struct{}
+
+// RequestDecision prompts the user on stdin for a gate decision.
+func (terminalGateHandler) RequestDecision(_ context.Context, req *loomv1.HITLGateRequest) (*loomv1.GateDecision, error) {
+	fmt.Println("\n" + strings.Repeat("=", 80))
+	fmt.Println("⏸  HUMAN REVIEW REQUIRED")
+	fmt.Println(strings.Repeat("=", 80))
+	fmt.Printf("\nStage %d (%s) asks:\n\n%s\n", req.StageNumber, req.StageAgentId, req.Question)
+	output := req.StageOutput
+	if len(output) > 4000 {
+		output = output[:4000] + "\n... (truncated)"
+	}
+	fmt.Println("\n--- Output under review " + strings.Repeat("-", 55))
+	fmt.Println(output)
+	fmt.Println(strings.Repeat("-", 80))
+
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Print("\nDecision — [a]pprove / [r]evise / re[j]ect / [s]uspend to checkpoint: ")
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, fmt.Errorf("failed to read decision: %w", err)
+		}
+		switch strings.ToLower(strings.TrimSpace(line)) {
+		case "a", "approve":
+			return &loomv1.GateDecision{Action: loomv1.GateAction_GATE_ACTION_APPROVE, DecidedBy: "terminal"}, nil
+		case "j", "reject":
+			return &loomv1.GateDecision{Action: loomv1.GateAction_GATE_ACTION_REJECT, DecidedBy: "terminal"}, nil
+		case "s", "suspend":
+			return nil, orchestration.ErrSuspendWorkflow
+		case "r", "revise":
+			fmt.Print("Revision feedback: ")
+			feedback, err := reader.ReadString('\n')
+			if err != nil {
+				return nil, fmt.Errorf("failed to read feedback: %w", err)
+			}
+			feedback = strings.TrimSpace(feedback)
+			if feedback == "" {
+				fmt.Println("Feedback is required for a revision.")
+				continue
+			}
+			return &loomv1.GateDecision{Action: loomv1.GateAction_GATE_ACTION_REVISE, Feedback: feedback, DecidedBy: "terminal"}, nil
+		default:
+			fmt.Println("Please answer a, r, j, or s.")
+		}
+	}
+}
+
+// workflowRuntime bundles the orchestrator and everything it depends on for a
+// CLI workflow execution, plus the teardown for those dependencies.
+type workflowRuntime struct {
+	orchestrator *orchestration.Orchestrator
+	logger       *zap.Logger
+	closers      []func()
+}
+
+// Close tears down runtime dependencies in reverse construction order.
+func (rt *workflowRuntime) Close() {
+	for i := len(rt.closers) - 1; i >= 0; i-- {
+		rt.closers[i]()
+	}
+}
+
+// setupWorkflowRuntime creates the LLM provider, observability, stores, agent
+// registry, communication infrastructure, and orchestrator for the pattern,
+// then creates and registers every referenced agent with the standard
+// auto-injected tools. When promptGates is true, HITL gates are decided
+// interactively on the terminal; otherwise they suspend with a checkpoint.
+func setupWorkflowRuntime(pattern *loomv1.WorkflowPattern, promptGates bool) (*workflowRuntime, error) {
+	rt := &workflowRuntime{}
+	ok := false
+	defer func() {
+		if !ok {
+			rt.Close()
+		}
+	}()
+
 	// Initialize LLM provider
 	llmProvider, providerName := createLLMProvider()
 	fmt.Printf("\n🤖 LLM Provider: %s\n", providerName)
@@ -220,10 +542,10 @@ func runWorkflow(cmd *cobra.Command, args []string) {
 	zapConfig.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
 	logger, err := zapConfig.Build(zap.AddStacktrace(zap.ErrorLevel))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create logger: %v\n", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("failed to create logger: %w", err)
 	}
-	defer func() { _ = logger.Sync() }()
+	rt.logger = logger
+	rt.closers = append(rt.closers, func() { _ = logger.Sync() })
 
 	// Create tracer based on observability mode (matches cmd_serve.go logic)
 	var tracer observability.Tracer
@@ -266,11 +588,11 @@ func runWorkflow(cmd *cobra.Command, args []string) {
 				tracer = observability.NewNoOpTracer()
 			} else {
 				tracer = embeddedTracer
-				defer func() {
+				rt.closers = append(rt.closers, func() {
 					if err := embeddedTracer.Close(); err != nil {
 						logger.Warn("Failed to close embedded tracer", zap.Error(err))
 					}
-				}()
+				})
 			}
 
 		case "service":
@@ -300,10 +622,9 @@ func runWorkflow(cmd *cobra.Command, args []string) {
 	}
 	sessionStore, err := agent.NewSessionStore(dbPath, tracer)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create session store: %v\n", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("failed to create session store: %w", err)
 	}
-	defer func() { _ = sessionStore.Close() }()
+	rt.closers = append(rt.closers, func() { _ = sessionStore.Close() })
 
 	// Initialize MCP manager if MCP servers are configured
 	var mcpMgr *mcpManager
@@ -337,8 +658,7 @@ func runWorkflow(cmd *cobra.Command, args []string) {
 		SessionStore: sessionStore,
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create agent registry: %v\n", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("failed to create agent registry: %w", err)
 	}
 
 	// Initialize MessageBus and SharedMemory for workflow communication
@@ -347,8 +667,7 @@ func runWorkflow(cmd *cobra.Command, args []string) {
 	messageBus := communication.NewMessageBus(memoryStore, nil, tracer, logger)
 	sharedMemory, err := communication.NewSharedMemoryStore(tracer, logger)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create shared memory: %v\n", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("failed to create shared memory: %w", err)
 	}
 	logger.Info("Initialized communication infrastructure",
 		zap.Bool("message_bus", true),
@@ -360,6 +679,13 @@ func runWorkflow(cmd *cobra.Command, args []string) {
 	logger.Info("LLM concurrency limit configured for workflow execution",
 		zap.Int("limit", llmConcurrencyLimit))
 
+	// HITL gates: prompt on the terminal when interactive, otherwise leave
+	// the handler nil so gates suspend with a durable checkpoint.
+	var hitlHandler orchestration.HITLHandler
+	if promptGates {
+		hitlHandler = terminalGateHandler{}
+	}
+
 	// Create orchestrator with registry and communication infrastructure
 	orchestrator := orchestration.NewOrchestrator(orchestration.Config{
 		Registry:     registry,
@@ -369,14 +695,14 @@ func runWorkflow(cmd *cobra.Command, args []string) {
 		MessageBus:   messageBus,
 		SharedMemory: sharedMemory,
 		LLMSemaphore: llmSemaphore,
+		HITLHandler:  hitlHandler,
 	})
 
 	// Load all agent configs from the directory first
 	ctx := context.Background()
 	fmt.Println("🔧 Loading agents from registry...")
 	if err := registry.LoadAgents(ctx); err != nil {
-		fmt.Fprintf(os.Stderr, "   ❌ Failed to load agents: %v\n", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("failed to load agents: %w", err)
 	}
 
 	// Extract agent IDs from workflow
@@ -400,14 +726,12 @@ func runWorkflow(cmd *cobra.Command, args []string) {
 		logger.Info("Creating agent", zap.String("agent", agentID))
 		ag, err := registry.CreateAgent(ctx, agentID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "   ❌ Failed to create agent %s: %v\n", agentID, err)
-			os.Exit(1)
+			return nil, fmt.Errorf("failed to create agent %s: %w", agentID, err)
 		}
 
 		// Start the agent (marks as running)
 		if err := registry.StartAgent(ctx, agentID); err != nil {
-			fmt.Fprintf(os.Stderr, "   ❌ Failed to start agent %s: %v\n", agentID, err)
-			os.Exit(1)
+			return nil, fmt.Errorf("failed to start agent %s: %w", agentID, err)
 		}
 
 		// Auto-inject restart coordination tool for iterative workflows
@@ -461,44 +785,9 @@ func runWorkflow(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	// Execute workflow
-	fmt.Println("\n⚡ Executing workflow...")
-	startTime := time.Now()
-
-	// Add timeout to context if specified
-	if workflowTimeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, time.Duration(workflowTimeout)*time.Second)
-		defer cancel()
-	}
-
-	result, err := orchestrator.ExecutePattern(ctx, pattern)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "\n❌ Execution failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	duration := time.Since(startTime)
-
-	// Print results
-	fmt.Println("\n" + strings.Repeat("=", 80))
-	fmt.Println("✅ WORKFLOW COMPLETED")
-	fmt.Println(strings.Repeat("=", 80))
-	fmt.Printf("\nDuration: %.2fs\n", duration.Seconds())
-	fmt.Printf("Total cost: $%.4f\n", result.Cost.TotalCostUsd)
-	fmt.Printf("Total tokens: %d\n", result.Cost.TotalTokens)
-	fmt.Printf("LLM calls: %d\n\n", result.Cost.LlmCalls)
-
-	// Print detailed results based on pattern type
-	if debateResult := result.GetDebateResult(); debateResult != nil {
-		printDebateResults(result, debateResult)
-	} else {
-		// Print merged output for non-debate patterns
-		fmt.Println("📊 Result:")
-		fmt.Println(strings.Repeat("-", 80))
-		fmt.Println(result.MergedOutput)
-		fmt.Println(strings.Repeat("-", 80))
-	}
+	rt.orchestrator = orchestrator
+	ok = true
+	return rt, nil
 }
 
 // printDebateResults prints detailed debate results with thinking, tool usage, and model info.

--- a/docs/guides/human-in-the-loop.md
+++ b/docs/guides/human-in-the-loop.md
@@ -17,6 +17,7 @@
 - [Examples](#examples)
   - [Example 1: Database Deletion Approval](#example-1-database-deletion-approval)
   - [Example 2: Multi-Choice Decision](#example-2-multi-choice-decision)
+- [Workflow HITL Gates (Durable Checkpoint/Resume)](#workflow-hitl-gates-durable-checkpointresume)
 - [Troubleshooting](#troubleshooting)
 - [Next Steps](#next-steps)
 
@@ -248,6 +249,91 @@ func selectDatabaseWithHuman(ctx context.Context, workload string) (string, erro
     return response["response"].(string), nil
 }
 ```
+
+## Workflow HITL Gates (Durable Checkpoint/Resume)
+
+✅ **Available** - Feature fully working with tests (see `pkg/orchestration/hitl_gate_test.go`)
+
+`contact_human` blocks an agent *mid-turn*. Workflow **HITL gates** are the
+complementary mechanism for pipelines: a declarative approval gate on a
+**stage boundary** that fires deterministically — no LLM decides whether to
+ask. Because gates only fire between stages, the workflow suspends into a
+small, durable `WorkflowCheckpoint` (proto) instead of a blocked goroutine:
+the process can exit, and any process holding the checkpoint can resume the
+run later.
+
+### Declaring a gate
+
+Gates are supported on `pipeline` and `iterative` patterns only:
+
+```yaml
+spec:
+  type: pipeline
+  initial_prompt: "Create a partitioned orders table in the sales database"
+  stages:
+    - agent_id: ddl-designer
+      prompt_template: "Design Teradata DDL for: {{previous}}"
+      hitl_gate:
+        prompt_template: "Review this DDL before execution:\n{{output}}"
+        request_type: approval          # approval | decision | input | review
+        timeout_seconds: 1800           # advisory; hosts enforce expiry in suspend mode
+        revise_target_stage_id: ddl-designer  # stage to restart on REVISE (default: this stage)
+        max_revisions: 3                # revision budget before the run fails
+        on_timeout: fail                # fail | reject | approve
+    - agent_id: ddl-executor
+      prompt_template: "Execute exactly this DDL: {{previous}}"
+```
+
+### Suspend / resume lifecycle
+
+1. The gated stage completes (including its output validation/retries).
+2. The executor emits a progress event carrying `HITLGateRequest`, then —
+   with no inline handler configured — returns a `*WorkflowSuspended` error
+   wrapping the checkpoint. Detect it with `errors.As`.
+3. The host persists the checkpoint and shows `pending_gate` to a human.
+4. `Orchestrator.ResumeWorkflow(ctx, pattern, checkpoint, decision)`:
+   - **APPROVE** — continues at the next stage.
+   - **REVISE** — jumps back to `revise_target_stage_id` with the feedback
+     threaded into that stage's prompt (`{{revision_feedback}}` placeholder,
+     or an appended `## REVISION FEEDBACK` section). The gate fires again
+     after the re-run; `max_revisions` bounds the loop.
+   - **REJECT** — returns `*GateRejected` without executing anything.
+5. The checkpoint records a SHA-256 fingerprint of the workflow definition;
+   resuming with a modified definition is refused (`fingerprint … changed
+   since suspension`) so edits can never bypass a pending review.
+
+### CLI
+
+```bash
+# Non-interactive (or with --suspend-to): a gate writes a checkpoint and exits
+looms workflow run create-table.yaml --suspend-to review.pb
+
+# Review, then resume with exactly one decision
+looms workflow resume create-table.yaml review.pb --approve
+looms workflow resume create-table.yaml review.pb --revise "Use MULTISET and add COMPRESS"
+looms workflow resume create-table.yaml review.pb --reject
+
+# On an interactive terminal, `run` prompts inline instead ([a]/[r]/[j]/[s])
+looms workflow run create-table.yaml
+```
+
+### Embedding hosts (inline decisions)
+
+A host that wants to decide gates in-process (chat bridge, terminal, tests)
+sets an `orchestration.HITLHandler` in `orchestration.Config`; returning
+`orchestration.ErrSuspendWorkflow` from the handler converts the gate into a
+durable suspension. Leave the handler nil to always suspend.
+
+### What a checkpoint contains (and does not)
+
+The checkpoint holds completed stage outputs, cost history, iteration and
+revision counters, the pending gate request, and agent-written
+workflow-namespace SharedMemory entries. It never contains in-flight
+agent-loop state — gates only fire at stage boundaries. Checkpoints are host
+state: persist them server-side, not on untrusted clients.
+
+See `examples/reference/workflows/orchestration-patterns/hitl-gated-pipeline.yaml`
+for a runnable example.
 
 ## Troubleshooting
 

--- a/examples/reference/workflows/orchestration-patterns/hitl-gated-pipeline.yaml
+++ b/examples/reference/workflows/orchestration-patterns/hitl-gated-pipeline.yaml
@@ -1,0 +1,85 @@
+# HITL-Gated DDL Pipeline
+# Pipeline with a human approval gate between design and execution:
+# analyze → design → [HUMAN REVIEW GATE] → execute
+#
+# The gate fires deterministically after the design stage's output passes
+# validation. With no interactive terminal (or with --suspend-to), the run
+# suspends into a durable checkpoint file; a human reviews the DDL and the
+# run resumes — approve to execute, revise to send feedback back to the
+# designer, reject to stop without executing anything.
+
+apiVersion: loom/v1
+kind: Workflow
+metadata:
+  name: hitl-gated-ddl-pipeline
+  description: Table-creation pipeline with a human approval gate before DDL execution
+  labels:
+    category: data-engineering
+    complexity: medium
+
+spec:
+  type: pipeline
+  initial_prompt: "Create a partitioned orders table in the sales database with order_id, customer_id, order_date, amount, and status columns. Partition by month on order_date."
+
+  stages:
+    - agent_id: schema-analyst
+      prompt_template: |
+        Analyze this table request and produce structured requirements
+        (target database, columns with types, primary index recommendation,
+        partitioning strategy, table options):
+
+        {{previous}}
+
+    - agent_id: ddl-designer
+      prompt_template: |
+        Generate syntactically correct Teradata CREATE TABLE DDL from these
+        requirements. Output ONLY the DDL statement.
+
+        {{previous}}
+
+        {{revision_feedback}}
+      validation_prompt: |
+        Is this valid Teradata CREATE TABLE DDL with an explicit SET/MULTISET
+        keyword and a PRIMARY INDEX clause? Answer yes or no.
+
+        {{output}}
+      retry_policy:
+        max_retries: 2
+      hitl_gate:
+        prompt_template: |
+          Review this DDL before it is executed against the database:
+
+          {{output}}
+        request_type: approval
+        timeout_seconds: 1800
+        revise_target_stage_id: ddl-designer
+        max_revisions: 3
+        on_timeout: fail
+
+    - agent_id: ddl-executor
+      prompt_template: |
+        Execute exactly the following approved DDL statement. Do not modify it.
+        Report the execution result verbatim.
+
+        {{previous}}
+
+  pass_full_history: false
+
+# Example execution:
+#
+#   # Interactive: the gate prompts on the terminal ([a]pprove/[r]evise/re[j]ect/[s]uspend)
+#   looms workflow run hitl-gated-pipeline.yaml
+#
+#   # Non-interactive: the gate writes a durable checkpoint and exits
+#   looms workflow run hitl-gated-pipeline.yaml --suspend-to review.pb
+#
+#   # Resume after review (the workflow file must be unchanged — the
+#   # checkpoint fingerprints the definition and refuses edited workflows)
+#   looms workflow resume hitl-gated-pipeline.yaml review.pb --approve
+#   looms workflow resume hitl-gated-pipeline.yaml review.pb --revise "Use MULTISET and COMPRESS the status column"
+#   looms workflow resume hitl-gated-pipeline.yaml review.pb --reject
+#
+# Agent configs used (from $LOOM_DATA_DIR/agents/):
+# - schema-analyst.yaml: read-only schema discovery and requirements analysis
+# - ddl-designer.yaml:   Teradata DDL generation (no execution tools)
+# - ddl-executor.yaml:   DDL execution against the target database

--- a/gen/go/loom/v1/orchestration.pb.go
+++ b/gen/go/loom/v1/orchestration.pb.go
@@ -26,6 +26,121 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// GateTimeoutAction defines gate behavior on decision timeout.
+type GateTimeoutAction int32
+
+const (
+	// Unset — treated as GATE_TIMEOUT_ACTION_FAIL.
+	GateTimeoutAction_GATE_TIMEOUT_ACTION_UNSPECIFIED GateTimeoutAction = 0
+	// Fail the workflow run (safe default).
+	GateTimeoutAction_GATE_TIMEOUT_ACTION_FAIL GateTimeoutAction = 1
+	// Treat as a rejection (workflow ends without executing later stages).
+	GateTimeoutAction_GATE_TIMEOUT_ACTION_REJECT GateTimeoutAction = 2
+	// Auto-approve and continue (use only for advisory gates).
+	GateTimeoutAction_GATE_TIMEOUT_ACTION_APPROVE GateTimeoutAction = 3
+)
+
+// Enum value maps for GateTimeoutAction.
+var (
+	GateTimeoutAction_name = map[int32]string{
+		0: "GATE_TIMEOUT_ACTION_UNSPECIFIED",
+		1: "GATE_TIMEOUT_ACTION_FAIL",
+		2: "GATE_TIMEOUT_ACTION_REJECT",
+		3: "GATE_TIMEOUT_ACTION_APPROVE",
+	}
+	GateTimeoutAction_value = map[string]int32{
+		"GATE_TIMEOUT_ACTION_UNSPECIFIED": 0,
+		"GATE_TIMEOUT_ACTION_FAIL":        1,
+		"GATE_TIMEOUT_ACTION_REJECT":      2,
+		"GATE_TIMEOUT_ACTION_APPROVE":     3,
+	}
+)
+
+func (x GateTimeoutAction) Enum() *GateTimeoutAction {
+	p := new(GateTimeoutAction)
+	*p = x
+	return p
+}
+
+func (x GateTimeoutAction) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (GateTimeoutAction) Descriptor() protoreflect.EnumDescriptor {
+	return file_loom_v1_orchestration_proto_enumTypes[0].Descriptor()
+}
+
+func (GateTimeoutAction) Type() protoreflect.EnumType {
+	return &file_loom_v1_orchestration_proto_enumTypes[0]
+}
+
+func (x GateTimeoutAction) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use GateTimeoutAction.Descriptor instead.
+func (GateTimeoutAction) EnumDescriptor() ([]byte, []int) {
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{0}
+}
+
+// GateAction is the human's decision at a gate.
+type GateAction int32
+
+const (
+	// Unset — invalid; hosts must supply an explicit action.
+	GateAction_GATE_ACTION_UNSPECIFIED GateAction = 0
+	// Continue to the next stage.
+	GateAction_GATE_ACTION_APPROVE GateAction = 1
+	// Restart at HITLGate.revise_target_stage_id with GateDecision.feedback
+	// threaded into that stage's prompt ({{revision_feedback}}).
+	GateAction_GATE_ACTION_REVISE GateAction = 2
+	// End the workflow without executing later stages.
+	GateAction_GATE_ACTION_REJECT GateAction = 3
+)
+
+// Enum value maps for GateAction.
+var (
+	GateAction_name = map[int32]string{
+		0: "GATE_ACTION_UNSPECIFIED",
+		1: "GATE_ACTION_APPROVE",
+		2: "GATE_ACTION_REVISE",
+		3: "GATE_ACTION_REJECT",
+	}
+	GateAction_value = map[string]int32{
+		"GATE_ACTION_UNSPECIFIED": 0,
+		"GATE_ACTION_APPROVE":     1,
+		"GATE_ACTION_REVISE":      2,
+		"GATE_ACTION_REJECT":      3,
+	}
+)
+
+func (x GateAction) Enum() *GateAction {
+	p := new(GateAction)
+	*p = x
+	return p
+}
+
+func (x GateAction) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (GateAction) Descriptor() protoreflect.EnumDescriptor {
+	return file_loom_v1_orchestration_proto_enumTypes[1].Descriptor()
+}
+
+func (GateAction) Type() protoreflect.EnumType {
+	return &file_loom_v1_orchestration_proto_enumTypes[1]
+}
+
+func (x GateAction) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use GateAction.Descriptor instead.
+func (GateAction) EnumDescriptor() ([]byte, []int) {
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{1}
+}
+
 // MergeStrategy defines how to combine multiple agent outputs.
 type MergeStrategy int32
 
@@ -78,11 +193,11 @@ func (x MergeStrategy) String() string {
 }
 
 func (MergeStrategy) Descriptor() protoreflect.EnumDescriptor {
-	return file_loom_v1_orchestration_proto_enumTypes[0].Descriptor()
+	return file_loom_v1_orchestration_proto_enumTypes[2].Descriptor()
 }
 
 func (MergeStrategy) Type() protoreflect.EnumType {
-	return &file_loom_v1_orchestration_proto_enumTypes[0]
+	return &file_loom_v1_orchestration_proto_enumTypes[2]
 }
 
 func (x MergeStrategy) Number() protoreflect.EnumNumber {
@@ -91,7 +206,7 @@ func (x MergeStrategy) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use MergeStrategy.Descriptor instead.
 func (MergeStrategy) EnumDescriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{0}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{2}
 }
 
 // ScheduledSessionMode controls session lifecycle for scheduled workflow executions.
@@ -132,11 +247,11 @@ func (x ScheduledSessionMode) String() string {
 }
 
 func (ScheduledSessionMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_loom_v1_orchestration_proto_enumTypes[1].Descriptor()
+	return file_loom_v1_orchestration_proto_enumTypes[3].Descriptor()
 }
 
 func (ScheduledSessionMode) Type() protoreflect.EnumType {
-	return &file_loom_v1_orchestration_proto_enumTypes[1]
+	return &file_loom_v1_orchestration_proto_enumTypes[3]
 }
 
 func (x ScheduledSessionMode) Number() protoreflect.EnumNumber {
@@ -145,7 +260,7 @@ func (x ScheduledSessionMode) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ScheduledSessionMode.Descriptor instead.
 func (ScheduledSessionMode) EnumDescriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{1}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{3}
 }
 
 // WorkflowPattern defines orchestration patterns for multi-agent coordination.
@@ -610,7 +725,14 @@ type PipelineStage struct {
 	OutputSchema string `protobuf:"bytes,5,opt,name=output_schema,json=outputSchema,proto3" json:"output_schema,omitempty"`
 	// Optional: Unified output validation policy. When set, takes precedence
 	// over the legacy validation_prompt + output_schema + retry_policy fields.
-	OutputPolicy  *OutputPolicy `protobuf:"bytes,6,opt,name=output_policy,json=outputPolicy,proto3" json:"output_policy,omitempty"`
+	OutputPolicy *OutputPolicy `protobuf:"bytes,6,opt,name=output_policy,json=outputPolicy,proto3" json:"output_policy,omitempty"`
+	// Optional: Human-in-the-loop approval gate evaluated AFTER this stage's
+	// output passes validation and BEFORE the next stage starts. When the gate
+	// fires, the executor either asks a configured HITLHandler for an inline
+	// decision or suspends the workflow with a WorkflowCheckpoint the host can
+	// persist and later resume. Gates are supported on pipeline and iterative
+	// patterns only.
+	HitlGate      *HITLGate `protobuf:"bytes,7,opt,name=hitl_gate,json=hitlGate,proto3" json:"hitl_gate,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -687,6 +809,595 @@ func (x *PipelineStage) GetOutputPolicy() *OutputPolicy {
 	return nil
 }
 
+func (x *PipelineStage) GetHitlGate() *HITLGate {
+	if x != nil {
+		return x.HitlGate
+	}
+	return nil
+}
+
+// HITLGate declares a human approval gate on a pipeline stage boundary.
+// Gates are deterministic control flow — they always fire when configured,
+// unlike agent-initiated contact_human tool calls.
+type HITLGate struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Prompt shown to the human reviewer. Supports the {{output}} placeholder,
+	// replaced with the gated stage's (possibly truncated) output.
+	// Empty = a default "review the output of stage N" prompt.
+	PromptTemplate string `protobuf:"bytes,1,opt,name=prompt_template,json=promptTemplate,proto3" json:"prompt_template,omitempty"`
+	// Request type shown to the host UI (approval, decision, input, review).
+	// Aligned with HITLRequestInfo.request_type. Default: "approval".
+	RequestType string `protobuf:"bytes,2,opt,name=request_type,json=requestType,proto3" json:"request_type,omitempty"`
+	// Advisory timeout for the human decision, in seconds. In suspend mode the
+	// HOST enforces expiry of the persisted checkpoint; in inline-handler mode
+	// the handler context is bounded by this timeout. 0 = host default.
+	TimeoutSeconds int32 `protobuf:"varint,3,opt,name=timeout_seconds,json=timeoutSeconds,proto3" json:"timeout_seconds,omitempty"`
+	// Stage (agent_id) to restart when the decision is REVISE.
+	// Empty = restart the gated stage itself. Must be at or before the gated
+	// stage in pipeline order — forward jumps are invalid.
+	ReviseTargetStageId string `protobuf:"bytes,4,opt,name=revise_target_stage_id,json=reviseTargetStageId,proto3" json:"revise_target_stage_id,omitempty"`
+	// Maximum REVISE round-trips this gate accepts before the workflow fails
+	// (prevents endless review loops). Default: 3.
+	MaxRevisions int32 `protobuf:"varint,5,opt,name=max_revisions,json=maxRevisions,proto3" json:"max_revisions,omitempty"`
+	// What to do when the decision times out (enforced by the host in suspend
+	// mode). Default (UNSPECIFIED) is treated as FAIL.
+	OnTimeout     GateTimeoutAction `protobuf:"varint,6,opt,name=on_timeout,json=onTimeout,proto3,enum=loom.v1.GateTimeoutAction" json:"on_timeout,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HITLGate) Reset() {
+	*x = HITLGate{}
+	mi := &file_loom_v1_orchestration_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HITLGate) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HITLGate) ProtoMessage() {}
+
+func (x *HITLGate) ProtoReflect() protoreflect.Message {
+	mi := &file_loom_v1_orchestration_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HITLGate.ProtoReflect.Descriptor instead.
+func (*HITLGate) Descriptor() ([]byte, []int) {
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *HITLGate) GetPromptTemplate() string {
+	if x != nil {
+		return x.PromptTemplate
+	}
+	return ""
+}
+
+func (x *HITLGate) GetRequestType() string {
+	if x != nil {
+		return x.RequestType
+	}
+	return ""
+}
+
+func (x *HITLGate) GetTimeoutSeconds() int32 {
+	if x != nil {
+		return x.TimeoutSeconds
+	}
+	return 0
+}
+
+func (x *HITLGate) GetReviseTargetStageId() string {
+	if x != nil {
+		return x.ReviseTargetStageId
+	}
+	return ""
+}
+
+func (x *HITLGate) GetMaxRevisions() int32 {
+	if x != nil {
+		return x.MaxRevisions
+	}
+	return 0
+}
+
+func (x *HITLGate) GetOnTimeout() GateTimeoutAction {
+	if x != nil {
+		return x.OnTimeout
+	}
+	return GateTimeoutAction_GATE_TIMEOUT_ACTION_UNSPECIFIED
+}
+
+// HITLGateRequest is what the executor hands the host (or HITLHandler) when a
+// gate fires: everything a UI needs to render the review and collect a decision.
+type HITLGateRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Workflow ID of the suspended run (session determinism on resume).
+	WorkflowId string `protobuf:"bytes,1,opt,name=workflow_id,json=workflowId,proto3" json:"workflow_id,omitempty"`
+	// Agent ID of the gated stage.
+	StageAgentId string `protobuf:"bytes,2,opt,name=stage_agent_id,json=stageAgentId,proto3" json:"stage_agent_id,omitempty"`
+	// 1-based stage number of the gated stage.
+	StageNumber int32 `protobuf:"varint,3,opt,name=stage_number,json=stageNumber,proto3" json:"stage_number,omitempty"`
+	// Rendered question for the human (prompt_template with {{output}} applied).
+	Question string `protobuf:"bytes,4,opt,name=question,proto3" json:"question,omitempty"`
+	// The full stage output under review.
+	StageOutput string `protobuf:"bytes,5,opt,name=stage_output,json=stageOutput,proto3" json:"stage_output,omitempty"`
+	// Request type (approval, decision, input, review).
+	RequestType string `protobuf:"bytes,6,opt,name=request_type,json=requestType,proto3" json:"request_type,omitempty"`
+	// Advisory decision timeout in seconds (from HITLGate.timeout_seconds).
+	TimeoutSeconds int32 `protobuf:"varint,7,opt,name=timeout_seconds,json=timeoutSeconds,proto3" json:"timeout_seconds,omitempty"`
+	// Suggested decision options for the UI (e.g. approve, revise, reject).
+	Options       []string `protobuf:"bytes,8,rep,name=options,proto3" json:"options,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HITLGateRequest) Reset() {
+	*x = HITLGateRequest{}
+	mi := &file_loom_v1_orchestration_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HITLGateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HITLGateRequest) ProtoMessage() {}
+
+func (x *HITLGateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_loom_v1_orchestration_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HITLGateRequest.ProtoReflect.Descriptor instead.
+func (*HITLGateRequest) Descriptor() ([]byte, []int) {
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *HITLGateRequest) GetWorkflowId() string {
+	if x != nil {
+		return x.WorkflowId
+	}
+	return ""
+}
+
+func (x *HITLGateRequest) GetStageAgentId() string {
+	if x != nil {
+		return x.StageAgentId
+	}
+	return ""
+}
+
+func (x *HITLGateRequest) GetStageNumber() int32 {
+	if x != nil {
+		return x.StageNumber
+	}
+	return 0
+}
+
+func (x *HITLGateRequest) GetQuestion() string {
+	if x != nil {
+		return x.Question
+	}
+	return ""
+}
+
+func (x *HITLGateRequest) GetStageOutput() string {
+	if x != nil {
+		return x.StageOutput
+	}
+	return ""
+}
+
+func (x *HITLGateRequest) GetRequestType() string {
+	if x != nil {
+		return x.RequestType
+	}
+	return ""
+}
+
+func (x *HITLGateRequest) GetTimeoutSeconds() int32 {
+	if x != nil {
+		return x.TimeoutSeconds
+	}
+	return 0
+}
+
+func (x *HITLGateRequest) GetOptions() []string {
+	if x != nil {
+		return x.Options
+	}
+	return nil
+}
+
+// GateDecision carries the human's decision back into the executor.
+type GateDecision struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The action to take.
+	Action GateAction `protobuf:"varint,1,opt,name=action,proto3,enum=loom.v1.GateAction" json:"action,omitempty"`
+	// Free-text feedback. Required for REVISE (it becomes {{revision_feedback}}
+	// in the restarted stage's prompt); optional context for APPROVE/REJECT.
+	Feedback string `protobuf:"bytes,2,opt,name=feedback,proto3" json:"feedback,omitempty"`
+	// Optional identity of the decision maker (audit metadata for the host).
+	DecidedBy     string `protobuf:"bytes,3,opt,name=decided_by,json=decidedBy,proto3" json:"decided_by,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GateDecision) Reset() {
+	*x = GateDecision{}
+	mi := &file_loom_v1_orchestration_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GateDecision) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GateDecision) ProtoMessage() {}
+
+func (x *GateDecision) ProtoReflect() protoreflect.Message {
+	mi := &file_loom_v1_orchestration_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GateDecision.ProtoReflect.Descriptor instead.
+func (*GateDecision) Descriptor() ([]byte, []int) {
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *GateDecision) GetAction() GateAction {
+	if x != nil {
+		return x.Action
+	}
+	return GateAction_GATE_ACTION_UNSPECIFIED
+}
+
+func (x *GateDecision) GetFeedback() string {
+	if x != nil {
+		return x.Feedback
+	}
+	return ""
+}
+
+func (x *GateDecision) GetDecidedBy() string {
+	if x != nil {
+		return x.DecidedBy
+	}
+	return ""
+}
+
+// WorkflowCheckpoint is the durable suspension state of a pipeline or
+// iterative workflow, captured at a stage boundary when a HITL gate fires.
+// It never contains in-flight agent-loop state: gates only fire between
+// stages, so completed stage outputs plus counters fully describe the run.
+// Hosts persist this server-side; it is not intended for untrusted clients.
+type WorkflowCheckpoint struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Checkpoint schema version for forward evolution. Current version: 1.
+	CheckpointVersion int32 `protobuf:"varint,1,opt,name=checkpoint_version,json=checkpointVersion,proto3" json:"checkpoint_version,omitempty"`
+	// SHA-256 (hex) of the deterministically-marshaled WorkflowPattern this
+	// checkpoint was taken against. Resume MUST verify this matches the
+	// pattern it is resuming with — resuming against an edited workflow is
+	// how unreviewed changes would get executed.
+	ConfigFingerprint string `protobuf:"bytes,2,opt,name=config_fingerprint,json=configFingerprint,proto3" json:"config_fingerprint,omitempty"`
+	// Resolved workflow ID of the original run (keeps stage session IDs
+	// deterministic across suspend/resume).
+	WorkflowId string `protobuf:"bytes,3,opt,name=workflow_id,json=workflowId,proto3" json:"workflow_id,omitempty"`
+	// Pattern type at suspension: "pipeline" or "iterative_pipeline".
+	PatternType string `protobuf:"bytes,4,opt,name=pattern_type,json=patternType,proto3" json:"pattern_type,omitempty"`
+	// 0-based index of the stage to execute on APPROVE (gated stage + 1).
+	NextStageIndex int32 `protobuf:"varint,5,opt,name=next_stage_index,json=nextStageIndex,proto3" json:"next_stage_index,omitempty"`
+	// Latest full output per completed stage, ordered by stage index for the
+	// current pass. Used to rehydrate {{previous}}/{{history}} context and to
+	// re-seed SharedMemory stage-N-output keys on resume.
+	StageSnapshots []*CheckpointStageSnapshot `protobuf:"bytes,6,rep,name=stage_snapshots,json=stageSnapshots,proto3" json:"stage_snapshots,omitempty"`
+	// Append-only execution history (all attempts, including superseded ones)
+	// so cost accounting stays accurate across suspend/resume.
+	AllResults []*AgentResult `protobuf:"bytes,7,rep,name=all_results,json=allResults,proto3" json:"all_results,omitempty"`
+	// Models used so far (agent_id -> model name).
+	ModelsUsed map[string]string `protobuf:"bytes,8,rep,name=models_used,json=modelsUsed,proto3" json:"models_used,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Validation warnings accumulated so far (plain pipeline graceful
+	// degradation path).
+	ValidationWarnings []string `protobuf:"bytes,9,rep,name=validation_warnings,json=validationWarnings,proto3" json:"validation_warnings,omitempty"`
+	// Iterative-pattern iteration counter at suspension (0 for plain pipeline).
+	Iteration int32 `protobuf:"varint,10,opt,name=iteration,proto3" json:"iteration,omitempty"`
+	// REVISE round-trips consumed per gate (keyed by gated stage agent_id).
+	GateRevisionCounts map[string]int32 `protobuf:"bytes,11,rep,name=gate_revision_counts,json=gateRevisionCounts,proto3" json:"gate_revision_counts,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
+	// The gate request awaiting a decision.
+	PendingGate *HITLGateRequest `protobuf:"bytes,12,opt,name=pending_gate,json=pendingGate,proto3" json:"pending_gate,omitempty"`
+	// Snapshot of agent-written WORKFLOW-namespace SharedMemory entries
+	// (stage-N-output keys are excluded — they are re-seeded from
+	// stage_snapshots). Restored on resume.
+	SharedMemory []*CheckpointMemoryEntry `protobuf:"bytes,13,rep,name=shared_memory,json=sharedMemory,proto3" json:"shared_memory,omitempty"`
+	// Checkpoint creation time (Unix milliseconds).
+	CreatedAtMs   int64 `protobuf:"varint,14,opt,name=created_at_ms,json=createdAtMs,proto3" json:"created_at_ms,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkflowCheckpoint) Reset() {
+	*x = WorkflowCheckpoint{}
+	mi := &file_loom_v1_orchestration_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkflowCheckpoint) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkflowCheckpoint) ProtoMessage() {}
+
+func (x *WorkflowCheckpoint) ProtoReflect() protoreflect.Message {
+	mi := &file_loom_v1_orchestration_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkflowCheckpoint.ProtoReflect.Descriptor instead.
+func (*WorkflowCheckpoint) Descriptor() ([]byte, []int) {
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *WorkflowCheckpoint) GetCheckpointVersion() int32 {
+	if x != nil {
+		return x.CheckpointVersion
+	}
+	return 0
+}
+
+func (x *WorkflowCheckpoint) GetConfigFingerprint() string {
+	if x != nil {
+		return x.ConfigFingerprint
+	}
+	return ""
+}
+
+func (x *WorkflowCheckpoint) GetWorkflowId() string {
+	if x != nil {
+		return x.WorkflowId
+	}
+	return ""
+}
+
+func (x *WorkflowCheckpoint) GetPatternType() string {
+	if x != nil {
+		return x.PatternType
+	}
+	return ""
+}
+
+func (x *WorkflowCheckpoint) GetNextStageIndex() int32 {
+	if x != nil {
+		return x.NextStageIndex
+	}
+	return 0
+}
+
+func (x *WorkflowCheckpoint) GetStageSnapshots() []*CheckpointStageSnapshot {
+	if x != nil {
+		return x.StageSnapshots
+	}
+	return nil
+}
+
+func (x *WorkflowCheckpoint) GetAllResults() []*AgentResult {
+	if x != nil {
+		return x.AllResults
+	}
+	return nil
+}
+
+func (x *WorkflowCheckpoint) GetModelsUsed() map[string]string {
+	if x != nil {
+		return x.ModelsUsed
+	}
+	return nil
+}
+
+func (x *WorkflowCheckpoint) GetValidationWarnings() []string {
+	if x != nil {
+		return x.ValidationWarnings
+	}
+	return nil
+}
+
+func (x *WorkflowCheckpoint) GetIteration() int32 {
+	if x != nil {
+		return x.Iteration
+	}
+	return 0
+}
+
+func (x *WorkflowCheckpoint) GetGateRevisionCounts() map[string]int32 {
+	if x != nil {
+		return x.GateRevisionCounts
+	}
+	return nil
+}
+
+func (x *WorkflowCheckpoint) GetPendingGate() *HITLGateRequest {
+	if x != nil {
+		return x.PendingGate
+	}
+	return nil
+}
+
+func (x *WorkflowCheckpoint) GetSharedMemory() []*CheckpointMemoryEntry {
+	if x != nil {
+		return x.SharedMemory
+	}
+	return nil
+}
+
+func (x *WorkflowCheckpoint) GetCreatedAtMs() int64 {
+	if x != nil {
+		return x.CreatedAtMs
+	}
+	return 0
+}
+
+// CheckpointStageSnapshot is the latest full output of one completed stage.
+type CheckpointStageSnapshot struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Agent ID of the stage.
+	AgentId string `protobuf:"bytes,1,opt,name=agent_id,json=agentId,proto3" json:"agent_id,omitempty"`
+	// Full (untruncated) stage output.
+	FullOutput    string `protobuf:"bytes,2,opt,name=full_output,json=fullOutput,proto3" json:"full_output,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CheckpointStageSnapshot) Reset() {
+	*x = CheckpointStageSnapshot{}
+	mi := &file_loom_v1_orchestration_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CheckpointStageSnapshot) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CheckpointStageSnapshot) ProtoMessage() {}
+
+func (x *CheckpointStageSnapshot) ProtoReflect() protoreflect.Message {
+	mi := &file_loom_v1_orchestration_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CheckpointStageSnapshot.ProtoReflect.Descriptor instead.
+func (*CheckpointStageSnapshot) Descriptor() ([]byte, []int) {
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *CheckpointStageSnapshot) GetAgentId() string {
+	if x != nil {
+		return x.AgentId
+	}
+	return ""
+}
+
+func (x *CheckpointStageSnapshot) GetFullOutput() string {
+	if x != nil {
+		return x.FullOutput
+	}
+	return ""
+}
+
+// CheckpointMemoryEntry is one preserved WORKFLOW-namespace SharedMemory entry.
+type CheckpointMemoryEntry struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// SharedMemory key.
+	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	// Raw value bytes.
+	Value []byte `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	// Agent that wrote the entry.
+	AgentId string `protobuf:"bytes,3,opt,name=agent_id,json=agentId,proto3" json:"agent_id,omitempty"`
+	// Entry metadata.
+	Metadata      map[string]string `protobuf:"bytes,4,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CheckpointMemoryEntry) Reset() {
+	*x = CheckpointMemoryEntry{}
+	mi := &file_loom_v1_orchestration_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CheckpointMemoryEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CheckpointMemoryEntry) ProtoMessage() {}
+
+func (x *CheckpointMemoryEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_loom_v1_orchestration_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CheckpointMemoryEntry.ProtoReflect.Descriptor instead.
+func (*CheckpointMemoryEntry) Descriptor() ([]byte, []int) {
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *CheckpointMemoryEntry) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+func (x *CheckpointMemoryEntry) GetValue() []byte {
+	if x != nil {
+		return x.Value
+	}
+	return nil
+}
+
+func (x *CheckpointMemoryEntry) GetAgentId() string {
+	if x != nil {
+		return x.AgentId
+	}
+	return ""
+}
+
+func (x *CheckpointMemoryEntry) GetMetadata() map[string]string {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 // IterativeWorkflowPattern extends PipelinePattern with autonomous restart capabilities.
 // Stages can trigger restarts of earlier stages via pub/sub coordination, enabling
 // agents to negotiate and self-correct without human intervention.
@@ -713,7 +1424,7 @@ type IterativeWorkflowPattern struct {
 
 func (x *IterativeWorkflowPattern) Reset() {
 	*x = IterativeWorkflowPattern{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[5]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -725,7 +1436,7 @@ func (x *IterativeWorkflowPattern) String() string {
 func (*IterativeWorkflowPattern) ProtoMessage() {}
 
 func (x *IterativeWorkflowPattern) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[5]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -738,7 +1449,7 @@ func (x *IterativeWorkflowPattern) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IterativeWorkflowPattern.ProtoReflect.Descriptor instead.
 func (*IterativeWorkflowPattern) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{5}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *IterativeWorkflowPattern) GetPipeline() *PipelinePattern {
@@ -798,7 +1509,7 @@ type RestartPolicy struct {
 
 func (x *RestartPolicy) Reset() {
 	*x = RestartPolicy{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[6]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -810,7 +1521,7 @@ func (x *RestartPolicy) String() string {
 func (*RestartPolicy) ProtoMessage() {}
 
 func (x *RestartPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[6]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -823,7 +1534,7 @@ func (x *RestartPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestartPolicy.ProtoReflect.Descriptor instead.
 func (*RestartPolicy) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{6}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *RestartPolicy) GetEnabled() bool {
@@ -890,7 +1601,7 @@ type RestartRequest struct {
 
 func (x *RestartRequest) Reset() {
 	*x = RestartRequest{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[7]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -902,7 +1613,7 @@ func (x *RestartRequest) String() string {
 func (*RestartRequest) ProtoMessage() {}
 
 func (x *RestartRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[7]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -915,7 +1626,7 @@ func (x *RestartRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestartRequest.ProtoReflect.Descriptor instead.
 func (*RestartRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{7}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *RestartRequest) GetRequesterStageId() string {
@@ -979,7 +1690,7 @@ type RestartResponse struct {
 
 func (x *RestartResponse) Reset() {
 	*x = RestartResponse{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[8]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -991,7 +1702,7 @@ func (x *RestartResponse) String() string {
 func (*RestartResponse) ProtoMessage() {}
 
 func (x *RestartResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[8]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1004,7 +1715,7 @@ func (x *RestartResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestartResponse.ProtoReflect.Descriptor instead.
 func (*RestartResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{8}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *RestartResponse) GetTargetStageId() string {
@@ -1058,7 +1769,7 @@ type ParallelPattern struct {
 
 func (x *ParallelPattern) Reset() {
 	*x = ParallelPattern{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[9]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1070,7 +1781,7 @@ func (x *ParallelPattern) String() string {
 func (*ParallelPattern) ProtoMessage() {}
 
 func (x *ParallelPattern) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[9]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1083,7 +1794,7 @@ func (x *ParallelPattern) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ParallelPattern.ProtoReflect.Descriptor instead.
 func (*ParallelPattern) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{9}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ParallelPattern) GetTasks() []*AgentTask {
@@ -1124,7 +1835,7 @@ type AgentTask struct {
 
 func (x *AgentTask) Reset() {
 	*x = AgentTask{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[10]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1136,7 +1847,7 @@ func (x *AgentTask) String() string {
 func (*AgentTask) ProtoMessage() {}
 
 func (x *AgentTask) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[10]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1149,7 +1860,7 @@ func (x *AgentTask) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentTask.ProtoReflect.Descriptor instead.
 func (*AgentTask) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{10}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *AgentTask) GetAgentId() string {
@@ -1202,7 +1913,7 @@ type ConditionalPattern struct {
 
 func (x *ConditionalPattern) Reset() {
 	*x = ConditionalPattern{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[11]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1214,7 +1925,7 @@ func (x *ConditionalPattern) String() string {
 func (*ConditionalPattern) ProtoMessage() {}
 
 func (x *ConditionalPattern) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[11]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1227,7 +1938,7 @@ func (x *ConditionalPattern) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConditionalPattern.ProtoReflect.Descriptor instead.
 func (*ConditionalPattern) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{11}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ConditionalPattern) GetConditionAgentId() string {
@@ -1301,7 +2012,7 @@ type WorkflowResult struct {
 
 func (x *WorkflowResult) Reset() {
 	*x = WorkflowResult{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[12]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1313,7 +2024,7 @@ func (x *WorkflowResult) String() string {
 func (*WorkflowResult) ProtoMessage() {}
 
 func (x *WorkflowResult) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[12]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1326,7 +2037,7 @@ func (x *WorkflowResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkflowResult.ProtoReflect.Descriptor instead.
 func (*WorkflowResult) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{12}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *WorkflowResult) GetPatternType() string {
@@ -1482,7 +2193,7 @@ type DebateResult struct {
 
 func (x *DebateResult) Reset() {
 	*x = DebateResult{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[13]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1494,7 +2205,7 @@ func (x *DebateResult) String() string {
 func (*DebateResult) ProtoMessage() {}
 
 func (x *DebateResult) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[13]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1507,7 +2218,7 @@ func (x *DebateResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DebateResult.ProtoReflect.Descriptor instead.
 func (*DebateResult) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{13}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *DebateResult) GetRounds() []*DebateRound {
@@ -1566,7 +2277,7 @@ type AgentResult struct {
 
 func (x *AgentResult) Reset() {
 	*x = AgentResult{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[14]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1578,7 +2289,7 @@ func (x *AgentResult) String() string {
 func (*AgentResult) ProtoMessage() {}
 
 func (x *AgentResult) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[14]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1591,7 +2302,7 @@ func (x *AgentResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentResult.ProtoReflect.Descriptor instead.
 func (*AgentResult) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{14}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *AgentResult) GetAgentId() string {
@@ -1657,7 +2368,7 @@ type AgentExecutionCost struct {
 
 func (x *AgentExecutionCost) Reset() {
 	*x = AgentExecutionCost{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[15]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1669,7 +2380,7 @@ func (x *AgentExecutionCost) String() string {
 func (*AgentExecutionCost) ProtoMessage() {}
 
 func (x *AgentExecutionCost) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[15]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1682,7 +2393,7 @@ func (x *AgentExecutionCost) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentExecutionCost.ProtoReflect.Descriptor instead.
 func (*AgentExecutionCost) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{15}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *AgentExecutionCost) GetTotalTokens() int32 {
@@ -1744,7 +2455,7 @@ type WorkflowCost struct {
 
 func (x *WorkflowCost) Reset() {
 	*x = WorkflowCost{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[16]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1756,7 +2467,7 @@ func (x *WorkflowCost) String() string {
 func (*WorkflowCost) ProtoMessage() {}
 
 func (x *WorkflowCost) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[16]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1769,7 +2480,7 @@ func (x *WorkflowCost) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkflowCost.ProtoReflect.Descriptor instead.
 func (*WorkflowCost) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{16}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *WorkflowCost) GetTotalCostUsd() float64 {
@@ -1823,7 +2534,7 @@ type WorkflowExecution struct {
 
 func (x *WorkflowExecution) Reset() {
 	*x = WorkflowExecution{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[17]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1835,7 +2546,7 @@ func (x *WorkflowExecution) String() string {
 func (*WorkflowExecution) ProtoMessage() {}
 
 func (x *WorkflowExecution) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[17]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1848,7 +2559,7 @@ func (x *WorkflowExecution) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkflowExecution.ProtoReflect.Descriptor instead.
 func (*WorkflowExecution) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{17}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *WorkflowExecution) GetId() string {
@@ -1924,7 +2635,7 @@ type ExecuteWorkflowRequest struct {
 
 func (x *ExecuteWorkflowRequest) Reset() {
 	*x = ExecuteWorkflowRequest{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[18]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1936,7 +2647,7 @@ func (x *ExecuteWorkflowRequest) String() string {
 func (*ExecuteWorkflowRequest) ProtoMessage() {}
 
 func (x *ExecuteWorkflowRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[18]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1949,7 +2660,7 @@ func (x *ExecuteWorkflowRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecuteWorkflowRequest.ProtoReflect.Descriptor instead.
 func (*ExecuteWorkflowRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{18}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ExecuteWorkflowRequest) GetPattern() *WorkflowPattern {
@@ -2009,7 +2720,7 @@ type WorkflowSummary struct {
 
 func (x *WorkflowSummary) Reset() {
 	*x = WorkflowSummary{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[19]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2021,7 +2732,7 @@ func (x *WorkflowSummary) String() string {
 func (*WorkflowSummary) ProtoMessage() {}
 
 func (x *WorkflowSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[19]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2034,7 +2745,7 @@ func (x *WorkflowSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkflowSummary.ProtoReflect.Descriptor instead.
 func (*WorkflowSummary) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{19}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *WorkflowSummary) GetName() string {
@@ -2067,7 +2778,7 @@ type ListWorkflowsRequest struct {
 
 func (x *ListWorkflowsRequest) Reset() {
 	*x = ListWorkflowsRequest{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[20]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2079,7 +2790,7 @@ func (x *ListWorkflowsRequest) String() string {
 func (*ListWorkflowsRequest) ProtoMessage() {}
 
 func (x *ListWorkflowsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[20]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2092,7 +2803,7 @@ func (x *ListWorkflowsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkflowsRequest.ProtoReflect.Descriptor instead.
 func (*ListWorkflowsRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{20}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{26}
 }
 
 // ListWorkflowsResponse returns the saved workflows.
@@ -2105,7 +2816,7 @@ type ListWorkflowsResponse struct {
 
 func (x *ListWorkflowsResponse) Reset() {
 	*x = ListWorkflowsResponse{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[21]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2117,7 +2828,7 @@ func (x *ListWorkflowsResponse) String() string {
 func (*ListWorkflowsResponse) ProtoMessage() {}
 
 func (x *ListWorkflowsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[21]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2130,7 +2841,7 @@ func (x *ListWorkflowsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkflowsResponse.ProtoReflect.Descriptor instead.
 func (*ListWorkflowsResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{21}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ListWorkflowsResponse) GetWorkflows() []*WorkflowSummary {
@@ -2153,7 +2864,7 @@ type ExecuteWorkflowResponse struct {
 
 func (x *ExecuteWorkflowResponse) Reset() {
 	*x = ExecuteWorkflowResponse{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[22]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2165,7 +2876,7 @@ func (x *ExecuteWorkflowResponse) String() string {
 func (*ExecuteWorkflowResponse) ProtoMessage() {}
 
 func (x *ExecuteWorkflowResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[22]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2178,7 +2889,7 @@ func (x *ExecuteWorkflowResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecuteWorkflowResponse.ProtoReflect.Descriptor instead.
 func (*ExecuteWorkflowResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{22}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ExecuteWorkflowResponse) GetExecutionId() string {
@@ -2223,7 +2934,7 @@ type ScheduleConfig struct {
 
 func (x *ScheduleConfig) Reset() {
 	*x = ScheduleConfig{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[23]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2235,7 +2946,7 @@ func (x *ScheduleConfig) String() string {
 func (*ScheduleConfig) ProtoMessage() {}
 
 func (x *ScheduleConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[23]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2248,7 +2959,7 @@ func (x *ScheduleConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScheduleConfig.ProtoReflect.Descriptor instead.
 func (*ScheduleConfig) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{23}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ScheduleConfig) GetCron() string {
@@ -2334,7 +3045,7 @@ type ScheduledWorkflow struct {
 
 func (x *ScheduledWorkflow) Reset() {
 	*x = ScheduledWorkflow{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[24]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2346,7 +3057,7 @@ func (x *ScheduledWorkflow) String() string {
 func (*ScheduledWorkflow) ProtoMessage() {}
 
 func (x *ScheduledWorkflow) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[24]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2359,7 +3070,7 @@ func (x *ScheduledWorkflow) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScheduledWorkflow.ProtoReflect.Descriptor instead.
 func (*ScheduledWorkflow) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{24}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ScheduledWorkflow) GetId() string {
@@ -2467,7 +3178,7 @@ type ScheduleStats struct {
 
 func (x *ScheduleStats) Reset() {
 	*x = ScheduleStats{}
-	mi := &file_loom_v1_orchestration_proto_msgTypes[25]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2479,7 +3190,7 @@ func (x *ScheduleStats) String() string {
 func (*ScheduleStats) ProtoMessage() {}
 
 func (x *ScheduleStats) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_orchestration_proto_msgTypes[25]
+	mi := &file_loom_v1_orchestration_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2492,7 +3203,7 @@ func (x *ScheduleStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScheduleStats.ProtoReflect.Descriptor instead.
 func (*ScheduleStats) Descriptor() ([]byte, []int) {
-	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{25}
+	return file_loom_v1_orchestration_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ScheduleStats) GetTotalExecutions() int32 {
@@ -2571,14 +3282,75 @@ const file_loom_v1_orchestration_proto_rawDesc = "" +
 	"\x0fPipelinePattern\x12%\n" +
 	"\x0einitial_prompt\x18\x01 \x01(\tR\rinitialPrompt\x12.\n" +
 	"\x06stages\x18\x02 \x03(\v2\x16.loom.v1.PipelineStageR\x06stages\x12*\n" +
-	"\x11pass_full_history\x18\x03 \x01(\bR\x0fpassFullHistory\"\xa0\x02\n" +
+	"\x11pass_full_history\x18\x03 \x01(\bR\x0fpassFullHistory\"\xd0\x02\n" +
 	"\rPipelineStage\x12\x19\n" +
 	"\bagent_id\x18\x01 \x01(\tR\aagentId\x12'\n" +
 	"\x0fprompt_template\x18\x02 \x01(\tR\x0epromptTemplate\x12+\n" +
 	"\x11validation_prompt\x18\x03 \x01(\tR\x10validationPrompt\x12=\n" +
 	"\fretry_policy\x18\x04 \x01(\v2\x1a.loom.v1.OutputRetryPolicyR\vretryPolicy\x12#\n" +
 	"\routput_schema\x18\x05 \x01(\tR\foutputSchema\x12:\n" +
-	"\routput_policy\x18\x06 \x01(\v2\x15.loom.v1.OutputPolicyR\foutputPolicy\"\x86\x02\n" +
+	"\routput_policy\x18\x06 \x01(\v2\x15.loom.v1.OutputPolicyR\foutputPolicy\x12.\n" +
+	"\thitl_gate\x18\a \x01(\v2\x11.loom.v1.HITLGateR\bhitlGate\"\x94\x02\n" +
+	"\bHITLGate\x12'\n" +
+	"\x0fprompt_template\x18\x01 \x01(\tR\x0epromptTemplate\x12!\n" +
+	"\frequest_type\x18\x02 \x01(\tR\vrequestType\x12'\n" +
+	"\x0ftimeout_seconds\x18\x03 \x01(\x05R\x0etimeoutSeconds\x123\n" +
+	"\x16revise_target_stage_id\x18\x04 \x01(\tR\x13reviseTargetStageId\x12#\n" +
+	"\rmax_revisions\x18\x05 \x01(\x05R\fmaxRevisions\x129\n" +
+	"\n" +
+	"on_timeout\x18\x06 \x01(\x0e2\x1a.loom.v1.GateTimeoutActionR\tonTimeout\"\xa0\x02\n" +
+	"\x0fHITLGateRequest\x12\x1f\n" +
+	"\vworkflow_id\x18\x01 \x01(\tR\n" +
+	"workflowId\x12$\n" +
+	"\x0estage_agent_id\x18\x02 \x01(\tR\fstageAgentId\x12!\n" +
+	"\fstage_number\x18\x03 \x01(\x05R\vstageNumber\x12\x1a\n" +
+	"\bquestion\x18\x04 \x01(\tR\bquestion\x12!\n" +
+	"\fstage_output\x18\x05 \x01(\tR\vstageOutput\x12!\n" +
+	"\frequest_type\x18\x06 \x01(\tR\vrequestType\x12'\n" +
+	"\x0ftimeout_seconds\x18\a \x01(\x05R\x0etimeoutSeconds\x12\x18\n" +
+	"\aoptions\x18\b \x03(\tR\aoptions\"v\n" +
+	"\fGateDecision\x12+\n" +
+	"\x06action\x18\x01 \x01(\x0e2\x13.loom.v1.GateActionR\x06action\x12\x1a\n" +
+	"\bfeedback\x18\x02 \x01(\tR\bfeedback\x12\x1d\n" +
+	"\n" +
+	"decided_by\x18\x03 \x01(\tR\tdecidedBy\"\x92\a\n" +
+	"\x12WorkflowCheckpoint\x12-\n" +
+	"\x12checkpoint_version\x18\x01 \x01(\x05R\x11checkpointVersion\x12-\n" +
+	"\x12config_fingerprint\x18\x02 \x01(\tR\x11configFingerprint\x12\x1f\n" +
+	"\vworkflow_id\x18\x03 \x01(\tR\n" +
+	"workflowId\x12!\n" +
+	"\fpattern_type\x18\x04 \x01(\tR\vpatternType\x12(\n" +
+	"\x10next_stage_index\x18\x05 \x01(\x05R\x0enextStageIndex\x12I\n" +
+	"\x0fstage_snapshots\x18\x06 \x03(\v2 .loom.v1.CheckpointStageSnapshotR\x0estageSnapshots\x125\n" +
+	"\vall_results\x18\a \x03(\v2\x14.loom.v1.AgentResultR\n" +
+	"allResults\x12L\n" +
+	"\vmodels_used\x18\b \x03(\v2+.loom.v1.WorkflowCheckpoint.ModelsUsedEntryR\n" +
+	"modelsUsed\x12/\n" +
+	"\x13validation_warnings\x18\t \x03(\tR\x12validationWarnings\x12\x1c\n" +
+	"\titeration\x18\n" +
+	" \x01(\x05R\titeration\x12e\n" +
+	"\x14gate_revision_counts\x18\v \x03(\v23.loom.v1.WorkflowCheckpoint.GateRevisionCountsEntryR\x12gateRevisionCounts\x12;\n" +
+	"\fpending_gate\x18\f \x01(\v2\x18.loom.v1.HITLGateRequestR\vpendingGate\x12C\n" +
+	"\rshared_memory\x18\r \x03(\v2\x1e.loom.v1.CheckpointMemoryEntryR\fsharedMemory\x12\"\n" +
+	"\rcreated_at_ms\x18\x0e \x01(\x03R\vcreatedAtMs\x1a=\n" +
+	"\x0fModelsUsedEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1aE\n" +
+	"\x17GateRevisionCountsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"U\n" +
+	"\x17CheckpointStageSnapshot\x12\x19\n" +
+	"\bagent_id\x18\x01 \x01(\tR\aagentId\x12\x1f\n" +
+	"\vfull_output\x18\x02 \x01(\tR\n" +
+	"fullOutput\"\xe1\x01\n" +
+	"\x15CheckpointMemoryEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value\x12\x19\n" +
+	"\bagent_id\x18\x03 \x01(\tR\aagentId\x12H\n" +
+	"\bmetadata\x18\x04 \x03(\v2,.loom.v1.CheckpointMemoryEntry.MetadataEntryR\bmetadata\x1a;\n" +
+	"\rMetadataEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x86\x02\n" +
 	"\x18IterativeWorkflowPattern\x124\n" +
 	"\bpipeline\x18\x01 \x01(\v2\x18.loom.v1.PipelinePatternR\bpipeline\x12%\n" +
 	"\x0emax_iterations\x18\x02 \x01(\x05R\rmaxIterations\x12=\n" +
@@ -2752,7 +3524,18 @@ const file_loom_v1_orchestration_proto_rawDesc = "" +
 	"\vlast_status\x18\x05 \x01(\tR\n" +
 	"lastStatus\x12\x1d\n" +
 	"\n" +
-	"last_error\x18\x06 \x01(\tR\tlastError*}\n" +
+	"last_error\x18\x06 \x01(\tR\tlastError*\x97\x01\n" +
+	"\x11GateTimeoutAction\x12#\n" +
+	"\x1fGATE_TIMEOUT_ACTION_UNSPECIFIED\x10\x00\x12\x1c\n" +
+	"\x18GATE_TIMEOUT_ACTION_FAIL\x10\x01\x12\x1e\n" +
+	"\x1aGATE_TIMEOUT_ACTION_REJECT\x10\x02\x12\x1f\n" +
+	"\x1bGATE_TIMEOUT_ACTION_APPROVE\x10\x03*r\n" +
+	"\n" +
+	"GateAction\x12\x1b\n" +
+	"\x17GATE_ACTION_UNSPECIFIED\x10\x00\x12\x17\n" +
+	"\x13GATE_ACTION_APPROVE\x10\x01\x12\x16\n" +
+	"\x12GATE_ACTION_REVISE\x10\x02\x12\x16\n" +
+	"\x12GATE_ACTION_REJECT\x10\x03*}\n" +
 	"\rMergeStrategy\x12\x1e\n" +
 	"\x1aMERGE_STRATEGY_UNSPECIFIED\x10\x00\x12\r\n" +
 	"\tCONSENSUS\x10\x01\x12\n" +
@@ -2779,113 +3562,134 @@ func file_loom_v1_orchestration_proto_rawDescGZIP() []byte {
 	return file_loom_v1_orchestration_proto_rawDescData
 }
 
-var file_loom_v1_orchestration_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_loom_v1_orchestration_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
+var file_loom_v1_orchestration_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_loom_v1_orchestration_proto_msgTypes = make([]protoimpl.MessageInfo, 44)
 var file_loom_v1_orchestration_proto_goTypes = []any{
-	(MergeStrategy)(0),               // 0: loom.v1.MergeStrategy
-	(ScheduledSessionMode)(0),        // 1: loom.v1.ScheduledSessionMode
-	(*WorkflowPattern)(nil),          // 2: loom.v1.WorkflowPattern
-	(*DebatePattern)(nil),            // 3: loom.v1.DebatePattern
-	(*ForkJoinPattern)(nil),          // 4: loom.v1.ForkJoinPattern
-	(*PipelinePattern)(nil),          // 5: loom.v1.PipelinePattern
-	(*PipelineStage)(nil),            // 6: loom.v1.PipelineStage
-	(*IterativeWorkflowPattern)(nil), // 7: loom.v1.IterativeWorkflowPattern
-	(*RestartPolicy)(nil),            // 8: loom.v1.RestartPolicy
-	(*RestartRequest)(nil),           // 9: loom.v1.RestartRequest
-	(*RestartResponse)(nil),          // 10: loom.v1.RestartResponse
-	(*ParallelPattern)(nil),          // 11: loom.v1.ParallelPattern
-	(*AgentTask)(nil),                // 12: loom.v1.AgentTask
-	(*ConditionalPattern)(nil),       // 13: loom.v1.ConditionalPattern
-	(*WorkflowResult)(nil),           // 14: loom.v1.WorkflowResult
-	(*DebateResult)(nil),             // 15: loom.v1.DebateResult
-	(*AgentResult)(nil),              // 16: loom.v1.AgentResult
-	(*AgentExecutionCost)(nil),       // 17: loom.v1.AgentExecutionCost
-	(*WorkflowCost)(nil),             // 18: loom.v1.WorkflowCost
-	(*WorkflowExecution)(nil),        // 19: loom.v1.WorkflowExecution
-	(*ExecuteWorkflowRequest)(nil),   // 20: loom.v1.ExecuteWorkflowRequest
-	(*WorkflowSummary)(nil),          // 21: loom.v1.WorkflowSummary
-	(*ListWorkflowsRequest)(nil),     // 22: loom.v1.ListWorkflowsRequest
-	(*ListWorkflowsResponse)(nil),    // 23: loom.v1.ListWorkflowsResponse
-	(*ExecuteWorkflowResponse)(nil),  // 24: loom.v1.ExecuteWorkflowResponse
-	(*ScheduleConfig)(nil),           // 25: loom.v1.ScheduleConfig
-	(*ScheduledWorkflow)(nil),        // 26: loom.v1.ScheduledWorkflow
-	(*ScheduleStats)(nil),            // 27: loom.v1.ScheduleStats
-	nil,                              // 28: loom.v1.RestartRequest.ParametersEntry
-	nil,                              // 29: loom.v1.AgentTask.MetadataEntry
-	nil,                              // 30: loom.v1.ConditionalPattern.BranchesEntry
-	nil,                              // 31: loom.v1.WorkflowResult.MetadataEntry
-	nil,                              // 32: loom.v1.WorkflowResult.ModelsUsedEntry
-	nil,                              // 33: loom.v1.AgentResult.MetadataEntry
-	nil,                              // 34: loom.v1.WorkflowCost.AgentCostsUsdEntry
-	nil,                              // 35: loom.v1.ExecuteWorkflowRequest.VariablesEntry
-	nil,                              // 36: loom.v1.ScheduleConfig.VariablesEntry
-	(*SwarmPattern)(nil),             // 37: loom.v1.SwarmPattern
-	(*PairProgrammingPattern)(nil),   // 38: loom.v1.PairProgrammingPattern
-	(*TeacherStudentPattern)(nil),    // 39: loom.v1.TeacherStudentPattern
-	(*OutputPolicy)(nil),             // 40: loom.v1.OutputPolicy
-	(*OutputRetryPolicy)(nil),        // 41: loom.v1.OutputRetryPolicy
-	(*SwarmResult)(nil),              // 42: loom.v1.SwarmResult
-	(*PairProgrammingResult)(nil),    // 43: loom.v1.PairProgrammingResult
-	(*TeacherStudentResult)(nil),     // 44: loom.v1.TeacherStudentResult
-	(*CollaborationMetrics)(nil),     // 45: loom.v1.CollaborationMetrics
-	(*DebateRound)(nil),              // 46: loom.v1.DebateRound
+	(GateTimeoutAction)(0),           // 0: loom.v1.GateTimeoutAction
+	(GateAction)(0),                  // 1: loom.v1.GateAction
+	(MergeStrategy)(0),               // 2: loom.v1.MergeStrategy
+	(ScheduledSessionMode)(0),        // 3: loom.v1.ScheduledSessionMode
+	(*WorkflowPattern)(nil),          // 4: loom.v1.WorkflowPattern
+	(*DebatePattern)(nil),            // 5: loom.v1.DebatePattern
+	(*ForkJoinPattern)(nil),          // 6: loom.v1.ForkJoinPattern
+	(*PipelinePattern)(nil),          // 7: loom.v1.PipelinePattern
+	(*PipelineStage)(nil),            // 8: loom.v1.PipelineStage
+	(*HITLGate)(nil),                 // 9: loom.v1.HITLGate
+	(*HITLGateRequest)(nil),          // 10: loom.v1.HITLGateRequest
+	(*GateDecision)(nil),             // 11: loom.v1.GateDecision
+	(*WorkflowCheckpoint)(nil),       // 12: loom.v1.WorkflowCheckpoint
+	(*CheckpointStageSnapshot)(nil),  // 13: loom.v1.CheckpointStageSnapshot
+	(*CheckpointMemoryEntry)(nil),    // 14: loom.v1.CheckpointMemoryEntry
+	(*IterativeWorkflowPattern)(nil), // 15: loom.v1.IterativeWorkflowPattern
+	(*RestartPolicy)(nil),            // 16: loom.v1.RestartPolicy
+	(*RestartRequest)(nil),           // 17: loom.v1.RestartRequest
+	(*RestartResponse)(nil),          // 18: loom.v1.RestartResponse
+	(*ParallelPattern)(nil),          // 19: loom.v1.ParallelPattern
+	(*AgentTask)(nil),                // 20: loom.v1.AgentTask
+	(*ConditionalPattern)(nil),       // 21: loom.v1.ConditionalPattern
+	(*WorkflowResult)(nil),           // 22: loom.v1.WorkflowResult
+	(*DebateResult)(nil),             // 23: loom.v1.DebateResult
+	(*AgentResult)(nil),              // 24: loom.v1.AgentResult
+	(*AgentExecutionCost)(nil),       // 25: loom.v1.AgentExecutionCost
+	(*WorkflowCost)(nil),             // 26: loom.v1.WorkflowCost
+	(*WorkflowExecution)(nil),        // 27: loom.v1.WorkflowExecution
+	(*ExecuteWorkflowRequest)(nil),   // 28: loom.v1.ExecuteWorkflowRequest
+	(*WorkflowSummary)(nil),          // 29: loom.v1.WorkflowSummary
+	(*ListWorkflowsRequest)(nil),     // 30: loom.v1.ListWorkflowsRequest
+	(*ListWorkflowsResponse)(nil),    // 31: loom.v1.ListWorkflowsResponse
+	(*ExecuteWorkflowResponse)(nil),  // 32: loom.v1.ExecuteWorkflowResponse
+	(*ScheduleConfig)(nil),           // 33: loom.v1.ScheduleConfig
+	(*ScheduledWorkflow)(nil),        // 34: loom.v1.ScheduledWorkflow
+	(*ScheduleStats)(nil),            // 35: loom.v1.ScheduleStats
+	nil,                              // 36: loom.v1.WorkflowCheckpoint.ModelsUsedEntry
+	nil,                              // 37: loom.v1.WorkflowCheckpoint.GateRevisionCountsEntry
+	nil,                              // 38: loom.v1.CheckpointMemoryEntry.MetadataEntry
+	nil,                              // 39: loom.v1.RestartRequest.ParametersEntry
+	nil,                              // 40: loom.v1.AgentTask.MetadataEntry
+	nil,                              // 41: loom.v1.ConditionalPattern.BranchesEntry
+	nil,                              // 42: loom.v1.WorkflowResult.MetadataEntry
+	nil,                              // 43: loom.v1.WorkflowResult.ModelsUsedEntry
+	nil,                              // 44: loom.v1.AgentResult.MetadataEntry
+	nil,                              // 45: loom.v1.WorkflowCost.AgentCostsUsdEntry
+	nil,                              // 46: loom.v1.ExecuteWorkflowRequest.VariablesEntry
+	nil,                              // 47: loom.v1.ScheduleConfig.VariablesEntry
+	(*SwarmPattern)(nil),             // 48: loom.v1.SwarmPattern
+	(*PairProgrammingPattern)(nil),   // 49: loom.v1.PairProgrammingPattern
+	(*TeacherStudentPattern)(nil),    // 50: loom.v1.TeacherStudentPattern
+	(*OutputPolicy)(nil),             // 51: loom.v1.OutputPolicy
+	(*OutputRetryPolicy)(nil),        // 52: loom.v1.OutputRetryPolicy
+	(*SwarmResult)(nil),              // 53: loom.v1.SwarmResult
+	(*PairProgrammingResult)(nil),    // 54: loom.v1.PairProgrammingResult
+	(*TeacherStudentResult)(nil),     // 55: loom.v1.TeacherStudentResult
+	(*CollaborationMetrics)(nil),     // 56: loom.v1.CollaborationMetrics
+	(*DebateRound)(nil),              // 57: loom.v1.DebateRound
 }
 var file_loom_v1_orchestration_proto_depIdxs = []int32{
-	3,  // 0: loom.v1.WorkflowPattern.debate:type_name -> loom.v1.DebatePattern
-	4,  // 1: loom.v1.WorkflowPattern.fork_join:type_name -> loom.v1.ForkJoinPattern
-	5,  // 2: loom.v1.WorkflowPattern.pipeline:type_name -> loom.v1.PipelinePattern
-	11, // 3: loom.v1.WorkflowPattern.parallel:type_name -> loom.v1.ParallelPattern
-	13, // 4: loom.v1.WorkflowPattern.conditional:type_name -> loom.v1.ConditionalPattern
-	37, // 5: loom.v1.WorkflowPattern.swarm:type_name -> loom.v1.SwarmPattern
-	38, // 6: loom.v1.WorkflowPattern.pair_programming:type_name -> loom.v1.PairProgrammingPattern
-	39, // 7: loom.v1.WorkflowPattern.teacher_student:type_name -> loom.v1.TeacherStudentPattern
-	7,  // 8: loom.v1.WorkflowPattern.iterative:type_name -> loom.v1.IterativeWorkflowPattern
-	0,  // 9: loom.v1.DebatePattern.merge_strategy:type_name -> loom.v1.MergeStrategy
-	0,  // 10: loom.v1.ForkJoinPattern.merge_strategy:type_name -> loom.v1.MergeStrategy
-	40, // 11: loom.v1.ForkJoinPattern.agent_output_policy:type_name -> loom.v1.OutputPolicy
-	6,  // 12: loom.v1.PipelinePattern.stages:type_name -> loom.v1.PipelineStage
-	41, // 13: loom.v1.PipelineStage.retry_policy:type_name -> loom.v1.OutputRetryPolicy
-	40, // 14: loom.v1.PipelineStage.output_policy:type_name -> loom.v1.OutputPolicy
-	5,  // 15: loom.v1.IterativeWorkflowPattern.pipeline:type_name -> loom.v1.PipelinePattern
-	8,  // 16: loom.v1.IterativeWorkflowPattern.restart_policy:type_name -> loom.v1.RestartPolicy
-	28, // 17: loom.v1.RestartRequest.parameters:type_name -> loom.v1.RestartRequest.ParametersEntry
-	12, // 18: loom.v1.ParallelPattern.tasks:type_name -> loom.v1.AgentTask
-	0,  // 19: loom.v1.ParallelPattern.merge_strategy:type_name -> loom.v1.MergeStrategy
-	29, // 20: loom.v1.AgentTask.metadata:type_name -> loom.v1.AgentTask.MetadataEntry
-	40, // 21: loom.v1.AgentTask.output_policy:type_name -> loom.v1.OutputPolicy
-	30, // 22: loom.v1.ConditionalPattern.branches:type_name -> loom.v1.ConditionalPattern.BranchesEntry
-	2,  // 23: loom.v1.ConditionalPattern.default_branch:type_name -> loom.v1.WorkflowPattern
-	41, // 24: loom.v1.ConditionalPattern.retry_policy:type_name -> loom.v1.OutputRetryPolicy
-	16, // 25: loom.v1.WorkflowResult.agent_results:type_name -> loom.v1.AgentResult
-	31, // 26: loom.v1.WorkflowResult.metadata:type_name -> loom.v1.WorkflowResult.MetadataEntry
-	18, // 27: loom.v1.WorkflowResult.cost:type_name -> loom.v1.WorkflowCost
-	15, // 28: loom.v1.WorkflowResult.debate_result:type_name -> loom.v1.DebateResult
-	42, // 29: loom.v1.WorkflowResult.swarm_result:type_name -> loom.v1.SwarmResult
-	43, // 30: loom.v1.WorkflowResult.pair_programming_result:type_name -> loom.v1.PairProgrammingResult
-	44, // 31: loom.v1.WorkflowResult.teacher_student_result:type_name -> loom.v1.TeacherStudentResult
-	45, // 32: loom.v1.WorkflowResult.metrics:type_name -> loom.v1.CollaborationMetrics
-	32, // 33: loom.v1.WorkflowResult.models_used:type_name -> loom.v1.WorkflowResult.ModelsUsedEntry
-	46, // 34: loom.v1.DebateResult.rounds:type_name -> loom.v1.DebateRound
-	33, // 35: loom.v1.AgentResult.metadata:type_name -> loom.v1.AgentResult.MetadataEntry
-	17, // 36: loom.v1.AgentResult.cost:type_name -> loom.v1.AgentExecutionCost
-	34, // 37: loom.v1.WorkflowCost.agent_costs_usd:type_name -> loom.v1.WorkflowCost.AgentCostsUsdEntry
-	2,  // 38: loom.v1.WorkflowExecution.pattern:type_name -> loom.v1.WorkflowPattern
-	14, // 39: loom.v1.WorkflowExecution.result:type_name -> loom.v1.WorkflowResult
-	2,  // 40: loom.v1.ExecuteWorkflowRequest.pattern:type_name -> loom.v1.WorkflowPattern
-	35, // 41: loom.v1.ExecuteWorkflowRequest.variables:type_name -> loom.v1.ExecuteWorkflowRequest.VariablesEntry
-	21, // 42: loom.v1.ListWorkflowsResponse.workflows:type_name -> loom.v1.WorkflowSummary
-	14, // 43: loom.v1.ExecuteWorkflowResponse.result:type_name -> loom.v1.WorkflowResult
-	36, // 44: loom.v1.ScheduleConfig.variables:type_name -> loom.v1.ScheduleConfig.VariablesEntry
-	1,  // 45: loom.v1.ScheduleConfig.session_mode:type_name -> loom.v1.ScheduledSessionMode
-	2,  // 46: loom.v1.ScheduledWorkflow.pattern:type_name -> loom.v1.WorkflowPattern
-	25, // 47: loom.v1.ScheduledWorkflow.schedule:type_name -> loom.v1.ScheduleConfig
-	27, // 48: loom.v1.ScheduledWorkflow.stats:type_name -> loom.v1.ScheduleStats
-	2,  // 49: loom.v1.ConditionalPattern.BranchesEntry.value:type_name -> loom.v1.WorkflowPattern
-	50, // [50:50] is the sub-list for method output_type
-	50, // [50:50] is the sub-list for method input_type
-	50, // [50:50] is the sub-list for extension type_name
-	50, // [50:50] is the sub-list for extension extendee
-	0,  // [0:50] is the sub-list for field type_name
+	5,  // 0: loom.v1.WorkflowPattern.debate:type_name -> loom.v1.DebatePattern
+	6,  // 1: loom.v1.WorkflowPattern.fork_join:type_name -> loom.v1.ForkJoinPattern
+	7,  // 2: loom.v1.WorkflowPattern.pipeline:type_name -> loom.v1.PipelinePattern
+	19, // 3: loom.v1.WorkflowPattern.parallel:type_name -> loom.v1.ParallelPattern
+	21, // 4: loom.v1.WorkflowPattern.conditional:type_name -> loom.v1.ConditionalPattern
+	48, // 5: loom.v1.WorkflowPattern.swarm:type_name -> loom.v1.SwarmPattern
+	49, // 6: loom.v1.WorkflowPattern.pair_programming:type_name -> loom.v1.PairProgrammingPattern
+	50, // 7: loom.v1.WorkflowPattern.teacher_student:type_name -> loom.v1.TeacherStudentPattern
+	15, // 8: loom.v1.WorkflowPattern.iterative:type_name -> loom.v1.IterativeWorkflowPattern
+	2,  // 9: loom.v1.DebatePattern.merge_strategy:type_name -> loom.v1.MergeStrategy
+	2,  // 10: loom.v1.ForkJoinPattern.merge_strategy:type_name -> loom.v1.MergeStrategy
+	51, // 11: loom.v1.ForkJoinPattern.agent_output_policy:type_name -> loom.v1.OutputPolicy
+	8,  // 12: loom.v1.PipelinePattern.stages:type_name -> loom.v1.PipelineStage
+	52, // 13: loom.v1.PipelineStage.retry_policy:type_name -> loom.v1.OutputRetryPolicy
+	51, // 14: loom.v1.PipelineStage.output_policy:type_name -> loom.v1.OutputPolicy
+	9,  // 15: loom.v1.PipelineStage.hitl_gate:type_name -> loom.v1.HITLGate
+	0,  // 16: loom.v1.HITLGate.on_timeout:type_name -> loom.v1.GateTimeoutAction
+	1,  // 17: loom.v1.GateDecision.action:type_name -> loom.v1.GateAction
+	13, // 18: loom.v1.WorkflowCheckpoint.stage_snapshots:type_name -> loom.v1.CheckpointStageSnapshot
+	24, // 19: loom.v1.WorkflowCheckpoint.all_results:type_name -> loom.v1.AgentResult
+	36, // 20: loom.v1.WorkflowCheckpoint.models_used:type_name -> loom.v1.WorkflowCheckpoint.ModelsUsedEntry
+	37, // 21: loom.v1.WorkflowCheckpoint.gate_revision_counts:type_name -> loom.v1.WorkflowCheckpoint.GateRevisionCountsEntry
+	10, // 22: loom.v1.WorkflowCheckpoint.pending_gate:type_name -> loom.v1.HITLGateRequest
+	14, // 23: loom.v1.WorkflowCheckpoint.shared_memory:type_name -> loom.v1.CheckpointMemoryEntry
+	38, // 24: loom.v1.CheckpointMemoryEntry.metadata:type_name -> loom.v1.CheckpointMemoryEntry.MetadataEntry
+	7,  // 25: loom.v1.IterativeWorkflowPattern.pipeline:type_name -> loom.v1.PipelinePattern
+	16, // 26: loom.v1.IterativeWorkflowPattern.restart_policy:type_name -> loom.v1.RestartPolicy
+	39, // 27: loom.v1.RestartRequest.parameters:type_name -> loom.v1.RestartRequest.ParametersEntry
+	20, // 28: loom.v1.ParallelPattern.tasks:type_name -> loom.v1.AgentTask
+	2,  // 29: loom.v1.ParallelPattern.merge_strategy:type_name -> loom.v1.MergeStrategy
+	40, // 30: loom.v1.AgentTask.metadata:type_name -> loom.v1.AgentTask.MetadataEntry
+	51, // 31: loom.v1.AgentTask.output_policy:type_name -> loom.v1.OutputPolicy
+	41, // 32: loom.v1.ConditionalPattern.branches:type_name -> loom.v1.ConditionalPattern.BranchesEntry
+	4,  // 33: loom.v1.ConditionalPattern.default_branch:type_name -> loom.v1.WorkflowPattern
+	52, // 34: loom.v1.ConditionalPattern.retry_policy:type_name -> loom.v1.OutputRetryPolicy
+	24, // 35: loom.v1.WorkflowResult.agent_results:type_name -> loom.v1.AgentResult
+	42, // 36: loom.v1.WorkflowResult.metadata:type_name -> loom.v1.WorkflowResult.MetadataEntry
+	26, // 37: loom.v1.WorkflowResult.cost:type_name -> loom.v1.WorkflowCost
+	23, // 38: loom.v1.WorkflowResult.debate_result:type_name -> loom.v1.DebateResult
+	53, // 39: loom.v1.WorkflowResult.swarm_result:type_name -> loom.v1.SwarmResult
+	54, // 40: loom.v1.WorkflowResult.pair_programming_result:type_name -> loom.v1.PairProgrammingResult
+	55, // 41: loom.v1.WorkflowResult.teacher_student_result:type_name -> loom.v1.TeacherStudentResult
+	56, // 42: loom.v1.WorkflowResult.metrics:type_name -> loom.v1.CollaborationMetrics
+	43, // 43: loom.v1.WorkflowResult.models_used:type_name -> loom.v1.WorkflowResult.ModelsUsedEntry
+	57, // 44: loom.v1.DebateResult.rounds:type_name -> loom.v1.DebateRound
+	44, // 45: loom.v1.AgentResult.metadata:type_name -> loom.v1.AgentResult.MetadataEntry
+	25, // 46: loom.v1.AgentResult.cost:type_name -> loom.v1.AgentExecutionCost
+	45, // 47: loom.v1.WorkflowCost.agent_costs_usd:type_name -> loom.v1.WorkflowCost.AgentCostsUsdEntry
+	4,  // 48: loom.v1.WorkflowExecution.pattern:type_name -> loom.v1.WorkflowPattern
+	22, // 49: loom.v1.WorkflowExecution.result:type_name -> loom.v1.WorkflowResult
+	4,  // 50: loom.v1.ExecuteWorkflowRequest.pattern:type_name -> loom.v1.WorkflowPattern
+	46, // 51: loom.v1.ExecuteWorkflowRequest.variables:type_name -> loom.v1.ExecuteWorkflowRequest.VariablesEntry
+	29, // 52: loom.v1.ListWorkflowsResponse.workflows:type_name -> loom.v1.WorkflowSummary
+	22, // 53: loom.v1.ExecuteWorkflowResponse.result:type_name -> loom.v1.WorkflowResult
+	47, // 54: loom.v1.ScheduleConfig.variables:type_name -> loom.v1.ScheduleConfig.VariablesEntry
+	3,  // 55: loom.v1.ScheduleConfig.session_mode:type_name -> loom.v1.ScheduledSessionMode
+	4,  // 56: loom.v1.ScheduledWorkflow.pattern:type_name -> loom.v1.WorkflowPattern
+	33, // 57: loom.v1.ScheduledWorkflow.schedule:type_name -> loom.v1.ScheduleConfig
+	35, // 58: loom.v1.ScheduledWorkflow.stats:type_name -> loom.v1.ScheduleStats
+	4,  // 59: loom.v1.ConditionalPattern.BranchesEntry.value:type_name -> loom.v1.WorkflowPattern
+	60, // [60:60] is the sub-list for method output_type
+	60, // [60:60] is the sub-list for method input_type
+	60, // [60:60] is the sub-list for extension type_name
+	60, // [60:60] is the sub-list for extension extendee
+	0,  // [0:60] is the sub-list for field type_name
 }
 
 func init() { file_loom_v1_orchestration_proto_init() }
@@ -2905,7 +3709,7 @@ func file_loom_v1_orchestration_proto_init() {
 		(*WorkflowPattern_TeacherStudent)(nil),
 		(*WorkflowPattern_Iterative)(nil),
 	}
-	file_loom_v1_orchestration_proto_msgTypes[12].OneofWrappers = []any{
+	file_loom_v1_orchestration_proto_msgTypes[18].OneofWrappers = []any{
 		(*WorkflowResult_DebateResult)(nil),
 		(*WorkflowResult_SwarmResult)(nil),
 		(*WorkflowResult_PairProgrammingResult)(nil),
@@ -2916,8 +3720,8 @@ func file_loom_v1_orchestration_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_loom_v1_orchestration_proto_rawDesc), len(file_loom_v1_orchestration_proto_rawDesc)),
-			NumEnums:      2,
-			NumMessages:   35,
+			NumEnums:      4,
+			NumMessages:   44,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/gen/openapiv2/loom/v1/loom.swagger.json
+++ b/gen/openapiv2/loom/v1/loom.swagger.json
@@ -5260,6 +5260,17 @@
       },
       "description": "ForkJoinPattern executes multiple agents in parallel on the same prompt,\nthen merges their results according to the specified strategy."
     },
+    "v1GateTimeoutAction": {
+      "type": "string",
+      "enum": [
+        "GATE_TIMEOUT_ACTION_UNSPECIFIED",
+        "GATE_TIMEOUT_ACTION_FAIL",
+        "GATE_TIMEOUT_ACTION_REJECT",
+        "GATE_TIMEOUT_ACTION_APPROVE"
+      ],
+      "default": "GATE_TIMEOUT_ACTION_UNSPECIFIED",
+      "description": "GateTimeoutAction defines gate behavior on decision timeout.\n\n - GATE_TIMEOUT_ACTION_UNSPECIFIED: Unset — treated as GATE_TIMEOUT_ACTION_FAIL.\n - GATE_TIMEOUT_ACTION_FAIL: Fail the workflow run (safe default).\n - GATE_TIMEOUT_ACTION_REJECT: Treat as a rejection (workflow ends without executing later stages).\n - GATE_TIMEOUT_ACTION_APPROVE: Auto-approve and continue (use only for advisory gates)."
+    },
     "v1GetArtifactContentResponse": {
       "type": "object",
       "properties": {
@@ -5477,6 +5488,38 @@
         }
       },
       "description": "GraphMemoryConfig configures the salience-driven graph-backed episodic memory layer."
+    },
+    "v1HITLGate": {
+      "type": "object",
+      "properties": {
+        "promptTemplate": {
+          "type": "string",
+          "description": "Prompt shown to the human reviewer. Supports the {{output}} placeholder,\nreplaced with the gated stage's (possibly truncated) output.\nEmpty = a default \"review the output of stage N\" prompt."
+        },
+        "requestType": {
+          "type": "string",
+          "description": "Request type shown to the host UI (approval, decision, input, review).\nAligned with HITLRequestInfo.request_type. Default: \"approval\"."
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Advisory timeout for the human decision, in seconds. In suspend mode the\nHOST enforces expiry of the persisted checkpoint; in inline-handler mode\nthe handler context is bounded by this timeout. 0 = host default."
+        },
+        "reviseTargetStageId": {
+          "type": "string",
+          "description": "Stage (agent_id) to restart when the decision is REVISE.\nEmpty = restart the gated stage itself. Must be at or before the gated\nstage in pipeline order — forward jumps are invalid."
+        },
+        "maxRevisions": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum REVISE round-trips this gate accepts before the workflow fails\n(prevents endless review loops). Default: 3."
+        },
+        "onTimeout": {
+          "$ref": "#/definitions/v1GateTimeoutAction",
+          "description": "What to do when the decision times out (enforced by the host in suspend\nmode). Default (UNSPECIFIED) is treated as FAIL."
+        }
+      },
+      "description": "HITLGate declares a human approval gate on a pipeline stage boundary.\nGates are deterministic control flow — they always fire when configured,\nunlike agent-initiated contact_human tool calls."
     },
     "v1HITLRequestInfo": {
       "type": "object",
@@ -7044,6 +7087,10 @@
         "outputPolicy": {
           "$ref": "#/definitions/v1OutputPolicy",
           "description": "Optional: Unified output validation policy. When set, takes precedence\nover the legacy validation_prompt + output_schema + retry_policy fields."
+        },
+        "hitlGate": {
+          "$ref": "#/definitions/v1HITLGate",
+          "description": "Optional: Human-in-the-loop approval gate evaluated AFTER this stage's\noutput passes validation and BEFORE the next stage starts. When the gate\nfires, the executor either asks a configured HITLHandler for an inline\ndecision or suspends the workflow with a WorkflowCheckpoint the host can\npersist and later resume. Gates are supported on pipeline and iterative\npatterns only."
         }
       },
       "description": "PipelineStage represents a single stage in a pipeline."

--- a/pkg/orchestration/hitl_gate.go
+++ b/pkg/orchestration/hitl_gate.go
@@ -1,0 +1,398 @@
+// Copyright © 2026 Teradata Corporation - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package orchestration
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+)
+
+// CheckpointVersion is the current WorkflowCheckpoint schema version.
+const CheckpointVersion = 1
+
+// DefaultMaxGateRevisions bounds REVISE round-trips per gate when
+// HITLGate.max_revisions is unset.
+const DefaultMaxGateRevisions = 3
+
+// RevisionFeedbackPlaceholder is replaced in a restarted stage's prompt with
+// the human's (or requesting stage's) revision feedback. Templates that omit
+// it get the feedback appended as a clearly-labeled section instead.
+const RevisionFeedbackPlaceholder = "{{revision_feedback}}"
+
+// ErrSuspendWorkflow can be returned by an HITLHandler to request durable
+// suspension instead of deciding inline. A nil handler suspends by default.
+var ErrSuspendWorkflow = errors.New("workflow suspension requested")
+
+// HITLHandler decides a HITL gate inline (e.g. a terminal prompt or a chat
+// bridge). Hosts that persist checkpoints and resume later should leave the
+// orchestrator's handler nil — gates then suspend by default.
+type HITLHandler interface {
+	// RequestDecision blocks until a decision is available or ctx expires.
+	// Returning ErrSuspendWorkflow (or wrapping it) converts the gate into a
+	// durable suspension.
+	RequestDecision(ctx context.Context, req *loomv1.HITLGateRequest) (*loomv1.GateDecision, error)
+}
+
+// WorkflowSuspended is returned (as an error) when a HITL gate suspends
+// execution. The host persists Checkpoint and later calls
+// Orchestrator.ResumeWorkflow with a decision. Detect it with errors.As.
+type WorkflowSuspended struct {
+	Checkpoint *loomv1.WorkflowCheckpoint
+}
+
+// Error implements the error interface.
+func (s *WorkflowSuspended) Error() string {
+	gate := s.Checkpoint.GetPendingGate()
+	return fmt.Sprintf("workflow suspended awaiting human decision at stage %d (%s)",
+		gate.GetStageNumber(), gate.GetStageAgentId())
+}
+
+// GateRejected is returned (as an error) when a human rejects a gate. The
+// workflow ends without executing later stages. Detect it with errors.As.
+type GateRejected struct {
+	StageAgentID string
+	Feedback     string
+}
+
+// Error implements the error interface.
+func (r *GateRejected) Error() string {
+	if r.Feedback == "" {
+		return fmt.Sprintf("workflow rejected by human at gate on stage %s", r.StageAgentID)
+	}
+	return fmt.Sprintf("workflow rejected by human at gate on stage %s: %s", r.StageAgentID, r.Feedback)
+}
+
+// WorkflowFingerprint returns the SHA-256 hex digest of the deterministically
+// marshaled pattern, with the execution-identity workflow_id field cleared so
+// two runs of the same definition fingerprint identically. Resume verifies
+// this against the checkpoint before executing anything.
+func WorkflowFingerprint(pattern *loomv1.WorkflowPattern) (string, error) {
+	if pattern == nil {
+		return "", fmt.Errorf("nil workflow pattern")
+	}
+	clone, ok := proto.Clone(pattern).(*loomv1.WorkflowPattern)
+	if !ok {
+		return "", fmt.Errorf("failed to clone workflow pattern")
+	}
+	clone.WorkflowId = ""
+	data, err := proto.MarshalOptions{Deterministic: true}.Marshal(clone)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal workflow pattern: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// pipelinePatternFingerprint fingerprints a bare PipelinePattern by wrapping
+// it the way ExecutePattern dispatches it.
+func pipelinePatternFingerprint(p *loomv1.PipelinePattern) (string, error) {
+	return WorkflowFingerprint(&loomv1.WorkflowPattern{
+		Pattern: &loomv1.WorkflowPattern_Pipeline{Pipeline: p},
+	})
+}
+
+// iterativePatternFingerprint fingerprints a bare IterativeWorkflowPattern by
+// wrapping it the way ExecutePattern dispatches it.
+func iterativePatternFingerprint(p *loomv1.IterativeWorkflowPattern) (string, error) {
+	return WorkflowFingerprint(&loomv1.WorkflowPattern{
+		Pattern: &loomv1.WorkflowPattern_Iterative{Iterative: p},
+	})
+}
+
+// buildGateRequest renders the HITLGateRequest handed to the host when a gate
+// fires on the given stage.
+func buildGateRequest(workflowID string, stage *loomv1.PipelineStage, stageNum int, output string) *loomv1.HITLGateRequest {
+	gate := stage.HitlGate
+
+	question := gate.PromptTemplate
+	if question == "" {
+		question = fmt.Sprintf("Review the output of stage %d (%s). Approve to continue, revise with feedback, or reject to stop.", stageNum, stage.AgentId)
+	}
+	question = strings.ReplaceAll(question, "{{output}}", output)
+
+	requestType := gate.RequestType
+	if requestType == "" {
+		requestType = "approval"
+	}
+
+	return &loomv1.HITLGateRequest{
+		WorkflowId:     workflowID,
+		StageAgentId:   stage.AgentId,
+		StageNumber:    int32(stageNum), // #nosec G115 -- stage counts are tiny
+		Question:       question,
+		StageOutput:    output,
+		RequestType:    requestType,
+		TimeoutSeconds: gate.TimeoutSeconds,
+		Options:        []string{"approve", "revise", "reject"},
+	}
+}
+
+// evaluateHITLGate asks the configured handler for an inline decision.
+// A nil decision with nil error means "suspend": either no handler is
+// configured (the durable default) or the handler chose ErrSuspendWorkflow.
+func evaluateHITLGate(ctx context.Context, o *Orchestrator, gate *loomv1.HITLGate, req *loomv1.HITLGateRequest) (*loomv1.GateDecision, error) {
+	handler := o.hitlHandler
+	if handler == nil {
+		return nil, nil
+	}
+
+	handlerCtx := ctx
+	if gate.TimeoutSeconds > 0 {
+		var cancel context.CancelFunc
+		handlerCtx, cancel = context.WithTimeout(ctx, time.Duration(gate.TimeoutSeconds)*time.Second)
+		defer cancel()
+	}
+
+	decision, err := handler.RequestDecision(handlerCtx, req)
+	if err != nil {
+		if errors.Is(err, ErrSuspendWorkflow) {
+			return nil, nil
+		}
+		// Timeout of the inline handler follows the gate's on_timeout action.
+		if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+			switch gate.OnTimeout {
+			case loomv1.GateTimeoutAction_GATE_TIMEOUT_ACTION_APPROVE:
+				o.logger.Warn("HITL gate timed out; auto-approving per on_timeout",
+					zap.String("stage", req.StageAgentId))
+				return &loomv1.GateDecision{Action: loomv1.GateAction_GATE_ACTION_APPROVE, DecidedBy: "on_timeout"}, nil
+			case loomv1.GateTimeoutAction_GATE_TIMEOUT_ACTION_REJECT:
+				return &loomv1.GateDecision{Action: loomv1.GateAction_GATE_ACTION_REJECT, Feedback: "gate decision timed out", DecidedBy: "on_timeout"}, nil
+			default:
+				return nil, fmt.Errorf("HITL gate on stage %s timed out awaiting decision", req.StageAgentId)
+			}
+		}
+		return nil, fmt.Errorf("HITL gate handler failed on stage %s: %w", req.StageAgentId, err)
+	}
+	if decision == nil || decision.Action == loomv1.GateAction_GATE_ACTION_UNSPECIFIED {
+		return nil, fmt.Errorf("HITL gate handler returned no decision for stage %s", req.StageAgentId)
+	}
+	return decision, nil
+}
+
+// maxGateRevisions returns the gate's revision budget with the default applied.
+func maxGateRevisions(gate *loomv1.HITLGate) int32 {
+	if gate.MaxRevisions > 0 {
+		return gate.MaxRevisions
+	}
+	return DefaultMaxGateRevisions
+}
+
+// resolveReviseTarget maps a REVISE decision to the stage index to restart.
+// The target must be at or before the gated stage (no forward jumps).
+func resolveReviseTarget(stages []*loomv1.PipelineStage, gatedIndex int, gate *loomv1.HITLGate) (int, error) {
+	if gate.ReviseTargetStageId == "" {
+		return gatedIndex, nil
+	}
+	for i, s := range stages {
+		if s.AgentId == gate.ReviseTargetStageId {
+			if i > gatedIndex {
+				return 0, fmt.Errorf("hitl_gate revise_target_stage_id %q is after the gated stage (forward jumps are invalid)", gate.ReviseTargetStageId)
+			}
+			return i, nil
+		}
+	}
+	return 0, fmt.Errorf("hitl_gate revise_target_stage_id %q not found in pipeline stages", gate.ReviseTargetStageId)
+}
+
+// injectRevisionFeedback threads feedback into a restarted stage's prompt.
+// With empty feedback it only blanks a stray placeholder. The header names
+// the feedback source ("human reviewer", "stage analyze-data", ...).
+func injectRevisionFeedback(prompt, feedback, source string) string {
+	if feedback == "" {
+		return strings.ReplaceAll(prompt, RevisionFeedbackPlaceholder, "")
+	}
+	if strings.Contains(prompt, RevisionFeedbackPlaceholder) {
+		return strings.ReplaceAll(prompt, RevisionFeedbackPlaceholder, feedback)
+	}
+	return fmt.Sprintf("%s\n\n## REVISION FEEDBACK (from %s)\nYour previous output for this stage was sent back for revision. Address this feedback:\n\n%s", prompt, source, feedback)
+}
+
+// formatRestartFeedback renders a RestartRequest's reason and parameters as
+// revision feedback for the restarted stage's prompt.
+func formatRestartFeedback(req *loomv1.RestartRequest) string {
+	var b strings.Builder
+	b.WriteString(req.Reason)
+	if len(req.Parameters) > 0 {
+		keys := make([]string, 0, len(req.Parameters))
+		for k := range req.Parameters {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		b.WriteString("\n\nParameters:")
+		for _, k := range keys {
+			b.WriteString(fmt.Sprintf("\n- %s: %s", k, req.Parameters[k]))
+		}
+	}
+	return b.String()
+}
+
+// stageOutputMemoryKeyPattern matches the executor-managed SharedMemory keys
+// that are re-seeded from checkpoint stage snapshots (excluded from the
+// generic memory snapshot to avoid storing outputs twice).
+var stageOutputMemoryKeyPattern = regexp.MustCompile(`^stage-\d+-output$`)
+
+// snapshotWorkflowMemory captures agent-written WORKFLOW-namespace entries for
+// a checkpoint. Best-effort: failures are logged and skipped so a flaky memory
+// backend cannot block suspension.
+func snapshotWorkflowMemory(ctx context.Context, o *Orchestrator) []*loomv1.CheckpointMemoryEntry {
+	if o.sharedMemory == nil {
+		return nil
+	}
+	listResp, err := o.sharedMemory.List(ctx, &loomv1.ListSharedMemoryKeysRequest{
+		Namespace: loomv1.SharedMemoryNamespace_SHARED_MEMORY_NAMESPACE_WORKFLOW,
+	})
+	if err != nil {
+		o.logger.Warn("checkpoint: failed to list workflow SharedMemory keys; snapshot skipped", zap.Error(err))
+		return nil
+	}
+
+	var entries []*loomv1.CheckpointMemoryEntry
+	for _, key := range listResp.Keys {
+		if stageOutputMemoryKeyPattern.MatchString(key) {
+			continue
+		}
+		getResp, err := o.sharedMemory.Get(ctx, &loomv1.GetSharedMemoryRequest{
+			Namespace: loomv1.SharedMemoryNamespace_SHARED_MEMORY_NAMESPACE_WORKFLOW,
+			Key:       key,
+			AgentId:   "workflow-checkpoint",
+		})
+		if err != nil || !getResp.Found || getResp.Value == nil {
+			o.logger.Warn("checkpoint: failed to read workflow SharedMemory key; entry skipped",
+				zap.String("key", key), zap.Error(err))
+			continue
+		}
+		entries = append(entries, &loomv1.CheckpointMemoryEntry{
+			Key:      key,
+			Value:    getResp.Value.Value,
+			AgentId:  getResp.Value.CreatedBy,
+			Metadata: getResp.Value.Metadata,
+		})
+	}
+	return entries
+}
+
+// restoreWorkflowMemory writes checkpointed entries and the completed stages'
+// full outputs back into the WORKFLOW namespace before a resumed run starts,
+// so shared_memory_read and truncation notices keep working. Best-effort.
+func restoreWorkflowMemory(ctx context.Context, o *Orchestrator, ckpt *loomv1.WorkflowCheckpoint) {
+	if o.sharedMemory == nil {
+		return
+	}
+	for _, entry := range ckpt.SharedMemory {
+		if _, err := o.sharedMemory.Put(ctx, &loomv1.PutSharedMemoryRequest{
+			Namespace: loomv1.SharedMemoryNamespace_SHARED_MEMORY_NAMESPACE_WORKFLOW,
+			Key:       entry.Key,
+			Value:     entry.Value,
+			AgentId:   entry.AgentId,
+			Metadata:  entry.Metadata,
+		}); err != nil {
+			o.logger.Warn("resume: failed to restore SharedMemory entry",
+				zap.String("key", entry.Key), zap.Error(err))
+		}
+	}
+	for i, snap := range ckpt.StageSnapshots {
+		if snap.FullOutput == "" {
+			// Iterative checkpoints keep index-aligned placeholder snapshots
+			// for stages whose outputs a restart discarded — nothing to seed.
+			continue
+		}
+		key := fmt.Sprintf("stage-%d-output", i+1)
+		if _, err := o.sharedMemory.Put(ctx, &loomv1.PutSharedMemoryRequest{
+			Namespace: loomv1.SharedMemoryNamespace_SHARED_MEMORY_NAMESPACE_WORKFLOW,
+			Key:       key,
+			Value:     []byte(snap.FullOutput),
+			AgentId:   snap.AgentId,
+			Metadata: map[string]string{
+				"type":      "stage_output",
+				"agent_id":  snap.AgentId,
+				"full_size": fmt.Sprintf("%d", len(snap.FullOutput)),
+			},
+		}); err != nil {
+			o.logger.Warn("resume: failed to re-seed stage output in SharedMemory",
+				zap.String("key", key), zap.Error(err))
+		}
+	}
+}
+
+// validateGatePlacement rejects HITL gates on pattern types that cannot
+// suspend/resume. Only pipeline and iterative pipelines support gates.
+func validateGatePlacement(pattern *loomv1.WorkflowPattern) error {
+	check := func(stages []*loomv1.PipelineStage) error {
+		for i, s := range stages {
+			if s.HitlGate == nil {
+				continue
+			}
+			if _, err := resolveReviseTarget(stages, i, s.HitlGate); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	switch p := pattern.Pattern.(type) {
+	case *loomv1.WorkflowPattern_Pipeline:
+		return check(p.Pipeline.Stages)
+	case *loomv1.WorkflowPattern_Iterative:
+		if p.Iterative.Pipeline != nil {
+			return check(p.Iterative.Pipeline.Stages)
+		}
+		return nil
+	case *loomv1.WorkflowPattern_Conditional:
+		for name, branch := range p.Conditional.Branches {
+			if hasHITLGate(branch) {
+				return fmt.Errorf("hitl_gate is not supported inside conditional branch %q — gates require a pipeline or iterative top-level pattern", name)
+			}
+		}
+		if p.Conditional.DefaultBranch != nil && hasHITLGate(p.Conditional.DefaultBranch) {
+			return fmt.Errorf("hitl_gate is not supported inside conditional default_branch")
+		}
+		return nil
+	default:
+		if hasHITLGate(pattern) {
+			return fmt.Errorf("hitl_gate is only supported on pipeline and iterative patterns")
+		}
+		return nil
+	}
+}
+
+// hasHITLGate reports whether any pipeline stage in the pattern declares a gate.
+func hasHITLGate(pattern *loomv1.WorkflowPattern) bool {
+	var stages []*loomv1.PipelineStage
+	switch p := pattern.Pattern.(type) {
+	case *loomv1.WorkflowPattern_Pipeline:
+		stages = p.Pipeline.Stages
+	case *loomv1.WorkflowPattern_Iterative:
+		if p.Iterative.Pipeline != nil {
+			stages = p.Iterative.Pipeline.Stages
+		}
+	case *loomv1.WorkflowPattern_Conditional:
+		for _, branch := range p.Conditional.Branches {
+			if hasHITLGate(branch) {
+				return true
+			}
+		}
+		if p.Conditional.DefaultBranch != nil {
+			return hasHITLGate(p.Conditional.DefaultBranch)
+		}
+	}
+	for _, s := range stages {
+		if s.HitlGate != nil {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/orchestration/hitl_gate_test.go
+++ b/pkg/orchestration/hitl_gate_test.go
@@ -1,0 +1,720 @@
+// Copyright © 2026 Teradata Corporation - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package orchestration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"github.com/teradata-labs/loom/pkg/communication"
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+	"github.com/teradata-labs/loom/pkg/observability"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+	"go.uber.org/zap/zaptest"
+	"google.golang.org/protobuf/proto"
+)
+
+// recordingLLMProvider is a scripted LLM provider that also records the user
+// prompt of every call, so tests can assert on threaded revision feedback.
+type recordingLLMProvider struct {
+	mu        sync.Mutex
+	responses []string
+	callCount int
+	prompts   []string
+}
+
+func newRecordingLLMProvider(responses ...string) *recordingLLMProvider {
+	return &recordingLLMProvider{responses: responses}
+}
+
+func (m *recordingLLMProvider) Chat(_ context.Context, messages []llmtypes.Message, _ []shuttle.Tool) (*llmtypes.LLMResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == "user" {
+			m.prompts = append(m.prompts, messages[i].Content)
+			break
+		}
+	}
+
+	var response string
+	if m.callCount < len(m.responses) {
+		response = m.responses[m.callCount]
+	} else {
+		response = fmt.Sprintf("Recorded mock response %d", m.callCount)
+	}
+	m.callCount++
+
+	return &llmtypes.LLMResponse{
+		Content:    response,
+		StopReason: "stop",
+		Usage: llmtypes.Usage{
+			InputTokens:  10,
+			OutputTokens: 20,
+			TotalTokens:  30,
+			CostUSD:      0.001,
+		},
+	}, nil
+}
+
+func (m *recordingLLMProvider) Name() string  { return "recording-mock" }
+func (m *recordingLLMProvider) Model() string { return "recording-mock-model" }
+
+func (m *recordingLLMProvider) recordedPrompts() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.prompts))
+	copy(out, m.prompts)
+	return out
+}
+
+// scriptedHITLHandler returns pre-scripted gate decisions in order.
+type scriptedHITLHandler struct {
+	mu        sync.Mutex
+	decisions []*loomv1.GateDecision
+	errs      []error
+	calls     int
+	requests  []*loomv1.HITLGateRequest
+}
+
+func (h *scriptedHITLHandler) RequestDecision(_ context.Context, req *loomv1.HITLGateRequest) (*loomv1.GateDecision, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.requests = append(h.requests, req)
+	i := h.calls
+	h.calls++
+	var err error
+	if i < len(h.errs) {
+		err = h.errs[i]
+	}
+	var d *loomv1.GateDecision
+	if i < len(h.decisions) {
+		d = h.decisions[i]
+	}
+	return d, err
+}
+
+// gatedPipelinePattern builds a 3-stage pipeline (analyst → designer → executor)
+// with a HITL gate on the designer stage.
+func gatedPipelinePattern(gate *loomv1.HITLGate) *loomv1.WorkflowPattern {
+	return &loomv1.WorkflowPattern{
+		Pattern: &loomv1.WorkflowPattern_Pipeline{
+			Pipeline: &loomv1.PipelinePattern{
+				InitialPrompt: "Create an orders table",
+				Stages: []*loomv1.PipelineStage{
+					{AgentId: "analyst", PromptTemplate: "Analyze: {{previous}}"},
+					{AgentId: "designer", PromptTemplate: "Design DDL for: {{previous}}", HitlGate: gate},
+					{AgentId: "executor", PromptTemplate: "Execute exactly: {{previous}}"},
+				},
+			},
+		},
+	}
+}
+
+// newGateTestOrchestrator builds an orchestrator with three scripted agents.
+func newGateTestOrchestrator(t *testing.T, handler HITLHandler) (*Orchestrator, *recordingLLMProvider, *recordingLLMProvider, *recordingLLMProvider) {
+	t.Helper()
+	logger := zaptest.NewLogger(t)
+	tracer := observability.NewNoOpTracer()
+
+	analystLLM := newRecordingLLMProvider("requirements: orders table")
+	designerLLM := newRecordingLLMProvider("CREATE TABLE orders (...)", "CREATE MULTISET TABLE orders (...)")
+	executorLLM := newRecordingLLMProvider("Table created successfully")
+
+	orch := NewOrchestrator(Config{
+		Logger:      logger,
+		Tracer:      tracer,
+		HITLHandler: handler,
+	})
+	orch.RegisterAgent("analyst", createMockAgent(t, "analyst", analystLLM))
+	orch.RegisterAgent("designer", createMockAgent(t, "designer", designerLLM))
+	orch.RegisterAgent("executor", createMockAgent(t, "executor", executorLLM))
+	return orch, analystLLM, designerLLM, executorLLM
+}
+
+func TestWorkflowFingerprint_StableAndIgnoresWorkflowID(t *testing.T) {
+	t.Parallel()
+
+	p1 := gatedPipelinePattern(&loomv1.HITLGate{})
+	p2 := gatedPipelinePattern(&loomv1.HITLGate{})
+	p2.WorkflowId = "some-stable-id"
+
+	fp1, err := WorkflowFingerprint(p1)
+	require.NoError(t, err)
+	fp2, err := WorkflowFingerprint(p2)
+	require.NoError(t, err)
+	assert.Equal(t, fp1, fp2, "workflow_id must not affect the fingerprint")
+
+	p3 := gatedPipelinePattern(&loomv1.HITLGate{})
+	p3.GetPipeline().Stages[1].PromptTemplate = "Design DIFFERENT DDL for: {{previous}}"
+	fp3, err := WorkflowFingerprint(p3)
+	require.NoError(t, err)
+	assert.NotEqual(t, fp1, fp3, "definition changes must change the fingerprint")
+}
+
+func TestInjectRevisionFeedback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		prompt   string
+		feedback string
+		source   string
+		want     []string
+		notWant  []string
+	}{
+		{
+			name:     "placeholder replaced",
+			prompt:   "Design DDL. Feedback: {{revision_feedback}}",
+			feedback: "use MULTISET",
+			source:   "human reviewer",
+			want:     []string{"Feedback: use MULTISET"},
+			notWant:  []string{"{{revision_feedback}}", "## REVISION FEEDBACK"},
+		},
+		{
+			name:     "no placeholder appends labeled section",
+			prompt:   "Design DDL.",
+			feedback: "use MULTISET",
+			source:   "human reviewer",
+			want:     []string{"## REVISION FEEDBACK (from human reviewer)", "use MULTISET"},
+		},
+		{
+			name:    "empty feedback blanks placeholder",
+			prompt:  "Design DDL. {{revision_feedback}}",
+			want:    []string{"Design DDL. "},
+			notWant: []string{"{{revision_feedback}}", "## REVISION FEEDBACK"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := injectRevisionFeedback(tt.prompt, tt.feedback, tt.source)
+			for _, w := range tt.want {
+				assert.Contains(t, got, w)
+			}
+			for _, nw := range tt.notWant {
+				assert.NotContains(t, got, nw)
+			}
+		})
+	}
+}
+
+func TestResolveReviseTarget(t *testing.T) {
+	t.Parallel()
+
+	stages := gatedPipelinePattern(nil).GetPipeline().Stages
+
+	tests := []struct {
+		name       string
+		gatedIndex int
+		gate       *loomv1.HITLGate
+		wantIndex  int
+		wantErr    string
+	}{
+		{name: "default is the gated stage", gatedIndex: 1, gate: &loomv1.HITLGate{}, wantIndex: 1},
+		{name: "named earlier stage", gatedIndex: 1, gate: &loomv1.HITLGate{ReviseTargetStageId: "analyst"}, wantIndex: 0},
+		{name: "forward jump rejected", gatedIndex: 1, gate: &loomv1.HITLGate{ReviseTargetStageId: "executor"}, wantErr: "forward jumps are invalid"},
+		{name: "unknown stage rejected", gatedIndex: 1, gate: &loomv1.HITLGate{ReviseTargetStageId: "nope"}, wantErr: "not found"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveReviseTarget(stages, tt.gatedIndex, tt.gate)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantIndex, got)
+		})
+	}
+}
+
+func TestHITLGateYAMLParsing(t *testing.T) {
+	t.Parallel()
+
+	yaml := `
+apiVersion: loom/v1
+kind: Workflow
+metadata:
+  name: create-table-pipeline
+spec:
+  type: pipeline
+  initial_prompt: "Create an orders table"
+  stages:
+    - agent_id: designer
+      prompt_template: "Design DDL: {{previous}}"
+      hitl_gate:
+        prompt_template: "Review this DDL:\n{{output}}"
+        request_type: approval
+        timeout_seconds: 1800
+        revise_target_stage_id: designer
+        max_revisions: 2
+        on_timeout: reject
+    - agent_id: executor
+      prompt_template: "Execute: {{previous}}"
+`
+	pattern, err := LoadWorkflowFromYAMLBytes([]byte(yaml))
+	require.NoError(t, err)
+	gate := pattern.GetPipeline().Stages[0].HitlGate
+	require.NotNil(t, gate)
+	assert.Contains(t, gate.PromptTemplate, "Review this DDL")
+	assert.Equal(t, "approval", gate.RequestType)
+	assert.Equal(t, int32(1800), gate.TimeoutSeconds)
+	assert.Equal(t, "designer", gate.ReviseTargetStageId)
+	assert.Equal(t, int32(2), gate.MaxRevisions)
+	assert.Equal(t, loomv1.GateTimeoutAction_GATE_TIMEOUT_ACTION_REJECT, gate.OnTimeout)
+	assert.Nil(t, pattern.GetPipeline().Stages[1].HitlGate)
+
+	badTimeout := strings.Replace(yaml, "on_timeout: reject", "on_timeout: explode", 1)
+	_, err = LoadWorkflowFromYAMLBytes([]byte(badTimeout))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "on_timeout")
+
+	forwardTarget := strings.Replace(yaml, "revise_target_stage_id: designer", "revise_target_stage_id: executor", 1)
+	_, err = LoadWorkflowFromYAMLBytes([]byte(forwardTarget))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forward jumps are invalid")
+}
+
+func TestHITLGateYAML_RejectedInConditionalBranch(t *testing.T) {
+	t.Parallel()
+
+	yaml := `
+apiVersion: loom/v1
+kind: Workflow
+metadata:
+  name: gated-branch
+spec:
+  type: conditional
+  condition_agent_id: router
+  condition_prompt: "route it"
+  branches:
+    build:
+      type: pipeline
+      initial_prompt: "go"
+      stages:
+        - agent_id: designer
+          prompt_template: "Design: {{previous}}"
+          hitl_gate: {}
+`
+	_, err := LoadWorkflowFromYAMLBytes([]byte(yaml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conditional branch")
+}
+
+func TestPipelineGate_SuspendsWithCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	pattern := gatedPipelinePattern(&loomv1.HITLGate{
+		PromptTemplate: "Review the DDL:\n{{output}}",
+	})
+	orch, _, _, executorLLM := newGateTestOrchestrator(t, nil)
+
+	result, err := orch.ExecutePattern(context.Background(), pattern)
+	assert.Nil(t, result)
+
+	var suspended *WorkflowSuspended
+	require.ErrorAs(t, err, &suspended)
+	ckpt := suspended.Checkpoint
+	require.NotNil(t, ckpt)
+
+	assert.Equal(t, int32(CheckpointVersion), ckpt.CheckpointVersion)
+	assert.Equal(t, "pipeline", ckpt.PatternType)
+	assert.Equal(t, int32(2), ckpt.NextStageIndex)
+	require.Len(t, ckpt.StageSnapshots, 2)
+	assert.Equal(t, "analyst", ckpt.StageSnapshots[0].AgentId)
+	assert.Equal(t, "designer", ckpt.StageSnapshots[1].AgentId)
+	assert.Equal(t, "CREATE TABLE orders (...)", ckpt.StageSnapshots[1].FullOutput)
+
+	require.NotNil(t, ckpt.PendingGate)
+	assert.Equal(t, "designer", ckpt.PendingGate.StageAgentId)
+	assert.Equal(t, int32(2), ckpt.PendingGate.StageNumber)
+	assert.Contains(t, ckpt.PendingGate.Question, "CREATE TABLE orders (...)", "{{output}} must be rendered into the question")
+
+	fp, err := WorkflowFingerprint(pattern)
+	require.NoError(t, err)
+	assert.Equal(t, fp, ckpt.ConfigFingerprint)
+
+	// The executor stage must not have run.
+	assert.Empty(t, executorLLM.recordedPrompts())
+}
+
+func TestPipelineGate_ResumeApprove_Completes(t *testing.T) {
+	t.Parallel()
+
+	pattern := gatedPipelinePattern(&loomv1.HITLGate{})
+	orch, _, _, executorLLM := newGateTestOrchestrator(t, nil)
+
+	_, err := orch.ExecutePattern(context.Background(), pattern)
+	var suspended *WorkflowSuspended
+	require.ErrorAs(t, err, &suspended)
+
+	result, err := orch.ResumeWorkflow(context.Background(), pattern, suspended.Checkpoint,
+		&loomv1.GateDecision{Action: loomv1.GateAction_GATE_ACTION_APPROVE})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "Table created successfully", result.MergedOutput)
+
+	prompts := executorLLM.recordedPrompts()
+	require.Len(t, prompts, 1)
+	assert.Contains(t, prompts[0], "CREATE TABLE orders (...)", "approved output must flow into the next stage as {{previous}}")
+}
+
+func TestPipelineGate_ResumeRevise_ThreadsFeedbackAndSuspendsAgain(t *testing.T) {
+	t.Parallel()
+
+	pattern := gatedPipelinePattern(&loomv1.HITLGate{})
+	orch, _, designerLLM, _ := newGateTestOrchestrator(t, nil)
+
+	_, err := orch.ExecutePattern(context.Background(), pattern)
+	var suspended *WorkflowSuspended
+	require.ErrorAs(t, err, &suspended)
+
+	// Revise: designer re-runs with feedback, then the gate fires again.
+	_, err = orch.ResumeWorkflow(context.Background(), pattern, suspended.Checkpoint,
+		&loomv1.GateDecision{Action: loomv1.GateAction_GATE_ACTION_REVISE, Feedback: "Use MULTISET and add COMPRESS"})
+	var suspendedAgain *WorkflowSuspended
+	require.ErrorAs(t, err, &suspendedAgain)
+
+	prompts := designerLLM.recordedPrompts()
+	require.Len(t, prompts, 2, "designer must run twice (original + revision)")
+	assert.Contains(t, prompts[1], "REVISION FEEDBACK (from human reviewer)")
+	assert.Contains(t, prompts[1], "Use MULTISET and add COMPRESS")
+
+	// The new checkpoint carries the revised output and the revision count.
+	ckpt := suspendedAgain.Checkpoint
+	assert.Equal(t, "CREATE MULTISET TABLE orders (...)", ckpt.StageSnapshots[1].FullOutput)
+	assert.Equal(t, int32(1), ckpt.GateRevisionCounts["designer"])
+
+	// Approve the revised output and complete.
+	result, err := orch.ResumeWorkflow(context.Background(), pattern, ckpt,
+		&loomv1.GateDecision{Action: loomv1.GateAction_GATE_ACTION_APPROVE})
+	require.NoError(t, err)
+	assert.Equal(t, "Table created successfully", result.MergedOutput)
+}
+
+func TestPipelineGate_ResumeReject(t *testing.T) {
+	t.Parallel()
+
+	pattern := gatedPipelinePattern(&loomv1.HITLGate{})
+	orch, _, _, executorLLM := newGateTestOrchestrator(t, nil)
+
+	_, err := orch.ExecutePattern(context.Background(), pattern)
+	var suspended *WorkflowSuspended
+	require.ErrorAs(t, err, &suspended)
+
+	_, err = orch.ResumeWorkflow(context.Background(), pattern, suspended.Checkpoint,
+		&loomv1.GateDecision{Action: loomv1.GateAction_GATE_ACTION_REJECT, Feedback: "not needed"})
+	var rejected *GateRejected
+	require.ErrorAs(t, err, &rejected)
+	assert.Equal(t, "designer", rejected.StageAgentID)
+	assert.Equal(t, "not needed", rejected.Feedback)
+	assert.Empty(t, executorLLM.recordedPrompts(), "nothing may execute after a rejection")
+}
+
+func TestPipelineGate_FingerprintMismatchRefusesResume(t *testing.T) {
+	t.Parallel()
+
+	pattern := gatedPipelinePattern(&loomv1.HITLGate{})
+	orch, _, _, _ := newGateTestOrchestrator(t, nil)
+
+	_, err := orch.ExecutePattern(context.Background(), pattern)
+	var suspended *WorkflowSuspended
+	require.ErrorAs(t, err, &suspended)
+
+	edited, ok := proto.Clone(pattern).(*loomv1.WorkflowPattern)
+	require.True(t, ok)
+	edited.GetPipeline().Stages[2].PromptTemplate = "DROP DATABASE; -- {{previous}}"
+
+	_, err = orch.ResumeWorkflow(context.Background(), edited, suspended.Checkpoint,
+		&loomv1.GateDecision{Action: loomv1.GateAction_GATE_ACTION_APPROVE})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "changed since suspension")
+}
+
+func TestPipelineGate_MaxRevisionsExceeded(t *testing.T) {
+	t.Parallel()
+
+	pattern := gatedPipelinePattern(&loomv1.HITLGate{MaxRevisions: 1})
+	orch, _, _, _ := newGateTestOrchestrator(t, nil)
+
+	_, err := orch.ExecutePattern(context.Background(), pattern)
+	var suspended *WorkflowSuspended
+	require.ErrorAs(t, err, &suspended)
+
+	// First revision: allowed, suspends again.
+	_, err = orch.ResumeWorkflow(context.Background(), pattern, suspended.Checkpoint,
+		&loomv1.GateDecision{Action: loomv1.GateAction_GATE_ACTION_REVISE, Feedback: "again"})
+	var suspendedAgain *WorkflowSuspended
+	require.ErrorAs(t, err, &suspendedAgain)
+
+	// Second revision: exceeds the budget.
+	_, err = orch.ResumeWorkflow(context.Background(), pattern, suspendedAgain.Checkpoint,
+		&loomv1.GateDecision{Action: loomv1.GateAction_GATE_ACTION_REVISE, Feedback: "and again"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max_revisions")
+}
+
+func TestPipelineGate_ResumeReviseRequiresFeedback(t *testing.T) {
+	t.Parallel()
+
+	pattern := gatedPipelinePattern(&loomv1.HITLGate{})
+	orch, _, _, _ := newGateTestOrchestrator(t, nil)
+
+	_, err := orch.ExecutePattern(context.Background(), pattern)
+	var suspended *WorkflowSuspended
+	require.ErrorAs(t, err, &suspended)
+
+	_, err = orch.ResumeWorkflow(context.Background(), pattern, suspended.Checkpoint,
+		&loomv1.GateDecision{Action: loomv1.GateAction_GATE_ACTION_REVISE})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires feedback")
+}
+
+func TestPipelineGate_InlineHandlerDecisions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("approve completes without suspension", func(t *testing.T) {
+		t.Parallel()
+		handler := &scriptedHITLHandler{decisions: []*loomv1.GateDecision{
+			{Action: loomv1.GateAction_GATE_ACTION_APPROVE},
+		}}
+		pattern := gatedPipelinePattern(&loomv1.HITLGate{})
+		orch, _, _, _ := newGateTestOrchestrator(t, handler)
+
+		result, err := orch.ExecutePattern(context.Background(), pattern)
+		require.NoError(t, err)
+		assert.Equal(t, "Table created successfully", result.MergedOutput)
+		assert.Equal(t, 1, handler.calls)
+	})
+
+	t.Run("revise then approve in-process", func(t *testing.T) {
+		t.Parallel()
+		handler := &scriptedHITLHandler{decisions: []*loomv1.GateDecision{
+			{Action: loomv1.GateAction_GATE_ACTION_REVISE, Feedback: "Use MULTISET"},
+			{Action: loomv1.GateAction_GATE_ACTION_APPROVE},
+		}}
+		pattern := gatedPipelinePattern(&loomv1.HITLGate{})
+		orch, _, designerLLM, _ := newGateTestOrchestrator(t, handler)
+
+		result, err := orch.ExecutePattern(context.Background(), pattern)
+		require.NoError(t, err)
+		assert.Equal(t, "Table created successfully", result.MergedOutput)
+
+		prompts := designerLLM.recordedPrompts()
+		require.Len(t, prompts, 2)
+		assert.Contains(t, prompts[1], "Use MULTISET")
+	})
+
+	t.Run("reject returns GateRejected", func(t *testing.T) {
+		t.Parallel()
+		handler := &scriptedHITLHandler{decisions: []*loomv1.GateDecision{
+			{Action: loomv1.GateAction_GATE_ACTION_REJECT, Feedback: "nope"},
+		}}
+		pattern := gatedPipelinePattern(&loomv1.HITLGate{})
+		orch, _, _, _ := newGateTestOrchestrator(t, handler)
+
+		_, err := orch.ExecutePattern(context.Background(), pattern)
+		var rejected *GateRejected
+		require.ErrorAs(t, err, &rejected)
+	})
+
+	t.Run("handler ErrSuspendWorkflow forces durable suspension", func(t *testing.T) {
+		t.Parallel()
+		handler := &scriptedHITLHandler{errs: []error{ErrSuspendWorkflow}}
+		pattern := gatedPipelinePattern(&loomv1.HITLGate{})
+		orch, _, _, _ := newGateTestOrchestrator(t, handler)
+
+		_, err := orch.ExecutePattern(context.Background(), pattern)
+		var suspended *WorkflowSuspended
+		require.ErrorAs(t, err, &suspended)
+	})
+}
+
+func TestGateOnLastStage_ResumeApproveCompletes(t *testing.T) {
+	t.Parallel()
+
+	pattern := gatedPipelinePattern(nil)
+	pattern.GetPipeline().Stages[2].HitlGate = &loomv1.HITLGate{}
+	orch, _, _, _ := newGateTestOrchestrator(t, nil)
+
+	_, err := orch.ExecutePattern(context.Background(), pattern)
+	var suspended *WorkflowSuspended
+	require.ErrorAs(t, err, &suspended)
+	assert.Equal(t, int32(3), suspended.Checkpoint.NextStageIndex)
+
+	result, err := orch.ResumeWorkflow(context.Background(), pattern, suspended.Checkpoint,
+		&loomv1.GateDecision{Action: loomv1.GateAction_GATE_ACTION_APPROVE})
+	require.NoError(t, err)
+	assert.Equal(t, "Table created successfully", result.MergedOutput)
+}
+
+func TestResumeWorkflow_RejectsUnsupportedPatterns(t *testing.T) {
+	t.Parallel()
+
+	orch := NewOrchestrator(Config{Logger: zaptest.NewLogger(t), Tracer: observability.NewNoOpTracer()})
+	pattern := &loomv1.WorkflowPattern{
+		Pattern: &loomv1.WorkflowPattern_ForkJoin{
+			ForkJoin: &loomv1.ForkJoinPattern{Prompt: "x", AgentIds: []string{"a"}},
+		},
+	}
+	_, err := orch.ResumeWorkflow(context.Background(), pattern, &loomv1.WorkflowCheckpoint{CheckpointVersion: 1},
+		&loomv1.GateDecision{Action: loomv1.GateAction_GATE_ACTION_APPROVE})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support HITL gates")
+}
+
+func TestIterativeGate_SuspendAndResume(t *testing.T) {
+	t.Parallel()
+
+	logger := zaptest.NewLogger(t)
+	tracer := observability.NewNoOpTracer()
+
+	analystLLM := newRecordingLLMProvider(`{"analysis": "orders table needed"}`)
+	designerLLM := newRecordingLLMProvider(`{"ddl": "CREATE TABLE orders"}`)
+	executorLLM := newRecordingLLMProvider(`{"result": "created"}`)
+
+	memoryStore := communication.NewMemoryStore(5 * time.Minute)
+	messageBus := communication.NewMessageBus(memoryStore, nil, tracer, logger)
+	sharedMemory, err := communication.NewSharedMemoryStore(tracer, logger)
+	require.NoError(t, err)
+
+	orch := NewOrchestrator(Config{
+		Logger:       logger,
+		Tracer:       tracer,
+		MessageBus:   messageBus,
+		SharedMemory: sharedMemory,
+	})
+	orch.RegisterAgent("analyst", createMockAgent(t, "analyst", analystLLM))
+	orch.RegisterAgent("designer", createMockAgent(t, "designer", designerLLM))
+	orch.RegisterAgent("executor", createMockAgent(t, "executor", executorLLM))
+
+	pattern := &loomv1.WorkflowPattern{
+		Pattern: &loomv1.WorkflowPattern_Iterative{
+			Iterative: &loomv1.IterativeWorkflowPattern{
+				Pipeline: &loomv1.PipelinePattern{
+					InitialPrompt: "Create an orders table",
+					Stages: []*loomv1.PipelineStage{
+						{AgentId: "analyst", PromptTemplate: "Analyze: {{previous}}"},
+						{AgentId: "designer", PromptTemplate: "Design: {{previous}}", HitlGate: &loomv1.HITLGate{}},
+						{AgentId: "executor", PromptTemplate: "Execute: {{previous}}"},
+					},
+				},
+				MaxIterations: 3,
+				RestartPolicy: &loomv1.RestartPolicy{
+					Enabled:              true,
+					PreserveOutputs:      true,
+					MaxValidationRetries: 0, // skip validation for deterministic mocks
+				},
+			},
+		},
+	}
+
+	_, err = orch.ExecutePattern(context.Background(), pattern)
+	var suspended *WorkflowSuspended
+	require.ErrorAs(t, err, &suspended)
+	ckpt := suspended.Checkpoint
+	assert.Equal(t, "iterative_pipeline", ckpt.PatternType)
+	assert.Equal(t, int32(2), ckpt.NextStageIndex)
+	assert.Equal(t, int32(1), ckpt.Iteration)
+	require.Len(t, ckpt.StageSnapshots, 2)
+	assert.Empty(t, executorLLM.recordedPrompts())
+
+	result, err := orch.ResumeWorkflow(context.Background(), pattern, ckpt,
+		&loomv1.GateDecision{Action: loomv1.GateAction_GATE_ACTION_APPROVE})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "iterative_pipeline", result.PatternType)
+	assert.Contains(t, result.MergedOutput, "created")
+
+	prompts := executorLLM.recordedPrompts()
+	require.Len(t, prompts, 1)
+	assert.Contains(t, prompts[0], "CREATE TABLE orders", "approved designer output must reach the executor stage")
+}
+
+func TestIterativeGate_RestartDisabledFallbackRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	logger := zaptest.NewLogger(t)
+	tracer := observability.NewNoOpTracer()
+
+	analystLLM := newRecordingLLMProvider("analysis done")
+	designerLLM := newRecordingLLMProvider("CREATE TABLE t (...)")
+	executorLLM := newRecordingLLMProvider("done")
+
+	orch := NewOrchestrator(Config{Logger: logger, Tracer: tracer})
+	orch.RegisterAgent("analyst", createMockAgent(t, "analyst", analystLLM))
+	orch.RegisterAgent("designer", createMockAgent(t, "designer", designerLLM))
+	orch.RegisterAgent("executor", createMockAgent(t, "executor", executorLLM))
+
+	// Iterative pattern with restart DISABLED — executes via the plain
+	// pipeline fallback, but checkpoints must fingerprint the iterative
+	// pattern so this exact pattern can resume.
+	pattern := &loomv1.WorkflowPattern{
+		Pattern: &loomv1.WorkflowPattern_Iterative{
+			Iterative: &loomv1.IterativeWorkflowPattern{
+				Pipeline: &loomv1.PipelinePattern{
+					InitialPrompt: "Create a table",
+					Stages: []*loomv1.PipelineStage{
+						{AgentId: "analyst", PromptTemplate: "Analyze: {{previous}}"},
+						{AgentId: "designer", PromptTemplate: "Design: {{previous}}", HitlGate: &loomv1.HITLGate{}},
+						{AgentId: "executor", PromptTemplate: "Execute: {{previous}}"},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := orch.ExecutePattern(context.Background(), pattern)
+	var suspended *WorkflowSuspended
+	require.ErrorAs(t, err, &suspended)
+	assert.Equal(t, "pipeline", suspended.Checkpoint.PatternType)
+
+	result, err := orch.ResumeWorkflow(context.Background(), pattern, suspended.Checkpoint,
+		&loomv1.GateDecision{Action: loomv1.GateAction_GATE_ACTION_APPROVE})
+	require.NoError(t, err)
+	assert.Equal(t, "done", result.MergedOutput)
+}
+
+func TestFormatRestartFeedback(t *testing.T) {
+	t.Parallel()
+
+	got := formatRestartFeedback(&loomv1.RestartRequest{
+		Reason:     "table too large",
+		Parameters: map[string]string{"row_limit": "1000", "approach": "sample"},
+	})
+	assert.Contains(t, got, "table too large")
+	assert.Contains(t, got, "- approach: sample")
+	assert.Contains(t, got, "- row_limit: 1000")
+	// Sorted parameter order for determinism.
+	assert.Less(t, strings.Index(got, "approach"), strings.Index(got, "row_limit"))
+}
+
+func TestWorkflowSuspendedAndGateRejectedErrors(t *testing.T) {
+	t.Parallel()
+
+	s := &WorkflowSuspended{Checkpoint: &loomv1.WorkflowCheckpoint{
+		PendingGate: &loomv1.HITLGateRequest{StageNumber: 2, StageAgentId: "designer"},
+	}}
+	assert.Contains(t, s.Error(), "stage 2")
+	assert.Contains(t, s.Error(), "designer")
+	assert.True(t, errors.As(error(s), new(*WorkflowSuspended)))
+
+	r := &GateRejected{StageAgentID: "designer", Feedback: "no"}
+	assert.Contains(t, r.Error(), "designer")
+	assert.Contains(t, r.Error(), "no")
+}

--- a/pkg/orchestration/iterative_pipeline_executor.go
+++ b/pkg/orchestration/iterative_pipeline_executor.go
@@ -59,6 +59,34 @@ type IterativePipelineExecutor struct {
 
 	// Structured context for agent hallucination prevention
 	structuredContext *StructuredContext
+
+	// REVISE round-trips consumed per HITL gate (agent_id -> count)
+	gateRevisions map[string]int32
+
+	// Latest FULL (untruncated) output per stage, for checkpoint snapshots
+	fullOutputs map[string]string
+
+	// Feedback threaded into the next executed stage's prompt (consumed once).
+	// Set by HITL gate REVISE decisions and by restart requests (reason +
+	// parameters — previously logged only, never reaching the target stage).
+	pendingFeedback string
+	feedbackSource  string
+
+	// Resume state rehydrated from a WorkflowCheckpoint (nil for fresh runs)
+	resume *iterativeResumeState
+}
+
+// iterativeResumeState carries checkpoint-rehydrated loop state into
+// executeWithRestarts.
+type iterativeResumeState struct {
+	startStageIndex int
+	iteration       int
+	currentInput    string
+	stageOutputs    map[string]string // agent_id -> truncated output
+	fullOutputs     map[string]string // agent_id -> full output
+	allResults      []*loomv1.AgentResult
+	modelsUsed      map[string]string
+	snapshots       []*loomv1.CheckpointStageSnapshot // ordered, for context replay
 }
 
 // NewIterativePipelineExecutor creates a new iterative pipeline executor.
@@ -77,6 +105,8 @@ func NewIterativePipelineExecutor(
 		restartRequests:  make(chan *loomv1.RestartRequest, 10),
 		restartResponses: make(map[string]chan *loomv1.RestartResponse),
 		lastRestartTime:  make(map[string]time.Time),
+		gateRevisions:    make(map[string]int32),
+		fullOutputs:      make(map[string]string),
 	}
 }
 
@@ -130,8 +160,15 @@ func (e *IterativePipelineExecutor) Execute(ctx context.Context) (*loomv1.Workfl
 	// Check if restart policy is enabled
 	if e.pattern.RestartPolicy == nil || !e.pattern.RestartPolicy.Enabled {
 		e.orchestrator.logger.Info("Restart policy disabled, executing as standard pipeline")
-		// Fall back to standard pipeline execution
+		// Fall back to standard pipeline execution. Checkpoints taken there
+		// must fingerprint the host-visible ITERATIVE pattern, not the inner
+		// pipeline, so resume verification matches what the host resubmits.
 		executor := NewPipelineExecutor(e.orchestrator, e.pattern.Pipeline, e.workflowID)
+		if fp, err := iterativePatternFingerprint(e.pattern); err == nil {
+			executor.fingerprintOverride = fp
+		} else {
+			e.orchestrator.logger.Warn("failed to fingerprint iterative pattern for fallback executor", zap.Error(err))
+		}
 		return executor.Execute(ctx)
 	}
 
@@ -189,6 +226,17 @@ func (e *IterativePipelineExecutor) executeWithRestarts(ctx context.Context, wor
 
 	e.currentIteration = 1
 
+	// Rehydrate loop state when resuming from a HITL gate checkpoint.
+	if e.resume != nil {
+		stageOutputs = e.resume.stageOutputs
+		allResults = e.resume.allResults
+		modelsUsed = e.resume.modelsUsed
+		e.fullOutputs = e.resume.fullOutputs
+		if e.resume.iteration > 0 {
+			e.currentIteration = e.resume.iteration
+		}
+	}
+
 	// Initialize structured context for hallucination prevention
 	ctx, contextSpan := e.orchestrator.tracer.StartSpan(ctx, "workflow.structured_context.init")
 	e.structuredContext = NewStructuredContext(workflowID, "npath-discovery")
@@ -209,6 +257,21 @@ func (e *IterativePipelineExecutor) executeWithRestarts(ctx context.Context, wor
 	// Execute pipeline stages
 	currentInput := e.pattern.Pipeline.InitialPrompt
 	stageIndex := 0
+	if e.resume != nil {
+		currentInput = e.resume.currentInput
+		stageIndex = e.resume.startStageIndex
+		// Replay completed stage outputs into the structured context
+		// (best-effort — parse failures are non-fatal, as in the main loop).
+		for i, snap := range e.resume.snapshots {
+			if snap.FullOutput == "" {
+				continue
+			}
+			if err := e.parseAndAddStageOutput(fmt.Sprintf("stage-%d", i+1), snap.AgentId, snap.FullOutput); err != nil {
+				e.orchestrator.logger.Debug("resume: stage output not parseable into structured context",
+					zap.String("stage_id", snap.AgentId), zap.Error(err))
+			}
+		}
+	}
 
 	for e.currentIteration <= int(maxIterations) {
 		if stageIndex >= len(e.pattern.Pipeline.Stages) {
@@ -242,6 +305,10 @@ func (e *IterativePipelineExecutor) executeWithRestarts(ctx context.Context, wor
 			}
 		}
 		prompt := e.buildStagePromptWithStructuredContext(stage, currentInput, outputsSlice)
+		// Thread pending revision/restart feedback into this stage's prompt
+		// (consumed once; blanks stray placeholders otherwise).
+		prompt = injectRevisionFeedback(prompt, e.pendingFeedback, e.feedbackSource)
+		e.pendingFeedback = ""
 
 		if promptSpan != nil {
 			// Add context size metrics
@@ -373,6 +440,7 @@ func (e *IterativePipelineExecutor) executeWithRestarts(ctx context.Context, wor
 		// Store truncated output for context passing (includes SharedMemory reference if truncated)
 		truncatedForStorage, _ := truncateStageOutput(result.Output, MaxStageOutputBytes, stageMemoryKey)
 		stageOutputs[stage.AgentId] = truncatedForStorage
+		e.fullOutputs[stage.AgentId] = result.Output
 		allResults = append(allResults, result)
 
 		// Try to parse stage output as JSON and add to structured context
@@ -435,6 +503,79 @@ func (e *IterativePipelineExecutor) executeWithRestarts(ctx context.Context, wor
 				zap.String("memory_key", stageMemoryKey))
 		}
 		currentInput = truncatedOutput
+
+		// HITL gate: evaluated after the stage completes and before the next
+		// stage (or restart handling). Default (no handler) is durable
+		// suspension via WorkflowSuspended.
+		if stage.HitlGate != nil {
+			gateReq := buildGateRequest(workflowID, stage, stageNum, result.Output)
+			totalStages := len(e.pattern.Pipeline.Stages)
+			e.orchestrator.emitProgress(WorkflowProgressEvent{
+				PatternType:    "iterative_pipeline",
+				Message:        fmt.Sprintf("Stage %d of %d awaiting human review", stageNum, totalStages),
+				Progress:       int32(float64(stageNum) / float64(totalStages) * 100), // #nosec G115
+				CurrentAgentID: stage.AgentId,
+				PartialResults: allResults,
+				HITLRequest:    gateReq,
+			})
+
+			decision, gateErr := evaluateHITLGate(execCtx, e.orchestrator, stage.HitlGate, gateReq)
+			if gateErr != nil {
+				return nil, gateErr
+			}
+			if decision == nil {
+				ckpt, ckptErr := e.buildCheckpoint(ctx, workflowID, gateReq, stageIndex, stageOutputs, allResults, modelsUsed)
+				if ckptErr != nil {
+					return nil, ckptErr
+				}
+				e.orchestrator.logger.Info("Iterative pipeline suspended at HITL gate",
+					zap.String("workflow_id", workflowID),
+					zap.String("stage", stage.AgentId),
+					zap.Int("stage_num", stageNum),
+					zap.Int("iteration", e.currentIteration))
+				return nil, &WorkflowSuspended{Checkpoint: ckpt}
+			}
+
+			switch decision.Action {
+			case loomv1.GateAction_GATE_ACTION_APPROVE:
+				// Fall through to restart handling / next stage.
+
+			case loomv1.GateAction_GATE_ACTION_REJECT:
+				return nil, &GateRejected{StageAgentID: stage.AgentId, Feedback: decision.Feedback}
+
+			case loomv1.GateAction_GATE_ACTION_REVISE:
+				target, terr := resolveReviseTarget(e.pattern.Pipeline.Stages, stageIndex, stage.HitlGate)
+				if terr != nil {
+					return nil, terr
+				}
+				e.gateRevisions[stage.AgentId]++
+				if e.gateRevisions[stage.AgentId] > maxGateRevisions(stage.HitlGate) {
+					return nil, fmt.Errorf("gate on stage %s exceeded max_revisions (%d)", stage.AgentId, maxGateRevisions(stage.HitlGate))
+				}
+				// Outputs from the target stage onward are superseded by the
+				// revision — drop them (mirrors restart semantics).
+				for i := target; i < len(e.pattern.Pipeline.Stages); i++ {
+					delete(stageOutputs, e.pattern.Pipeline.Stages[i].AgentId)
+					delete(e.fullOutputs, e.pattern.Pipeline.Stages[i].AgentId)
+				}
+				if target == 0 {
+					currentInput = e.pattern.Pipeline.InitialPrompt
+				} else {
+					currentInput = stageOutputs[e.pattern.Pipeline.Stages[target-1].AgentId]
+				}
+				e.pendingFeedback = decision.Feedback
+				e.feedbackSource = "human reviewer"
+				e.orchestrator.logger.Info("Gate revision: restarting stage",
+					zap.String("gated_stage", stage.AgentId),
+					zap.Int("target_stage", target+1),
+					zap.Int32("revision", e.gateRevisions[stage.AgentId]))
+				stageIndex = target
+				continue
+
+			default:
+				return nil, fmt.Errorf("gate on stage %s received unsupported decision %s", stage.AgentId, decision.Action)
+			}
+		}
 
 		// Check for restart requests (non-blocking)
 		select {
@@ -534,6 +675,12 @@ func (e *IterativePipelineExecutor) executeWithRestarts(ctx context.Context, wor
 
 			// Update last restart time
 			e.lastRestartTime[restartReq.TargetStageId] = time.Now()
+
+			// Thread the restart reason/parameters into the restarted stage's
+			// prompt. Previously these were logged only — the target stage
+			// never learned why it was restarted.
+			e.pendingFeedback = formatRestartFeedback(restartReq)
+			e.feedbackSource = fmt.Sprintf("stage %s restart request", restartReq.RequesterStageId)
 
 			// Jump back to target stage
 			stageIndex = targetIndex
@@ -1208,4 +1355,166 @@ func (e *IterativePipelineExecutor) resetWorkflowNamespace(ctx context.Context) 
 		zap.Int("keys_deleted", len(listResp.Keys)))
 
 	return nil
+}
+
+// buildCheckpoint captures the durable suspension state of the iterative
+// pipeline at the gate on stage gatedIndex. Snapshots are index-aligned with
+// pipeline stages up to and including the gated stage; stages whose outputs a
+// restart discarded get empty placeholders so index-keyed re-seeding stays
+// correct on resume.
+func (e *IterativePipelineExecutor) buildCheckpoint(
+	ctx context.Context,
+	workflowID string,
+	gateReq *loomv1.HITLGateRequest,
+	gatedIndex int,
+	stageOutputs map[string]string,
+	allResults []*loomv1.AgentResult,
+	modelsUsed map[string]string,
+) (*loomv1.WorkflowCheckpoint, error) {
+	fp, err := iterativePatternFingerprint(e.pattern)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fingerprint iterative pattern for checkpoint: %w", err)
+	}
+
+	snaps := make([]*loomv1.CheckpointStageSnapshot, 0, gatedIndex+1)
+	for idx := 0; idx <= gatedIndex; idx++ {
+		agentID := e.pattern.Pipeline.Stages[idx].AgentId
+		full := e.fullOutputs[agentID]
+		if full == "" {
+			// Fall back to the (possibly truncated) context copy if the full
+			// output is unavailable for a completed stage.
+			full = stageOutputs[agentID]
+		}
+		snaps = append(snaps, &loomv1.CheckpointStageSnapshot{
+			AgentId:    agentID,
+			FullOutput: full,
+		})
+	}
+
+	return &loomv1.WorkflowCheckpoint{
+		CheckpointVersion:  CheckpointVersion,
+		ConfigFingerprint:  fp,
+		WorkflowId:         workflowID,
+		PatternType:        "iterative_pipeline",
+		NextStageIndex:     int32(gatedIndex + 1), // #nosec G115 -- stage counts are tiny
+		StageSnapshots:     snaps,
+		AllResults:         allResults,
+		ModelsUsed:         modelsUsed,
+		Iteration:          types.SafeInt32(e.currentIteration),
+		GateRevisionCounts: e.gateRevisions,
+		PendingGate:        gateReq,
+		SharedMemory:       snapshotWorkflowMemory(ctx, e.orchestrator),
+		CreatedAtMs:        time.Now().UnixMilli(),
+	}, nil
+}
+
+// Resume continues a suspended iterative pipeline from a WorkflowCheckpoint
+// after a human gate decision. REJECT is handled by
+// Orchestrator.ResumeWorkflow; this method applies APPROVE and REVISE.
+func (e *IterativePipelineExecutor) Resume(ctx context.Context, ckpt *loomv1.WorkflowCheckpoint, decision *loomv1.GateDecision) (*loomv1.WorkflowResult, error) {
+	// A checkpoint taken by the restart-disabled fallback is a plain pipeline
+	// checkpoint (fingerprinted against the iterative pattern) — resume it the
+	// same way it was executed.
+	if e.pattern.RestartPolicy == nil || !e.pattern.RestartPolicy.Enabled {
+		executor := NewPipelineExecutor(e.orchestrator, e.pattern.Pipeline, e.workflowID)
+		if fp, err := iterativePatternFingerprint(e.pattern); err == nil {
+			executor.fingerprintOverride = fp
+		} else {
+			e.orchestrator.logger.Warn("failed to fingerprint iterative pattern for fallback resume", zap.Error(err))
+		}
+		return executor.Resume(ctx, ckpt, decision)
+	}
+
+	fp, err := iterativePatternFingerprint(e.pattern)
+	if err != nil {
+		return nil, fmt.Errorf("resume: failed to fingerprint iterative pattern: %w", err)
+	}
+	if fp != ckpt.ConfigFingerprint {
+		return nil, fmt.Errorf("resume: workflow definition changed since suspension (fingerprint %s != checkpoint %s) — re-run the workflow instead", fp, ckpt.ConfigFingerprint)
+	}
+
+	stages := e.pattern.Pipeline.Stages
+	gatedIndex := int(ckpt.NextStageIndex) - 1
+	if gatedIndex < 0 || gatedIndex >= len(stages) || len(ckpt.StageSnapshots) != gatedIndex+1 {
+		return nil, fmt.Errorf("resume: corrupt checkpoint (next_stage_index=%d, snapshots=%d, stages=%d)",
+			ckpt.NextStageIndex, len(ckpt.StageSnapshots), len(stages))
+	}
+
+	state := &iterativeResumeState{
+		iteration:    int(ckpt.Iteration),
+		stageOutputs: make(map[string]string),
+		fullOutputs:  make(map[string]string),
+		allResults:   ckpt.AllResults,
+		modelsUsed:   ckpt.ModelsUsed,
+		snapshots:    ckpt.StageSnapshots,
+	}
+	if state.modelsUsed == nil {
+		state.modelsUsed = make(map[string]string)
+	}
+	if ckpt.GateRevisionCounts != nil {
+		e.gateRevisions = ckpt.GateRevisionCounts
+	}
+	for i, snap := range ckpt.StageSnapshots {
+		if snap.FullOutput == "" {
+			continue
+		}
+		state.fullOutputs[snap.AgentId] = snap.FullOutput
+		truncated, _ := truncateStageOutput(snap.FullOutput, MaxStageOutputBytes, fmt.Sprintf("stage-%d-output", i+1))
+		state.stageOutputs[snap.AgentId] = truncated
+	}
+
+	switch decision.Action {
+	case loomv1.GateAction_GATE_ACTION_APPROVE:
+		state.startStageIndex = gatedIndex + 1
+		state.currentInput = state.stageOutputs[stages[gatedIndex].AgentId]
+
+	case loomv1.GateAction_GATE_ACTION_REVISE:
+		gate := stages[gatedIndex].HitlGate
+		if gate == nil {
+			return nil, fmt.Errorf("resume: checkpointed gate stage %s has no hitl_gate", stages[gatedIndex].AgentId)
+		}
+		if strings.TrimSpace(decision.Feedback) == "" {
+			return nil, fmt.Errorf("resume: REVISE decision requires feedback")
+		}
+		target, terr := resolveReviseTarget(stages, gatedIndex, gate)
+		if terr != nil {
+			return nil, fmt.Errorf("resume: %w", terr)
+		}
+		gatedAgentID := stages[gatedIndex].AgentId
+		e.gateRevisions[gatedAgentID]++
+		if e.gateRevisions[gatedAgentID] > maxGateRevisions(gate) {
+			return nil, fmt.Errorf("resume: gate on stage %s exceeded max_revisions (%d)", gatedAgentID, maxGateRevisions(gate))
+		}
+		for i := target; i < len(stages); i++ {
+			delete(state.stageOutputs, stages[i].AgentId)
+			delete(state.fullOutputs, stages[i].AgentId)
+		}
+		state.startStageIndex = target
+		if target == 0 {
+			state.currentInput = e.pattern.Pipeline.InitialPrompt
+		} else {
+			state.currentInput = state.stageOutputs[stages[target-1].AgentId]
+		}
+		e.pendingFeedback = decision.Feedback
+		e.feedbackSource = "human reviewer"
+
+	default:
+		return nil, fmt.Errorf("resume: unsupported gate decision %s", decision.Action)
+	}
+
+	// Restore agent-written SharedMemory and re-seed stage output keys before
+	// the resumed loop starts.
+	restoreWorkflowMemory(ctx, e.orchestrator, ckpt)
+
+	e.resume = state
+	e.orchestrator.logger.Info("Resuming iterative pipeline execution",
+		zap.String("workflow_id", ckpt.WorkflowId),
+		zap.String("decision", decision.Action.String()),
+		zap.Int("start_stage", state.startStageIndex+1),
+		zap.Int("iteration", state.iteration))
+
+	if ckpt.WorkflowId != "" {
+		e.workflowID = ckpt.WorkflowId
+	}
+	return e.Execute(ctx)
 }

--- a/pkg/orchestration/orchestrator.go
+++ b/pkg/orchestration/orchestrator.go
@@ -36,6 +36,10 @@ type WorkflowProgressEvent struct {
 
 	// Partial results available so far
 	PartialResults []*loomv1.AgentResult
+
+	// HITL gate awaiting a human decision (set when a gate fires, right
+	// before the workflow suspends or an inline handler is consulted)
+	HITLRequest *loomv1.HITLGateRequest
 }
 
 // WorkflowProgressCallback is called during workflow execution to report progress.
@@ -80,6 +84,10 @@ type Orchestrator struct {
 
 	// TaskManager for persistent workflow tracking (optional).
 	taskManager *task.Manager
+
+	// HITLHandler for inline gate decisions (optional). When nil, HITL gates
+	// suspend the workflow with a checkpoint instead (the durable default).
+	hitlHandler HITLHandler
 }
 
 // taskTrackingKey is a context key to prevent recursive task tracking.
@@ -117,6 +125,10 @@ type Config struct {
 	// When set, ExecutePattern wraps execution with task-based state tracking,
 	// providing persistence, resume capability, and progress visibility.
 	TaskManager *task.Manager
+
+	// HITLHandler decides HITL gates inline (optional). Leave nil to have
+	// gates suspend with a durable WorkflowCheckpoint (see ResumeWorkflow).
+	HITLHandler HITLHandler
 }
 
 // NewOrchestrator creates a new orchestrator instance.
@@ -139,6 +151,7 @@ func NewOrchestrator(config Config) *Orchestrator {
 		progressCallback: config.ProgressCallback,
 		llmSemaphore:     config.LLMSemaphore,
 		taskManager:      config.TaskManager,
+		hitlHandler:      config.HITLHandler,
 	}
 
 	// Initialize collaboration engine with orchestrator as provider

--- a/pkg/orchestration/pipeline_executor.go
+++ b/pkg/orchestration/pipeline_executor.go
@@ -24,6 +24,11 @@ type PipelineExecutor struct {
 	orchestrator *Orchestrator
 	pattern      *loomv1.PipelinePattern
 	workflowID   string
+
+	// fingerprintOverride replaces the executor's own pattern fingerprint in
+	// checkpoints. Set by the iterative executor's plain-pipeline fallback so
+	// suspension/resume verify against the host-visible iterative pattern.
+	fingerprintOverride string
 }
 
 // NewPipelineExecutor creates a new pipeline executor.
@@ -33,6 +38,61 @@ func NewPipelineExecutor(orchestrator *Orchestrator, pattern *loomv1.PipelinePat
 		pattern:      pattern,
 		workflowID:   workflowID,
 	}
+}
+
+// pipelineState is the inter-stage loop state of a pipeline run. It is built
+// fresh by Execute and rehydrated from a WorkflowCheckpoint by Resume — HITL
+// gates only fire at stage boundaries, so this fully describes a run.
+type pipelineState struct {
+	// Index of the stage to execute first.
+	startIndex int
+
+	// Append-only execution history (all attempts) for cost accounting.
+	allResults []*loomv1.AgentResult
+
+	// Full output per completed stage of the current pass, index-aligned.
+	stageOutputs []string
+
+	// Input for the next stage ({{previous}}).
+	currentInput string
+
+	// agent_id -> model name.
+	modelsUsed map[string]string
+
+	// Stages that continued with unvalidated output.
+	validationWarnings []string
+
+	// REVISE round-trips consumed per gated stage (agent_id -> count).
+	gateRevisions map[string]int32
+
+	// Feedback to thread into the next executed stage's prompt (consumed once).
+	revisionFeedback string
+
+	// Human-readable source of revisionFeedback for the prompt header.
+	revisionSource string
+}
+
+// pipelineFingerprint returns the fingerprint recorded in checkpoints taken
+// by this executor.
+func (e *PipelineExecutor) pipelineFingerprint() (string, error) {
+	if e.fingerprintOverride != "" {
+		return e.fingerprintOverride, nil
+	}
+	return pipelinePatternFingerprint(e.pattern)
+}
+
+// validateStagesAndAgents checks the pipeline is non-empty and every stage
+// agent resolves.
+func (e *PipelineExecutor) validateStagesAndAgents(ctx context.Context) error {
+	if len(e.pattern.Stages) == 0 {
+		return fmt.Errorf("pipeline has no stages")
+	}
+	for i, stage := range e.pattern.Stages {
+		if _, err := e.orchestrator.GetAgent(ctx, stage.AgentId); err != nil {
+			return fmt.Errorf("agent not found for stage %d: %s: %w", i, stage.AgentId, err)
+		}
+	}
+	return nil
 }
 
 // Execute runs the pipeline and returns the result.
@@ -57,26 +117,179 @@ func (e *PipelineExecutor) Execute(ctx context.Context) (*loomv1.WorkflowResult,
 	e.orchestrator.logger.Info("Starting pipeline execution",
 		zap.Int("stages", len(e.pattern.Stages)))
 
-	// Check for empty pipeline
-	if len(e.pattern.Stages) == 0 {
-		return nil, fmt.Errorf("pipeline has no stages")
+	if err := e.validateStagesAndAgents(ctx); err != nil {
+		return nil, err
 	}
 
-	// Validate all agents exist
-	for i, stage := range e.pattern.Stages {
-		if _, err := e.orchestrator.GetAgent(ctx, stage.AgentId); err != nil {
-			return nil, fmt.Errorf("agent not found for stage %d: %s: %w", i, stage.AgentId, err)
+	state := &pipelineState{
+		startIndex:    0,
+		allResults:    make([]*loomv1.AgentResult, 0, len(e.pattern.Stages)),
+		stageOutputs:  make([]string, 0, len(e.pattern.Stages)),
+		currentInput:  e.pattern.InitialPrompt,
+		modelsUsed:    make(map[string]string),
+		gateRevisions: make(map[string]int32),
+	}
+
+	return e.executeFrom(ctx, startTime, workflowID, state)
+}
+
+// Resume continues a suspended pipeline from a WorkflowCheckpoint after a
+// human gate decision. REJECT is handled by Orchestrator.ResumeWorkflow; this
+// method applies APPROVE (continue at the next stage) and REVISE (jump back
+// to the gate's revise target with feedback threaded into its prompt).
+func (e *PipelineExecutor) Resume(ctx context.Context, ckpt *loomv1.WorkflowCheckpoint, decision *loomv1.GateDecision) (*loomv1.WorkflowResult, error) {
+	startTime := time.Now()
+
+	fp, err := e.pipelineFingerprint()
+	if err != nil {
+		return nil, fmt.Errorf("resume: failed to fingerprint pipeline: %w", err)
+	}
+	if fp != ckpt.ConfigFingerprint {
+		return nil, fmt.Errorf("resume: workflow definition changed since suspension (fingerprint %s != checkpoint %s) — re-run the workflow instead", fp, ckpt.ConfigFingerprint)
+	}
+
+	workflowID := ckpt.WorkflowId
+	if workflowID == "" {
+		workflowID = e.workflowID
+	}
+
+	ctx, workflowSpan := e.orchestrator.tracer.StartSpan(ctx, "workflow.pipeline.resume")
+	defer e.orchestrator.tracer.EndSpan(workflowSpan)
+	if workflowSpan != nil {
+		workflowSpan.SetAttribute("workflow.type", "pipeline")
+		workflowSpan.SetAttribute("workflow.id", workflowID)
+		workflowSpan.SetAttribute("resume.decision", decision.Action.String())
+		workflowSpan.SetAttribute("resume.next_stage_index", fmt.Sprintf("%d", ckpt.NextStageIndex))
+	}
+
+	if err := e.validateStagesAndAgents(ctx); err != nil {
+		return nil, err
+	}
+
+	gatedIndex := int(ckpt.NextStageIndex) - 1
+	if gatedIndex < 0 || gatedIndex >= len(e.pattern.Stages) || len(ckpt.StageSnapshots) != gatedIndex+1 {
+		return nil, fmt.Errorf("resume: corrupt checkpoint (next_stage_index=%d, snapshots=%d, stages=%d)",
+			ckpt.NextStageIndex, len(ckpt.StageSnapshots), len(e.pattern.Stages))
+	}
+
+	state := &pipelineState{
+		allResults:         ckpt.AllResults,
+		stageOutputs:       make([]string, 0, len(e.pattern.Stages)),
+		modelsUsed:         ckpt.ModelsUsed,
+		validationWarnings: ckpt.ValidationWarnings,
+		gateRevisions:      ckpt.GateRevisionCounts,
+	}
+	if state.modelsUsed == nil {
+		state.modelsUsed = make(map[string]string)
+	}
+	if state.gateRevisions == nil {
+		state.gateRevisions = make(map[string]int32)
+	}
+	for _, snap := range ckpt.StageSnapshots {
+		state.stageOutputs = append(state.stageOutputs, snap.FullOutput)
+	}
+
+	switch decision.Action {
+	case loomv1.GateAction_GATE_ACTION_APPROVE:
+		state.startIndex = gatedIndex + 1
+		state.currentInput = e.deriveInputFromOutput(gatedIndex+1, state.stageOutputs[gatedIndex])
+
+	case loomv1.GateAction_GATE_ACTION_REVISE:
+		gate := e.pattern.Stages[gatedIndex].HitlGate
+		if gate == nil {
+			return nil, fmt.Errorf("resume: checkpointed gate stage %s has no hitl_gate", e.pattern.Stages[gatedIndex].AgentId)
 		}
+		if strings.TrimSpace(decision.Feedback) == "" {
+			return nil, fmt.Errorf("resume: REVISE decision requires feedback")
+		}
+		target, err := resolveReviseTarget(e.pattern.Stages, gatedIndex, gate)
+		if err != nil {
+			return nil, fmt.Errorf("resume: %w", err)
+		}
+		gatedAgentID := e.pattern.Stages[gatedIndex].AgentId
+		state.gateRevisions[gatedAgentID]++
+		if state.gateRevisions[gatedAgentID] > maxGateRevisions(gate) {
+			return nil, fmt.Errorf("resume: gate on stage %s exceeded max_revisions (%d)", gatedAgentID, maxGateRevisions(gate))
+		}
+		state.startIndex = target
+		state.stageOutputs = state.stageOutputs[:target]
+		if target == 0 {
+			state.currentInput = e.pattern.InitialPrompt
+		} else {
+			state.currentInput = e.deriveInputFromOutput(target, state.stageOutputs[target-1])
+		}
+		state.revisionFeedback = decision.Feedback
+		state.revisionSource = "human reviewer"
+
+	default:
+		return nil, fmt.Errorf("resume: unsupported gate decision %s", decision.Action)
 	}
 
-	// Execute pipeline stages sequentially
-	allResults := make([]*loomv1.AgentResult, 0, len(e.pattern.Stages))
-	stageOutputs := make([]string, 0, len(e.pattern.Stages))
-	currentInput := e.pattern.InitialPrompt
-	modelsUsed := make(map[string]string)
-	var validationWarnings []string // tracks stages that used unvalidated output
+	// Restore agent-written SharedMemory and re-seed stage-N-output keys so
+	// shared_memory_read and truncation notices keep working after resume.
+	restoreWorkflowMemory(ctx, e.orchestrator, ckpt)
 
-	for i, stage := range e.pattern.Stages {
+	e.orchestrator.logger.Info("Resuming pipeline execution",
+		zap.String("workflow_id", workflowID),
+		zap.String("decision", decision.Action.String()),
+		zap.Int("start_stage", state.startIndex+1))
+
+	return e.executeFrom(ctx, startTime, workflowID, state)
+}
+
+// deriveInputFromOutput computes the {{previous}} input the next stage would
+// have received after the given stage completed (truncated with a SharedMemory
+// pointer when a store is available, full text otherwise).
+func (e *PipelineExecutor) deriveInputFromOutput(stageNum int, fullOutput string) string {
+	if e.orchestrator.sharedMemory == nil {
+		return fullOutput
+	}
+	out, _ := truncateStageOutput(fullOutput, MaxStageOutputBytes, fmt.Sprintf("stage-%d-output", stageNum))
+	return out
+}
+
+// buildCheckpoint captures the durable suspension state at the gate on stage
+// gatedIndex (whose output is the last entry of state.stageOutputs).
+func (e *PipelineExecutor) buildCheckpoint(ctx context.Context, workflowID string, state *pipelineState, gatedIndex int, gateReq *loomv1.HITLGateRequest) (*loomv1.WorkflowCheckpoint, error) {
+	fp, err := e.pipelineFingerprint()
+	if err != nil {
+		return nil, fmt.Errorf("failed to fingerprint pipeline for checkpoint: %w", err)
+	}
+	snaps := make([]*loomv1.CheckpointStageSnapshot, 0, len(state.stageOutputs))
+	for idx, out := range state.stageOutputs {
+		snaps = append(snaps, &loomv1.CheckpointStageSnapshot{
+			AgentId:    e.pattern.Stages[idx].AgentId,
+			FullOutput: out,
+		})
+	}
+	return &loomv1.WorkflowCheckpoint{
+		CheckpointVersion:  CheckpointVersion,
+		ConfigFingerprint:  fp,
+		WorkflowId:         workflowID,
+		PatternType:        "pipeline",
+		NextStageIndex:     int32(gatedIndex + 1), // #nosec G115 -- stage counts are tiny
+		StageSnapshots:     snaps,
+		AllResults:         state.allResults,
+		ModelsUsed:         state.modelsUsed,
+		ValidationWarnings: state.validationWarnings,
+		GateRevisionCounts: state.gateRevisions,
+		PendingGate:        gateReq,
+		SharedMemory:       snapshotWorkflowMemory(ctx, e.orchestrator),
+		CreatedAtMs:        time.Now().UnixMilli(),
+	}, nil
+}
+
+// executeFrom runs pipeline stages starting at state.startIndex until
+// completion, suspension (HITL gate), rejection, or failure.
+func (e *PipelineExecutor) executeFrom(ctx context.Context, startTime time.Time, workflowID string, state *pipelineState) (*loomv1.WorkflowResult, error) {
+	allResults := state.allResults
+	stageOutputs := state.stageOutputs
+	currentInput := state.currentInput
+	modelsUsed := state.modelsUsed
+	validationWarnings := state.validationWarnings
+
+	for i := state.startIndex; i < len(e.pattern.Stages); {
+		stage := e.pattern.Stages[i]
 		stageNum := i + 1
 
 		// Start stage-level span
@@ -91,8 +304,12 @@ func (e *PipelineExecutor) Execute(ctx context.Context) (*loomv1.WorkflowResult,
 			zap.Int("total_stages", len(e.pattern.Stages)),
 			zap.String("agent_id", stage.AgentId))
 
-		// Build prompt for this stage
+		// Build prompt for this stage. Revision feedback (from a HITL gate
+		// REVISE decision) is threaded into the first stage executed after
+		// the jump, then consumed; the call also blanks stray placeholders.
 		prompt := e.buildStagePrompt(stage, currentInput, stageOutputs)
+		prompt = injectRevisionFeedback(prompt, state.revisionFeedback, state.revisionSource)
+		state.revisionFeedback = ""
 
 		// Execute stage with agent span
 		result, model, err := e.executeStageWithSpan(ctx, workflowID, stage, prompt, stageNum)
@@ -177,6 +394,80 @@ func (e *PipelineExecutor) Execute(ctx context.Context) (*loomv1.WorkflowResult,
 			}
 		}
 
+		// HITL gate: evaluated after the stage's output passes validation and
+		// before the next stage starts. Default (no handler) is durable
+		// suspension via WorkflowSuspended; an inline handler may decide
+		// approve/revise/reject in-process.
+		if stage.HitlGate != nil {
+			// Sync loop-local slices back into state so the checkpoint (and
+			// revise bookkeeping) sees the current pass, not stale slices.
+			state.allResults = allResults
+			state.stageOutputs = stageOutputs
+			state.modelsUsed = modelsUsed
+			state.validationWarnings = validationWarnings
+
+			gateReq := buildGateRequest(workflowID, stage, stageNum, result.Output)
+			e.orchestrator.emitProgress(WorkflowProgressEvent{
+				PatternType:    "pipeline",
+				Message:        fmt.Sprintf("Stage %d of %d awaiting human review", stageNum, len(e.pattern.Stages)),
+				Progress:       int32(float64(stageNum) / float64(len(e.pattern.Stages)) * 100), // #nosec G115
+				CurrentAgentID: stage.AgentId,
+				PartialResults: allResults,
+				HITLRequest:    gateReq,
+			})
+
+			decision, gateErr := evaluateHITLGate(ctx, e.orchestrator, stage.HitlGate, gateReq)
+			if gateErr != nil {
+				return nil, gateErr
+			}
+			if decision == nil {
+				ckpt, ckptErr := e.buildCheckpoint(ctx, workflowID, state, i, gateReq)
+				if ckptErr != nil {
+					return nil, ckptErr
+				}
+				e.orchestrator.logger.Info("Pipeline suspended at HITL gate",
+					zap.String("workflow_id", workflowID),
+					zap.String("stage", stage.AgentId),
+					zap.Int("stage_num", stageNum))
+				return nil, &WorkflowSuspended{Checkpoint: ckpt}
+			}
+
+			switch decision.Action {
+			case loomv1.GateAction_GATE_ACTION_APPROVE:
+				// Fall through to advance normally.
+
+			case loomv1.GateAction_GATE_ACTION_REJECT:
+				return nil, &GateRejected{StageAgentID: stage.AgentId, Feedback: decision.Feedback}
+
+			case loomv1.GateAction_GATE_ACTION_REVISE:
+				target, terr := resolveReviseTarget(e.pattern.Stages, i, stage.HitlGate)
+				if terr != nil {
+					return nil, terr
+				}
+				state.gateRevisions[stage.AgentId]++
+				if state.gateRevisions[stage.AgentId] > maxGateRevisions(stage.HitlGate) {
+					return nil, fmt.Errorf("gate on stage %s exceeded max_revisions (%d)", stage.AgentId, maxGateRevisions(stage.HitlGate))
+				}
+				stageOutputs = stageOutputs[:target]
+				if target == 0 {
+					currentInput = e.pattern.InitialPrompt
+				} else {
+					currentInput = e.deriveInputFromOutput(target, stageOutputs[target-1])
+				}
+				state.revisionFeedback = decision.Feedback
+				state.revisionSource = "human reviewer"
+				e.orchestrator.logger.Info("Gate revision: restarting stage",
+					zap.String("gated_stage", stage.AgentId),
+					zap.Int("target_stage", target+1),
+					zap.Int32("revision", state.gateRevisions[stage.AgentId]))
+				i = target
+				continue
+
+			default:
+				return nil, fmt.Errorf("gate on stage %s received unsupported decision %s", stage.AgentId, decision.Action)
+			}
+		}
+
 		// Update input for next stage. Hybrid context passing: stash the FULL stage
 		// output in SharedMemory (key stage-N-output) so a later stage can fetch it
 		// by reference, and pass the next stage a truncated summary when the output
@@ -196,9 +487,14 @@ func (e *PipelineExecutor) Execute(ctx context.Context) (*loomv1.WorkflowResult,
 		} else {
 			currentInput = result.Output
 		}
+
+		i++
 	}
 
 	// The final output is the last stage's output
+	if len(stageOutputs) == 0 {
+		return nil, fmt.Errorf("pipeline produced no stage outputs")
+	}
 	finalOutput := stageOutputs[len(stageOutputs)-1]
 
 	// Calculate total cost

--- a/pkg/orchestration/resume.go
+++ b/pkg/orchestration/resume.go
@@ -1,0 +1,67 @@
+// Copyright © 2026 Teradata Corporation - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package orchestration
+
+import (
+	"context"
+	"fmt"
+
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"go.uber.org/zap"
+)
+
+// ResumeWorkflow continues a workflow that suspended at a HITL gate.
+//
+// The host supplies the SAME workflow pattern the run was started with (the
+// checkpoint's config fingerprint is verified against it — a mismatch fails
+// fast rather than executing an edited, unreviewed definition), the persisted
+// WorkflowCheckpoint, and the human's GateDecision.
+//
+//   - APPROVE continues at the stage after the gate.
+//   - REVISE jumps back to the gate's revise target with GateDecision.feedback
+//     threaded into that stage's prompt ({{revision_feedback}}).
+//   - REJECT ends the run immediately with a *GateRejected error; nothing
+//     executes.
+//
+// A resumed run can suspend again at a later gate — callers should handle
+// *WorkflowSuspended exactly as they do for ExecutePattern.
+func (o *Orchestrator) ResumeWorkflow(ctx context.Context, pattern *loomv1.WorkflowPattern, ckpt *loomv1.WorkflowCheckpoint, decision *loomv1.GateDecision) (*loomv1.WorkflowResult, error) {
+	if pattern == nil {
+		return nil, fmt.Errorf("resume: nil workflow pattern")
+	}
+	if ckpt == nil {
+		return nil, fmt.Errorf("resume: nil checkpoint")
+	}
+	if ckpt.CheckpointVersion > CheckpointVersion {
+		return nil, fmt.Errorf("resume: checkpoint version %d is newer than supported version %d", ckpt.CheckpointVersion, CheckpointVersion)
+	}
+	if decision == nil || decision.Action == loomv1.GateAction_GATE_ACTION_UNSPECIFIED {
+		return nil, fmt.Errorf("resume: a gate decision (approve, revise, or reject) is required")
+	}
+
+	if decision.Action == loomv1.GateAction_GATE_ACTION_REJECT {
+		o.logger.Info("Workflow rejected at HITL gate",
+			zap.String("workflow_id", ckpt.WorkflowId),
+			zap.String("stage", ckpt.GetPendingGate().GetStageAgentId()))
+		return nil, &GateRejected{
+			StageAgentID: ckpt.GetPendingGate().GetStageAgentId(),
+			Feedback:     decision.Feedback,
+		}
+	}
+
+	switch p := pattern.Pattern.(type) {
+	case *loomv1.WorkflowPattern_Pipeline:
+		executor := NewPipelineExecutor(o, p.Pipeline, ckpt.WorkflowId)
+		return executor.Resume(ctx, ckpt, decision)
+
+	case *loomv1.WorkflowPattern_Iterative:
+		executor := NewIterativePipelineExecutor(o, p.Iterative, o.messageBus, ckpt.WorkflowId)
+		return executor.Resume(ctx, ckpt, decision)
+
+	default:
+		return nil, fmt.Errorf("resume: pattern type %s does not support HITL gates", GetPatternType(pattern))
+	}
+}

--- a/pkg/orchestration/task_tracked_executor.go
+++ b/pkg/orchestration/task_tracked_executor.go
@@ -16,6 +16,7 @@ package orchestration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -97,6 +98,16 @@ func (t *TaskTrackedOrchestrator) ExecutePattern(ctx context.Context, pattern *l
 
 	// Execute the actual workflow.
 	result, err := t.inner.ExecutePattern(ctx, pattern)
+
+	// A HITL gate suspension is not a failure — the run resumes later against
+	// the same board, so leave task state untouched instead of closing
+	// in-progress tasks as failed.
+	var suspended *WorkflowSuspended
+	if errors.As(err, &suspended) {
+		t.logger.Info("task tracking: workflow suspended at HITL gate; board left open",
+			zap.String("gated_stage", suspended.Checkpoint.GetPendingGate().GetStageAgentId()))
+		return result, err
+	}
 
 	// Record results into tasks regardless of success/failure.
 	t.recordResults(ctx, stageTasks, result, err)

--- a/pkg/orchestration/workflow_config.go
+++ b/pkg/orchestration/workflow_config.go
@@ -89,7 +89,16 @@ func LoadWorkflowFromYAMLBytes(data []byte) (*loomv1.WorkflowPattern, error) {
 	if err := validateWorkflowStructure(config); err != nil {
 		return nil, err
 	}
-	return convertToProto(config)
+	pattern, err := convertToProto(config)
+	if err != nil {
+		return nil, err
+	}
+	// HITL gates are only valid on pipeline/iterative patterns and must have
+	// resolvable, non-forward revise targets.
+	if err := validateGatePlacement(pattern); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidWorkflow, err.Error())
+	}
+	return pattern, nil
 }
 
 // readWorkflowFile reads the workflow file from disk
@@ -339,6 +348,10 @@ func convertPipelinePattern(spec map[string]interface{}) (*loomv1.WorkflowPatter
 		validationPrompt, _ := stageMap["validation_prompt"].(string)
 		outputSchema, _ := stageMap["output_schema"].(string)
 		retryPolicy := parseOutputRetryPolicy(stageMap)
+		hitlGate, err := parseHITLGate(stageMap)
+		if err != nil {
+			return nil, fmt.Errorf("%w: stage %d: %s", ErrInvalidWorkflow, i, err.Error())
+		}
 
 		stages[i] = &loomv1.PipelineStage{
 			AgentId:          agentID,
@@ -346,6 +359,7 @@ func convertPipelinePattern(spec map[string]interface{}) (*loomv1.WorkflowPatter
 			ValidationPrompt: validationPrompt,
 			OutputSchema:     outputSchema,
 			RetryPolicy:      retryPolicy,
+			HitlGate:         hitlGate,
 		}
 	}
 
@@ -745,6 +759,77 @@ func parseOutputRetryPolicy(raw map[string]interface{}) *loomv1.OutputRetryPolic
 	}
 
 	return policy
+}
+
+// parseHITLGate parses an optional hitl_gate block from a pipeline stage.
+// Returns nil when the stage has no gate.
+//
+// YAML shape:
+//
+//	hitl_gate:
+//	  prompt_template: "Review this DDL:\n{{output}}"   # optional
+//	  request_type: approval                             # optional
+//	  timeout_seconds: 1800                              # optional
+//	  revise_target_stage_id: ddl-designer               # optional
+//	  max_revisions: 3                                   # optional
+//	  on_timeout: fail | reject | approve                # optional
+func parseHITLGate(stageMap map[string]interface{}) (*loomv1.HITLGate, error) {
+	gateRaw, ok := stageMap["hitl_gate"]
+	if !ok || gateRaw == nil {
+		return nil, nil
+	}
+	gateMap, ok := gateRaw.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("hitl_gate must be an object")
+	}
+
+	gate := &loomv1.HITLGate{}
+	gate.PromptTemplate, _ = gateMap["prompt_template"].(string)
+	gate.RequestType, _ = gateMap["request_type"].(string)
+	gate.ReviseTargetStageId, _ = gateMap["revise_target_stage_id"].(string)
+
+	if raw, ok := gateMap["timeout_seconds"]; ok {
+		switch v := raw.(type) {
+		case int:
+			gate.TimeoutSeconds = types.SafeInt32(v)
+		case int32:
+			gate.TimeoutSeconds = v
+		case int64:
+			gate.TimeoutSeconds = types.SafeInt32FromInt64(v)
+		default:
+			return nil, fmt.Errorf("hitl_gate.timeout_seconds must be an integer, got %T", v)
+		}
+	}
+	if raw, ok := gateMap["max_revisions"]; ok {
+		switch v := raw.(type) {
+		case int:
+			gate.MaxRevisions = types.SafeInt32(v)
+		case int32:
+			gate.MaxRevisions = v
+		case int64:
+			gate.MaxRevisions = types.SafeInt32FromInt64(v)
+		default:
+			return nil, fmt.Errorf("hitl_gate.max_revisions must be an integer, got %T", v)
+		}
+	}
+	if raw, ok := gateMap["on_timeout"]; ok {
+		s, ok := raw.(string)
+		if !ok {
+			return nil, fmt.Errorf("hitl_gate.on_timeout must be a string")
+		}
+		switch s {
+		case "", "fail":
+			gate.OnTimeout = loomv1.GateTimeoutAction_GATE_TIMEOUT_ACTION_FAIL
+		case "reject":
+			gate.OnTimeout = loomv1.GateTimeoutAction_GATE_TIMEOUT_ACTION_REJECT
+		case "approve":
+			gate.OnTimeout = loomv1.GateTimeoutAction_GATE_TIMEOUT_ACTION_APPROVE
+		default:
+			return nil, fmt.Errorf("hitl_gate.on_timeout must be one of fail, reject, approve (got %q)", s)
+		}
+	}
+
+	return gate, nil
 }
 
 // parseMergeStrategy converts string to MergeStrategy enum

--- a/proto/loom/v1/orchestration.proto
+++ b/proto/loom/v1/orchestration.proto
@@ -112,6 +112,201 @@ message PipelineStage {
   // Optional: Unified output validation policy. When set, takes precedence
   // over the legacy validation_prompt + output_schema + retry_policy fields.
   OutputPolicy output_policy = 6;
+
+  // Optional: Human-in-the-loop approval gate evaluated AFTER this stage's
+  // output passes validation and BEFORE the next stage starts. When the gate
+  // fires, the executor either asks a configured HITLHandler for an inline
+  // decision or suspends the workflow with a WorkflowCheckpoint the host can
+  // persist and later resume. Gates are supported on pipeline and iterative
+  // patterns only.
+  HITLGate hitl_gate = 7;
+}
+
+// HITLGate declares a human approval gate on a pipeline stage boundary.
+// Gates are deterministic control flow — they always fire when configured,
+// unlike agent-initiated contact_human tool calls.
+message HITLGate {
+  // Prompt shown to the human reviewer. Supports the {{output}} placeholder,
+  // replaced with the gated stage's (possibly truncated) output.
+  // Empty = a default "review the output of stage N" prompt.
+  string prompt_template = 1;
+
+  // Request type shown to the host UI (approval, decision, input, review).
+  // Aligned with HITLRequestInfo.request_type. Default: "approval".
+  string request_type = 2;
+
+  // Advisory timeout for the human decision, in seconds. In suspend mode the
+  // HOST enforces expiry of the persisted checkpoint; in inline-handler mode
+  // the handler context is bounded by this timeout. 0 = host default.
+  int32 timeout_seconds = 3;
+
+  // Stage (agent_id) to restart when the decision is REVISE.
+  // Empty = restart the gated stage itself. Must be at or before the gated
+  // stage in pipeline order — forward jumps are invalid.
+  string revise_target_stage_id = 4;
+
+  // Maximum REVISE round-trips this gate accepts before the workflow fails
+  // (prevents endless review loops). Default: 3.
+  int32 max_revisions = 5;
+
+  // What to do when the decision times out (enforced by the host in suspend
+  // mode). Default (UNSPECIFIED) is treated as FAIL.
+  GateTimeoutAction on_timeout = 6;
+}
+
+// GateTimeoutAction defines gate behavior on decision timeout.
+enum GateTimeoutAction {
+  // Unset — treated as GATE_TIMEOUT_ACTION_FAIL.
+  GATE_TIMEOUT_ACTION_UNSPECIFIED = 0;
+
+  // Fail the workflow run (safe default).
+  GATE_TIMEOUT_ACTION_FAIL = 1;
+
+  // Treat as a rejection (workflow ends without executing later stages).
+  GATE_TIMEOUT_ACTION_REJECT = 2;
+
+  // Auto-approve and continue (use only for advisory gates).
+  GATE_TIMEOUT_ACTION_APPROVE = 3;
+}
+
+// HITLGateRequest is what the executor hands the host (or HITLHandler) when a
+// gate fires: everything a UI needs to render the review and collect a decision.
+message HITLGateRequest {
+  // Workflow ID of the suspended run (session determinism on resume).
+  string workflow_id = 1;
+
+  // Agent ID of the gated stage.
+  string stage_agent_id = 2;
+
+  // 1-based stage number of the gated stage.
+  int32 stage_number = 3;
+
+  // Rendered question for the human (prompt_template with {{output}} applied).
+  string question = 4;
+
+  // The full stage output under review.
+  string stage_output = 5;
+
+  // Request type (approval, decision, input, review).
+  string request_type = 6;
+
+  // Advisory decision timeout in seconds (from HITLGate.timeout_seconds).
+  int32 timeout_seconds = 7;
+
+  // Suggested decision options for the UI (e.g. approve, revise, reject).
+  repeated string options = 8;
+}
+
+// GateAction is the human's decision at a gate.
+enum GateAction {
+  // Unset — invalid; hosts must supply an explicit action.
+  GATE_ACTION_UNSPECIFIED = 0;
+
+  // Continue to the next stage.
+  GATE_ACTION_APPROVE = 1;
+
+  // Restart at HITLGate.revise_target_stage_id with GateDecision.feedback
+  // threaded into that stage's prompt ({{revision_feedback}}).
+  GATE_ACTION_REVISE = 2;
+
+  // End the workflow without executing later stages.
+  GATE_ACTION_REJECT = 3;
+}
+
+// GateDecision carries the human's decision back into the executor.
+message GateDecision {
+  // The action to take.
+  GateAction action = 1;
+
+  // Free-text feedback. Required for REVISE (it becomes {{revision_feedback}}
+  // in the restarted stage's prompt); optional context for APPROVE/REJECT.
+  string feedback = 2;
+
+  // Optional identity of the decision maker (audit metadata for the host).
+  string decided_by = 3;
+}
+
+// WorkflowCheckpoint is the durable suspension state of a pipeline or
+// iterative workflow, captured at a stage boundary when a HITL gate fires.
+// It never contains in-flight agent-loop state: gates only fire between
+// stages, so completed stage outputs plus counters fully describe the run.
+// Hosts persist this server-side; it is not intended for untrusted clients.
+message WorkflowCheckpoint {
+  // Checkpoint schema version for forward evolution. Current version: 1.
+  int32 checkpoint_version = 1;
+
+  // SHA-256 (hex) of the deterministically-marshaled WorkflowPattern this
+  // checkpoint was taken against. Resume MUST verify this matches the
+  // pattern it is resuming with — resuming against an edited workflow is
+  // how unreviewed changes would get executed.
+  string config_fingerprint = 2;
+
+  // Resolved workflow ID of the original run (keeps stage session IDs
+  // deterministic across suspend/resume).
+  string workflow_id = 3;
+
+  // Pattern type at suspension: "pipeline" or "iterative_pipeline".
+  string pattern_type = 4;
+
+  // 0-based index of the stage to execute on APPROVE (gated stage + 1).
+  int32 next_stage_index = 5;
+
+  // Latest full output per completed stage, ordered by stage index for the
+  // current pass. Used to rehydrate {{previous}}/{{history}} context and to
+  // re-seed SharedMemory stage-N-output keys on resume.
+  repeated CheckpointStageSnapshot stage_snapshots = 6;
+
+  // Append-only execution history (all attempts, including superseded ones)
+  // so cost accounting stays accurate across suspend/resume.
+  repeated AgentResult all_results = 7;
+
+  // Models used so far (agent_id -> model name).
+  map<string, string> models_used = 8;
+
+  // Validation warnings accumulated so far (plain pipeline graceful
+  // degradation path).
+  repeated string validation_warnings = 9;
+
+  // Iterative-pattern iteration counter at suspension (0 for plain pipeline).
+  int32 iteration = 10;
+
+  // REVISE round-trips consumed per gate (keyed by gated stage agent_id).
+  map<string, int32> gate_revision_counts = 11;
+
+  // The gate request awaiting a decision.
+  HITLGateRequest pending_gate = 12;
+
+  // Snapshot of agent-written WORKFLOW-namespace SharedMemory entries
+  // (stage-N-output keys are excluded — they are re-seeded from
+  // stage_snapshots). Restored on resume.
+  repeated CheckpointMemoryEntry shared_memory = 13;
+
+  // Checkpoint creation time (Unix milliseconds).
+  int64 created_at_ms = 14;
+}
+
+// CheckpointStageSnapshot is the latest full output of one completed stage.
+message CheckpointStageSnapshot {
+  // Agent ID of the stage.
+  string agent_id = 1;
+
+  // Full (untruncated) stage output.
+  string full_output = 2;
+}
+
+// CheckpointMemoryEntry is one preserved WORKFLOW-namespace SharedMemory entry.
+message CheckpointMemoryEntry {
+  // SharedMemory key.
+  string key = 1;
+
+  // Raw value bytes.
+  bytes value = 2;
+
+  // Agent that wrote the entry.
+  string agent_id = 3;
+
+  // Entry metadata.
+  map<string, string> metadata = 4;
 }
 
 // IterativeWorkflowPattern extends PipelinePattern with autonomous restart capabilities.


### PR DESCRIPTION
## Summary

Declarative human-in-the-loop **approval gates** for pipeline/iterative workflows, with **durable checkpoint/resume** — the loom half of the Tera Cloud workflow HITL design (cloud side lands separately in tera-backend).

- `PipelineStage.hitl_gate` (proto): fires deterministically after the stage's output validates, before the next stage. No LLM decides whether to ask — this is control flow, not a tool call.
- With no inline handler the run **suspends** into a versioned `WorkflowCheckpoint` proto and returns `*WorkflowSuspended` (detect via `errors.As`). No blocked goroutine; any process holding the checkpoint resumes via `Orchestrator.ResumeWorkflow(ctx, pattern, checkpoint, decision)`.
- Decisions: **APPROVE** (continue), **REVISE** (jump back to `revise_target_stage_id` with feedback threaded into the prompt via `{{revision_feedback}}`, bounded by `max_revisions`), **REJECT** (`*GateRejected`, nothing executes).
- **Fingerprint safety**: checkpoints record a SHA-256 of the deterministically-marshaled pattern; resume refuses an edited definition — a workflow change can never bypass a pending review.
- Checkpoints capture inter-stage state only (gates fire at stage boundaries): stage outputs, cost history, iteration/revision counters, pending gate, and workflow-namespace SharedMemory (restored on resume).
- Bonus fix: `publish_restart_request` reason/parameters now reach the restarted stage's prompt (previously logged only). Task-tracked execution leaves boards open on suspension instead of failing tasks.
- CLI: `looms workflow run` prompts inline on a TTY or writes a checkpoint (`--suspend-to`); new `looms workflow resume <wf> <ckpt> --approve|--revise "…"|--reject`.

## Testing

- `go test -race ./pkg/orchestration/` — full suite green, including 15 new gate tests (suspend/resume round-trip, revise feedback threading + re-suspension, fingerprint mismatch refusal, max_revisions, last-stage gate, iterative + restart-disabled fallback round-trips, inline handler paths, YAML parse/validation).
- `golangci-lint run` on changed packages — 0 issues. `buf lint` + `buf generate` clean.
- Example validated end-to-end with the real CLI: `looms workflow validate examples/reference/workflows/orchestration-patterns/hitl-gated-pipeline.yaml`.

Docs: `docs/guides/human-in-the-loop.md` (new "Workflow HITL Gates" section) + runnable example YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)