### PR TITLE
feat(agent): configurable offload-exempt tool set (§5.2 step 6 carve-out)

### DIFF
--- a/docs/architecture/memory-systems.md
+++ b/docs/architecture/memory-systems.md
@@ -757,21 +757,30 @@ Cross-agent access (blocked):
 - Internal context that shouldn't be shared (private notes, internal state)
 - Temporary computation results (agent-local caching)
 
-**Large Tool Result Offload**:
+**Large Tool Result Offload** (render-time):
 
-One threshold governs both offload sites: `storage.DefaultSharedMemoryThreshold`, **64 KiB**. A serialized tool result strictly below it stays inline in the conversation; a result at or above it is stored by reference. Per-agent override via `MemoryConfig.SharedMemoryThresholdBytes` (`-1` = use the default, `0` = always reference, `>0` = reference at or above N bytes).
+*Arrival appends*: a tool result enters the in-memory conversation whole — nothing is examined, sized, or transformed at arrival. Bounding happens at exactly two later points: persist (a stored row is truncated to a bounded core plus tail) and compile (the copy rendered for the LLM). One threshold value — `storage.DefaultSharedMemoryThreshold`, **16 KiB**, per-agent override via `MemoryConfig.SharedMemoryThresholdBytes` — plays three roles: compile-time offload bound, persist-time row bound, retrieval page bound.
 
-The two sites:
-- **Tool Executor** (`pkg/shuttle/executor.go`, `handleLargeResult`): intercepts the result as it leaves the tool. SQL-shaped results go to the queryable `SQLResultStore`; everything else goes to the `SharedMemoryStore` as a blob.
-- **Agent result formatting** (`pkg/agent/agent.go`): applies the same byte threshold when rendering a tool result into the conversation.
+At compile time, each tool row renders by the first matching case:
 
-**Exempt set** — `manage_skills`, `get_tool_result`, `query_tool_result` — enters the conversation whole regardless of size. `manage_skills` delivers a skill body that must arrive intact; the two recall tools already return stored data, so re-wrapping them would recurse (`query_tool_result` → ref A → `query_tool_result(A)` → …).
+1. **Relief-evicted row** → the evicted stub (tool name, estimated token figure, 160-byte preview). Its only door is re-running the call.
+2. **Current-turn row strictly over the threshold** → the offload stub (tool name, estimated token figure, 160-byte preview, and a `query_tool_result(message_id=…)` door; `sql=` for tabular payloads) — unless the producing tool is in the offload-exempt set, in which case the row renders whole.
+3. **Prior-turn row strictly over the threshold** → the evicted stub.
+4. **Otherwise** → the row renders whole.
 
-**What lands in context**: a preview plus a handle — a rendered summary carrying the data type, byte size, estimated tokens, a first/last-items preview, schema when derivable, and the reference id.
+**Recall is turn-scoped**: `query_tool_result` resolves a `message_id` only within the turn that produced it — the whole payload is held in memory for one turn and persisted truncated, so the only cross-turn door is re-running the call. Every `query_tool_result` return, page or SQL result, is bounded at the same threshold. A session without a persistent store has no `message_id` to print, so its current-turn oversize rows render the evicted stub.
 
-**Recall**: `query_tool_result(reference_id, …)` returns the stored data — a page of rows by default, or the result of a SQL query against a stored SQL result. `get_tool_result` exists as a type and stays in the exempt set, but its registration is commented out in `NewAgent`, so agents do not see it; the inline preview plus `query_tool_result` cover retrieval.
+**Offload-exempt carve-out** (configurable, none by default): for some tools the full output *is* the product of the call — reference or lookup content the model must read inline in the turn it asked for it — and a 160-byte preview plus a recall door defeats the call. The embedding application registers its own exempt set via `SetOffloadExemptTools` (available at the `Agent`, `Memory`, and per-session `SegmentedMemory` levels); the framework bakes in no tool names. Three constraints keep the carve-out from weakening the memory model:
 
