### PR TITLE
fix(packaging): repo templates are source of truth for Homebrew formulas

### DIFF
--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -55,6 +55,7 @@ jobs:
             "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/loom-darwin-arm64.tar.gz"
             "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/looms-darwin-amd64.tar.gz"
             "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/looms-darwin-arm64.tar.gz"
+            "https://github.com/${{ github.repository }}/archive/refs/tags/v${VERSION}.tar.gz"
           )
 
           for url in "${URLS[@]}"; do
@@ -124,28 +125,30 @@ jobs:
           LOOMS_ARM64_HASH="${{ steps.hashes.outputs.looms_arm64_hash }}"
           PATTERNS_HASH="${{ steps.hashes.outputs.patterns_hash }}"
 
+          # The repo's packaging templates are the single source of truth
+          # for formula structure. Hand-edits to the tap get overwritten on
+          # the next release — make structural changes in
+          # packaging/macos/homebrew/ instead. Inside a Homebrew `resource`
+          # block, #{version} resolves to the (unset) resource version, not
+          # the formula's, so all URLs use literal versions and are stamped
+          # here along with `version` and the three sha256 values.
+          cp packaging/macos/homebrew/loom.rb homebrew-tap/Formula/loom.rb
+          cp packaging/macos/homebrew/loom-server.rb homebrew-tap/Formula/loom-server.rb
+
           cd homebrew-tap
 
-          # Binary and source URLs derive from v#{version} in the formulas
-          # (teradata-labs/homebrew-tap#9), so only `version` and the three
-          # sha256 values need rewriting per formula.
+          for f in Formula/loom.rb Formula/loom-server.rb; do
+            sed -i '' "s/version \".*\"/version \"$VERSION\"/" "$f"
+            sed -i '' "s|releases/download/v[0-9.]*/|releases/download/v$VERSION/|g" "$f"
+            sed -i '' "s|archive/refs/tags/v[0-9.]*\.tar\.gz|archive/refs/tags/v$VERSION.tar.gz|" "$f"
+            # SHA256 for the loom-patterns resource (source tag tarball)
+            sed -i '' "\|archive/refs/tags|,/sha256/s/sha256 \".*\"/sha256 \"$PATTERNS_HASH\"/" "$f"
+          done
 
-          # Update loom.rb
-          sed -i '' "s/version \".*\"/version \"$VERSION\"/" Formula/loom.rb
-          # SHA256 for the loom-patterns resource (source tag tarball)
-          sed -i '' "\|archive/refs/tags|,/sha256/s/sha256 \".*\"/sha256 \"$PATTERNS_HASH\"/" Formula/loom.rb
-          # SHA256 for arm64
+          # SHA256 for the binaries
           sed -i '' "/loom-darwin-arm64.tar.gz/,/sha256/s/sha256 \".*\"/sha256 \"$LOOM_ARM64_HASH\"/" Formula/loom.rb
-          # SHA256 for amd64
           sed -i '' "/loom-darwin-amd64.tar.gz/,/sha256/s/sha256 \".*\"/sha256 \"$LOOM_AMD64_HASH\"/" Formula/loom.rb
-
-          # Update loom-server.rb
-          sed -i '' "s/version \".*\"/version \"$VERSION\"/" Formula/loom-server.rb
-          # SHA256 for the loom-patterns resource (source tag tarball)
-          sed -i '' "\|archive/refs/tags|,/sha256/s/sha256 \".*\"/sha256 \"$PATTERNS_HASH\"/" Formula/loom-server.rb
-          # SHA256 for arm64
           sed -i '' "/looms-darwin-arm64.tar.gz/,/sha256/s/sha256 \".*\"/sha256 \"$LOOMS_ARM64_HASH\"/" Formula/loom-server.rb
-          # SHA256 for amd64
           sed -i '' "/looms-darwin-amd64.tar.gz/,/sha256/s/sha256 \".*\"/sha256 \"$LOOMS_AMD64_HASH\"/" Formula/loom-server.rb
 
           echo "Updated formulas:"
@@ -153,13 +156,25 @@ jobs:
           echo "---"
           cat Formula/loom-server.rb | grep -A 2 "version\|url\|sha256"
 
