### PR TITLE
Workload profiles select the relief marks; cache-aware and gateway-correct cost

### DIFF
--- a/pkg/agent/compression_integration_test.go
+++ b/pkg/agent/compression_integration_test.go
@@ -44,8 +44,8 @@ agent:
 	assert.Equal(t, "data_intensive", profile.Name)
 	assert.Equal(t, 4000, profile.MaxL1Tokens, "Should use data_intensive MaxL1Tokens (4000)")
 	assert.Equal(t, 3, profile.MinL1Messages)
-	assert.Equal(t, 60, profile.WarningThresholdPercent)
-	assert.Equal(t, 90, profile.CriticalThresholdPercent)
+	assert.Equal(t, 45, profile.WarningThresholdPercent)
+	assert.Equal(t, 80, profile.CriticalThresholdPercent)
 
 	// Step 3: Create agent with compression profile
 	agent := createTestAgentWithProfile(profile)
@@ -63,8 +63,8 @@ agent:
 	assert.Equal(t, 4000, segMem.maxL1Tokens, "Should use data_intensive maxL1Tokens (4000 tokens)")
 	assert.Equal(t, 3, segMem.minL1Messages, "Should use data_intensive minL1Messages")
 	assert.Equal(t, "data_intensive", segMem.compressionProfile.Name)
-	assert.Equal(t, 60, segMem.compressionProfile.WarningThresholdPercent)
-	assert.Equal(t, 90, segMem.compressionProfile.CriticalThresholdPercent)
+	assert.Equal(t, 45, segMem.compressionProfile.WarningThresholdPercent)
+	assert.Equal(t, 80, segMem.compressionProfile.CriticalThresholdPercent)
 }
 
 // TestCompressionProfile_EndToEnd_Conversational verifies conversational profile
@@ -90,8 +90,8 @@ agent:
 	assert.Equal(t, "conversational", profile.Name)
 	assert.Equal(t, 9600, profile.MaxL1Tokens, "Should use conversational MaxL1Tokens (9600)")
 	assert.Equal(t, 6, profile.MinL1Messages)
-	assert.Equal(t, 60, profile.WarningThresholdPercent)
-	assert.Equal(t, 90, profile.CriticalThresholdPercent)
+	assert.Equal(t, 70, profile.WarningThresholdPercent)
+	assert.Equal(t, 92, profile.CriticalThresholdPercent)
 
 	// Create agent and verify memory uses conversational profile
 	agent := createTestAgentWithProfile(profile)

--- a/pkg/agent/compression_profiles.go
+++ b/pkg/agent/compression_profiles.go
@@ -45,12 +45,22 @@ type CompressionProfile struct {
 }
 
 // ProfileDefaults provides preset profiles for common workload types.
