### PR TITLE
fix(security): Snyk triage — Go 1.26 toolchain, artifact path containment, postMessage origin guard

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Setup Buf
@@ -108,7 +108,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Setup Buf
@@ -176,7 +176,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ['1.25']
+        go-version: ['1.26']
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
@@ -293,7 +293,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Setup Buf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Verify version matches tag
         run: |
@@ -214,7 +214,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Setup Buf

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Verify version consistency
         run: |

--- a/.github/workflows/windows-quickstart.yml
+++ b/.github/workflows/windows-quickstart.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Install Just (Windows)

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 ARG GIT_COMMIT=unknown
 

--- a/docs/reference/security-scan-triage.md
+++ b/docs/reference/security-scan-triage.md
@@ -1,0 +1,32 @@
+# Security Scan Triage — Snyk Findings (2026-07)
+
+Triage record for the Snyk SAST/SCA findings reported against `teradata-labs/loom:main`
+via ArmorCode as of 2026-07-22. Each class of finding was verified against the code
+before being classified. This document exists so future scans don't re-litigate the
+same findings from scratch.
+
+## Fixed
+
+| Finding | Location | Fix |
+|---|---|---|
+| SQL Injection ×3 (High) | `pkg/storage/sql_result_store.go` | PR #267 (`306728f`): every table-name interpolation site (`CREATE`/`INSERT`/`DROP`/`SELECT`) goes through `sanitizeIdentifier`, a strict `[A-Za-z0-9_]` allowlist. |
+| Go stdlib SCA findings on `go.mod` — "Symlink Attack" (High), "Memory Allocation with Excessive Size" ×2, "Cleartext Transmission" (Medium) | `go.mod` | These map to Go standard-library CVEs (os.Root symlink escape GO-2026-4602, archive/tar GO-2026-4869, net/url GO-2026-4341, crypto/tls GO-2026-4337/5856) keyed off the `go` directive. Fixed by bumping `go.mod` to `go 1.26.0` / `toolchain go1.26.5` and aligning all CI workflows and `deploy/Dockerfile` to Go 1.26. |
+| Path Traversal (Medium) | `pkg/artifacts/store.go` | `ValidateSessionID` (strict allowlist: `[A-Za-z0-9._-]`, no `..`) now gates `GetArtifactDir` and `GetScratchpadDir`; `session_metadata.go`'s weaker blocklist validator delegates to it. Session IDs arrive from API callers via context, so this was a real (if low-exploitability) gap. |
+| Insufficient postMessage Validation (Low) | `pkg/mcp/apps/html/data-chart.html` | Adopted the trust-on-first-use origin-pinning guard already used by the other three MCP app viewers, plus a payload shape check (`labels`/`values` arrays). |
+
+## No fix available upstream
+
+| Finding | Location | Status |
+|---|---|---|
+| `github.com/docker/docker` vulns (incl. the "Symlink Attack"-class docker-cp races GO-2026-5617/5668, archive endpoint GO-2026-5746, AuthZ bypass GO-2026-4887/4883) | `go.mod` | Docker migrated the engine to `github.com/moby/moby/v2`; fixes exist only there (≥ 2.0.0-beta.14, still beta). Every version of the `docker/docker` module path is permanently marked vulnerable. All five CVEs are **daemon-side**; Loom uses only the client SDK (`pkg/docker/executor.go`). Revisit when moby/v2 reaches GA. |
+
+## Verified false positives / intentional behavior
+
+- **Hardcoded passwords/credentials ×34 in `_test.go` files** (`pkg/backends/teradata`, `pkg/backends/supabase`, `internal/pgxdriver`, `cmd/looms`, `pkg/artifacts`): all obviously fake fixtures (`testpass`, `secret`, URL-escaping cases like `p@ss/w:rd?#`, a bare JWT header with no payload/signature).
+- **Hardcoded Credentials ×2 in `pkg/agent/session_store.go`**: the string `"default-user"` — a single-tenant identity label for the SQLite backend, not a credential.
+- **Hardcoded Secret in `scripts/longmemeval-eval/evaluate_qa.py`**: `openai_api_key = "EMPTY"` — the conventional placeholder required by the OpenAI client when pointing at a local vLLM server. Real keys come from `OPENAI_API_KEY`.
+- **XSS in `pkg/server/http.go`**: the only reflected value is escaped with both `url.PathEscape` and `html.EscapeString`; app names are allowlist-validated (`[A-Za-z0-9_-]`); responses carry nosniff, X-Frame-Options, and a strict CSP.
+- **Permissive TrustManager in `cmd/loom/skills_classify.go` and `pkg/tui/client/client.go`**: `InsecureSkipVerify` only activates behind the default-off `--tls-insecure` CLI flag (self-signed cert support); otherwise system cert pool + optional `--tls-ca`. Both sites now carry `//nolint:gosec` annotations.
+- **Permissive TrustManager in `internal/supabaseauth/management_test.go`**: test-only client talking to a local `httptest` loopback server.
+- **Path Traversal ×14 in `cmd/looms/cmd_serve.go`, `cmd/loom-mcp`, `cmd/workflow-viz`, `cmd/loom-bench-harness`, and the longmemeval eval scripts**: every flagged path is a CLI flag, positional argument, or operator-authored config — standard "operator picks the file" cases with no network attack surface.
+- **postMessage validation in `conversation-viewer.html`, `explain-plan-visualizer.html`, `data-quality-dashboard.html`**: all three already implement TOFU origin pinning plus JSON-RPC 2.0 shape validation. The host origin is unknowable at build time under the `ui://` MCP Apps scheme, so `'*'` is used only for the initial handshake before locking.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/teradata-labs/loom
 