-**Session partitioning**: every store is keyed by session. `SharedMemoryStore.Store` records the owning session and `Get`/`GetMetadata` resolve a handle only for a caller carrying that same session; `SQLResultStore.Store` partitions by the session id on the context, and `Query`/`GetMetadata` resolve an id only within that partition. The metadata/describe path is scoped like the read path — there is no unscoped way to learn about another session's stored result.
+- Exemption is a render condition of the producing turn only: later turns render the evicted stub, so the carve-out suits cheap, idempotent lookups for which the re-run door is adequate.
+- Relief's `Evicted` flag wins over exemption — the exempt set can never block pressure release.
+- Exempt results count at full size toward the pressure estimate.
+
+**Trade-off**: an oversize exempt result spends its full size in the producing turn's prompt. Accepted: the spend is bounded to that one turn, and the alternative — a stub — makes the exempted tool useless for its purpose.
+
+**Large parameters**: the tool executor's shared-memory site applies to tool *inputs* (`handleLargeParameters`, `pkg/shuttle/executor.go`): a parameter strictly over the threshold is stored in the `SharedMemoryStore` as a `DataReference` and dereferenced transparently before the tool executes.
+
+**Session partitioning**: `SharedMemoryStore.Store` records the owning session, and `Get`/`GetMetadata` resolve a handle only for a caller carrying that same session. The metadata/describe path is scoped like the read path — there is no unscoped way to learn about another session's stored data.
 
 **Concurrency**:
 - **RWMutex**: Protects memory tier map

--- a/docs/reference/agent-configuration.md
+++ b/docs/reference/agent-configuration.md
@@ -409,12 +409,23 @@ Under `spec.memory` (k8s-style) or `agent.memory` (legacy).
 | `path` | `string` | `""` | SQLite database file path |
 | `dsn` | `string` | `""` | PostgreSQL connection string |
 | `max_history` | `int` | `50` | Max conversation messages to retain |