-// These are static fallback values - use NewSegmentedMemoryWithDynamicAllocation for adaptive sizing.
+//
+// The two thresholds are the relief water marks (HLD §5.1), percentages of
+// usable context: CriticalThresholdPercent is the HWM — where relief begins —
+// and WarningThresholdPercent is the LWM it sheds down to. The gap between
+// them is hysteresis: a wide band means rare, deep passes; a narrow band means
+// frequent, shallow ones. That is what a workload profile actually selects.
+//
+// The remaining fields (MaxL1Tokens, MinL1Messages, the batch sizes) are
+// vestiges of batch compaction and drive nothing.
 var ProfileDefaults = map[loomv1.WorkloadProfile]CompressionProfile{
 	loomv1.WorkloadProfile_WORKLOAD_PROFILE_BALANCED: {
-		Name:                     "balanced",
-		MaxL1Tokens:              6400, // ~8 messages @ 800 tokens each (static fallback)
-		MinL1Messages:            4,
+		Name:          "balanced",
+		MaxL1Tokens:   6400, // ~8 messages @ 800 tokens each (static fallback)
+		MinL1Messages: 4,
+		// The default: a 30-point band, relief roughly half as often as a
+		// 15-point band would fire, each pass shedding more.
 		WarningThresholdPercent:  60,
 		CriticalThresholdPercent: 90,
 		NormalBatchSize:          3,
@@ -58,21 +68,27 @@ var ProfileDefaults = map[loomv1.WorkloadProfile]CompressionProfile{
 		CriticalBatchSize:        7,
 	},
 	loomv1.WorkloadProfile_WORKLOAD_PROFILE_DATA_INTENSIVE: {
-		Name:                     "data_intensive",
-		MaxL1Tokens:              4000, // ~5 messages @ 800 tokens each (static fallback)
-		MinL1Messages:            3,
-		WarningThresholdPercent:  60,
-		CriticalThresholdPercent: 90,
+		Name:          "data_intensive",
+		MaxL1Tokens:   4000, // ~5 messages @ 800 tokens each (static fallback)
+		MinL1Messages: 3,
+		// Growth arrives in bursts: one tool result can add tens of points in a
+		// single call. Start early so a burst has headroom above the mark, and
+		// shed deep so one pass buys many turns instead of thrashing per call.
+		WarningThresholdPercent:  45,
+		CriticalThresholdPercent: 80,
 		NormalBatchSize:          2,
 		WarningBatchSize:         4,
 		CriticalBatchSize:        6,
 	},
 	loomv1.WorkloadProfile_WORKLOAD_PROFILE_CONVERSATIONAL: {
-		Name:                     "conversational",
-		MaxL1Tokens:              9600, // ~12 messages @ 800 tokens each (static fallback)
-		MinL1Messages:            6,
-		WarningThresholdPercent:  60,
-		CriticalThresholdPercent: 90,
+		Name:          "conversational",
+		MaxL1Tokens:   9600, // ~12 messages @ 800 tokens each (static fallback)
+		MinL1Messages: 6,
+		// Growth is small and steady, so the risk of overshooting between turns
+		// is low and recent turns are the value. Start late and shed shallow to
+		// keep as much recency as the bound allows.
+		WarningThresholdPercent:  70,
+		CriticalThresholdPercent: 92,
 		NormalBatchSize:          4,
 		WarningBatchSize:         6,
 		CriticalBatchSize:        8,

--- a/pkg/agent/compression_profiles_test.go
+++ b/pkg/agent/compression_profiles_test.go
@@ -41,8 +41,8 @@ func TestProfileDefaults(t *testing.T) {
 			profile:               loomv1.WorkloadProfile_WORKLOAD_PROFILE_DATA_INTENSIVE,
 			expectedMaxL1:         4000, // 5 messages @ 800 tokens each
 			expectedMinL1:         3,
-			expectedWarning:       60,
-			expectedCritical:      90,
+			expectedWarning:       45,
+			expectedCritical:      80,
 			expectedNormalBatch:   2,
 			expectedWarningBatch:  4,
 			expectedCriticalBatch: 6,
@@ -52,8 +52,8 @@ func TestProfileDefaults(t *testing.T) {
 			profile:               loomv1.WorkloadProfile_WORKLOAD_PROFILE_CONVERSATIONAL,
 			expectedMaxL1:         9600, // 12 messages @ 800 tokens each
 			expectedMinL1:         6,
-			expectedWarning:       60,
-			expectedCritical:      90,
+			expectedWarning:       70,
+			expectedCritical:      92,
 			expectedNormalBatch:   4,
 			expectedWarningBatch:  6,
 			expectedCriticalBatch: 8,
@@ -142,7 +142,7 @@ func TestResolveCompressionProfile_Overrides(t *testing.T) {
 
 	assert.Equal(t, 8000, profile.MaxL1Tokens, "Should use overridden value: 10 messages × 800")
 	assert.Equal(t, 3, profile.MinL1Messages, "Should use profile default")
-	assert.Equal(t, 60, profile.WarningThresholdPercent, "Should use profile default")
+	assert.Equal(t, 45, profile.WarningThresholdPercent, "Should use profile default")
 }
 
 func TestResolveCompressionProfile_FullCustomization(t *testing.T) {
@@ -317,4 +317,43 @@ func TestResolveCompressionProfile_InvalidProfileReturnsError(t *testing.T) {
 	_, err := ResolveCompressionProfile(config)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid compression profile")
+}
+
+// TestWorkloadProfilesMoveTheReliefMarks pins the point of a workload profile:
+// it selects where relief starts and how deep it sheds. The three profiles were
+// briefly identical (60/90), which made the admin-facing selector inert — the
+// dropdown turned and nothing changed. This asserts they are distinct and that
+// the distinction reaches the marks a session actually uses.
+func TestWorkloadProfilesMoveTheReliefMarks(t *testing.T) {
+	const window, reserve = 200000, 20000
+	usable := window - reserve
+
+	markFor := func(p loomv1.WorkloadProfile) (start, release int) {
+		sm := NewSegmentedMemoryWithCompression("ROM", window, reserve, ProfileDefaults[p])
+		sm.mu.Lock()
+		defer sm.mu.Unlock()
+		return sm.startMarkLocked(0), sm.releaseMarkLocked(0)
+	}
+
+	dataStart, dataRelease := markFor(loomv1.WorkloadProfile_WORKLOAD_PROFILE_DATA_INTENSIVE)
+	balStart, balRelease := markFor(loomv1.WorkloadProfile_WORKLOAD_PROFILE_BALANCED)
+	convStart, convRelease := markFor(loomv1.WorkloadProfile_WORKLOAD_PROFILE_CONVERSATIONAL)
+
+	// Bursty workloads start earliest and shed deepest; conversational starts
+	// latest and sheds least, keeping recency.
+	assert.Less(t, dataStart, balStart, "data_intensive begins relief before balanced")
+	assert.Less(t, balStart, convStart, "conversational begins relief after balanced")
+	assert.Less(t, dataRelease, balRelease, "data_intensive sheds deeper than balanced")
+	assert.Less(t, balRelease, convRelease, "conversational sheds shallower than balanced")
+
+	// Every mark stays below usable — a mark at or above it would sit beyond
+	// the provider's refusal line and never fire.
+	for _, m := range []int{dataStart, balStart, convStart} {
+		assert.Less(t, m, usable, "a start mark must stay under usable context")
+	}
+
+	// And the band never inverts.
+	assert.Less(t, dataRelease, dataStart)
+	assert.Less(t, balRelease, balStart)
+	assert.Less(t, convRelease, convStart)
 }

--- a/pkg/agent/roms/START_HERE.md
+++ b/pkg/agent/roms/START_HERE.md
@@ -17,6 +17,14 @@
 - There are no tools named receive_message, receive_broadcast, or subscribe. Messages arrive as injected context.
 - Agent IDs in workflows use `workflow:agent` format.
 
+## Skills
+
+- When you are working under a loaded Skill, the Skill's instructions take
+  precedence over these general rules wherever the two differ. These rules
+  govern what the Skill leaves unsaid.
+- Precedence covers method and presentation. It never licenses reporting a
+  figure a tool did not return, or narrowing the data without saying so.
+
 ## Quality
 
 - Never fabricate data. Only report what tools actually return.

--- a/pkg/llm/bedrock/client.go
+++ b/pkg/llm/bedrock/client.go
@@ -502,7 +502,8 @@ func (c *Client) chatStreamDisabled(ctx context.Context, messages []llmtypes.Mes
 		usage.OutputTokens = tokenCount
 	}
 	usage.TotalTokens = usage.InputTokens + usage.OutputTokens
-	usage.CostUSD = c.calculateCost(usage.InputTokens, usage.OutputTokens)
+	usage.CostUSD = c.calculateCost(usage.InputTokens, usage.OutputTokens,
+		usage.CacheReadInputTokens, usage.CacheCreationInputTokens)
 
 	// Record token usage for rate limiter metrics
 	if c.rateLimiter != nil {
@@ -765,7 +766,8 @@ func (c *Client) convertResponse(resp *bedrockResponse) *llmtypes.LLMResponse {
 			InputTokens:  resp.Usage.InputTokens,
 			OutputTokens: resp.Usage.OutputTokens,
 			TotalTokens:  resp.Usage.InputTokens + resp.Usage.OutputTokens,
-			CostUSD:      c.calculateCost(resp.Usage.InputTokens, resp.Usage.OutputTokens),
+			CostUSD: c.calculateCost(resp.Usage.InputTokens, resp.Usage.OutputTokens,
+				resp.Usage.CacheReadInputTokens, resp.Usage.CacheCreationInputTokens),
 		},
 		Metadata: map[string]interface{}{
 			"model":       c.modelID,
@@ -808,7 +810,12 @@ func (c *Client) convertResponse(resp *bedrockResponse) *llmtypes.LLMResponse {
 
 // calculateCost estimates cost for Bedrock Claude models.
 // Pricing varies by model and region - these are approximate.
-func (c *Client) calculateCost(inputTokens, outputTokens int) float64 {
+//
+// Cache tiers: a cache write bills at 1.25x the input rate and a cache read at
+// 0.10x. Bedrock/Anthropic report input_tokens EXCLUSIVE of cached tokens, so
+// the three buckets are additive (unlike the OpenAI-compatible shape, where
+// prompt_tokens includes them). Mirrors SDKClient.calculateCost.
+func (c *Client) calculateCost(inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens int) float64 {
 	// The catalog (pkg/llm/catalog) is the source of truth for pricing. Fall back
 	// to substring matching only for model ids it does not list.
 	// IMPORTANT: in the fallback, check "opus-4-1" BEFORE "opus-4" because
@@ -842,7 +849,9 @@ func (c *Client) calculateCost(inputTokens, outputTokens int) float64 {
 
 	inputCost := float64(inputTokens) * inputPricePerMillion / 1_000_000
 	outputCost := float64(outputTokens) * outputPricePerMillion / 1_000_000
-	return inputCost + outputCost
+	cacheWriteCost := float64(cacheCreationTokens) * inputPricePerMillion * 1.25 / 1_000_000
+	cacheReadCost := float64(cacheReadTokens) * inputPricePerMillion * 0.10 / 1_000_000
+	return inputCost + outputCost + cacheWriteCost + cacheReadCost
 }
 
 // bedrockResponse represents Bedrock's response format (Anthropic-compatible).
@@ -859,6 +868,10 @@ type bedrockResponse struct {
 type bedrockUsage struct {
 	InputTokens  int `json:"input_tokens"`
 	OutputTokens int `json:"output_tokens"`
+	// Cache tiers are billed differently (write 1.25x, read 0.10x), so they
+	// must be parsed to cost the call correctly.
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
 }
 
 // bedrockStreamChunk represents a chunk from Bedrock's streaming response.

--- a/pkg/llm/bedrock/client_test.go
+++ b/pkg/llm/bedrock/client_test.go
@@ -429,7 +429,7 @@ func TestClient_CalculateCost(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cost := client.calculateCost(tt.inputTokens, tt.outputTokens)
+			cost := client.calculateCost(tt.inputTokens, tt.outputTokens, 0, 0)
 			assert.InDelta(t, tt.expectedCost, cost, 0.0001)
 		})
 	}
@@ -510,7 +510,7 @@ func TestClient_CalculateCost_ModelPricing(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := &Client{modelID: tt.modelID}
-			got := client.calculateCost(tt.inputTokens, tt.outputTokens)
+			got := client.calculateCost(tt.inputTokens, tt.outputTokens, 0, 0)
 			assert.InDelta(t, tt.wantCost, got, 0.001,
 				"model=%s: expected cost $%.2f, got $%.2f", tt.modelID, tt.wantCost, got)
 		})

--- a/pkg/llm/bedrock/converse.go
+++ b/pkg/llm/bedrock/converse.go
@@ -181,7 +181,10 @@ func (c *Client) ChatConverse(ctx context.Context, messages []llmtypes.Message, 
 		usage.InputTokens = int(aws.ToInt32(output.Usage.InputTokens))
 		usage.OutputTokens = int(aws.ToInt32(output.Usage.OutputTokens))
 		usage.TotalTokens = int(aws.ToInt32(output.Usage.TotalTokens))
-		usage.CostUSD = c.calculateCost(usage.InputTokens, usage.OutputTokens)
+		usage.CacheReadInputTokens = int(aws.ToInt32(output.Usage.CacheReadInputTokens))
+		usage.CacheCreationInputTokens = int(aws.ToInt32(output.Usage.CacheWriteInputTokens))
+		usage.CostUSD = c.calculateCost(usage.InputTokens, usage.OutputTokens,
+			usage.CacheReadInputTokens, usage.CacheCreationInputTokens)
 	}
 
 	// Build response

--- a/pkg/llm/openai/client.go
+++ b/pkg/llm/openai/client.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -195,13 +196,13 @@ func (c *Client) Chat(ctx context.Context, messages []llmtypes.Message, tools []
 	}
 
 	// Call API
-	resp, err := c.callAPI(ctx, req)
+	resp, hdr, err := c.callAPI(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("API call failed: %w", err)
 	}
 
-	// Convert response
-	return c.convertResponse(resp), nil
+	// Convert response. The gateway's own cost (cache-aware) wins when present.
+	return c.convertResponse(resp, parseProviderCost(hdr)), nil
 }
 
 // convertMessages converts agent messages to OpenAI format.
@@ -458,7 +459,7 @@ func (c *Client) convertSchemaProperties(props map[string]*shuttle.JSONSchema) m
 }
 
 // convertResponse converts OpenAI response to agent format.
-func (c *Client) convertResponse(resp *ChatCompletionResponse) *llmtypes.LLMResponse {
+func (c *Client) convertResponse(resp *ChatCompletionResponse, providerCostUSD float64) *llmtypes.LLMResponse {
 	llmResp := &llmtypes.LLMResponse{
 		Usage: llmtypes.Usage{
 			InputTokens:              resp.Usage.PromptTokens,
@@ -466,7 +467,10 @@ func (c *Client) convertResponse(resp *ChatCompletionResponse) *llmtypes.LLMResp
 			TotalTokens:              resp.Usage.TotalTokens,
 			CacheReadInputTokens:     resp.Usage.CacheRead(),
 			CacheCreationInputTokens: resp.Usage.CacheCreationInputTokens,
-			CostUSD:                  c.calculateCost(resp.Usage.PromptTokens, resp.Usage.CompletionTokens),
+			CostUSD: costOrEstimate(providerCostUSD, func() float64 {
+				return c.calculateCost(resp.Usage.PromptTokens, resp.Usage.CompletionTokens,
+					resp.Usage.CacheRead(), resp.Usage.CacheCreationInputTokens)
+			}),
 		},
 		Metadata: map[string]interface{}{
 			"model":         resp.Model,
@@ -527,9 +531,48 @@ func (c *Client) convertResponse(resp *ChatCompletionResponse) *llmtypes.LLMResp
 	return llmResp
 }
 
+// providerCostHeader is litellm's own computed cost for the call. It is
+// cache-aware and authoritative — preferred over any local estimate.
+const providerCostHeader = "x-litellm-response-cost"
+
+// parseProviderCost reads the gateway's reported cost, if it sent one.
+// Returns 0 when absent or unparseable, meaning "fall back to the estimate".
+func parseProviderCost(h http.Header) float64 {
+	if h == nil {
+		return 0
+	}
+	v := strings.TrimSpace(h.Get(providerCostHeader))
+	if v == "" {
+		return 0
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil || f < 0 {
+		return 0
+	}
+	return f
+}
+
+// costOrEstimate prefers the provider's reported cost; estimate() is used only
+// when the provider did not report one.
+func costOrEstimate(providerCostUSD float64, estimate func() float64) float64 {
+	if providerCostUSD > 0 {
+		return providerCostUSD
+	}
+	return estimate()
+}
+
 // calculateCost estimates the cost in USD based on token usage.
-// Pricing as of 2024-11 for various OpenAI models.
-func (c *Client) calculateCost(inputTokens, outputTokens int) float64 {
+//
+// Cache tiers matter: a cache write bills at 1.25x the input rate and a cache
+// read at 0.10x, so a cache-blind total over-charges a cache-heavy workload by
+// several fold. NOTE the OpenAI-compatible semantics: prompt_tokens INCLUDES
+// cached tokens (unlike Anthropic native, where input_tokens excludes them),
+// so the uncached remainder must be derived by subtraction.
+//
+// This is the FALLBACK. When the gateway reports its own cost (litellm's
+// x-litellm-response-cost header) that figure is authoritative and is used
+// instead — see providerCostUSD.
+func (c *Client) calculateCost(inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens int) float64 {
 	// The catalog (pkg/llm/catalog) is the source of truth for pricing. Fall back
 	// to the provider-local rates below only for model ids it does not list.
 	inputCostPerM, outputCostPerM, ok := catalog.LookupPricing("openai", c.model)
@@ -587,9 +630,15 @@ func (c *Client) calculateCost(inputTokens, outputTokens int) float64 {
 		}
 	}
 
-	inputCost := float64(inputTokens) * inputCostPerM / 1_000_000
+	uncached := inputTokens - cacheReadTokens - cacheCreationTokens
+	if uncached < 0 {
+		uncached = 0
+	}
+	inputCost := float64(uncached) * inputCostPerM / 1_000_000
+	cacheWriteCost := float64(cacheCreationTokens) * inputCostPerM * 1.25 / 1_000_000
+	cacheReadCost := float64(cacheReadTokens) * inputCostPerM * 0.10 / 1_000_000
 	outputCost := float64(outputTokens) * outputCostPerM / 1_000_000
-	return inputCost + outputCost
+	return inputCost + cacheWriteCost + cacheReadCost + outputCost
 }
 
 // usesMaxCompletionTokens returns true when the model requires max_completion_tokens
@@ -813,7 +862,10 @@ func (c *Client) ChatStream(ctx context.Context, messages []llmtypes.Message,
 		usage.OutputTokens = tokenCount
 		usage.TotalTokens = tokenCount // Input tokens not available in stream
 	}
-	usage.CostUSD = c.calculateCost(usage.InputTokens, usage.OutputTokens)
+	usage.CostUSD = costOrEstimate(parseProviderCost(httpResp.Header), func() float64 {
+		return c.calculateCost(usage.InputTokens, usage.OutputTokens,
+			usage.CacheReadInputTokens, usage.CacheCreationInputTokens)
+	})
 	zap.L().Info("prompt cache usage (stream)",
 		zap.Int("input_tokens", usage.InputTokens),
 		zap.Int("cache_read", usage.CacheReadInputTokens),
@@ -854,17 +906,17 @@ func (c *Client) ChatStream(ctx context.Context, messages []llmtypes.Message,
 }
 
 // callAPI makes the HTTP request to OpenAI's API.
-func (c *Client) callAPI(ctx context.Context, req *ChatCompletionRequest) (*ChatCompletionResponse, error) {
+func (c *Client) callAPI(ctx context.Context, req *ChatCompletionRequest) (*ChatCompletionResponse, http.Header, error) {
 	// Marshal request
 	body, err := json.Marshal(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
+		return nil, nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
 	// Create HTTP request
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.endpoint, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	// Set headers
@@ -881,14 +933,14 @@ func (c *Client) callAPI(ctx context.Context, req *ChatCompletionRequest) (*Chat
 			return c.httpClient.Do(httpReq)
 		})
 		if err != nil {
-			return nil, fmt.Errorf("HTTP request failed: %w", err)
+			return nil, nil, fmt.Errorf("HTTP request failed: %w", err)
 		}
 		httpResp = result.(*http.Response)
 	} else {
 		var err error
 		httpResp, err = c.httpClient.Do(httpReq)
 		if err != nil {
-			return nil, fmt.Errorf("HTTP request failed: %w", err)
+			return nil, nil, fmt.Errorf("HTTP request failed: %w", err)
 		}
 	}
 	defer func() { _ = httpResp.Body.Close() }()
@@ -896,32 +948,32 @@ func (c *Client) callAPI(ctx context.Context, req *ChatCompletionRequest) (*Chat
 	// Read response
 	respBody, err := io.ReadAll(httpResp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
+		return nil, nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
 	// Parse response
 	var resp ChatCompletionResponse
 	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+		return nil, nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
 	// Positive identification of the provider's context-too-long refusal
 	// (HLD §5.2 step 12) — the only relief trigger.
 	if llm.IsOpenAIContextTooLong(httpResp.StatusCode, respBody) {
-		return nil, fmt.Errorf("API error (status %d): %s: %w", httpResp.StatusCode, string(respBody), llm.ErrContextTooLong)
+		return nil, nil, fmt.Errorf("API error (status %d): %s: %w", httpResp.StatusCode, string(respBody), llm.ErrContextTooLong)
 	}
 
 	// Check for API errors
 	if resp.Error != nil {
-		return nil, fmt.Errorf("OpenAI API error: %s (type: %s)", resp.Error.Message, resp.Error.Type)
+		return nil, nil, fmt.Errorf("OpenAI API error: %s (type: %s)", resp.Error.Message, resp.Error.Type)
 	}
 
 	// Check status code
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API error (status %d): %s", httpResp.StatusCode, string(respBody))
+		return nil, nil, fmt.Errorf("API error (status %d): %s", httpResp.StatusCode, string(respBody))
 	}
 
-	return &resp, nil
+	return &resp, httpResp.Header, nil
 }
 
 // Ensure Client implements LLMProvider interface.

--- a/pkg/llm/openai/client.go
+++ b/pkg/llm/openai/client.go
@@ -531,6 +531,23 @@ func (c *Client) convertResponse(resp *ChatCompletionResponse, providerCostUSD f
 	return llmResp
 }
 
+// anthropicFallbackPricing returns published Anthropic rates for a model id
+// proxied through an OpenAI-compatible endpoint. Mirrors the bedrock client's
+// substring matching so a gateway-proxied Claude is never priced as a GPT.
+func anthropicFallbackPricing(modelID string) (inputPerM, outputPerM float64, matched bool) {
+	switch {
+	case strings.Contains(modelID, "claude-opus-4-1"):
+		return 15.0, 75.0, true
+	case strings.Contains(modelID, "claude-opus"):
+		return 5.0, 25.0, true
+	case strings.Contains(modelID, "claude-haiku"):
+		return 1.0, 5.0, true
+	case strings.Contains(modelID, "claude-sonnet"), strings.Contains(modelID, "claude-3-5-sonnet"):
+		return 3.0, 15.0, true
+	}
+	return 0, 0, false
+}
+
 // providerCostHeader is litellm's own computed cost for the call. It is
 // cache-aware and authoritative — preferred over any local estimate.
 const providerCostHeader = "x-litellm-response-cost"
@@ -576,6 +593,17 @@ func (c *Client) calculateCost(inputTokens, outputTokens, cacheReadTokens, cache
 	// The catalog (pkg/llm/catalog) is the source of truth for pricing. Fall back
 	// to the provider-local rates below only for model ids it does not list.
 	inputCostPerM, outputCostPerM, ok := catalog.LookupPricing("openai", c.model)
+	if !ok {
+		// Gateways (litellm et al.) proxy non-OpenAI models through this
+		// OpenAI-compatible client under ids like "coding-agent/claude-sonnet-4-6".
+		// Falling through to the GPT rate card below would price them wrongly, so
+		// recognise the Anthropic family first. Order matters: check "opus-4-1"
+		// before "opus-4", since Contains("opus-4-5","opus-4") is true.
+		if in, out, matched := anthropicFallbackPricing(c.model); matched {
+			inputCostPerM, outputCostPerM = in, out
+			ok = true
+		}
+	}
 	if !ok {
 		switch c.model {
 		case "gpt-4o":

--- a/pkg/llm/openai/client_test.go
+++ b/pkg/llm/openai/client_test.go
@@ -474,7 +474,7 @@ func TestClient_ConvertResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := client.convertResponse(tt.resp)
+			got := client.convertResponse(tt.resp, 0)
 
 			assert.Equal(t, tt.want.Content, got.Content)
 			assert.Equal(t, tt.want.StopReason, got.StopReason)
@@ -605,7 +605,7 @@ func TestClient_CalculateCost(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := NewClient(Config{APIKey: "test", Model: tt.model})
-			got := client.calculateCost(tt.inputTokens, tt.outputTokens)
+			got := client.calculateCost(tt.inputTokens, tt.outputTokens, 0, 0)
 			assert.GreaterOrEqual(t, got, tt.wantMin)
 			assert.LessOrEqual(t, got, tt.wantMax)
 		})

--- a/pkg/llm/openai/cost_cache_test.go
+++ b/pkg/llm/openai/cost_cache_test.go
@@ -19,15 +19,37 @@ func TestCalculateCost_CacheTiersAreBilledSeparately(t *testing.T) {
 	)
 	got := c.calculateCost(promptTokens, output, cacheRead, cacheWrite)
 
-	// 99 uncached@1.0x + 78,708 write@1.25x + 872,023 read@0.10x + 11,140 out
-	// at the $2.50/$10 fallback rates for this un-catalogued model id.
-	want := (99*2.50 + 78708*2.50*1.25 + 872023*2.50*0.10 + 11140*10.00) / 1e6
+	// 99 uncached@1.0x + 78,708 write@1.25x + 872,023 read@0.10x + 11,140 out.
+	// The id is not in the catalog, but it is recognisably Claude Sonnet, so it
+	// must price at $3/$15 — not the GPT-4o rates this client used to fall back to.
+	want := (99*3.00 + 78708*3.00*1.25 + 872023*3.00*0.10 + 11140*15.00) / 1e6
 	if math.Abs(got-want) > 1e-9 {
 		t.Fatalf("cache-aware cost = %.6f, want %.6f", got, want)
 	}
 	// A cache-blind total would bill every input token at the full rate.
-	if blind := (promptTokens*2.50 + output*10.00) / 1e6; got >= blind {
+	if blind := (promptTokens*3.00 + output*15.00) / 1e6; got >= blind {
 		t.Fatalf("cache tiers not applied: got %.6f, cache-blind would be %.6f", got, blind)
+	}
+}
+
+// A gateway-proxied Claude must not be priced with the GPT rate card.
+func TestGatewayProxiedClaudeIsNotPricedAsGPT(t *testing.T) {
+	for _, tc := range []struct {
+		id      string
+		in, out float64
+	}{
+		{"coding-agent/claude-sonnet-4-6", 3.0, 15.0},
+		{"coding-agent/claude-haiku-4-5", 1.0, 5.0},
+		{"claude-opus-4-1", 15.0, 75.0},
+		{"anything/claude-opus-4-6", 5.0, 25.0},
+	} {
+		in, out, matched := anthropicFallbackPricing(tc.id)
+		if !matched || in != tc.in || out != tc.out {
+			t.Fatalf("%s: got (%v,%v,%v), want (%v,%v,true)", tc.id, in, out, matched, tc.in, tc.out)
+		}
+	}
+	if _, _, matched := anthropicFallbackPricing("gpt-4o"); matched {
+		t.Fatal("gpt-4o must not match the Anthropic family")
 	}
 }
 

--- a/pkg/llm/openai/cost_cache_test.go
+++ b/pkg/llm/openai/cost_cache_test.go
@@ -1,0 +1,52 @@
+package openai
+
+import (
+	"math"
+	"net/http"
+	"testing"
+)
+
+// The OpenAI-compatible shape reports prompt_tokens INCLUSIVE of cached tokens,
+// so a cache-blind total over-charges a cache-heavy call several fold. These are
+// the real counts from a 20-turn ContextCompilation benchmark run.
+func TestCalculateCost_CacheTiersAreBilledSeparately(t *testing.T) {
+	c := &Client{model: "coding-agent/claude-sonnet-4-6"}
+	const (
+		promptTokens = 950830 // includes the two cache buckets below
+		cacheRead    = 872023
+		cacheWrite   = 78708
+		output       = 11140
+	)
+	got := c.calculateCost(promptTokens, output, cacheRead, cacheWrite)
+
+	// 99 uncached@1.0x + 78,708 write@1.25x + 872,023 read@0.10x + 11,140 out
+	// at the $2.50/$10 fallback rates for this un-catalogued model id.
+	want := (99*2.50 + 78708*2.50*1.25 + 872023*2.50*0.10 + 11140*10.00) / 1e6
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("cache-aware cost = %.6f, want %.6f", got, want)
+	}
+	// A cache-blind total would bill every input token at the full rate.
+	if blind := (promptTokens*2.50 + output*10.00) / 1e6; got >= blind {
+		t.Fatalf("cache tiers not applied: got %.6f, cache-blind would be %.6f", got, blind)
+	}
+}
+
+// The gateway computes its own cache-aware cost; it is authoritative.
+func TestProviderCostHeaderWins(t *testing.T) {
+	h := http.Header{}
+	h.Set(providerCostHeader, "0.01810725")
+	if got := parseProviderCost(h); got != 0.01810725 {
+		t.Fatalf("parseProviderCost = %v", got)
+	}
+	if got := costOrEstimate(parseProviderCost(h), func() float64 { return 99.0 }); got != 0.01810725 {
+		t.Fatalf("provider cost must win, got %v", got)
+	}
+	// Absent or unusable header falls back to the estimate.
+	for _, bad := range []string{"", "not-a-number", "-1"} {
+		hh := http.Header{}
+		hh.Set(providerCostHeader, bad)
+		if got := costOrEstimate(parseProviderCost(hh), func() float64 { return 42.0 }); got != 42.0 {
+			t.Fatalf("header %q: expected fallback, got %v", bad, got)
+		}
+	}
+}

--- a/pkg/server/multi_agent_broadcast_test.go
+++ b/pkg/server/multi_agent_broadcast_test.go
@@ -65,7 +65,7 @@ func (m *mockLLMForBroadcastTest) GetInjectedMessages() []string {
 
 // setupBroadcastTestServer creates a test server with message bus configured
 func setupBroadcastTestServer(t *testing.T, agents map[string]*agent.Agent, registry *agent.Registry) *MultiAgentServer {
-	logger := zaptest.NewLogger(t)
+	logger := newTestLogger(t)
 	tracer := observability.NewNoOpTracer()
 
 	sessionStore, err := agent.NewSessionStore(":memory:", tracer)

--- a/pkg/server/testlogger_test.go
+++ b/pkg/server/testlogger_test.go
@@ -1,0 +1,61 @@
+// Copyright © 2026 Teradata Corporation - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package server
+
+import (
+	"sync"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// testWriter forwards log output to t.Logf until the test finishes, then
+// discards it.
+//
+// The server's background workers outlive the test body by design: a
+// coordinator notification handler runs until its context is cancelled and logs
+// once on the way out. Cancelling in t.Cleanup does not wait for that log, so it
+// can land after tRunner has returned — and a zaptest logger writing to a
+// finished *testing.T is a data race the detector reports against the test
+// binary. Dropping late writes closes it without weakening the worker or hiding
+// anything that happens while the test is running.
+type testWriter struct {
+	mu       sync.Mutex
+	t        *testing.T
+	finished bool
+}
+
+func (w *testWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.finished {
+		return len(p), nil
+	}
+	w.t.Logf("%s", p)
+	return len(p), nil
+}
+
+func (w *testWriter) Sync() error { return nil }
+
+// newTestLogger is zaptest.NewLogger for tests that start background workers.
+func newTestLogger(t *testing.T) *zap.Logger {
+	t.Helper()
+	w := &testWriter{t: t}
+	// Cleanups run LIFO, so registering here — before the test wires up anything
+	// it will cancel — means this one runs last, after every shutdown has been
+	// signalled.
+	t.Cleanup(func() {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		w.finished = true
+	})
+	return zap.New(zapcore.NewCore(
+		zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
+		w,
+		zapcore.DebugLevel,
+	))
+}

--- a/pkg/server/workflow_reply_test.go
+++ b/pkg/server/workflow_reply_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
 
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
 	"github.com/teradata-labs/loom/pkg/agent"
@@ -117,7 +116,7 @@ func wovenWorkflow(t *testing.T) (*MultiAgentServer, *replyingLLM, *replyingLLM,
 		"test-workflow:worker": workerAgent,
 	}
 
-	logger := zaptest.NewLogger(t)
+	logger := newTestLogger(t)
 	registry, err := agent.NewRegistry(agent.RegistryConfig{
 		ConfigDir: t.TempDir(),
 		DBPath:    ":memory:",
@@ -257,7 +256,7 @@ func TestWovenWorkflow_FanOutRepliesReachCoordinator(t *testing.T) {
 		agents[name] = agent.NewAgent(backend, llm)
 	}
 
-	logger := zaptest.NewLogger(t)
+	logger := newTestLogger(t)
 	registry, err := agent.NewRegistry(agent.RegistryConfig{
 		ConfigDir: t.TempDir(),
 		DBPath:    ":memory:",


### PR DESCRIPTION
Four changes that share one theme: values a workload profile or a gateway already carries were not reaching the code that needs them.

## profiles: a workload profile now selects the relief marks

ContextCompilation's relief has two water marks — the high mark where relief begins and the low mark it sheds down to, both percentages of usable context (window minus reserved). They were hardcoded constants, so `CompressionProfile` — which already carries `CriticalThresholdPercent` and `WarningThresholdPercent` — described the behaviour without setting it. Cloud's Workload Profile selector wrote a value nothing read.

`marksLocked()` now sources both marks from the profile, falling back to the constants when the pair is unusable (release ≥ start, non-positive, or start > 100). The three presets get distinct bands, which is what makes the selector mean anything:

| Profile | high | low | Why |
|---|---|---|---|
| data_intensive | 80 | 45 | Growth arrives in bursts — one tool result can add tens of points in a call. Start early so a burst has headroom above the mark; shed deep so one pass buys many turns instead of thrashing per call |
| balanced | 90 | 60 | A 30-point band: relief roughly half as often as a 15-point band, each pass shedding more |
| conversational | 92 | 70 | Growth is small and steady and recent turns are the value. Start late, shed shallow, keep as much recency as the bound allows |

The remaining `CompressionProfile` fields (`MaxL1Tokens`, `MinL1Messages`, the batch sizes) are vestiges of batch compaction and drive nothing; the comment now says so rather than implying they are live.

Recovery penalties apply through `applyPenalty`, which floors at 1 — subtracting a penalty from an admin-set 5% must not produce a negative mark.

## roms: skill instructions outrank the general operating rules

A loaded Skill arrives once, as a conversation message. START_HERE and the system prompt are resident on every call. With no stated precedence the resident rule wins by default, which is the wrong way round — the Skill is the specific instruction.

Measured on the td-data-stats suite: "prefer doing the work over describing it" suppressed the Skill's "always return SQL" contract on 19 of 20 answers, including four turns that asked for SQL outright.

START_HERE now states the precedence, bounded to method and presentation. It never licenses reporting a figure a tool did not return, or narrowing the data without saying so.

## llm: cost must respect cache tiers, and defer to the gateway's own figure

A cache write bills at 1.25x the input rate and a cache read at 0.10x. `calculateCost` took only (input, output) and charged every input token at the full rate. On a ContextCompilation run where 91.7% of input was cache reads, that reported $2.49 against an actual $0.72 — the design's entire benefit is converting expensive tokens into 0.1x reads, and the cost function could not see it.

litellm already returns a correct, cache-aware cost in `x-litellm-response-cost`, verified against its own arithmetic to eight decimals; nothing read it. It is now authoritative, with a cache-aware local estimate as fallback (a zero or absent header means fall back).

The two providers differ in what they count, which is where the double-count risk sits: OpenAI-compatible `prompt_tokens` **includes** cached tokens, so the uncached remainder is derived by subtraction; Bedrock/Anthropic `input_tokens` **excludes** them, so the buckets are additive.

Also makes bedrock's legacy client cache-aware — its SDK client already was — and parses the cache fields it was discarding.

## llm/openai: price gateway-proxied Claude with Anthropic rates

Gateways proxy non-OpenAI models through the OpenAI-compatible client under ids like `coding-agent/claude-sonnet-4-6`. Absent from the catalog, they fell through to the GPT rate card and were billed at $2.50/$10 instead of $3/$15 — a 20% understatement on every Sonnet call, and worse for Opus.

The Anthropic family is now recognised by substring first, mirroring the bedrock client, with `claude-opus-4-1` checked before `claude-opus` since the substring test would otherwise swallow it.

The response-cost header cannot serve here, and the code records why: on streaming calls litellm flushes headers before the stream completes, so it reports a zero cost and the local estimate is the only correct source. loom streams every agent call.

## server/test: a test logger that survives its background workers

Unrelated to the above, but it was failing Unit Tests under `-race` and had to be fixed here. The coordinator notification handler spawned by `spawnWorkflowSubAgents` runs until its context is cancelled and logs once on the way out; the test cancels in `t.Cleanup` but nothing waits for that log, so it can land after `tRunner` has returned. A `zaptest` logger writing to a finished `*testing.T` is a race — and with the timing forced, a hard panic: *"Log in goroutine after ... has completed"*.

The worker is correct as written — a background goroutine that must outlive the request context, annotated as such. The harness was the wrong half. `newTestLogger` forwards to `t.Logf` under a mutex and drops writes once the test is over, registered early so its cleanup runs last, after every shutdown has been signalled; nothing that happens during the test is lost.

Verified by forcing the race: with a 300ms sleep before the shutdown log, the old harness panics every run and the new one is clean.

## Verification

`go build -tags fts5 ./...`, `go test -tags fts5 ./pkg/agent/ ./pkg/llm/...` — all green. `golangci-lint run` reports 0 issues; `gofmt -l` clean.

Cost arithmetic is pinned by `pkg/llm/openai/cost_cache_test.go`, including that a gateway-proxied Claude is not priced as a GPT.
