### PR TITLE
fix(security): make session metadata path containment provable to CodeQL

### DIFF
--- a/docs/reference/security-scan-triage.md
+++ b/docs/reference/security-scan-triage.md
@@ -14,6 +14,17 @@ same findings from scratch.
 | Path Traversal (Medium) | `pkg/artifacts/store.go` | `ValidateSessionID` (strict allowlist: `[A-Za-z0-9._-]`, no `..`) now gates `GetArtifactDir` and `GetScratchpadDir`; `session_metadata.go`'s weaker blocklist validator delegates to it. Session IDs arrive from API callers via context, so this was a real (if low-exploitability) gap. |
 | Insufficient postMessage Validation (Low) | `pkg/mcp/apps/html/data-chart.html` | Adopted the trust-on-first-use origin-pinning guard already used by the other three MCP app viewers, plus a payload shape check (`labels`/`values` arrays). |
 
+## CodeQL follow-up (2026-07-23)
+
+The PR #271 hardening itself surfaced three `go/path-injection` CodeQL alerts
+(#666–668) in `pkg/artifacts/session_metadata.go` (`WriteSessionArtifactMetadata`:
+`os.MkdirAll`, `os.CreateTemp`, `os.Rename`). Not exploitable — `ValidateSessionID`
+already allowlists `[A-Za-z0-9._-]` and rejects `..` — but CodeQL doesn't model that
+function as a sanitizer. Fixed by adding the CodeQL-recognized containment pattern
+(`filepath.Clean` + `filepath.Rel` + `filepath.IsLocal`) inside `SessionArtifactsRoot`,
+the single choke point every session metadata path derives from;
+`ReadSessionArtifactMetadata`'s duplicate inline check was folded into it.
+
 ## No fix available upstream
 
 | Finding | Location | Status |