-| `shared_memory_threshold_bytes` | `int64` | `65536` (64 KiB) | Byte threshold for offloading a tool result: `>0` offloads results of at least N bytes, `-1` selects the 64 KiB default. Only a non-zero value is applied, so `0` in YAML is indistinguishable from unset and leaves the agent on the 64 KiB default; the always-offload mode (threshold 0) is reachable only through the Go API `SetSharedMemoryThreshold`. |
+| `shared_memory_threshold_bytes` | `int64` | `16384` (16 KiB) | One byte threshold, three roles: compile-time offload bound (a current-turn tool result strictly over it renders as an offload stub), persist-time row bound, and retrieval page bound — plus the tool executor's large-parameter offload. `>0` sets the bound (the compile/persist roles floor it at 256 bytes); `-1` keeps the 16 KiB default; `0` in YAML is indistinguishable from unset. `0` through the Go API `SetSharedMemoryThreshold` makes the executor store every tool parameter by reference and leaves the compile-time bound at its default. |
 | `max_tool_results` | `int` | `5` | Max tool results kept in conversation kernel |
 | `memory_compression` | object | optional | See [Memory Compression](#memory-compression-configuration) |
 | `graph_memory` | object | optional | See [Graph Memory](#graph-memory-configuration) |
 
-**Large tool results**: the same byte threshold governs both offload sites (the tool executor and the agent's result formatter). A result at or above it is stored by reference and replaced in the conversation with a preview plus a handle; the model recalls the full data with `query_tool_result`. Three tools are exempt and always enter whole regardless of size: `manage_skills` (its load body is delivered as its own message), `get_tool_result` and `query_tool_result` (re-offloading a recall tool would recurse).
+**Large tool results**: a result always enters the conversation whole — offload is a render condition of context compilation, not an arrival event. When a tool row's content is strictly over the threshold, the copy compiled for the LLM is replaced by a stub. In the producing turn this is the offload stub — tool name, estimated token figure, a 160-byte preview, and a `query_tool_result(message_id=…)` door (`sql=` for tabular payloads); `query_tool_result` resolves only within that turn, and every return is bounded at the same threshold. In later turns, and for rows evicted by memory-pressure relief, it is the evicted stub, whose only door is re-running the call. Rows are persisted truncated to a bounded core plus tail at the same threshold. A session without a persistent store has no `message_id` to print, so its current-turn oversize results render the evicted stub.
+
+**Offload-exempt tools** (Go API only; no YAML field): `Agent.SetOffloadExemptTools(names []string)` names the tools whose current-turn results always render whole regardless of the threshold. Use it for tools whose full output is the product of the call — reference or lookup content the model must read inline in the turn it asked for it — where an offload stub would defeat the call.
+
+```go
+ag.SetOffloadExemptTools([]string{"reference_lookup", "get_syntax_help"})
+```
+
+- Each call replaces the whole set; `nil` or an empty slice clears it; empty-string names are skipped. No tools are exempt by default.
+- Applies to existing and future sessions. Also available on `Memory` and per-session `SegmentedMemory`. Safe for concurrent use.
+- Exemption is a render condition of the producing turn only: prior-turn oversize rows and relief-evicted rows still render the evicted stub, and the persist-time row bound is unchanged.
+- An exempt result counts at full size toward memory-pressure estimates; a very large exempt result spends a correspondingly large share of the producing turn's context window.
 
 ---
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -3625,6 +3625,19 @@ func (a *Agent) SetSharedMemoryThreshold(threshold int64) {
 	}
 }
 
+// SetOffloadExemptTools replaces the set of tool names whose current-turn
+// results always render whole regardless of the offload threshold (§5.2
+// step 6 carve-out), for existing and future sessions. Use it for tools
+// whose full output is the product of the call — content the model must
+// read inline in the producing turn — where an offload stub would defeat
+// the call. Prior-turn and evicted rows still render stubs, so relief and
+// turn-end truncation behave identically for every tool.
+func (a *Agent) SetOffloadExemptTools(names []string) {
+	if a.memory != nil {
+		a.memory.SetOffloadExemptTools(names)
+	}
+}
+
 // SetSharedMemory configures shared memory for this agent.
 // This injects the shared memory store into:
 // - The agent itself (for formatToolResult to store large results)

--- a/pkg/agent/context_compilation.go
+++ b/pkg/agent/context_compilation.go
@@ -164,6 +164,10 @@ func hasQueryToolResultCall(m *Message) bool {
 // renderLocked applies §5.2 step 6's five render cases — first matching case
 // wins. Conversation is never stubbed; offload is a pure render condition of
 // the current turn; evicted and legacy-oversize rows render the evicted stub.
+// The offload case carves out the exempt set (SetOffloadExemptTools): an
+// exempt tool's current-turn result renders whole — exemption never reaches
+// the evicted cases, so relief and prior turns behave identically for every
+// tool.
 func (sm *SegmentedMemory) renderLocked(m *Message, t int64, callName map[string]string) Message {
 	if m.Role != "tool" {
 		return *m
@@ -174,6 +178,9 @@ func (sm *SegmentedMemory) renderLocked(m *Message, t int64, callName map[string
 		r.Content = sm.evictedStub(m, callName)
 		return r
 	case len(m.Content) > sm.threshold && m.Turn == t:
+		if sm.offloadExempt[callName[m.ToolUseID]] {
+			return *m
+		}
 		r := *m
 		r.Content = sm.offloadStub(m, callName)
 		return r

--- a/pkg/agent/context_compilation_test.go
+++ b/pkg/agent/context_compilation_test.go
@@ -131,6 +131,156 @@ func TestCompile_LegacyOversizePriorTurnRendersEvictedStub(t *testing.T) {
 	assert.Equal(t, want, rendered, "a legacy unbounded prior-turn row renders the evicted stub")
 }
 
+// --- §5.2 step 6: offload-exempt carve-out -----------------------------------
+
+func TestCompile_OffloadExemptToolRendersWholeCurrentTurn(t *testing.T) {
+	sm := newCompileMemory(t)
+	sm.SetOffloadExemptTools([]string{"reference_lookup"})
+	exemptBig := strings.Repeat("e", 5000)
+	plainBig := strings.Repeat("p", 5000)
+	sm.AddMessage(context.Background(), Message{Role: "user", Content: "q", Turn: 1})
+	sm.AddMessage(context.Background(), Message{Role: "assistant", Turn: 1,
+		ToolCalls: []ToolCall{
+			{ID: "c1", Name: "reference_lookup"},
+			{ID: "c2", Name: "web_search"},
+		}})
+	sm.AddMessage(context.Background(), Message{Role: "tool", ID: "41", ToolUseID: "c1", Content: exemptBig, Turn: 1})
+	sm.AddMessage(context.Background(), Message{Role: "tool", ID: "42", ToolUseID: "c2", Content: plainBig, Turn: 1})
+
+	rendered := map[string]string{}
+	for _, m := range sm.GetMessagesForLLM() {
+		if m.Role == "tool" {
+			rendered[m.ToolUseID] = m.Content
+		}
+	}
+	assert.Equal(t, exemptBig, rendered["c1"],
+		"an exempt tool's current-turn oversize result renders whole")
+	want := fmt.Sprintf(offloadStubFormat, "web_search", tokenFigure(len(plainBig)), int64(42), "", previewOf(plainBig))
+	assert.Equal(t, want, rendered["c2"],
+		"a non-exempt tool in the same compile still renders the offload stub")
+}
+
+func TestCompile_OffloadExemptPriorTurnStillRendersEvictedStub(t *testing.T) {
+	sm := newCompileMemory(t)
+	sm.SetOffloadExemptTools([]string{"reference_lookup"})
+	big := strings.Repeat("e", 5000)
+	sm.AddMessage(context.Background(), Message{Role: "assistant", Turn: 1,
+		ToolCalls: []ToolCall{{ID: "c1", Name: "reference_lookup"}}})
+	sm.AddMessage(context.Background(), Message{Role: "tool", ID: "3", ToolUseID: "c1", Content: big, Turn: 1})
+	sm.AddMessage(context.Background(), Message{Role: "user", Content: "next", Turn: 2})
+
+	var rendered string
+	for _, m := range sm.GetMessagesForLLM() {
+		if m.Role == "tool" {
+			rendered = m.Content
+		}
+	}
+	want := fmt.Sprintf(evictedStubFormat, "reference_lookup", tokenFigure(len(big)), "", previewOf(big))
+	assert.Equal(t, want, rendered,
+		"exemption is a render condition of the producing turn only — prior turns evict as usual")
+}
+
+func TestCompile_OffloadExemptEvictedFlagStillRendersEvictedStub(t *testing.T) {
+	sm := newCompileMemory(t)
+	sm.SetOffloadExemptTools([]string{"reference_lookup"})
+	big := strings.Repeat("e", 5000)
+	sm.AddMessage(context.Background(), Message{Role: "user", Content: "q", Turn: 1})
+	sm.AddMessage(context.Background(), Message{Role: "assistant", Turn: 1,
+		ToolCalls: []ToolCall{{ID: "c1", Name: "reference_lookup"}}})
+	sm.AddMessage(context.Background(), Message{Role: "tool", ID: "5", ToolUseID: "c1", Content: big, Turn: 1, Evicted: true})
+
+	var rendered string
+	for _, m := range sm.GetMessagesForLLM() {
+		if m.Role == "tool" {
+			rendered = m.Content
+		}
+	}
+	want := fmt.Sprintf(evictedStubFormat, "reference_lookup", tokenFigure(len(big)), "", previewOf(big))
+	assert.Equal(t, want, rendered,
+		"relief's evicted flag wins over exemption — the exempt set never blocks pressure release")
+}
+
+func TestSetOffloadExemptTools_ReplaceClearsAndSkipsEmptyNames(t *testing.T) {
+	sm := newCompileMemory(t)
+	big := strings.Repeat("e", 5000)
+	addBig := func() {
+		sm.AddMessage(context.Background(), Message{Role: "user", Content: "q", Turn: 1})
+		sm.AddMessage(context.Background(), Message{Role: "assistant", Turn: 1,
+			ToolCalls: []ToolCall{{ID: "c1", Name: "reference_lookup"}}})
+		sm.AddMessage(context.Background(), Message{Role: "tool", ID: "9", ToolUseID: "c1", Content: big, Turn: 1})
+	}
+	toolContent := func() string {
+		var s string
+		for _, m := range sm.GetMessagesForLLM() {
+			if m.Role == "tool" {
+				s = m.Content
+			}
+		}
+		return s
+	}
+
+	addBig()
+	sm.SetOffloadExemptTools([]string{"", "reference_lookup"})
+	assert.Equal(t, big, toolContent(), "empty names are skipped, real names apply")
+
+	sm.SetOffloadExemptTools([]string{"other_tool"})
+	assert.NotEqual(t, big, toolContent(), "SetOffloadExemptTools replaces the set — the old name no longer exempts")
+
+	sm.SetOffloadExemptTools(nil)
+	assert.NotEqual(t, big, toolContent(), "a nil slice clears the set")
+}
+
+func TestMemory_SetOffloadExemptTools_PropagatesToExistingAndFutureSessions(t *testing.T) {
+	m := NewMemory()
+	m.SetThresholdBytes(1024)
+	big := strings.Repeat("e", 5000)
+
+	existing := m.GetOrCreateSession(context.Background(), "sess-existing")
+	m.SetOffloadExemptTools([]string{"reference_lookup"})
+	future := m.GetOrCreateSession(context.Background(), "sess-future")
+
+	for name, session := range map[string]*Session{"existing": existing, "future": future} {
+		segMem, ok := session.SegmentedMem.(*SegmentedMemory)
+		require.True(t, ok, "%s session carries a SegmentedMemory", name)
+		segMem.AddMessage(context.Background(), Message{Role: "user", Content: "q", Turn: 1})
+		segMem.AddMessage(context.Background(), Message{Role: "assistant", Turn: 1,
+			ToolCalls: []ToolCall{{ID: "c1", Name: "reference_lookup"}}})
+		segMem.AddMessage(context.Background(), Message{Role: "tool", ID: "11", ToolUseID: "c1", Content: big, Turn: 1})
+		var rendered string
+		for _, msg := range segMem.GetMessagesForLLM() {
+			if msg.Role == "tool" {
+				rendered = msg.Content
+			}
+		}
+		assert.Equal(t, big, rendered, "%s session honors the exempt set", name)
+	}
+}
+
+func TestAgent_SetOffloadExemptTools_ForwardsToMemory(t *testing.T) {
+	a := &Agent{memory: NewMemory()}
+	a.memory.SetThresholdBytes(1024)
+	a.SetOffloadExemptTools([]string{"reference_lookup"})
+
+	session := a.memory.GetOrCreateSession(context.Background(), "sess-agent")
+	segMem, ok := session.SegmentedMem.(*SegmentedMemory)
+	require.True(t, ok)
+	big := strings.Repeat("e", 5000)
+	segMem.AddMessage(context.Background(), Message{Role: "user", Content: "q", Turn: 1})
+	segMem.AddMessage(context.Background(), Message{Role: "assistant", Turn: 1,
+		ToolCalls: []ToolCall{{ID: "c1", Name: "reference_lookup"}}})
+	segMem.AddMessage(context.Background(), Message{Role: "tool", ID: "12", ToolUseID: "c1", Content: big, Turn: 1})
+	var rendered string
+	for _, msg := range segMem.GetMessagesForLLM() {
+		if msg.Role == "tool" {
+			rendered = msg.Content
+		}
+	}
+	assert.Equal(t, big, rendered, "the agent-level setter reaches sessions through Memory")
+
+	// nil memory must not panic.
+	(&Agent{}).SetOffloadExemptTools([]string{"reference_lookup"})
+}
+
 // TestCompile_CurrentTurnQueryPairSitsBehindCacheBreakpoint proves the cache
 // breakpoint freezes BEFORE a current-turn query_tool_result call/result pair.
 // That pair is ephemeral (§4.3) and pruned when the turn settles; if it sat

--- a/pkg/agent/memory.go
+++ b/pkg/agent/memory.go
@@ -62,6 +62,7 @@ type Memory struct {
 	compressionProfile   *CompressionProfile        // Optional compression profile for new sessions (nil = use defaults)
 	compressor           MemoryCompressor           // Optional LLM compressor for L2 compaction (nil = heuristic fallback)
 	thresholdBytes       int64                      // Offload / row / page bound in bytes (0 = default; HLD §5.1)
+	offloadExemptTools   []string                   // Tool names whose current-turn results render whole (§5.2 step 6 carve-out)
 
 	// Real-time observers for cross-session updates
 	// Map of agentID -> list of observers
@@ -196,6 +197,20 @@ func (m *Memory) SetThresholdBytes(bytes int64) {
 	}
 }
 
+// SetOffloadExemptTools replaces the set of tool names whose current-turn
+// results always render whole regardless of the threshold (§5.2 step 6
+// carve-out), for existing and future sessions. An empty slice clears the set.
+func (m *Memory) SetOffloadExemptTools(names []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.offloadExemptTools = append([]string(nil), names...)
+	for _, session := range m.sessions {
+		if segMem, ok := session.SegmentedMem.(*SegmentedMemory); ok && segMem != nil {
+			segMem.SetOffloadExemptTools(m.offloadExemptTools)
+		}
+	}
+}
+
 // thresholdOrDefault returns the configured threshold, else the default bound.
 // Never below minThreshold: this value is the persist-time row bound, and a
 // smaller one cannot hold stored = core + tail ≤ threshold (§4.1).
@@ -272,6 +287,7 @@ func (m *Memory) GetOrCreateSessionWithAgent(ctx context.Context, sessionID, age
 	compProfile := m.compressionProfile
 	compressor := m.compressor
 	thresholdBytes := m.thresholdBytes
+	offloadExemptTools := append([]string(nil), m.offloadExemptTools...)
 	logger := m.logger
 	ctxDebug := m.ctxDebug
 	skillDeactivation := m.skillDeactivation
@@ -380,6 +396,9 @@ func (m *Memory) GetOrCreateSessionWithAgent(ctx context.Context, sessionID, age
 	}
 	if thresholdBytes > 0 {
 		segMem.SetThreshold(thresholdBytes)
+	}
+	if len(offloadExemptTools) > 0 {
+		segMem.SetOffloadExemptTools(offloadExemptTools)
 	}
 	segMem.SetContextDebug(ctxDebug)
 	segMem.SetSkillDeactivationHook(skillDeactivation)
@@ -604,6 +623,9 @@ func (m *Memory) ensureSessionMemory(session *Session, sessionID string,
 		// m.mu is held by the caller, so m.thresholdBytes is read safely here.
 		if m.thresholdBytes > 0 {
 			segMem.SetThreshold(m.thresholdBytes)
+		}
+		if len(m.offloadExemptTools) > 0 {
+			segMem.SetOffloadExemptTools(m.offloadExemptTools)
 		}
 		segMem.SetContextDebug(m.ctxDebug)
 		segMem.SetSkillDeactivationHook(m.skillDeactivation)

--- a/pkg/agent/segmented_memory.go
+++ b/pkg/agent/segmented_memory.go
@@ -107,6 +107,15 @@ type SegmentedMemory struct {
 	// bound, persist-time row bound, retrieval page bound. Bytes.
 	threshold int
 
+	// offloadExempt names the tools whose CURRENT-TURN results always render
+	// whole (§5.2 step 6 carve-out) — for tools whose full output is the
+	// product of the call, read inline in the producing turn, where an offload
+	// stub would defeat the call. Exemption is a render condition of the
+	// producing turn only: prior-turn and evicted rows render stubs as usual,
+	// and the persist-time row bound (§4.1) still applies — the re-run door
+	// covers later turns.
+	offloadExempt map[string]bool
+
 	// protectedRecentTurns is K (HLD §5.1): the K newest turns are never
 	// touched by relief.
 	protectedRecentTurns int
@@ -269,6 +278,23 @@ func (sm *SegmentedMemory) SetThreshold(bytes int64) {
 // minThreshold is the floor for the §5.1 threshold: enough room for the §4.1
 // truncation tail plus a meaningful core.
 const minThreshold = 256
+
+// SetOffloadExemptTools replaces the set of tool names whose current-turn
+// results always render whole regardless of the threshold (§5.2 step 6
+// carve-out). Empty names are ignored; an empty slice clears the set.
+// Exemption affects only the producing turn's render: prior-turn and evicted
+// rows still render stubs, and the persist-time row bound (§4.1) is unchanged.
+func (sm *SegmentedMemory) SetOffloadExemptTools(names []string) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	exempt := make(map[string]bool, len(names))
+	for _, n := range names {
+		if n != "" {
+			exempt[n] = true
+		}
+	}
+	sm.offloadExempt = exempt
+}
 
 // Threshold returns the configured threshold in bytes.
 func (sm *SegmentedMemory) Threshold() int {


### PR DESCRIPTION
## What

Adds a configurable **offload-exempt tool set** to context compilation: `SetOffloadExemptTools` at the `Agent`, `Memory` (existing + future sessions), and `SegmentedMemory` levels. An exempt tool's **current-turn** result renders whole regardless of the offload threshold.

## Why

Some tools' full output *is* the product of the call — reference/lookup content the model must read inline in the turn it asked for it. For those, the §5.2 offload stub defeats the call: the model gets a 160-byte preview and a `query_tool_result` door instead of the text it needs to do its job. Today there is no way for an embedding application to express this; the render condition applies uniformly to every tool.

## Design constraints honored

- **Carve-out is a render condition of the producing turn only.** Prior-turn oversize rows still render the evicted stub; relief's `Evicted` flag wins over exemption (the exempt set can never block pressure release); the persist-time row bound (§4.1) is unchanged. The re-run door covers later turns — appropriate for the cheap, idempotent lookup tools this targets.
- **Estimate accounting is automatic**: `estimateLocked` runs over compiled output, so exempt results count at full size toward the pressure marks.
- **Cache-breakpoint freeze logic is unchanged and stays correct**: a current-turn oversize result is turn-unstable whether it renders whole (truncates at turn end) or as an offload stub (re-renders evicted), and the existing freeze condition (`len > threshold && Turn == t`) covers both.
- **No tool names are baked in.** The embedding application registers its own exempt set alongside its tool registration — no framework knowledge of downstream tools.

## Tests

Six new tests in `pkg/agent/context_compilation_test.go` (byte-exact stub assertions, matching the existing §5.2 suite): exempt-whole vs non-exempt-stub in the same compile, prior-turn eviction unchanged, `Evicted` flag wins, replace/clear/empty-name setter semantics, `Memory` propagation to existing + future sessions, `Agent` forwarding + nil-memory safety.

`GOWORK=off go test -tags fts5 -race -short ./pkg/agent/` passes; full module builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)