-      - name: Verify formulas reference no stale hashes
+      - name: Verify formulas reference no stale hashes or URLs
         run: |
+          VERSION="${{ steps.version.outputs.version }}"
           cd homebrew-tap
           for f in Formula/loom.rb Formula/loom-server.rb; do
+            ruby -c "$f"
             COUNT=$(grep -c 'sha256 "' "$f")
             if [ "$COUNT" -ne 3 ]; then
               echo "::error::$f has $COUNT sha256 lines, expected 3 (resource + arm64 + amd64)"
+              exit 1
+            fi
+            if grep -q 'sha256 "0\{64\}"' "$f"; then
+              echo "::error::$f still contains a placeholder sha256"
+              exit 1
+            fi
+            grep -q "releases/download/v$VERSION/" "$f" || { echo "::error::$f binary URLs not stamped to v$VERSION"; exit 1; }
+            grep -q "archive/refs/tags/v$VERSION.tar.gz" "$f" || { echo "::error::$f patterns resource URL not stamped to v$VERSION"; exit 1; }
+            if grep -q '#{version}' "$f"; then
+              echo "::error::$f uses #{version} interpolation, which is nil inside resource blocks — use literal versions"
               exit 1
             fi
           done

--- a/packaging/macos/homebrew/loom-server.rb
+++ b/packaging/macos/homebrew/loom-server.rb
@@ -4,6 +4,13 @@ class LoomServer < Formula
   version "1.3.0"
   license "Apache-2.0"
 
+  # sha256 placeholders are stamped with real hashes by
+  # .github/workflows/publish-homebrew.yml at release time.
+  resource "loom-patterns" do
+    url "https://github.com/teradata-labs/loom/archive/refs/tags/v1.3.0.tar.gz"
+    sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  end
+
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/teradata-labs/loom/releases/download/v1.3.0/looms-darwin-arm64.tar.gz"
@@ -15,107 +22,52 @@ class LoomServer < Formula
   end
 
   def install
-    # Install binary
     bin.install "looms-darwin-arm64" => "looms" if Hardware::CPU.arm?
     bin.install "looms-darwin-amd64" => "looms" if Hardware::CPU.intel?
 
-    # Create Loom data directory (respects LOOM_DATA_DIR env var)
-    loom_dir = ENV["LOOM_DATA_DIR"] || "#{Dir.home}/.loom"
-    patterns_dir = "#{loom_dir}/patterns"
-    config_file = "#{loom_dir}/looms.yaml"
-
-    system "mkdir", "-p", loom_dir
-    system "mkdir", "-p", patterns_dir
-
-    # Download and install patterns
-    ohai "Downloading patterns..."
-    patterns_url = "https://github.com/teradata-labs/loom/archive/refs/tags/v#{version}.tar.gz"
-    patterns_tmp = "#{Dir.tmpdir}/loom-patterns-#{version}.tar.gz"
-
-    system "curl", "-L", "-o", patterns_tmp, patterns_url
-    system "tar", "xzf", patterns_tmp, "-C", Dir.tmpdir
-
-    extracted_dir = "#{Dir.tmpdir}/loom-#{version}"
-    if File.directory?("#{extracted_dir}/patterns")
-      system "cp", "-R", "#{extracted_dir}/patterns/", patterns_dir
-      pattern_count = Dir.glob("#{patterns_dir}/**/*.yaml").length
-      ohai "Installed #{pattern_count} pattern files to #{patterns_dir}"
+    # HOME is sandboxed during install, so patterns go into the keg;
+    # users copy them to ~/.loom/patterns (see caveats). Config is
+    # created by the binary itself via 'looms config init'.
+    resource("loom-patterns").stage do
+      src = Pathname.pwd
+      unless src.join("patterns").directory?
+        src = Pathname.glob("loom-*").find { |d| d.join("patterns").directory? }
+      end
+      odie "Could not find patterns/ in Loom source (archive layout may have changed)" if src.nil?
+      pkgshare.install src/"patterns"
     end
