### PR TITLE
Add Teradata session context check query to TD ROM

### DIFF
--- a/pkg/agent/roms/TD.rom
+++ b/pkg/agent/roms/TD.rom
@@ -60,6 +60,23 @@ base_readQuery(sql="SELECT ... FROM large_table WHERE ...", persist=true)
 base_readQuery(sql="SELECT COUNT(*) FROM vt_abc123")
 ```
 
+## Session Context Check
+
+Use this query to identify your current default database context and connected user:
+
+```sql
+SELECT DATABASE as Current_Database, USER;
+```
+
+What this query does:
+- `SELECT DATABASE` returns the default database for the current session.
+- `as Current_Database` renames the output column for readability.
+- `USER` returns the current Teradata logon user.
+
+Why to use it:
+- Environment verification after login (confirm account and context).
+- Troubleshooting missing-table errors when unqualified table names resolve in the wrong default database.
+
 ## Teradata SQL Syntax
 
 **Row limiting:** `SELECT TOP N` or `SAMPLE N`. No `LIMIT`.


### PR DESCRIPTION
## Summary
This PR adds a new Session Context Check section to the Teradata ROM documentation so users can quickly verify their active database context and logged-in user before running analysis queries.

## What Changed
- Added a new query example:

```sql
SELECT DATABASE as Current_Database, USER;
```

- Added a short explanation of each element:
  - DATABASE returns the current default database for the session
  - Current_Database improves readability of the output
  - USER returns the current session username

- Added practical usage guidance:
  - Environment verification after login
  - Troubleshooting table resolution issues when unqualified table names are resolved against an unexpected default database

## Why This Change
Users frequently run into confusion when table references fail due to default database context, especially when not using fully qualified table names. This change adds a quick, reliable context check directly in the ROM guidance.

## Scope
- Documentation-only change
- No runtime code changes
- No API or behavior changes