-go 1.25.0
+go 1.26.0
+
+toolchain go1.26.5
 
 require (
 	github.com/google/uuid v1.6.0

--- a/pkg/artifacts/session_metadata.go
+++ b/pkg/artifacts/session_metadata.go
@@ -113,13 +113,7 @@ func validateSessionArtifactPathSegment(sessionID string) error {
 	if sessionID == "" {
 		return fmt.Errorf("session ID is required")
 	}
-	if strings.Contains(sessionID, "..") {
-		return fmt.Errorf("invalid session ID")
-	}
-	if strings.ContainsAny(sessionID, "/\\") {
-		return fmt.Errorf("invalid session ID")
-	}
-	return nil
+	return ValidateSessionID(sessionID)
 }
 
 // SessionArtifactsRoot returns $LOOM_DATA_DIR/artifacts/sessions/<sessionID>.

--- a/pkg/artifacts/store.go
+++ b/pkg/artifacts/store.go
@@ -86,6 +86,25 @@ type Stats struct {
 	DeletedFiles   int
 }
 
+// ValidateSessionID rejects session IDs that could escape the artifacts
+// directory when joined into a filesystem path. Session IDs are normally
+// server-generated UUIDs; path separators or traversal sequences indicate
+// hostile input from an API caller.
+func ValidateSessionID(sessionID string) error {
+	if sessionID == "" || sessionID == "." || strings.Contains(sessionID, "..") {
+		return fmt.Errorf("invalid session ID %q", sessionID)
+	}
+	for _, r := range sessionID {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9',
+			r == '-', r == '_', r == '.':
+		default:
+			return fmt.Errorf("invalid session ID %q: character %q not allowed", sessionID, r)
+		}
+	}
+	return nil
+}
+
 // GetArtifactDir returns the artifact directory for a given context.
 // Directory structure:
 //   - No session + user: $LOOM_DATA_DIR/artifacts/user/
@@ -103,6 +122,10 @@ func GetArtifactDir(sessionID string, source SourceType) (string, error) {
 		}
 		// Generated artifacts without session (legacy or temp)
 		return filepath.Join(artifactsDir, "temp"), nil
+	}
+
+	if err := ValidateSessionID(sessionID); err != nil {
+		return "", err
 	}
 
 	// Session-based artifacts
