### PR TITLE
fix(agent): accept canonical fork-join pattern type in workflow loader

### DIFF
--- a/pkg/agent/config_loader.go
+++ b/pkg/agent/config_loader.go
@@ -1426,7 +1426,7 @@ func loadOrchestrationWorkflow(path string, data map[string]interface{}, llmProv
 			agentIDs = append(agentIDs, moderator)
 		}
 
-	case "fork_join", "parallel":
+	case "fork-join", "parallel":
 		if ids, ok := spec["agent_ids"].([]interface{}); ok {
 			for _, id := range ids {
 				if idStr, ok := id.(string); ok {

--- a/pkg/agent/config_loader_workflow_test.go
+++ b/pkg/agent/config_loader_workflow_test.go
@@ -6,6 +6,7 @@
 package agent
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -153,4 +154,76 @@ spec:
 
 	t.Logf("✓ Coordinator: %s", coordinator.Name)
 	t.Logf("✓ Sub-agents: %v", expectedSubAgents)
+}
+
+// TestLoadWorkflowAgents_ForkJoinPatternType verifies the registry loader accepts the
+// canonical hyphenated spelling used by the workflow validator, the canonical converter
+// and Weaver's template emitter. The underscored fork_join form is an internal Go and
+// proto identifier, not part of the YAML vocabulary, and is rejected.
+func TestLoadWorkflowAgents_ForkJoinPatternType(t *testing.T) {
+	const workflowTemplate = `apiVersion: loom/v1
+kind: Workflow
+metadata:
+  name: test-forkjoin
+  description: Test fork-join workflow
+spec:
+  type: %s
+  agent_ids:
+    - agent-a
+    - agent-b
+  prompt: 'Research the target: {{input}}'
+  merge_strategy: summary
+`
+
+	tests := []struct {
+		name        string
+		patternType string
+		wantErr     string
+	}{
+		{
+			name:        "canonical hyphenated form loads",
+			patternType: "fork-join",
+		},
+		{
+			name:        "internal underscored form is rejected",
+			patternType: "fork_join",
+			wantErr:     "unsupported workflow pattern type: fork_join",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workflowPath := filepath.Join(t.TempDir(), "test-forkjoin.yaml")
+			workflowYAML := fmt.Sprintf(workflowTemplate, tt.patternType)
+			require.NoError(t, os.WriteFile(workflowPath, []byte(workflowYAML), 0600))
+
+			configs, err := LoadWorkflowAgents(workflowPath, &mockLLMProvider{})
+
+			if tt.wantErr != "" {
+				require.Error(t, err, "expected %q to be rejected", tt.patternType)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+
+			var coordinator *loomv1.AgentConfig
+			subAgents := make(map[string]*loomv1.AgentConfig)
+			for _, config := range configs {
+				if config.Metadata["role"] == "coordinator" {
+					coordinator = config
+					continue
+				}
+				subAgents[config.Name] = config
+			}
+
+			require.NotNil(t, coordinator, "no coordinator generated")
+			assert.Equal(t, "test-forkjoin", coordinator.Name)
+			assert.Equal(t, "fork-join", coordinator.Metadata["pattern"])
+
+			require.Len(t, subAgents, 2)
+			assert.Contains(t, subAgents, "test-forkjoin:agent-a")
+			assert.Contains(t, subAgents, "test-forkjoin:agent-b")
+		})
+	}
 }


### PR DESCRIPTION
## Description

The agent registry loader and the canonical workflow parser disagreed on the spelling of the fork-join pattern type, so **no spelling was accepted by both paths**:

- `fork-join` — accepted by the validator and canonical converter, **rejected by the registry loader**
- `fork_join` — accepted by the registry loader, **rejected by the canonical converter**

`loadOrchestrationWorkflow` in `pkg/agent/config_loader.go:1429` matched only the internal underscored spelling `fork_join`, while the documented hyphenated form is used by:

- `pkg/orchestration/workflow_config.go:167` (valid types list) and `:192` (`case "fork-join":`)
- `pkg/validation/validator.go:385` (valid patterns list)
- `pkg/shuttle/builtin/agent_management_templates.go:416` (`spec["type"] = "fork-join"`), with `:377` documenting *"spec.type uses hyphenated pattern names (e.g. `fork-join`, not `fork_join`)"*

**Consequence:** canonical fork-join workflows — including every workflow generated by Weaver's `apply_template` — were reported valid by `looms workflow validate` but silently skipped by the agent registry at startup and on hot reload. Their coordinator and namespaced sub-agent configs were never registered. The error was logged at ERROR level and execution continued, so users were told the workflow was valid while it remained unavailable.

This also affected Loom's own shipped reference material: `examples/reference/workflows/workflow-all-fields-reference.yaml` uses `type: fork-join` at lines 302, 361 and 372, and the server copies `examples/` into `$LOOM_DATA_DIR/examples` on every startup.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] 🧪 Test update
- [ ] 🏗️ Infrastructure/Build change

## Related Issues

No tracking issue was filed — the full root-cause analysis is inline in this description.

## Changes Made

- `pkg/agent/config_loader.go:1429` — changed `case "fork_join", "parallel":` to `case "fork-join", "parallel":` so the registry loader accepts the canonical spelling.
- `pkg/agent/config_loader_workflow_test.go` — added `TestLoadWorkflowAgents_ForkJoinPatternType`, a table-driven regression test asserting that canonical `fork-join` loads (coordinator registered with `pattern` metadata `fork-join`, both sub-agents namespaced as `test-forkjoin:agent-a` / `test-forkjoin:agent-b`) and that `fork_join` returns `unsupported workflow pattern type: fork_join`.

### Why match the canonical spelling instead of adding an alias

Retaining `fork_join` as an accepted alias was considered and rejected:

- No shipped workflow YAML uses `spec.type: fork_join`. Every remaining `fork_join` occurrence in the repo is an internal Go, proto, or tracing identifier (span names, proto oneof field names, `PatternType` strings, test function names) — none of which are affected by this change.
- The canonical converter and validator both reject `fork_join`, so the underscored spelling was **never usable end to end**; it only ever satisfied the registry loader in isolation.
- Weaver emits the hyphenated form.
- Keeping the alias would preserve the exact vocabulary inconsistency that caused this defect.

It cannot be proven that no external user has an underscored file, but such a file was never usable end to end, so rejecting it consistently is the clearer behaviour.

### Out of scope

`parallel` remains in this case label and is **still broken for an unrelated reason** — it reads `agent_ids` rather than the canonical `tasks[]` schema. The same loader has separate schema and vocabulary mismatches for `conditional`, `iterative` and `swarm`. These are deliberately left alone so each can be verified independently.

## Testing

The new test was verified to be a genuine regression test — it **fails before the fix and passes after**:

Before the one-line change (reproducing the reported error exactly):

```
=== RUN   TestLoadWorkflowAgents_ForkJoinPatternType/canonical_hyphenated_form_loads
    Error: Received unexpected error:
           unsupported workflow pattern type: fork-join
=== RUN   TestLoadWorkflowAgents_ForkJoinPatternType/internal_underscored_form_is_rejected
    Error: An error is expected but got nil.
--- FAIL: TestLoadWorkflowAgents_ForkJoinPatternType (0.03s)
```

After:

```
--- PASS: TestLoadWorkflowAgents_ForkJoinPatternType (0.06s)
    --- PASS: .../canonical_hyphenated_form_loads (0.03s)
    --- PASS: .../internal_underscored_form_is_rejected (0.03s)
```

### Test Checklist

- [ ] All new and existing tests pass (`just test`) — **see note below**
- [ ] Race detector shows zero race conditions (`just race-check`) — **not verified locally, see note below**
- [x] Code builds successfully (`go build -tags fts5 ./...` passes)
- [ ] All checks pass (`just check`) — **partially, see note below**

**Note on local verification.** I could not run the race detector on my machine: `-race` requires cgo and no C compiler is available on this Windows environment (`cgo: C compiler "gcc" not found`). `golangci-lint` is also not installed locally. I am relying on CI for both. What I did verify locally:

- `gofmt -l` on both changed files — clean
- `go vet -tags fts5 ./pkg/agent/` — clean
- `go build -tags fts5 ./...` — clean
- The new test, plus `./pkg/agent/ ./pkg/orchestration/ ./pkg/validation/ ./pkg/shuttle/...` without `-race`
- Go 1.26.5, matching the version CI pins

This environment has a number of **pre-existing** test failures in those packages (sqlcipher/encryption, context-debug, skills, Windows-specific shell paths). I captured the failing-test set before and after my change and it is unchanged. The two apparent deltas were both investigated and are not caused by this change: `TestPipeline_PartialResultsCostAndDuration` fails 5/5 on a clean tree as well, and `TestSegmentedMemory_CacheSchema_LRUEviction` is flaky.

### Test Coverage

- [x] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] No tests needed (explain why):

## Proto Changes

- [x] No proto changes in this PR

## Documentation

- [ ] README.md updated (if user-facing changes)
- [ ] ARCHITECTURE.md updated (if architectural changes)
- [ ] TODO.md updated (if implementation plan changed)
- [x] Code comments added/updated
- [x] No documentation changes needed

The hyphenated form was already the documented spelling everywhere; this change makes the loader match the existing documentation rather than requiring a doc update.

## Security

- [x] No security implications

## Performance

- [x] No performance impact

## Deployment Notes

- [x] No special deployment steps needed

Workflows using `spec.type: fork_join` would now be rejected by the loader, but such files were never usable end to end (the canonical converter has always rejected them), so there is no working configuration to migrate.

## Checklist

### Required

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style (gofmt, proto format)
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (none needed — see above)
- [x] My changes generate no new warnings or errors
- [ ] All CI checks pass (proto, lint, test, build, security) — awaiting CI
- [ ] Zero race conditions detected — **could not verify locally (no cgo/C compiler); relying on CI**
- [x] I have added tests that prove my fix is effective
- [ ] New and existing tests pass locally with `go test -race ./...` — **could not run `-race` locally; ran without it**
- [x] Commit messages follow convention: `<type>(<scope>): <subject>`

## Screenshots/Examples

Minimal reproducer — this file validates successfully but was skipped by the registry before this change:

```yaml
apiVersion: loom/v1
kind: Workflow
metadata:
  name: test-forkjoin
spec:
  type: fork-join
  agent_ids:
    - agent-a
    - agent-b
  prompt: 'Research the target: {{input}}'
  merge_strategy: summary
```

`looms workflow validate` reported it valid:

```
Workflow is valid: ~/.loom/workflows/test-forkjoin.yaml
   Pattern type: *loomv1.WorkflowPattern_ForkJoin
   Pattern: fork-join
```

while `looms serve` skipped it:

```json
{"level":"error","caller":"agent/registry.go:428","msg":"Failed to load workflow agents",
 "file":"...\\.loom\\workflows\\teradata-competitors.yaml",
 "error":"unsupported workflow pattern type: fork-join"}
```

A `pipeline` workflow in the same directory loaded its coordinator and sub-agents in the same pass, which isolates the failure to the fork-join branch of the loader switch.

## Additional Context

Found while using Weaver to generate a workflow from the `competitive-intel` template — Weaver reported success and wrote a valid file, but the resulting agents were absent from `loom agents`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