--- a/pkg/artifacts/session_metadata.go
+++ b/pkg/artifacts/session_metadata.go
@@ -270,7 +270,10 @@ func ReadSessionArtifactMetadata(sessionID string) (*SessionArtifactMetadata, er
 	if err != nil {
 		return nil, err
 	}
-	data, err := os.ReadFile(path)
+	// filepath.Clean is a semantic no-op here (the path is already contained by
+	// SessionArtifactsRoot) but gosec's G304 check is intraprocedural and needs
+	// the sanitizer at the read site.
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/artifacts/session_metadata.go
+++ b/pkg/artifacts/session_metadata.go
@@ -117,12 +117,25 @@ func validateSessionArtifactPathSegment(sessionID string) error {
 }
 
 // SessionArtifactsRoot returns $LOOM_DATA_DIR/artifacts/sessions/<sessionID>.
+// The joined path is verified to stay inside the sessions directory, so the
+// returned root is safe to use in filesystem operations even though sessionID
+// originates from API callers. ValidateSessionID already rejects separators
+// and traversal sequences; the Rel/IsLocal check makes that containment
+// explicit at the path level.
 func SessionArtifactsRoot(sessionID string) (string, error) {
 	if err := validateSessionArtifactPathSegment(sessionID); err != nil {
 		return "", err
 	}
-	base := config.GetLoomDataDir()
-	return filepath.Join(base, "artifacts", "sessions", sessionID), nil
+	base := filepath.Join(config.GetLoomDataDir(), "artifacts", "sessions")
+	root := filepath.Clean(filepath.Join(base, sessionID))
+	rel, err := filepath.Rel(base, root)
+	if err != nil {
+		return "", fmt.Errorf("invalid session artifact path: %w", err)
+	}
+	if !filepath.IsLocal(rel) {
+		return "", fmt.Errorf("invalid session artifact path")
+	}
+	return root, nil
 }
 
 // sessionMetadataPath returns the path to metadata.json for a session.
@@ -250,27 +263,14 @@ func WriteSessionArtifactMetadata(meta *SessionArtifactMetadata) error {
 }
 
 // ReadSessionArtifactMetadata reads and parses metadata.json under the session artifact root.
-// The resolved path is checked so the file cannot lie outside that directory. If the file
-// is missing, the error typically wraps [os.ErrNotExist].
+// Path containment is enforced by [SessionArtifactsRoot], which every metadata path derives
+// from. If the file is missing, the error typically wraps [os.ErrNotExist].
 func ReadSessionArtifactMetadata(sessionID string) (*SessionArtifactMetadata, error) {
 	path, err := sessionMetadataPath(sessionID)
 	if err != nil {
 		return nil, err
 	}
-	root, err := SessionArtifactsRoot(sessionID)
-	if err != nil {
-		return nil, err
-	}
-	root = filepath.Clean(root)
-	cleanPath := filepath.Clean(path)
-	rel, err := filepath.Rel(root, cleanPath)
-	if err != nil {
-		return nil, fmt.Errorf("invalid session metadata path: %w", err)
-	}
-	if !filepath.IsLocal(rel) {
-		return nil, fmt.Errorf("invalid session metadata path")
-	}
-	data, err := os.ReadFile(cleanPath)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/artifacts/session_metadata_test.go
+++ b/pkg/artifacts/session_metadata_test.go
@@ -87,15 +87,23 @@ func TestWriteAndReadSessionArtifactMetadata_roundTrip(t *testing.T) {
 
 func TestSessionArtifactsRoot_rejectsBadPath(t *testing.T) {
 	t.Parallel()
-	for _, id := range []string{"../x", "a/b", `a\b`, "ok"} {
+	valid := map[string]bool{"ok": true, "sess-abc.1_2": true}
+	for _, id := range []string{"../x", "a/b", `a\b`, "..", ".", "", "a..b", "/etc", "ok", "sess-abc.1_2"} {
 		_, err := SessionArtifactsRoot(id)
-		switch id {
-		case "ok":
-			require.NoError(t, err)
-		default:
-			require.Error(t, err)
+		if valid[id] {
+			require.NoError(t, err, "id %q should be accepted", id)
+		} else {
+			require.Error(t, err, "id %q should be rejected", id)
 		}
 	}
+}
+
+func TestSessionArtifactsRoot_containedUnderSessionsDir(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("LOOM_DATA_DIR", dataDir)
+	got, err := SessionArtifactsRoot("sess-abc.1_2")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(dataDir, "artifacts", "sessions", "sess-abc.1_2"), got)
 }
 
 func TestSyncSessionArtifactMetadata_preservesCompleted(t *testing.T) {


### PR DESCRIPTION
## Problem

Three open `go/path-injection` CodeQL alerts on main (#666, #667, #668), all in `WriteSessionArtifactMetadata` (`pkg/artifacts/session_metadata.go`): `os.MkdirAll`, `os.CreateTemp`, and `os.Rename` on paths derived from `SessionID`. Ironically they first appeared in the #271 security-hardening commit (`291e2bc`).

**Not exploitable**: `ValidateSessionID` gates every flow with a strict `[A-Za-z0-9._-]` allowlist and rejects `..`/empty/`.` — no separator or traversal sequence survives. CodeQL just doesn't model that function as a sanitizer, while it *does* recognize the `filepath.Clean` + `filepath.Rel` + `filepath.IsLocal` pattern (proof: the read path in the same file uses it and was never flagged).

## Fix

- Move the containment check into `SessionArtifactsRoot` — the single choke point every session metadata path derives from — so write path, read path, and future callers share one canonical guard.
- Fold `ReadSessionArtifactMetadata`'s duplicated inline check into it (net simplification, one containment point instead of two).
- Extend the traversal test matrix (`..`, `.`, empty, `a..b`, `/etc`, `a\b`, `a/b`) and assert the happy-path root lands exactly under `artifacts/sessions/`.
- Record the triage in `docs/reference/security-scan-triage.md`.

## Verification

- `go test -tags fts5 -race -count=1 ./pkg/artifacts/` passes; `gofmt`/`go vet` clean
- The PR's **Analyze (go)** CodeQL run is the empirical gate: it should report alerts #666–668 as fixed on this branch. If the interprocedural guard isn't recognized, fallback is inlining the guard at each sink — please don't merge until the CodeQL run confirms.

Closes alerts #666, #667, #668.

🤖 Generated with [Claude Code](https://claude.com/claude-code)