### PR TITLE
docs: loop-engineering analysis and P0-P3 roadmap spec

### DIFF
--- a/docs/architecture/loop-engineering.md
+++ b/docs/architecture/loop-engineering.md
@@ -1,0 +1,225 @@
+# Loop Engineering and Loom
+
+Analysis of Loom's conversation loop and surrounding machinery against the "loop engineering" discipline that crystallized in mid-2026. Companion to [12-factor-architecture.md](12-factor-architecture.md).
+
+**Target audience**: Contributors, architects
+**Version**: v1.3.0 (analyzed on `main` @ `68208a0a`, 2026-07-30)
+
+---
+
+## Table of Contents
+
+- [What Loop Engineering Is](#what-loop-engineering-is)
+- [The Four-Loop Model Mapped to Loom](#the-four-loop-model-mapped-to-loom)
+  - [Loop 1: The Agent Loop](#loop-1-the-agent-loop--implemented)
+  - [Loop 2: The Verification Loop](#loop-2-the-verification-loop--implemented-for-workflows-missing-in-the-agent-loop)
+  - [Loop 3: The Event-Driven Loop](#loop-3-the-event-driven-loop--partial)
+  - [Loop 4: The Hill-Climbing Loop](#loop-4-the-hill-climbing-loop--implemented-offline-not-closed)
+- [Principles Scorecard](#principles-scorecard)
+- [Gap Analysis and Recommendations](#gap-analysis-and-recommendations)
+- [References](#references)
+
+---
+
+## What Loop Engineering Is
+
+"Loop engineering" named a discipline in June 2026 through three converging statements: Boris Cherny (Claude Code creator): *"I don't prompt Claude anymore... my job is to write loops"*; Peter Steinberger (June 7): *"You shouldn't be prompting coding agents anymore. You should be designing loops that prompt your agents"*; and Addy Osmani's essay "Loop Engineering" (June 8, canonized by O'Reilly Radar June 22). The substance predates the name — most of it is in Anthropic's engineering posts (2024–25), Simon Willison's "Designing agentic loops" (Sept 2025), Cognition's "Don't Build Multi-Agents" (June 2025), and HumanLayer's 12-Factor Agents.
+
+The now-standard layered stack:
+
+| Layer | Optimizes | Era |
+|---|---|---|
+| Prompt engineering | One message | 2022–24 |
+| Context engineering | What fills the context window each turn | 2025 |
+| Harness engineering | The environment around one agent run (tools, prompts, sandbox, hooks) | early 2026 |
+| **Loop engineering** | **The machinery across runs: triggers, topology, verifiers, stop rules, budgets, persistent state, escalation, cross-run improvement** | mid 2026 |
+
+The empirical case that this matters: Harness-Bench ([arXiv:2605.27922](https://arxiv.org/abs/2605.27922)) measured 13–21 point swings on the *same model* across harnesses, concluding "agent capability should be reported at the model-harness configuration level rather than attributed to the base model alone." The loop is a first-order capability variable.
+
+Loom is a loop-engineering framework by construction — the framework, not the user, owns the control flow (12-Factor Agents' "own your control flow"). This document assesses how much of the discipline Loom actually covers.
+
+---
+
+## The Four-Loop Model Mapped to Loom
+
+LangChain's "The Art of Loop Engineering" (June 2026) describes four stacked loops. This is the cleanest skeleton for mapping Loom.
+
+### Loop 1: The Agent Loop — ✅ Implemented
+
+The inner loop: model calls tools until done. Loom's implementation is `Agent.runConversationLoop` (`pkg/agent/agent.go:2187`).
+
+Pre-loop, once per `Chat`: freeze the base advertised tool set (`captureBaseTools`, `agent.go:2197`), initialize the self-healing recovery orchestrator if enabled (`agent.go:2208`), run lazy tool disclosure against the incoming user message, and inject graph-memory context (`injectGraphMemoryContext`, `agent.go:3216`).
+
+Per-iteration order:
+
+1. **Budget guard**: `for turnCount < MaxTurns && toolExecutionCount < MaxToolExecutions` (`agent.go:2235`) — defaults 25 / 50, plus a per-turn tool-call cap `MaxIterations` (default 10, `pkg/agent/types.go:371-373`)
+2. **Token-budget enforcement** before the LLM call: `enforceTokenBudget` (`pkg/agent/conversation_helpers.go:154`) force-compacts memory above 70% budget; if still >85% after compaction, the recovery tier trims aggressively or the loop fails with a recoverable error (`agent.go:2246-2287`)
+3. **Message assembly**: `SegmentedMemory.GetMessagesForLLM` (`pkg/agent/segmented_memory.go:1003`) assembles ROM system prompt → L2 summary → promoted-from-swap context → L1 hot messages. The system slot carries **only ROM + L2 summary** — a test-enforced invariant (`pattern_findings_channels_deletion_black_box_test.go`); everything else enters context as tool results or sidecars
+4. **Soft reminders**: nudge text appended in the 75–90% window of the tool/turn budgets (`conversation_helpers.go:177-216`)
+5. **Tools re-derived every iteration**: `advertisedTools(session)` filtered by `recovery.activeTools` (`agent.go:2331`) — progressive disclosure and circuit-breaker exclusions take effect mid-conversation
+6. **LLM call** with retry/backoff (`chatWithRetry`, `pkg/agent/llm_retry.go`), optionally tapped by the context dumper (see Loop 4)
+7. **Output-token circuit breaker**: trips after 8 consecutive `max_tokens` responses that contain a truncated/empty tool call; plain text hitting the limit clears the counter; configurable via `OutputTokenCBThreshold` (`agent.go:2387-2470`, `types.go:304-307`)
+8. **Tool dispatch**: dedup, HITL `contact_human` detection, then `executeToolWithSelfCorrection` (`agent.go:2684`) wrapping each call in per-tool circuit breakers and guardrail error annotation; consecutive identical failures inject a "stop retrying, change approach" escalation at threshold 2 (`agent.go:2794`)
+9. **Background graph-memory extraction** fires asynchronously after tool execution (`agent.go:2858`); `text_body` sidecars (e.g. skill bodies) are buffered and drained after the tool batch to preserve tool_use/tool_result adjacency (`agent.go:2844-2883`)
+10. **On turn/execution exhaustion**: one final tools-disabled synthesis call forces a text answer instead of dying mid-thought (`agent.go:2911-2912`)
+
+Mapped to Anthropic's "gather context → take action → verify work → repeat":
+
+| Phase | Anthropic guidance | Loom mechanism | Status |
+|---|---|---|---|
+| Gather | Compaction preserving decisions | Segmented memory (ROM/Kernel/L1/L2/Swap) with LLM compaction default-on (registry prompt `memory.compaction`) and a tool-pair-preserving compression boundary (`segmented_memory.go:466`) | ✅ |
+| Gather | Structured note-taking / memory | Graph memory: context injected pre-loop, entities extracted asynchronously post-tool (`WithGraphMemoryStore`, `agent.go:4361`) | ✅ |
+| Gather | Just-in-time retrieval via lightweight identifiers | Skills: ROM carries only a name+description menu; bodies pull-loaded via `manage_skills(load)` as sidecars. Patterns loaded on demand via `load_pattern` tool. Large tool results offloaded to shared memory as `DataReference`; SQL results queryable via `query_tool_result` | ✅ |
+| Act | Tools reflect primary actions; progressive disclosure | Tool surface re-derived per iteration (`agent.go:2331`); lazy disclosure; MCP dynamic discovery | ✅ |
+| Verify | Deterministic feedback > judges | — (agent loop) | ⚠️ See Loop 2 |
+
+**Notable strengths vs. published practice**:
+- The system-slot minimalism (ROM + L2 only, everything else pull-based) is a deliberate redesign directly aligned with Anthropic's just-in-time retrieval guidance — earlier designs auto-injected pattern guidance and a findings block into the system slot; both were removed in favor of tool-loaded context
+- The tool-pair-preserving compaction boundary addresses Cognition's warning that compression "is hard to get right"
+- The forced-synthesis exit, truncation-gated output-token breaker, and adaptive failure escalation are stop-rule refinements most frameworks lack
+- A self-healing recovery tier (`pkg/agent/recovery.go`: token-budget trim, output-token rewind, tool circuit-breaker exclusion) sits between "retry" and "abort"
+
+**Limitations**:
+- No dollar/cost ceiling on the loop: `Usage.CostUSD` is recorded to spans but is not a stop condition (`max_cost_usd` exists only in `eval.proto` for offline evals)
+- Pattern intent classification and recommendation are dormant: the classifier infrastructure exists (`pkg/patterns/llm_classifier.go`) but nothing in the runtime calls `ClassifyIntent`/`RecommendPattern` — pattern choice is delegated to the model via `load_pattern`
+
+### Loop 2: The Verification Loop — ✅ Implemented for workflows, 📋 missing in the agent loop
+
+The discipline's near-unanimous core claim: **verification is the reward signal**. "Agent runs, output is scored against a rubric, retried with feedback if it fails" (LangChain). Deterministic verifiers (tests, schemas) beat LLM judges, which are "generally not very robust" (Anthropic). Without a verifier that can *reject* output, a loop is theater.
+
+**At the workflow-stage level (`pkg/orchestration`), Loom now implements the full pattern:**
+- ✅ JSON-Schema structural validation: `PipelineStage.output_schema` → `validateStageOutputSchema` (`pipeline_executor.go:350-361`)
+- ✅ LLM judge per stage: `stage.ValidationPrompt` scored by a merge LLM (`pipeline_executor.go:720-764`)
+- ✅ `OutputRetryPolicy` with feedback retry: max retries, cooldown, feedback template, and `RetrySessionMode` (CONTINUE / FRESH / ESCALATE) driving `retryStage` (`pipeline_executor.go:374-395`) — retries carry an explanation of what failed, matching the "retries must adapt" principle
+- ✅ HITL gates: human approve/revise/reject between stages, with revision feedback threaded back to a target stage (see Loop 3)
+
+**At the single-agent loop level:**
+- 📋 Nothing scores the assistant's *final output* before it is returned — no verifier hook, no output-schema contract on `Chat`, no judge-in-loop
+- ⚠️ A universal `OutputValidator.ValidateAndRetry` exists (`pkg/orchestration/output_validator.go`) but has **no production callers** — the live path is the pipeline executor's own `retryStage`
+- ✅ Error-path correction exists (guardrail annotation, circuit breakers, escalation), but that verifies *tool failures*, not *answer quality*
+
+This split is the highest-leverage gap: the machinery exists one layer up — see [recommendations](#gap-analysis-and-recommendations).
+
+### Loop 3: The Event-Driven Loop — ⚠️ Partial
+
+External triggers fire runs (Osmani's "automations — the heartbeat").
+
+**What Loom has:**
+- ✅ Cron scheduler: `pkg/scheduler/` (robfig/cron, 5-field) triggers workflow executions on schedule, persisted in `scheduler.db`, wired into `looms serve`
+- ✅ API triggers: `Weave`/`StreamWeave` over gRPC/HTTP — any external system can fire a run
+- ✅ MCP bridge: `loom_weave` exposes the loop as an MCP tool to external clients (`pkg/mcp/server/bridge_tools.go`)
+- ✅ Durable suspend/resume: HITL gates raise `WorkflowSuspended` with a `WorkflowCheckpoint` (shared memory + stage outputs snapshotted); hosts persist it and later call `ResumeWorkflow` with a `GateDecision`; a workflow fingerprint check refuses resume against edited definitions (`pkg/orchestration/hitl_gate.go`, `resume.go`, `proto/loom/v1/orchestration.proto`) — long-lived loops survive process restarts
+- ✅ Inter-agent events: communication bus topics with auto-subscription; inbound messages injected into agent context
+
+**What Loom lacks:**
+- 📋 Webhook/event-source triggers (file watch, repo events, queue consumers) — cron and explicit API calls only
+- 📋 User-definable lifecycle hooks (deterministic pre/post-tool interception, as in Claude Code hooks); the guardrail engine and end-of-turn skill hygiene enforcer are internal, not user extension points
+
+### Loop 4: The Hill-Climbing Loop — ✅ Implemented offline, not closed
+
+"Traces from production runs feed an analysis agent that improves the harness config" (LangChain Loop 4). This is the frontier of the discipline ("Self-Harness" research, swyx's "go up a loop as models improve") — and Loom's strongest differentiator relative to other frameworks.
+
+**What Loom has:**
+- ✅ Traces → evals automatically: `EmbeddedTracer.spanToEvalRun` (`pkg/observability/embedded.go:282`) converts every root conversation span into an eval run
+- ✅ Prompt optimizers: MIPRO (`pkg/metaagent/teleprompter/mipro.go:56`), COPRO, BootstrapFewShot, TextGrad — judge-scored, DSPy-derived; TextGrad has a proto-level `AutoApplyMode` for applying optimized prompts (defaults to MANUAL)
+- ✅ Deployment metrics collection (`pkg/metaagent/learning/collector.go`)
+- ✅ Ground-truth loop observability: the context dumper (`pkg/agent/context_dump.go`) captures the exact `(messages, tools)` sent on every provider call as local JSONL (off by default, never exported) — the raw material for analyzing loop behavior offline
+
+**What Loom lacks:**
+- 📋 The loop around the loop is not closed: teleprompter runs are human-initiated, not scheduled; nothing automatically re-optimizes prompts/patterns from accumulated eval runs
+- ⚠️ Pattern effectiveness tracking is present but unwired: `PatternEffectivenessTracker` and `RecordPatternUsage` exist (`pkg/patterns/orchestrator.go:426`) and `PatternConfig.EnableTracking` defaults true, but **no production code calls the recording path** — pattern usage currently generates no learning signal
+
+### Cross-cutting: Osmani's six components
+
+| Component | Loom analogue | Status |
+|---|---|---|
+| Automations (triggers) | Cron scheduler, API/MCP triggers | ⚠️ cron + API only |
+| Worktrees (isolation) | Docker executor sandbox (`pkg/docker/executor.go`); ephemeral agents with per-parent cap and cost limits | ✅ |
+| Skills (codified knowledge) | `pkg/skills/`: 3-tier library, LLM-routed discovery index, ROM menu + pull-loaded bodies, end-of-turn hygiene auditor, hot reload, docs importer; skills reference patterns via `PatternRefs` | ✅ |
+| Plugins & connectors (MCP) | MCP client + server bridge (both directions) | ✅ |
+| Subagents | `manage_ephemeral_agents` tool — mid-loop spawn/despawn with per-parent cap and `cost_limit_usd` (`pkg/server/spawn_agent.go`); declarative workflows (pipeline, fork-join, debate, swarm) | ✅ |
+| External state | SQLite sessions, swap-layer "forever conversations", graph memory, shared memory store, task board (`pkg/agent/task_board_tool.go`, opt-in kanban with LLM decomposition) | ✅ |
+
+---
+
+## Principles Scorecard
+
+Synthesized principles from the literature, scored against Loom:
+
+| # | Principle (source) | Loom | Evidence |
+|---|---|---|---|
+| 1 | Own the control flow in code, not the model (12-Factor Agents) | ✅ | Framework owns loop, budgets, retries, HITL (`agent.go:2187`) |
+| 2 | Termination is a first-class design requirement — multiple independent exits (Masood) | ✅ | MaxTurns + MaxToolExecutions + per-turn MaxIterations + truncation-gated output-token breaker + failure escalation + forced synthesis + self-healing recovery tier; ⚠️ no cost ceiling |
+| 3 | Verification is the reward signal; prefer deterministic verifiers (Anthropic, LangChain) | ⚠️ | Workflow stages: output_schema + ValidationPrompt + OutputRetryPolicy ✅; agent loop: nothing 📋 |
+| 4 | Maker/checker split (Black Matter, Osmani) | ⚠️ | HITL gates = human checker; stage ValidationPrompt = LLM checker; no verifier-subagent primitive for the agent loop |
+| 5 | Pick loop-shaped problems: clear success criteria + trial-and-error (Willison) | ⚠️ | Skills/patterns encode problem shape; success criteria machine-checkable only at workflow-stage level (see #3) |
+| 6 | Externalize state; treat context as disposable (Huntley, Anthropic) | ✅ | SQLite sessions, swap layer, graph memory, shared memory, task board |
+| 7 | Manage the attention budget every iteration (Anthropic) | ✅ | Token counting, layered memory, pre-call enforcement, LLM compaction default-on, system-slot minimalism (ROM + L2 only) |
+| 8 | Single-threaded default; share full traces if parallel (Cognition) | ⚠️ | Single loop is the default ✅; multi-agent shares messages via bus, not full traces |
+| 9 | Sandbox + least privilege + scoped credentials (Willison) | ✅ | Docker executor, guardrails, `allow_code_execution`/`allowed_domains` config, high-risk skill approval gating |
+| 10 | Transactional, idempotent, auditable loop actions (Cockroach Labs) | ⚠️ | Every step persisted + span-traced; workflow checkpoints are fingerprint-verified; tool actions themselves have no idempotency/transaction contract |
+| 11 | Retries must adapt, not repeat (Masood) | ✅ | Consecutive-failure escalation in-loop; stage retries with feedback templates and FRESH/ESCALATE session modes |
+| 12 | Stay the engineer — observability against comprehension debt (Osmani) | ✅ | Span taxonomy per iteration/LLM/tool call; OTLP export with GenAI semconv (`pkg/observability/otel.go`); exact per-call context dumps (`context_dump.go`) |
+
+---
+
+## Gap Analysis and Recommendations
+
+Prioritized. Each follows "proto is law" — API surface changes start in `proto/loom/v1/`.
+
+### P0: Verification in the agent loop
+
+The single highest-leverage addition, and most of the machinery already exists one layer up in `pkg/orchestration`:
+
+1. Add a verification config to `BehaviorConfig` (proto), mirroring the stage-level surface: output schema, validation prompt, retry policy with feedback template
+2. On loop exit (the terminal check, before returning), run the verifier against the final response; on failure, re-enter the loop with a retry message that **explains why it failed and shows the expected form** — feedback-free retries just repeat the failure
+3. Concrete starting point: `OutputValidator.ValidateAndRetry` (`pkg/orchestration/output_validator.go`) already composes schema validation with retry-session modes but has no callers — wire it rather than writing new machinery
+4. Order verifiers by cost and determinism: schema validation → command execution (exit code) → LLM judge, per Anthropic's hierarchy
+
+### P1: Cost budget as a stop rule
+
+Cost per conversation is already computed for spans/metrics. Promote it to a loop guard alongside MaxTurns: `max_cost_usd` in `BehaviorConfig`, checked at the top of each iteration, with the same forced-synthesis exit. Ephemeral agents already have `cost_limit_usd`, and `eval.proto` already models `max_cost_usd` for offline evals — this closes the gap for the primary loop. Directly addresses the discipline's most-cited operational failure (silent cost blowup; agent loops ≈ 4x chat token burn).
+
+### P1: Re-wire pattern effectiveness recording
+
+`RecordPatternUsage` and `PatternEffectivenessTracker` exist but nothing calls them since pattern loading moved to the `load_pattern` tool. Without this signal, pattern usage generates no learning data and Loop 4 has a blind spot. The natural hook is the `load_pattern` tool handler plus end-of-conversation outcome attribution.
+
+### P2: Maker/checker as a first-class pattern
+
+A verifier-subagent template: ephemeral agent spawned with the output to check, different prompt (and optionally different model), returning pass/fail + critique. The spawn machinery and collaboration patterns already exist; this is a template plus a documented convention, not new infrastructure. HITL gates already cover the human-checker variant at workflow level.
+
+### P2: Close the hill-climbing loop
+
+Schedule teleprompter/analysis runs via the existing cron scheduler: accumulate eval runs (already automatic via `spanToEvalRun`) → periodic optimization pass → propose prompt/pattern updates gated by a HITL gate (dogfooding the workflow machinery). `AutoApplyMode` already exists in proto for TextGrad (default MANUAL) — the missing piece is the trigger and the approval flow, not the optimizer.
+
+### P2: Loop-config fingerprint on spans
+
+Harness-Bench's conclusion is that results are only meaningful at the model+harness configuration level. Record the loop configuration (max_turns, max_tool_executions, compaction profile, verification config, skill/pattern bindings) as attributes on the root conversation span — the OTel attribute mapping (`otel_attrs.go`) already forwards unknown keys with a `loom.` prefix, so eval runs become attributable to a specific loop design and A/B-ing loop changes works with existing infrastructure.
+
+### P3: Event-source triggers and lifecycle hooks
+
+Webhook/queue/file-watch trigger sources for the scheduler; user-definable pre/post-tool hooks as a guardrail-engine extension point. Lower priority: the API-trigger path already covers most integration needs.
+
+---
+
+## References
+
+**Coinage and discipline:**
+- Osmani, "Loop Engineering" — [O'Reilly Radar](https://www.oreilly.com/radar/loop-engineering/) (June 2026)
+- LangChain, "The Art of Loop Engineering" — [langchain.com](https://www.langchain.com/blog/the-art-of-loop-engineering) (June 2026)
+- swyx, "Loopcraft: The Art of Stacking Loops" — [latent.space](https://www.latent.space/p/loopcraft) (June 2026)
+- Masood, "Loop Engineering: A Guide for Engineers and Practitioners" — [Medium](https://medium.com/@adnanmasood/loop-engineering-a-guide-for-engineers-and-practitioners-893bb65ea943) (June 2026)
+
+**Precursors (the substance):**
+- Anthropic, "Building Effective Agents" — [anthropic.com](https://www.anthropic.com/engineering/building-effective-agents) (Dec 2024)
+- Anthropic, "Effective Context Engineering for AI Agents" — [anthropic.com](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) (Sept 2025)
+- Anthropic, "Building Agents with the Claude Agent SDK" — [claude.com](https://claude.com/blog/building-agents-with-the-claude-agent-sdk) (Sept 2025)
+- Willison, "Designing Agentic Loops" — [simonwillison.net](https://simonwillison.net/2025/Sep/30/designing-agentic-loops/) (Sept 2025)
+- Cognition, "Don't Build Multi-Agents" — [cognition.com](https://cognition.com/blog/dont-build-multi-agents) (June 2025)
+- HumanLayer, "12-Factor Agents" (2025)
+
+**Evaluation and criticism:**
+- Harness-Bench — [arXiv:2605.27922](https://arxiv.org/abs/2605.27922) (May 2026)
+- "When Agents Do Not Stop: Uncovering Infinite Agentic Loops in LLM Agents" — [arXiv:2607.01641](https://arxiv.org/abs/2607.01641) (July 2026)
+- Hagoel, "Loop Engineering Minus the Hype" — [dev.to](https://dev.to/isaachagoel/loop-engineering-minus-the-hype-4ibn) (July 2026)
+- Cockroach Labs, "Agent Loops: Production Database Patterns" — [cockroachlabs.com](https://www.cockroachlabs.com/blog/agent-loops-production-database-patterns/) (July 2026)

--- a/docs/plans/loop-engineering-roadmap-spec.md
+++ b/docs/plans/loop-engineering-roadmap-spec.md
@@ -1,0 +1,391 @@
+# Loop Engineering Roadmap — Specification
+
+**Status**: 📋 Proposed (nothing in this document is implemented yet)
+**Baseline**: `main` @ `68208a0a` (v1.3.0)
+**Source analysis**: [docs/architecture/loop-engineering.md](../architecture/loop-engineering.md)
+**Scope**: P0–P3 roadmap closing the gaps identified in the loop-engineering fit/gap analysis. Every claim about existing code below was verified against the baseline commit.
+
+This is the *what* (contracts, semantics, proto surfaces). The *how* (step ordering, file-level changes, test matrices) lives in the implementation plan. All proto changes are append-only; field numbers stated here are verified free at the baseline and are binding.
+
+---
+
+## Contents
+
+1. [P0 — Final-output verification in the agent loop](#p0--final-output-verification-in-the-agent-loop)
+2. [P1a — Per-conversation cost ceiling](#p1a--per-conversation-cost-ceiling)
+3. [P1b — Pattern effectiveness recording](#p1b--pattern-effectiveness-recording)
+4. [P2c — Loop-config fingerprint](#p2c--loop-config-fingerprint)
+5. [P2a — Verifier subagent (maker/checker)](#p2a--verifier-subagent-makerchecker)
+6. [P2b — TeleprompterService and scheduled optimization](#p2b--teleprompterservice-and-scheduled-optimization)
+7. [P3 — Webhook triggers and lifecycle hooks](#p3--webhook-triggers-and-lifecycle-hooks)
+8. [Compatibility](#compatibility)
+
+---
+
+## P0 — Final-output verification in the agent loop
+
+### Proto
+
+```proto
+// agent_config.proto (new import: loom/v1/collaboration.proto)
+message BehaviorConfig {
+  // ... existing fields 1-8 unchanged ...
+
+  // Verifies the final assistant output of a conversation before it is
+  // returned to the caller. In this (agent-loop) context only output_schema
+  // and acceptance_criteria are honored. validator_agent_id and
+  // judge_config_id are workflow-only and are REJECTED at config load.
+  // retry_policy.session_mode must be CONTINUE or unspecified
+  // (unspecified maps to CONTINUE); FRESH and ESCALATE are REJECTED.
+  // Retries are capped at min(retry_policy.max_retries, 10).
+  OutputPolicy output_policy = 9;
+}
+```
+
+`OutputPolicy`, `OutputRetryPolicy`, and `RetrySessionMode` are the existing messages in `collaboration.proto` (same `loom.v1` package); no new sibling messages.
+
+### Runtime semantics
+
+1. **Trigger point.** Verification runs when the conversation loop reaches a terminal response (no tool calls), after the empty-response nudge and end-of-turn skill hygiene, immediately before the response is returned. The forced-synthesis output produced on budget exhaustion is **never** verified.
+2. **Verifier order** (cost/determinism hierarchy):
+   a. `output_schema` — JSON Schema validation (gojsonschema) against JSON extracted from the response text. Deterministic, no LLM call.
+   b. `acceptance_criteria` — one no-tools LLM call using the agent's own provider. The evaluation prompt is task-oriented (no role prompting), supports the documented `{{output}}` placeholder, and demands a strict first-line verdict: `PASS` or `FAIL: <reason>`. Runs only if (a) passed or no schema is set. The evaluation call is **never streamed to the client**: it runs with the progress callback stripped from its context, and a self-correction progress event marks each retry injection so streaming clients get a semantic boundary between rejected and replacement generations.
+3. **On failure**: a feedback message (role `user`) is injected into the session and the loop continues. The feedback includes the failure reason, the truncated previous output (≤500 chars), and the schema or criteria text. `retry_policy.feedback_template` overrides the default; supported variables: `{{error}}`, `{{previous_output}}`, `{{attempt}}`, `{{max_retries}}`. `cooldown_ms` waits are context-aware (cancellation aborts the wait).
+4. **On exhaustion**: graceful degradation. The last output is returned unchanged with failure metadata — verification never turns a completed conversation into an error.
+5. **Fail-open judge**: a malformed verdict (neither `PASS` nor `FAIL:` on the first line) does not burn a retry; the response is returned with `output_verification: "judge_inconclusive"`.
+6. **Content is validated, never rewritten.** Prose-plus-JSON responses are legal; machine consumers extract downstream.
+7. **Budget interaction**: verification retries consume conversation turns; `max_turns` bounds total work. If the loop budget trips during verification retries, the synthesized response carries `output_verification: "skipped_budget_exhausted"`.
+8. **Layering with workflows**: `behavior.output_policy` applies to *every* Chat, including pipeline stage executions and each stage retry — nesting it inside stage-level `output_schema`/`validation_prompt`/`retry_policy` multiplies retries and judge cost. Guidance: set one layer, not both (or keep the schemas identical).
+
+### Config-load validation (hard errors, not warnings)
+
+| Field | Rule |
+|---|---|
+| `validator_agent_id`, `judge_config_id` | Rejected: "not supported in behavior.output_policy; use workflow-level OutputPolicy" |
+| `retry_policy.session_mode` = FRESH or ESCALATE | Rejected: the live conversation is the session; only CONTINUE semantics exist in-loop |
+| `retry_policy.max_retries` > 10 | Clamped to 10 |
+
+### Response metadata contract
+
+| Key | Values |
+|---|---|
+| `output_verification` | `passed` \| `failed` \| `judge_inconclusive` \| `skipped_budget_exhausted` |
+| `output_verification_attempts` | int |
+| `output_verification_error` | last failure string (only when `failed`) |
+
+### Observability contract
+
+Span events: `output_verification.retry_injected`, `output_verification.passed`, `output_verification.exhausted`, `output_verification.judge_inconclusive`. Span attributes: `verification.attempts`, `verification.outcome`; root attribute `config.output_verification` (bool).
+
+### YAML example
+
+```yaml
+behavior:
+  output_policy:
+    output_schema: |
+      {"type": "object", "required": ["answer", "confidence"]}
+    acceptance_criteria: "The answer cites at least one table name from the schema."
+    retry_policy:
+      max_retries: 2
+      cooldown_ms: 500
+```
+
+### Shared code consequence
+
+A new leaf package `pkg/validation/output` (JSON extraction, schema validation, feedback building, verdict parsing) becomes the single implementation used by both the pipeline executor and the agent loop. The dead `pkg/orchestration/output_validator.go` (zero callers, zero tests) is deleted.
+
+---
+
+## P1a — Per-conversation cost ceiling
+
+### Proto
+
+```proto
+// agent_config.proto
+message BehaviorConfig {
+  // ... fields 1-9 ...
+
+  // Maximum estimated LLM spend (USD) for one conversation
+  // (one Chat invocation), 0 = disabled. Cost values are best-effort
+  // estimates from the pricing catalog; Bedrock prices vary by region.
+  // The limit may overshoot by up to one turn plus one synthesis call.
+  double max_cost_usd = 10;
+}
+```
+
+### Runtime semantics
+
+1. **Scope**: one conversation loop invocation — *not* session-lifetime spend (`Session.TotalCostUSD` continues to accumulate independently).
+2. **Accumulation**: every main-loop LLM call adds its `Usage.CostUSD` to a conversation total — including empty-nudge, hygiene, P0 verification-eval calls, and **L2 compression calls** (which grow on exactly the long conversations the ceiling targets). Background graph-memory extraction is **excluded** (asynchronous, post-turn) and documented as such.
+3. **Enforcement**: checked in the loop guard alongside `max_turns`/`max_tool_executions`. The loop is never broken mid-iteration (that would split assistant/tool_result pairing); enforcement happens at the top of the next iteration.
+4. **On trip**: the loop exits into the existing forced tools-disabled synthesis call, so the caller always receives a coherent text answer. The synthesis call's own cost is added to the reported total (the documented overshoot).
+5. **Zero-cost providers** (e.g., Ollama) report `CostUSD == 0` and never trip the limit. When `max_cost_usd > 0` and a turn reports zero cost, a debug log flags possible undercounting (streaming Usage propagation is provider-dependent).
+6. **Sub-agents budget independently**: agents spawned via `manage_ephemeral_agents` run their own conversations — each bus message they process gets a fresh budget, and the parent's `max_cost_usd` does not aggregate their spend. (`EphemeralAgentPolicy.cost_limit_usd` covers only the swarm spawn path.)
+
+### Metadata / observability contract
+
+`total_cost_usd` (all exit paths) and `cost_limit_hit: true` (trip only) in response metadata and the `conversation.completed` event; span event `cost_budget.exceeded {total_cost_usd, max_cost_usd, turns}`; root attribute `config.max_cost_usd`; metric `agent.conversations.cost_limit_hit`.
+
+---
+
+## P1b — Pattern effectiveness recording
+
+No proto change. Re-wires the existing, currently caller-less `patterns.Orchestrator.RecordPatternUsage` → `PatternEffectivenessTracker` pipeline to the `load_pattern` era.
+
+### Semantics
+
+1. **Recording a load**: when `load_pattern` successfully loads a pattern inside a conversation (session identity present in tool context), the canonical `pattern.Name` is recorded against the session (deduplicated; aliases aggregate under the canonical name). Loads outside a conversation are silently not recorded and do not affect the tool result.
+2. **Attribution window**: per Chat invocation, drain-on-read — each recorded pattern is attributed exactly once, at the end of the Chat that follows its load.
+3. **Outcome attribution**: each pattern loaded during the conversation receives one `RecordPatternUsage` call carrying the **whole-conversation** outcome:
+   - `success` = Chat returned without error AND the final output was not `output_verification: failed/exhausted` AND the cost ceiling did not trip (P0/P1a metadata folds into the flag)
+   - `costUSD` = conversation total (P1a metadata) when available, else final-call cost (documented degraded fallback)
+   - `latency` = Chat wall time; `errorType` ∈ {`""`, `timeout`, `canceled`, `llm_error`}
+   - live `llmProvider`/`llmModel` (fixes the historical hardcoding defect)
+4. **Gate**: `patterns.enable_tracking` (existing config, default true; already fully plumbed proto→YAML→registry).
+5. **Documented caveat**: when multiple patterns are loaded in one conversation, each receives the full conversation cost — summing cost across patterns double-counts. The stored metric answers "what do conversations using this pattern cost/succeed like," not "what did this pattern cost."
+6. **Concurrency caveat**: concurrent Chats on the *same session* produce best-effort attribution — drain-on-read means patterns attribute to whichever Chat drains first. Race-safe; documented.
+
+Downstream storage and bus publication are unchanged (existing `pattern_effectiveness` SQLite table; `meta.pattern.effectiveness` topic). New span event: `pattern.effectiveness_recorded {patterns, success, cost_usd}`.
+
+---
+
+## P2c — Loop-config fingerprint
+
+No proto change.
+
+### Contract
+
+Every root conversation span carries:
+
+- `config.loop_fingerprint` = `"v1:" + hex(sha256(sorted key=value lines))` over an **explicit, versioned field list**: `MaxTurns`, `MaxToolExecutions`, `MaxIterations`, `OutputTokenCBThreshold`, `MaxContextTokens`, `ReservedOutputTokens`, `EnableSelfHealing`, retry-policy scalars, `MaxCostUSD` (P1a), and the output-verification fields (P0).
+- Individual attributes for fields not already emitted: `config.max_iterations`, `config.max_context_tokens`, `config.self_healing`, `config.retry_max_attempts`, `config.output_token_cb_threshold`.
+
+Rules:
+
+1. **Model/provider are excluded** — they are already separate span attributes. Harness-Bench-style attribution = model attrs + loop fingerprint together.
+2. **Versioning**: any change to the field list bumps the version prefix (`v2:` …). Fingerprints with different versions are never comparable.
+3. **Effective values**: computed lazily at first chat (post config-loader defaulting), cached per agent. A config built through the loader and one with identical explicit values MUST produce identical fingerprints.
+4. **Zero downstream wiring**: the attribute flows to OTLP as `loom.config.loop_fingerprint` (automatic unmapped-key prefixing) and into `EvalRun.ConfigurationJSON` (spanToEvalRun marshals all span attributes). Eval runs become attributable to a specific loop design; A/B-ing loop changes uses existing infrastructure.
+
+---
+
+## P2a — Verifier subagent (maker/checker)
+
+Three deliverables: one behavior fix, one template, one documented convention.
+
+### Spawn `initial_message` delivery (behavior fix)
+
+Current behavior: `manage_ephemeral_agents(spawn).initial_message` is stored in metadata and never delivered. New contract:
+
+1. If `auto_subscribe` is non-empty, `initial_message` is published to the **first successfully subscribed** topic immediately after subscriptions are registered (registration is synchronous inside SpawnSubAgent, before the child loop starts — buffered channels make publish-after-subscribe race-free; subscribe failures are tolerated per topic, so the target is `subscribedTopics[0]`, and all-subscriptions-failed with an initial_message is an error, not silence). `FromAgent` = parent agent ID, so the child's self-echo filter does not suppress it.
+2. `initial_message` without `auto_subscribe` → `InvalidArgument` ("initial_message requires auto_subscribe"). No silent drop. **Behavior change** (today the message is silently stored in metadata) — called out in CHANGELOG.
+3. Documented limitations (pre-existing, not new): the spawned-agent loop services only its first subscription; delivery is asynchronous and advisory (parent does not block on a reply); 10 spawns per parent.
+
+### Verifier template
+
+`examples/reference/agent-templates/verifier.yaml` — `kind: AgentTemplate`, `extends: base-expert`. Parameters: `artifact_description`, `verification_criteria`, `output_contract`. Task-oriented system prompt (no role prompting) requiring the strict verdict contract:
+
+```json
+{
+  "passed": false,
+  "critique": "one-paragraph summary",
+  "violations": [
+    {"criterion": "…", "severity": "BLOCKER|MAJOR|MINOR", "detail": "…"}
+  ]
+}
+```
+
+Checker discipline: `temperature: 0.1`, `max_turns: 3`, and an **empty tool set** (a pure checker reads; it does not act). Note: `max_tool_executions: 0` cannot express this — proto3 zero-values are rewritten to the default (50) by config mapping, and a true 0 would prevent the loop from running.
+
+### Maker/checker conventions (documented in docs/guides/maker-checker.md)
+
+- **Synchronous gating** → pipeline variant: maker stage → checker stage with `output_schema` enforcing the verdict JSON and a stage `retry_policy` routing the critique back into the maker's retry prompt. Expressible entirely with existing PipelineStage fields.
+- **Advisory checks** → ephemeral variant: spawn the verifier with `auto_subscribe` + `initial_message` (works after the fix above); verdict arrives on the shared topic.
+- Known limitation stated: the preset/policy-template spawn path is unwired at baseline and out of scope.
+
+---
+
+## P2b — TeleprompterService and scheduled optimization
+
+Fixes a real defect — the CLI targets `loomv1.TeleprompterServiceClient`, but **no server implementation exists**; additionally there is **no learned-layer runtime at all** (`teleprompter.Memory` has no production implementation and `getSystemPrompt` has no injection point). Two PRs.
+
+### PR 1 — Service + durable learned layer
+
+**Proto (teleprompter.proto):**
+
+```proto
+message CompileRequest {
+  // ... fields 1-6 ...
+  AutoApplyMode apply_mode = 7;  // UNSPECIFIED => MANUAL
+}
+
+enum CompilationStatus {
+  COMPILATION_STATUS_UNSPECIFIED = 0;
+  COMPILATION_STATUS_PENDING = 1;
+  COMPILATION_STATUS_APPLIED = 2;
+  COMPILATION_STATUS_REJECTED = 3;
+  COMPILATION_STATUS_ROLLED_BACK = 4;
+  COMPILATION_STATUS_DRY_RUN = 5;
+}
+
+message CompilationResult {
+  // ... fields 1-15 ...
+  CompilationStatus status = 16;
+}
+
+message GetCompilationHistoryRequest {
+  // ... fields 1-3 ...
+  CompilationStatus status_filter = 4;
+}
+```
+
+**Durable store** (SQLite, WAL): `compilations` (history; `result_json` = protojson of CompilationResult) and `learned_layers` (exactly one active layer per agent = truth). Learned layers survive restart.
+
+**Learned-layer application semantics** (normative):
+
+1. The active learned layer is appended to the agent's system prompt as a supplement — it **never replaces** the configured prompt. Demonstrations render as a few-shot block.
+2. **Applies at session ROM build — creation, or restore after a server restart.** The system prompt is baked into per-session ROM (deliberately byte-stable for provider prompt caching); session *restore* re-renders ROM, so restarted servers rebuild in-flight sessions with the then-active layer. This is a documented property, not "hot reload."
+3. The learned version is **stamped on the session at ROM render time**, and that per-session stamp — never the store's current active version — is emitted as `config.learned_version` on conversation spans (ties into P2c for before/after attribution; guarantees the span never disagrees with the ROM actually in use).
+4. Rollback restores a prior compilation's layer transactionally; the displaced compilation is marked `ROLLED_BACK`.
+
+**RPC semantics:**
+
+| RPC | Behavior |
+|---|---|
+| `Compile` | Validates (agent exists, trainset non-empty, cap ~200 examples, per-compile timeout, one in-flight compile per agent). Optimizers: BootstrapFewShot, MIPRO; others → `Unimplemented` with supported list. Metrics: MultiJudge (`FailedPrecondition` without judge orchestrator), ExactMatch; others → `InvalidArgument`. Compile-time prompt candidates run on **one agent instance per candidate** (non-registering construction, in-memory memory — compile sessions never touch production storage) with a **fresh session per example**, flowing through the same injection path as production; the live agent is never mutated during compile. Examples execute **real tools** — read-only agents/backends are the recommended optimization targets. |
+| apply modes | `MANUAL` → result saved `PENDING` (nothing applied). `DRY_RUN` → report only. `VALIDATED` → applied iff devset score does not regress, else `PENDING`; **`VALIDATED` with no devset → `InvalidArgument`**. `AUTONOMOUS` → applied immediately. |
+| `GetCompilationHistory` | Paginated, honors `status_filter`. |
+| `RollbackCompilation` | Target must belong to the agent; applies target layer, marks previous `ROLLED_BACK`. |
+| `CompareCompilations` | Runs the testset through both layers with the requested metric; fills the comparison including paired-sign-test significance. |
+
+TextGrad remains local/CLI-only (its DRY_RUN/AUTONOMOUS stubs are out of scope and stay documented as such).
+
+### PR 2 — Scheduling + approval
+
+**Proto:**
+
+```proto
+// teleprompter.proto
+rpc ApplyCompilation(ApplyCompilationRequest) returns (ApplyCompilationResponse);
+rpc RejectCompilation(RejectCompilationRequest) returns (RejectCompilationResponse);
+
+// orchestration.proto
+message ScheduledWorkflow {
+  // ... fields 1-12 ...
+  ScheduledJobType job_type = 13;          // UNSPECIFIED = workflow (back-compat)
+  OptimizationJobSpec optimization = 14;
+}
+
+message OptimizationJobSpec {
+  string agent_id = 1;
+  TeleprompterType teleprompter = 2;
+  TeleprompterConfig config = 3;
+  MetricConfig metric = 4;
+  string trainset_path = 5;      // JSONL
+  string eval_suite_path = 6;    // alternative source
+  string devset_path = 7;
+  AutoApplyMode apply_mode = 8;  // AUTONOMOUS is REJECTED for scheduled jobs
+  string notify_topic = 9;       // default "loom.optimization.completed"
+}
+```
+
+**Semantics:**
+
+1. **Back-compat is absolute**: `job_type` unset behaves byte-for-byte like today's workflow scheduling. The loader continues to key on `schedule:` presence; the optimization section is additive.
+2. Scheduled runs call Compile in-process and publish `{compilation_id, agent_id, trainset_score, devset_score, status}` to `notify_topic`.
+3. **No unattended prompt mutation**: scheduled jobs may use `MANUAL` or `VALIDATED` only; `AUTONOMOUS` is rejected at schedule validation.
+4. **Approval**: `ApplyCompilation`/`RejectCompilation` transition `PENDING` results only (`FailedPrecondition` otherwise); CLI gains `pending`/`apply`/`reject`. A contact_human approver-agent pattern is documented but not built.
+5. **Explicitly deferred**: mining accumulated eval runs as trainsets (the observability eval-run store is write-only). Follow-up: `ListEvalRuns` + an `eval_runs` trainset source. Trainset v1 = JSONL and eval-suite YAML.
+
+---
+
+## P3 — Webhook triggers and lifecycle hooks
+
+User decision: declarative config policies + bus events. **No arbitrary command execution.**
+
+### Proto
+
+```proto
+// agent_config.proto
+message AgentConfig {
+  // ... fields 1-20 ...
+  HooksConfig hooks = 21;
+}
+
+message HooksConfig {
+  repeated ToolHookRule pre_tool_use = 1;
+  repeated ToolHookRule post_tool_use = 2;
+  LifecycleEventsConfig events = 3;
+}
+
+message ToolHookRule {
+  string name = 1;          // rule identifier (appears in logs/events/deny messages)
+  string tool_matcher = 2;  // glob over tool name
+  HookAction action = 3;    // ALLOW | DENY | WARN
+  string reason = 4;
+  bool emit_event = 5;
+  string topic = 6;         // override event topic
+}
+
+message LifecycleEventsConfig {
+  optional bool enabled = 1;      // default false
+  string topic_prefix = 2;        // default "loom.lifecycle"
+  bool include_arguments = 3;     // default false (privacy)
+  repeated string emit = 4;       // "tool.pre" | "tool.post" | "turn.completed" | "conversation.completed"
+}
+
+// orchestration.proto
+message ScheduleConfig {
+  // ... fields 1-7 ...
+  WebhookTrigger webhook = 8;
+}
+
+message WebhookTrigger {
+  string path = 1;             // suffix under /v1/webhooks/
+  string hmac_secret_env = 2;  // NAME of env var holding the secret — never a literal
+  map<string, string> variable_mapping = 3;  // schedule variable <- JSON body field
+  bool skip_if_running = 4;
+}
+```
+
+Plus a `LifecycleEvent` bus payload message: `agent_id, session_id, event_type, tool_name, duration_ms, success, error (truncated), arguments_json (only when include_arguments)`.
+
+### Hook semantics (normative)
+
+1. **Evaluation**: ordered rules, first match wins, default ALLOW when no rule matches or no config present.
+2. **Placement and restrictiveness**: pre-hooks run before circuit breaker and executor dispatch. Hooks are **restrict-only** — a hook ALLOW never bypasses the executor-level permission checker or circuit breakers; DENY short-circuits before them. Post-hooks run after execution and may only WARN/emit (no retroactive deny).
+3. **DENY is model-visible but is not a failure**: the tool call returns a structured error — `tool <name> denied by policy '<rule>': <reason>` — never a silent drop, but it is classified **`policy_denied`** for analytics (message aligned with the migration-000018 outcome patterns) and does **not** feed the circuit breaker or guardrail failure tracking (an open breaker would replace the actionable policy reason with an opaque error).
+4. Tools matched by an **unconditional DENY** rule are hidden from tool advertisement (consistent with the disabled-tools discovery filter) so the model does not burn turns calling them.
+5. **WARN**: log + span event, execution proceeds.
+6. A configuration whose first matching rule set denies everything (catch-all DENY) produces a startup warning.
+
+### Lifecycle events
+
+Published to `<topic_prefix>.<event_type>` only for event types in the explicit `emit` list (`enabled` default false — no firehose). Tool arguments are excluded unless `include_arguments: true`; errors are truncated. Publish failures are logged and never fail the tool call or turn.
+
+### Webhook endpoint
+
+`POST /v1/webhooks/<path>` on the existing HTTP server (registered before the grpc-gateway catch-all).
+
+| Aspect | Contract |
+|---|---|
+| Auth | HMAC-SHA256 over **`timestamp + "." + rawBody`** (Stripe/Slack scheme — the timestamp is covered by the MAC, so a captured pair cannot be replayed with a fresh timestamp) with the secret from `hmac_secret_env`; headers `X-Loom-Signature` (hex) + `X-Loom-Timestamp`; constant-time compare |
+| Freshness | timestamp within ±5 minutes; replayed signatures within the window rejected (LRU) |
+| Resolution | `path → schedule` resolved **dynamically per request** (schedules mutate at runtime via RPCs and YAML hot-reload); path collisions rejected at schedule create/update; removed schedule → 404; per-schedule replay/rate-limit state is lifecycle-managed |
+| Scheduling | cron is **optional** when a webhook trigger is present — webhook-only schedules are valid |
+| Limits | 1 MiB body cap enforced before read; per-hook rate limit → 429 |
+| Missing secret env | hook **disabled**; requests → 503 (auth is never skipped) |
+| Success | body fields mapped per `variable_mapping` → `scheduler.TriggerNow` → `202 {execution_id}`; **variables are interpolated into stage prompt templates** before pattern execution (P3 completes the scheduler's existing variable-interpolation TODO — `variable_mapping` is not inert config) |
+| Failures | 401 bad/stale/replayed signature; 404 unknown path; 405 non-POST; 413 oversize |
+| Privacy | request body and signatures never logged or echoed |
+
+Out of scope (stated in docs): queue consumers and file-watch trigger sources.
+
+---
+
+## Compatibility
+
+- All proto changes are **append-only**; every phase independently passes `buf breaking` against `main`. Field allocations are binding: `BehaviorConfig.output_policy = 9`, `BehaviorConfig.max_cost_usd = 10`, `AgentConfig.hooks = 21`, `ScheduleConfig.webhook = 8`, `ScheduledWorkflow.job_type = 13` / `optimization = 14`, `CompileRequest.apply_mode = 7`, `CompilationResult.status = 16`, `GetCompilationHistoryRequest.status_filter = 4`.
+- All new behavior is **opt-in and default-off**: no output_policy → no verification; `max_cost_usd = 0` → no ceiling; no hooks config → all tools allowed, no events; no webhook config → no endpoint for that schedule; `job_type` unset → workflow scheduling unchanged; no applied compilation → system prompts unchanged.
+- Landing order: P0 → P1a → P1b → P2c → P2a → P2b-1 → P2b-2 → P3. Later phases reference earlier metadata (`total_cost_usd`, fingerprint fields) with documented fallbacks, so no phase hard-depends on another except P2b-2 on P2b-1.
+- Each phase flips its section of `docs/architecture/loop-engineering.md` from 📋/⚠️ to ✅ — that document is the roadmap's scoreboard.


### PR DESCRIPTION
## Summary

Phase 0 of the loop-engineering roadmap: adds the analysis document and the normative spec that the subsequent implementation PRs (P0–P3) execute against.

- **docs/architecture/loop-engineering.md** — fit/gap analysis of Loom's loop anatomy (main @ 68208a0a, v1.3.0) against the loop-engineering discipline: the four-loop model, a 12-principle scorecard with verified `file:line` evidence, and prioritized recommendations. Serves as the roadmap scoreboard — each implementation PR flips its section from 📋/⚠️ to ✅.
- **docs/plans/loop-engineering-roadmap-spec.md** — normative spec: proto surfaces with binding field numbers (all verified free, all append-only), runtime semantics, metadata/observability contracts, and compatibility rules. Status: 📋 Proposed.

## Provenance

The roadmap was refined through: full anchor re-verification against `68208a0a`, plus two independent review passes (adversarial design + runtime-integration seams) whose findings — including two blockers (webhook HMAC timestamp signing; inert `variable_mapping`) — are folded into the spec.

## Roadmap (implemented in follow-up PRs)

| Phase | Scope |
|---|---|
| P0 | Final-output verification in the agent loop (`behavior.output_policy`) |
| P1a | `max_cost_usd` per-conversation stop rule |
| P1b | Re-wire pattern effectiveness recording |
| P2c | Loop-config fingerprint on root spans |
| P2a | Verifier subagent template + spawn `initial_message` fix |
| P2b | TeleprompterService + durable learned layer + scheduled optimization |
| P3 | Webhook triggers + config-driven lifecycle hooks |

Docs-only change; no code, no proto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)