-
-    # Cleanup
-    system "rm", "-rf", patterns_tmp, extracted_dir
-
-    # Create default config if it doesn't exist
-    unless File.exist?(config_file)
-      ohai "Creating default configuration..."
-      File.write(config_file, <<~YAML)
-        # Loom Server Configuration
-        server:
-          host: "0.0.0.0"
-          port: 60051
-
-        # Database stored in Loom data directory
-        database:
-          path: "#{loom_dir}/loom.db"
-
-        # Communication system (shared memory, message queue)
-        communication:
-          store:
-            backend: sqlite
-            path: "#{loom_dir}/loom.db"
-
-        # Observability (optional - requires Hawk)
-        observability:
-          enabled: false
-
-        # MCP servers (add your own)
-        mcp:
-          servers: {}
-
-        # No pre-configured agents - use the weaver to create threads on demand
-        agents:
-          agents: {}
-      YAML
-      ohai "Configuration created at #{config_file}"
-    end
-  end
-
-  def post_install
-    ohai "Loom server installed successfully!"
-    ohai ""
-    ohai "Next steps:"
-    ohai "  1. Configure an LLM provider:"
-    ohai "       looms config set llm.provider anthropic"
-    ohai "       looms config set-key anthropic_api_key"
-    ohai ""
-    ohai "  2. Start the server:"
-    ohai "       looms serve"
-    ohai ""
-    ohai "  3. Install the TUI client (if not already installed):"
-    ohai "       brew install loom"
-    ohai ""
-    ohai "  4. Create your first agent (in another terminal):"
-    ohai "       loom --thread weaver"
   end
 
   def caveats
     <<~EOS
       Loom server has been installed.
 
-      Configuration file: $LOOM_DATA_DIR/looms.yaml (default: $HOME/.loom/looms.yaml)
-      Patterns directory: $LOOM_DATA_DIR/patterns (default: $HOME/.loom/patterns)
+      Pattern library is staged at:
+        #{opt_pkgshare}/patterns
 
-      To start the server:
-        looms serve
+      To install patterns into your Loom data directory:
+        mkdir -p ~/.loom/patterns
+        cp -R #{opt_pkgshare}/patterns/. ~/.loom/patterns/
 
-      The server will run on:
-        - gRPC: localhost:60051
-        - HTTP: http://localhost:5006
-        - Swagger UI: http://localhost:5006/swagger-ui
+      Next steps:
+        1. Create a starter configuration ($LOOM_DATA_DIR/looms.yaml,
+           default: $HOME/.loom/looms.yaml):
+             looms config init
 
-      To configure an LLM provider:
-        looms config set llm.provider anthropic
-        looms config set-key anthropic_api_key
+        2. Configure an LLM provider:
+             looms config set llm.provider anthropic
+             looms config set-key anthropic_api_key
+
+        3. Start the server:
+             looms serve
+
+           The server will run on:
+             - gRPC: localhost:60051
+             - HTTP: http://localhost:5006
+             - Swagger UI: http://localhost:5006/swagger-ui
+
+        4. Install the TUI client (if not already installed):
+             brew install teradata-labs/tap/loom
 
       Documentation: https://github.com/teradata-labs/loom
     EOS
@@ -131,6 +83,7 @@ class LoomServer < Formula
 
   test do
     assert_match "Usage:", shell_output("#{bin}/looms --help")
+    assert_predicate pkgshare/"patterns", :directory?
 
     # Test config command
     system "#{bin}/looms", "config", "list"

--- a/packaging/macos/homebrew/loom.rb
+++ b/packaging/macos/homebrew/loom.rb
@@ -4,6 +4,13 @@ class Loom < Formula
   version "1.3.0"
   license "Apache-2.0"
 
+  # sha256 placeholders are stamped with real hashes by
+  # .github/workflows/publish-homebrew.yml at release time.
+  resource "loom-patterns" do
+    url "https://github.com/teradata-labs/loom/archive/refs/tags/v1.3.0.tar.gz"
+    sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  end
+
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/teradata-labs/loom/releases/download/v1.3.0/loom-darwin-arm64.tar.gz"
@@ -15,69 +22,50 @@ class Loom < Formula
   end
 
   def install
-    # Install binary
     bin.install "loom-darwin-arm64" => "loom" if Hardware::CPU.arm?
     bin.install "loom-darwin-amd64" => "loom" if Hardware::CPU.intel?
 