@@ -123,6 +146,9 @@ func GetArtifactDir(sessionID string, source SourceType) (string, error) {
 func GetScratchpadDir(sessionID string) (string, error) {
 	if sessionID == "" {
 		return "", fmt.Errorf("session ID is required for scratchpad")
+	}
+	if err := ValidateSessionID(sessionID); err != nil {
+		return "", err
 	}
 	baseDir := config.GetLoomDataDir()
 	return filepath.Join(baseDir, "artifacts", "sessions", sessionID, "scratchpad"), nil

--- a/pkg/artifacts/store_validate_test.go
+++ b/pkg/artifacts/store_validate_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package artifacts
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateSessionID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		sessionID string
+		wantErr   bool
+	}{
+		{"uuid", "550e8400-e29b-41d4-a716-446655440000", false},
+		{"underscore prefix", "sess_rt", false},
+		{"dots and dashes", "a.b-c_9", false},
+		{"empty", "", true},
+		{"dot", ".", true},
+		{"dotdot", "..", true},
+		{"traversal prefix", "../x", true},
+		{"embedded dotdot", "a..b", true},
+		{"forward slash", "a/b", true},
+		{"backslash", `a\b`, true},
+		{"absolute path", "/etc/passwd", true},
+		{"space", "a b", true},
+		{"null byte", "a\x00b", true},
+		{"non-ascii", "über", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateSessionID(tt.sessionID)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetArtifactDir_RejectsTraversal(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("LOOM_DATA_DIR", root)
+
+	for _, id := range []string{"../evil", "..", "a/b", `a\b`} {
+		_, err := GetArtifactDir(id, SourceAgent)
+		require.Error(t, err, "session ID %q must be rejected", id)
+	}
+
+	dir, err := GetArtifactDir("550e8400-e29b-41d4-a716-446655440000", SourceAgent)
+	require.NoError(t, err)
+	sessionsRoot := filepath.Join(root, "artifacts", "sessions")
+	require.True(t, strings.HasPrefix(dir, sessionsRoot+string(filepath.Separator)),
+		"artifact dir %q must stay under %q", dir, sessionsRoot)
+}
+
+func TestGetScratchpadDir_RejectsTraversal(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("LOOM_DATA_DIR", root)
+
+	for _, id := range []string{"../evil", "..", "a/b", `a\b`} {
+		_, err := GetScratchpadDir(id)
+		require.Error(t, err, "session ID %q must be rejected", id)
+	}
+
+	dir, err := GetScratchpadDir("sess_ok")
+	require.NoError(t, err)
+	sessionsRoot := filepath.Join(root, "artifacts", "sessions")
+	require.True(t, strings.HasPrefix(dir, sessionsRoot+string(filepath.Separator)),
+		"scratchpad dir %q must stay under %q", dir, sessionsRoot)
+}

--- a/pkg/mcp/apps/html/data-chart.html
+++ b/pkg/mcp/apps/html/data-chart.html
@@ -363,11 +363,22 @@ function renderChart(data) {
   });
 }
 
-// Listen for postMessage data from MCP client
+// Listen for postMessage data from MCP client.
+// Origin validation: trust-on-first-use, matching the other MCP app viewers.
+// The host origin is not known at build time because this app runs as an
+// embedded MCP Apps resource (ui:// scheme), so lock to the origin of the
+// first well-formed chart-data message and reject all other origins after.
+var trustedOrigin = null;
 window.addEventListener('message', function(event) {
-  if (event.data && event.data.type === 'chart-data') {
-    renderChart(event.data.payload);
+  if (trustedOrigin && event.origin !== trustedOrigin) return;
+  var data = event.data;
+  if (!data || typeof data !== 'object' || data.type !== 'chart-data') return;
+  var payload = data.payload;
+  if (!payload || typeof payload !== 'object' || !Array.isArray(payload.labels) || !Array.isArray(payload.values)) return;
+  if (!trustedOrigin && event.origin) {
+    trustedOrigin = event.origin;
   }
+  renderChart(payload);
 });
 
 // Render default data on load

--- a/pkg/tui/client/client.go
+++ b/pkg/tui/client/client.go
@@ -124,7 +124,7 @@ func createTLSConfig(cfg Config) (*tls.Config, error) {
 
 	// If insecure mode, skip certificate verification
 	if cfg.TLSInsecure {
-		tlsConfig.InsecureSkipVerify = true
+		tlsConfig.InsecureSkipVerify = true //nolint:gosec // user opted in via --tls-insecure for self-signed certs
 		return tlsConfig, nil
 	}
 


### PR DESCRIPTION
## Summary

Actionable fixes from the 2026-07 Snyk scan triage (67 loom findings reviewed; full record in `docs/reference/security-scan-triage.md`).

- **Go toolchain → 1.26.5** (`go 1.26.0` directive): clears all 22 reachable Go stdlib vulns govulncheck reported against 1.25.3 — including the os.Root symlink escape (GO-2026-4602), archive/tar and net/url allocation issues, and several crypto/tls CVEs. These are what Snyk surfaces as the `go.mod` SCA findings ("Symlink Attack", "Memory Allocation with Excessive Size", "Cleartext Transmission"). Also aligns nightly/release/version-check/windows-quickstart workflows and `deploy/Dockerfile` to Go 1.26 (ci.yml already was).
- **Artifact path containment**: new `artifacts.ValidateSessionID` (strict `[A-Za-z0-9._-]` allowlist, `..` rejected) enforced in `GetArtifactDir`/`GetScratchpadDir`; the weaker blocklist validator in `session_metadata.go` now delegates to it. Session IDs flow in from API callers via context, so traversal was reachable in principle. Table-driven tests added.
- **`data-chart.html` postMessage guard**: adopts the trust-on-first-use origin pinning + payload shape validation the other three MCP app viewers already use. It previously accepted `chart-data` messages from any origin.
- **`pkg/tui/client` nolint annotation**: the `--tls-insecure` opt-in now carries `//nolint:gosec` for parity with `cmd/loom/skills_classify.go` (behavior unchanged — default-off flag).

## Not fixed here (documented in the triage doc)

- **docker/docker vulns (5)**: no fix exists on the `github.com/docker/docker` module path — the engine moved to `github.com/moby/moby/v2` and fixes are only in `2.0.0-beta.14+` (beta). All five CVEs are daemon-side; loom uses only the client SDK. Revisit at moby/v2 GA.
- **SQL injection (High ×3)**: already fixed on main by #267.
- **~51 findings verified as false positives** (test fixtures, `"default-user"` tenant label, escaped/CSP'd HTML, CLI-operator-controlled paths, vLLM `"EMPTY"` placeholder) — itemized in `docs/reference/security-scan-triage.md` for ArmorCode disposition.

## Test plan

- [x] `just check` passes (lint + gosec 0 issues + tests with `-tags fts5 -race` + build, matches GitHub CI)
- [x] `govulncheck -tags fts5 ./...` now reports only the five no-fix docker/docker findings (was 27)
- [x] New table-driven tests for `ValidateSessionID` and traversal rejection in `GetArtifactDir`/`GetScratchpadDir`
- [x] `gofmt -l` clean on changed packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)