### PR TITLE
buf: pin remote plugin versions to the committed codegen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,15 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Verify remote plugins are version-pinned
+        run: |
+          unpinned=$(grep -E '^[[:space:]]*-?[[:space:]]*remote:' buf.gen.yaml | grep -vE 'remote:[[:space:]]*[^:[:space:]]+/[^:[:space:]]+/[^:[:space:]]+:v[0-9]' || true)
+          if [ -n "$unpinned" ]; then
+            echo "::error::Unpinned remote plugin(s) in buf.gen.yaml — pin each to a version (plugin:vX.Y.Z):"
+            echo "$unpinned"
+            exit 1
+          fi
+
       - name: Buf Lint
         run: buf lint
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,6 +35,15 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Verify remote plugins are version-pinned
+        run: |
+          unpinned=$(grep -E '^[[:space:]]*-?[[:space:]]*remote:' buf.gen.yaml | grep -vE 'remote:[[:space:]]*[^:[:space:]]+/[^:[:space:]]+/[^:[:space:]]+:v[0-9]' || true)
+          if [ -n "$unpinned" ]; then
+            echo "::error::Unpinned remote plugin(s) in buf.gen.yaml — pin each to a version (plugin:vX.Y.Z):"
+            echo "$unpinned"
+            exit 1
+          fi
+
       - name: Buf Lint
         run: buf lint
 

--- a/Justfile
+++ b/Justfile
@@ -17,8 +17,23 @@ proto:
     buf generate
 
 # Lint proto files
-proto-lint:
+proto-lint: proto-pin-check
     buf lint
+
+# Verify every remote plugin in buf.gen.yaml is version-pinned. Unpinned
+# plugins float on upstream "latest": a new plugin release changes codegen
+# output and turns every branch's proto-drift check red with no code change
+# (grpc-gateway v2.30.0, 2026-08-06).
+proto-pin-check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    unpinned=$(grep -E '^[[:space:]]*-?[[:space:]]*remote:' buf.gen.yaml | grep -vE 'remote:[[:space:]]*[^:[:space:]]+/[^:[:space:]]+/[^:[:space:]]+:v[0-9]' || true)
+    if [ -n "$unpinned" ]; then
+        echo "::error::Unpinned remote plugin(s) in buf.gen.yaml — pin each to a version (plugin:vX.Y.Z):"
+        echo "$unpinned"
+        exit 1
+    fi
+    echo "✅ All remote plugins in buf.gen.yaml are version-pinned"
 
 # Breaking change detection
 proto-breaking:

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -2,15 +2,15 @@ version: v2
 managed:
   enabled: false
 plugins:
-  - remote: buf.build/protocolbuffers/go
+  - remote: buf.build/protocolbuffers/go:v1.36.11
     out: gen/go
     opt:
       - paths=source_relative
-  - remote: buf.build/grpc/go
+  - remote: buf.build/grpc/go:v1.6.2
     out: gen/go
     opt:
       - paths=source_relative
-  - remote: buf.build/grpc-ecosystem/gateway
+  - remote: buf.build/grpc-ecosystem/gateway:v2.29.0
     out: gen/go
     opt:
       - paths=source_relative


### PR DESCRIPTION
## Problem

The nightly on main and every open PR's **Proto Lint & Breaking Changes** job started failing on 2026-08-06 with `Generated proto files are out of date` — without any proto changes.

Root cause: `buf.gen.yaml` used **unpinned** remote plugins. grpc-gateway **v2.30.0 was released 2026-08-05 05:02 UTC** (between the last green nightly and the first red one), and its codegen moved the `req.Body` drain block in `*.pb.gw.go`, so `buf generate` in CI no longer reproduces the committed `gen/`.

## Fix

Cherry-pick of 2386e3b6 from #288 (@mrg-ray) so that PR merges cleanly over this: pin the three unpinned remote plugins to the versions that produced the committed codegen —

- `buf.build/protocolbuffers/go:v1.36.11` (matches the `protoc-gen-go v1.36.11` headers in `gen/`)
- `buf.build/grpc/go:v1.6.2` (matches `protoc-gen-go-grpc v1.6.2` headers)
- `buf.build/grpc-ecosystem/gateway:v2.29.0` (matches `go.mod`'s `grpc-gateway/v2 v2.29.0`)

`openapiv2` was already pinned.

## Verification

`buf generate` + `git diff gen/` is clean with the pins (verified on buf 1.50.0-pinned CI via #288's green run, and locally on buf 1.58.0 — the pins make codegen deterministic across CLI versions).

Upgrading to gateway v2.30.0 (plugin pin + `go.mod` + regenerated `gen/`) can follow as a deliberate dependency bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Recurrence guard (added)

`just proto-pin-check` — fails when any `remote:` plugin in `buf.gen.yaml` lacks a `:vX.Y.Z` pin — wired into `just proto-lint` (and thus `just check`), plus the same step in the CI and nightly proto jobs so an unpinned plugin can never be reintroduced silently. Verified: passes on this branch's pinned file, flags exactly main's 3 unpinned lines.