-    # Create Loom data directory (respects LOOM_DATA_DIR env var)
-    loom_dir = ENV["LOOM_DATA_DIR"] || "#{Dir.home}/.loom"
-    patterns_dir = "#{loom_dir}/patterns"
-
-    # Download and install patterns
-    ohai "Downloading patterns..."
-    system "mkdir", "-p", patterns_dir
-
-    patterns_url = "https://github.com/teradata-labs/loom/archive/refs/tags/v#{version}.tar.gz"
-    patterns_tmp = "#{Dir.tmpdir}/loom-patterns-#{version}.tar.gz"
-
-    system "curl", "-L", "-o", patterns_tmp, patterns_url
-    system "tar", "xzf", patterns_tmp, "-C", Dir.tmpdir
-
-    extracted_dir = "#{Dir.tmpdir}/loom-#{version}"
-    if File.directory?("#{extracted_dir}/patterns")
-      system "cp", "-R", "#{extracted_dir}/patterns/", patterns_dir
-      pattern_count = Dir.glob("#{patterns_dir}/**/*.yaml").length
-      ohai "Installed #{pattern_count} pattern files to #{patterns_dir}"
+    # HOME is sandboxed during install, so patterns go into the keg;
+    # users copy them to ~/.loom/patterns (see caveats).
+    resource("loom-patterns").stage do
+      src = Pathname.pwd
+      unless src.join("patterns").directory?
+        src = Pathname.glob("loom-*").find { |d| d.join("patterns").directory? }
+      end
+      odie "Could not find patterns/ in Loom source (archive layout may have changed)" if src.nil?
+      pkgshare.install src/"patterns"
     end
-
-    # Cleanup
-    system "rm", "-rf", patterns_tmp, extracted_dir
-
-    # Set environment variable hint
-    opoo "Loom TUI client installed successfully!"
-    opoo "To use Loom, you also need to install the server:"
-    opoo "  brew install loom-server"
-    opoo ""
-    opoo "Or start the server manually:"
-    opoo "  looms serve"
   end
 
   def caveats
     <<~EOS
       Loom TUI client has been installed.
 
+      Pattern library is staged at:
+        #{opt_pkgshare}/patterns
+
+      To install patterns into your Loom data directory:
+        mkdir -p ~/.loom/patterns
+        cp -R #{opt_pkgshare}/patterns/. ~/.loom/patterns/
+
       Next steps:
         1. Install the Loom server:
-           brew install loom-server
+           brew install teradata-labs/tap/loom-server
 
-        2. Configure an LLM provider:
-           export ANTHROPIC_API_KEY="your-key"
-           # or configure Bedrock, OpenAI, etc.
-
-        3. Start the server (in another terminal):
+        2. Start the server (in another terminal):
            looms serve
 
-        4. Create your first agent:
+        3. Create your first agent:
            loom --thread weaver
 
         Then type: "Create a code review assistant"
 
       Documentation: https://github.com/teradata-labs/loom
-      Patterns installed to: $LOOM_DATA_DIR/patterns (default: $HOME/.loom/patterns)
     EOS
   end
 
   test do
     assert_match "Usage:", shell_output("#{bin}/loom --help")
+    assert_predicate pkgshare/"patterns", :directory?
   end
 end

--- a/pkg/versionmgr/files.go
+++ b/pkg/versionmgr/files.go
@@ -186,6 +186,10 @@ func updateHomebrewFormula(path string, version Version) error {
 	re2 := regexp.MustCompile(`/v[0-9]+\.[0-9]+\.[0-9]+/`)
 	text = re2.ReplaceAllString(text, fmt.Sprintf("/%s/", version.WithV()))
 
+	// Replace source tag archive URLs: refs/tags/vX.Y.Z.tar.gz
+	re3 := regexp.MustCompile(`refs/tags/v[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz`)
+	text = re3.ReplaceAllString(text, fmt.Sprintf("refs/tags/%s.tar.gz", version.WithV()))
+
 	return os.WriteFile(path, []byte(text), 0644) // #nosec -- path from GetAllTargets(), controlled by version manager tool
 }
 
@@ -207,6 +211,14 @@ func extractHomebrewFormula(path string) ([]string, error) {
 	// Extract versions from URLs
 	re2 := regexp.MustCompile(`/v([0-9]+\.[0-9]+\.[0-9]+)/`)
 	for _, match := range re2.FindAllStringSubmatch(string(content), -1) {
+		if len(match) >= 2 {
+			versions[match[1]] = true
+		}
+	}
+
+	// Extract versions from source tag archive URLs: refs/tags/vX.Y.Z.tar.gz
+	re3 := regexp.MustCompile(`refs/tags/v([0-9]+\.[0-9]+\.[0-9]+)\.tar\.gz`)
+	for _, match := range re3.FindAllStringSubmatch(string(content), -1) {
 		if len(match) >= 2 {
 			versions[match[1]] = true
 		}

--- a/pkg/versionmgr/files_test.go
+++ b/pkg/versionmgr/files_test.go
@@ -213,6 +213,22 @@ end
 			expectedURL:   "https://example.com/v3.0.0/mac.tar.gz",
 			expectExtract: []string{"1.0.0"},
 		},
+		{
+			name: "source tag archive resource",
+			inputContent: `class Loom < Formula
+  version "1.2.3"
+  resource "loom-patterns" do
+    url "https://github.com/teradata-labs/loom/archive/refs/tags/v1.2.3.tar.gz"
+    sha256 "abc123"
+  end
+  url "https://github.com/teradata-labs/loom/releases/download/v1.2.3/loom-darwin-arm64.tar.gz"
+  sha256 "def456"
+end
+`,
+			updateVersion: Version{Major: 2, Minor: 0, Patch: 0},
+			expectedURL:   "https://github.com/teradata-labs/loom/archive/refs/tags/v2.0.0.tar.gz",
+			expectExtract: []string{"1.2.3"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

`brew install`/`brew upgrade` of both `loom` and `loom-server` 1.3.0 failed:

```
==> Downloading https://github.com/teradata-labs/loom/archive/refs/tags/v.tar.gz
curl: (56) The requested URL returned error: 404
Error: ... Failed to download resource "loom-server--loom-patterns"
```

Three stacked bugs:

1. **`#{version}` is nil inside Homebrew `resource` blocks** — it resolves to the resource's own (unset) version, not the formula's, so the patterns URL rendered as `v.tar.gz`. PR #272's workflow design assumed interpolation works there (comment cited homebrew-tap#9).
2. **Resource staging strips the tarball's top-level directory** — the `Pathname.glob("loom-*")` in the stage block never matched, so even with the URL fixed, install died with "Could not find Loom source directory".
3. **`Dir.home` during install is the sandboxed build home** (`/private/tmp/loom-server-*/.brew_home`) — the `~/.loom` patterns/config seeding has *never* worked from brew; it wrote into a throwaway directory since 1.0.x.

The tap was hotfixed directly (teradata-labs/homebrew-tap#10, teradata-labs/homebrew-tap#11) — installs work now. This PR fixes the machinery that produced the broken formulas.

## Changes

- **`publish-homebrew.yml`**: copies `packaging/macos/homebrew/*.rb` into the tap each release (single source of truth — hand-edits to the tap no longer survive), then stamps version, binary URLs, resource URL, and all three sha256s. All URLs literal; no `#{version}`. Verify step gains `ruby -c`, placeholder-hash, stale-URL, and interpolation guards.
- **Templates** (`packaging/macos/homebrew/`): synced to the fixed structure — patterns install into `pkgshare` with copy instructions in caveats; config creation delegated to `looms config init` (dogfooding); staging handles both archive layouts.
- **`pkg/versionmgr`**: bumps/extracts `refs/tags/vX.Y.Z.tar.gz` archive URLs so the resource URL stays version-consistent; new table-driven test case.

## Verification

- Sed-pipeline dry-run on the templates reproduces the merged tap formulas **byte-for-byte** (modulo an intentional template comment)
- `brew install teradata-labs/tap/loom-server` and `.../loom` both succeed on arm64 macOS: `looms version` = v1.3.0, 158 pattern YAMLs staged in pkgshare
- `go test -tags fts5 -race ./pkg/versionmgr/` passes; `gofmt -l` clean
- `just version-verify`: 14/14 files in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)