### PR TITLE
fix(agent): correct temporal grounding leak into user messages

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1194,15 +1194,14 @@ func (a *Agent) getSystemPrompt(ctx context.Context) string {
 		basePrompt = `Use available tools to help the user accomplish their goals. Never fabricate data - only report what tools actually return.`
 	}
 
-	// Anchor the model in wall-clock time so relative phrases ("today",
-	// "this month", "yesterday") resolve to real dates. This lives in the
-	// system prompt — NOT prepended to user message Content — so it never
-	// leaks into the user-visible, persisted message body (clients render
-	// Content verbatim). Like the rest of the ROM slot, this is rendered once
-	// at session creation and is byte-stable for the session, so it carries
-	// date granularity (sufficient for temporal grounding); a session that
-	// spans midnight keeps its creation-time anchor rather than a live clock.
-	basePrompt = "CURRENT DATE AND TIME: " + time.Now().Format("Monday, 2006-01-02 15:04 MST") + "\n\n" + basePrompt
+	// Temporal grounding does NOT live here. A wall-clock anchor baked into the
+	// ROM slot would freeze the model's "now" at session creation (warm sessions
+	// span days; a DB-restored session would re-anchor to a different instant),
+	// and — because ROM has its own cross-session cache breakpoint — a
+	// per-session timestamp would defeat prompt-cache reuse across an agent's
+	// sessions. Instead, each user turn carries its arrival time, rendered into
+	// the compiled view only (see renderLocked): the newest user turn always
+	// supplies current time, and inter-turn gaps stay visible.
 
 	// Inject task context (current tasks, ready front, board stats).
 	// Rendered once into ROM at session creation — the ROM slot is
@@ -1835,9 +1834,10 @@ func (a *Agent) chat(ctx context.Context, sessionID string, userMessage string, 
 	// Content is the canonical, user-visible message body: it is persisted and
 	// returned verbatim to clients.
 	// Do NOT prepend a timestamp here — that leaks a "[Mon 2006-01-02 15:04 MST]"
-	// prefix into every displayed user message. Arrival time is already captured
-	// durably in the Timestamp field; per-turn temporal grounding ("today",
-	// "this month") belongs in the system prompt / ROM, not baked into the body.
+	// prefix into every displayed user message. Arrival time is captured durably
+	// in the Timestamp field; per-turn temporal grounding ("today", "this month")
+	// is restored by rendering that Timestamp into the compiled view only
+	// (renderLocked), never into the stored body.
 	userMsg := a.appendMessage(ctx, session, Message{
 		Role:          "user",
 		Content:       userMessage,

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1194,6 +1194,16 @@ func (a *Agent) getSystemPrompt(ctx context.Context) string {
 		basePrompt = `Use available tools to help the user accomplish their goals. Never fabricate data - only report what tools actually return.`
 	}
 
+	// Anchor the model in wall-clock time so relative phrases ("today",
+	// "this month", "yesterday") resolve to real dates. This lives in the
+	// system prompt — NOT prepended to user message Content — so it never
+	// leaks into the user-visible, persisted message body (clients render
+	// Content verbatim). Like the rest of the ROM slot, this is rendered once
+	// at session creation and is byte-stable for the session, so it carries
+	// date granularity (sufficient for temporal grounding); a session that
+	// spans midnight keeps its creation-time anchor rather than a live clock.
+	basePrompt = "CURRENT DATE AND TIME: " + time.Now().Format("Monday, 2006-01-02 15:04 MST") + "\n\n" + basePrompt
+
 	// Inject task context (current tasks, ready front, board stats).
 	// Rendered once into ROM at session creation — the ROM slot is
 	// byte-stable for the session, so this is a snapshot, not a live view.
@@ -1822,13 +1832,15 @@ func (a *Agent) chat(ctx context.Context, sessionID string, userMessage string, 
 	// This is the Chat()-entry persist site — the only turn-incrementing event
 	// (HLD §4.5) — hence turnStart=true.
 	//
-	// Time enters the session here, written into the turn at arrival: temporal
-	// words ("today", "this month") resolve at utterance time, and a value
-	// written once is durable content like any other row — the whole session
-	// stays byte-stable. Nothing renders time dynamically anywhere.
+	// Content is the canonical, user-visible message body: it is persisted and
+	// returned verbatim to clients.
+	// Do NOT prepend a timestamp here — that leaks a "[Mon 2006-01-02 15:04 MST]"
+	// prefix into every displayed user message. Arrival time is already captured
+	// durably in the Timestamp field; per-turn temporal grounding ("today",
+	// "this month") belongs in the system prompt / ROM, not baked into the body.
 	userMsg := a.appendMessage(ctx, session, Message{
 		Role:          "user",
-		Content:       time.Now().Format("[Mon 2006-01-02 15:04 MST] ") + userMessage,
+		Content:       userMessage,
 		ContentBlocks: p.contentBlocks,
 		AgentID:       a.id, // Track which agent received this message
 		Timestamp:     time.Now(),

--- a/pkg/agent/chat_content_blocks_test.go
+++ b/pkg/agent/chat_content_blocks_test.go
@@ -341,4 +341,3 @@ func TestSystemPrompt_CarriesCurrentDate(t *testing.T) {
 	require.Contains(t, prompt, "CURRENT DATE AND TIME:", "system prompt anchors the model in wall-clock time")
 	require.Contains(t, prompt, time.Now().Format("2006-01-02"), "the anchor carries today's date")
 }
-

--- a/pkg/agent/chat_content_blocks_test.go
+++ b/pkg/agent/chat_content_blocks_test.go
@@ -95,8 +95,7 @@ func sampleBlocks() []ContentBlock {
 }
 
 // findUserMessage returns the first user-role message whose content ends with
-// the given text — the turn carries its arrival timestamp as a prefix, so the
-// caller's words are the suffix of the stored content.
+// the given text.
 func findUserMessage(messages []llmtypes.Message, content string) (llmtypes.Message, bool) {
 	for _, msg := range messages {
 		if msg.Role == "user" && strings.HasSuffix(msg.Content, content) {
@@ -155,7 +154,7 @@ func TestAgent_ChatWithContentBlocks_PersistsCanonicalText(t *testing.T) {
 	for i := range messages {
 		switch messages[i].Role {
 		case "user":
-			if strings.HasSuffix(messages[i].Content, "canonical text") {
+			if messages[i].Content == "canonical text" {
 				userMsg = &messages[i]
 			}
 		case "assistant":
@@ -164,10 +163,8 @@ func TestAgent_ChatWithContentBlocks_PersistsCanonicalText(t *testing.T) {
 	}
 
 	require.NotNil(t, userMsg, "stored user turn should keep the canonical text")
-	assert.True(t, strings.HasPrefix(userMsg.Content, "["),
-		"the turn carries its arrival timestamp as a prefix")
-	assert.True(t, strings.HasSuffix(userMsg.Content, "] canonical text"),
-		"the caller's words follow the stamp unchanged")
+	assert.Equal(t, "canonical text", userMsg.Content,
+		"the caller's words are stored verbatim, no timestamp prefix")
 	assert.Len(t, userMsg.ContentBlocks, 2, "content blocks should be stored on the user turn")
 	assert.True(t, sawAssistant, "assistant response should be appended to history")
 }
@@ -309,11 +306,11 @@ func TestContentBlockAlias(t *testing.T) {
 	assert.Equal(t, "hi", back.Text)
 }
 
-// TestChat_UserTurnCarriesArrivalTimestamp pins the write-gate rule: time
-// enters the session written into the user turn at arrival — "[Mon 2006-01-02
-// 15:04 MST] " before the user's words — and nothing renders time dynamically,
-// so the stored turn is byte-stable from the moment it is written.
-func TestChat_UserTurnCarriesArrivalTimestamp(t *testing.T) {
+// TestChat_UserTurnContentIsVerbatim pins the write-gate rule: the stored
+// user-turn Content is the user's words verbatim, with NO timestamp prefix.
+// Content is user-visible (clients render it directly), so arrival time lives
+// in the Timestamp field, not baked into the body.
+func TestChat_UserTurnContentIsVerbatim(t *testing.T) {
 	llm := &capturingLLM{response: "ok"}
 	ag := contentBlocksTestAgent(llm)
 
@@ -322,16 +319,26 @@ func TestChat_UserTurnCarriesArrivalTimestamp(t *testing.T) {
 
 	session, ok := ag.GetSession("stamp_session")
 	require.True(t, ok)
-	var content string
+	var msg Message
 	for _, m := range session.GetMessages() {
 		if m.Role == "user" {
-			content = m.Content
+			msg = m
 		}
 	}
-	require.NotEmpty(t, content)
-	require.True(t, strings.HasSuffix(content, "] what ran today?"), "user words follow the stamp: %q", content)
-	stamp := strings.TrimPrefix(content[:strings.Index(content, "] ")+1], "[")
-	stamp = strings.Trim(stamp, "[]")
-	_, err = time.Parse("Mon 2006-01-02 15:04 MST", stamp)
-	require.NoError(t, err, "stamp %q parses as the arrival-time format", stamp)
+	require.Equal(t, "what ran today?", msg.Content, "user Content is stored verbatim, no timestamp prefix")
+	require.False(t, msg.Timestamp.IsZero(), "arrival time is captured in the Timestamp field")
 }
+
+// TestSystemPrompt_CarriesCurrentDate pins the temporal-grounding rule: the
+// current date/time reaches the model through the system prompt (not the user
+// message body), so relative phrases like "today" resolve without leaking a
+// timestamp into user-visible Content.
+func TestSystemPrompt_CarriesCurrentDate(t *testing.T) {
+	llm := &capturingLLM{response: "ok"}
+	ag := contentBlocksTestAgent(llm)
+
+	prompt := ag.getSystemPrompt(context.Background())
+	require.Contains(t, prompt, "CURRENT DATE AND TIME:", "system prompt anchors the model in wall-clock time")
+	require.Contains(t, prompt, time.Now().Format("2006-01-02"), "the anchor carries today's date")
+}
+

--- a/pkg/agent/chat_content_blocks_test.go
+++ b/pkg/agent/chat_content_blocks_test.go
@@ -123,13 +123,27 @@ func TestAgent_ChatWithContentBlocks_PropagatesBlocksToLLM(t *testing.T) {
 	require.Len(t, userMsg.ContentBlocks, 2, "both content blocks must reach the provider")
 
 	assert.Equal(t, "text", userMsg.ContentBlocks[0].Type)
-	assert.Equal(t, "What is in this image?", userMsg.ContentBlocks[0].Text)
+	assert.True(t, strings.HasSuffix(userMsg.ContentBlocks[0].Text, "What is in this image?"),
+		"the forwarded text block carries the arrival stamp ahead of the prompt: %q", userMsg.ContentBlocks[0].Text)
 
 	imgBlock := userMsg.ContentBlocks[1]
 	assert.Equal(t, "image", imgBlock.Type)
 	require.NotNil(t, imgBlock.Image)
 	assert.Equal(t, "image/png", imgBlock.Image.Source.MediaType)
 	assert.Equal(t, "aGVsbG8=", imgBlock.Image.Source.Data)
+}
+
+// storedTurns returns the raw, persisted conversation rows for a session — the
+// client-visible bodies, before the compile-time arrival-stamp render. Use this
+// (not Session.GetMessages, which returns the compiled LLM view) to assert what
+// clients actually see persisted.
+func storedTurns(t *testing.T, ag *Agent, sessionID string) []Message {
+	t.Helper()
+	session, ok := ag.GetSession(sessionID)
+	require.True(t, ok, "session should exist")
+	sm, ok := session.SegmentedMem.(*SegmentedMemory)
+	require.True(t, ok, "session should use SegmentedMemory")
+	return sm.GetRecentConversationTurns(1000)
 }
 
 // TestAgent_ChatWithContentBlocks_PersistsCanonicalText verifies userMessage
@@ -143,13 +157,10 @@ func TestAgent_ChatWithContentBlocks_PersistsCanonicalText(t *testing.T) {
 	_, err := ag.ChatWithContentBlocks(context.Background(), sessionID, "canonical text", sampleBlocks(), nil)
 	require.NoError(t, err)
 
-	session, ok := ag.GetSession(sessionID)
-	require.True(t, ok, "session should exist after the call")
-
-	messages := session.GetMessages()
+	messages := storedTurns(t, ag, sessionID)
 	require.GreaterOrEqual(t, len(messages), 2, "expected at least the user turn and assistant reply")
 
-	var userMsg *types.Message
+	var userMsg *Message
 	var sawAssistant bool
 	for i := range messages {
 		switch messages[i].Role {
@@ -216,7 +227,10 @@ func TestAgent_ChatWithContentBlocks_ImageOnlyPrependsText(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, userMsg.ContentBlocks, 2, "text block must be prepended to the image-only set")
 	assert.Equal(t, "text", userMsg.ContentBlocks[0].Type)
-	assert.Equal(t, "What is in this image?", userMsg.ContentBlocks[0].Text, "prepended text must be the canonical userMessage")
+	// The compiled view carries the arrival stamp on the leading text block so it
+	// reaches the multimodal provider; the canonical userMessage follows it.
+	assert.True(t, strings.HasSuffix(userMsg.ContentBlocks[0].Text, "] What is in this image?"),
+		"prepended text is the canonical userMessage behind its arrival stamp: %q", userMsg.ContentBlocks[0].Text)
 	assert.Equal(t, "image", userMsg.ContentBlocks[1].Type)
 }
 
@@ -317,10 +331,8 @@ func TestChat_UserTurnContentIsVerbatim(t *testing.T) {
 	_, err := ag.Chat(context.Background(), "stamp_session", "what ran today?")
 	require.NoError(t, err)
 
-	session, ok := ag.GetSession("stamp_session")
-	require.True(t, ok)
 	var msg Message
-	for _, m := range session.GetMessages() {
+	for _, m := range storedTurns(t, ag, "stamp_session") {
 		if m.Role == "user" {
 			msg = m
 		}
@@ -329,15 +341,50 @@ func TestChat_UserTurnContentIsVerbatim(t *testing.T) {
 	require.False(t, msg.Timestamp.IsZero(), "arrival time is captured in the Timestamp field")
 }
 
-// TestSystemPrompt_CarriesCurrentDate pins the temporal-grounding rule: the
-// current date/time reaches the model through the system prompt (not the user
-// message body), so relative phrases like "today" resolve without leaking a
-// timestamp into user-visible Content.
-func TestSystemPrompt_CarriesCurrentDate(t *testing.T) {
+// TestChat_CompiledUserTurnCarriesTimestamp pins the temporal-grounding rule:
+// the arrival timestamp reaches the model through the COMPILED view of the user
+// turn (rendered from Timestamp), not through the stored body and not through a
+// ROM date anchor. The stored Content stays verbatim; the forwarded message
+// carries the "[Mon 2006-01-02 15:04 MST] " stamp so relative phrases resolve.
+func TestChat_CompiledUserTurnCarriesTimestamp(t *testing.T) {
 	llm := &capturingLLM{response: "ok"}
 	ag := contentBlocksTestAgent(llm)
 
+	// Capture the date band around the call. getSystemPrompt/the stamp read the
+	// clock independently of this assertion, so straddling midnight would flake a
+	// single time.Now() check; accept either day the call could have landed on.
+	dateBefore := time.Now().UTC().Format("2006-01-02")
+	_, err := ag.Chat(context.Background(), "stamp_session", "what ran today?")
+	require.NoError(t, err)
+	dateAfter := time.Now().UTC().Format("2006-01-02")
+
+	// The forwarded (compiled) user turn carries the arrival stamp.
+	var forwarded string
+	for _, m := range llm.lastMessages() {
+		if m.Role == "user" {
+			forwarded = m.Content
+		}
+	}
+	require.NotEmpty(t, forwarded)
+	assert.True(t, strings.HasPrefix(forwarded, "["),
+		"compiled user turn is prefixed with its arrival stamp: %q", forwarded)
+	assert.True(t, strings.HasSuffix(forwarded, "] what ran today?"),
+		"the user's words follow the stamp unchanged: %q", forwarded)
+	assert.True(t, strings.Contains(forwarded, dateBefore) || strings.Contains(forwarded, dateAfter),
+		"the stamp carries today's date (%s or %s): %q", dateBefore, dateAfter, forwarded)
+
+	// The stored body stays verbatim — no stamp leaks into persisted Content.
+	var stored Message
+	for _, m := range storedTurns(t, ag, "stamp_session") {
+		if m.Role == "user" {
+			stored = m
+		}
+	}
+	require.Equal(t, "what ran today?", stored.Content,
+		"stored Content is verbatim, no timestamp prefix")
+
+	// Temporal grounding no longer rides a per-session ROM anchor.
 	prompt := ag.getSystemPrompt(context.Background())
-	require.Contains(t, prompt, "CURRENT DATE AND TIME:", "system prompt anchors the model in wall-clock time")
-	require.Contains(t, prompt, time.Now().Format("2006-01-02"), "the anchor carries today's date")
+	assert.NotContains(t, prompt, "CURRENT DATE AND TIME:",
+		"no wall-clock anchor is baked into the ROM slot")
 }

--- a/pkg/agent/context_compilation.go
+++ b/pkg/agent/context_compilation.go
@@ -169,6 +169,29 @@ func hasQueryToolResultCall(m *Message) bool {
 // the evicted cases, so relief and prior turns behave identically for every
 // tool.
 func (sm *SegmentedMemory) renderLocked(m *Message, t int64, callName map[string]string) Message {
+	// User turns carry their arrival time into the compiled view ONLY, so the
+	// model keeps per-turn temporal grounding ("today", "this month") while the
+	// stored, client-visible Content stays verbatim. Timestamp is write-once and
+	// persisted as Unix seconds, so every compile — including after restart —
+	// renders identical bytes: byte-stability and all cache breakpoints hold.
+	// Rendered in UTC so a server timezone change across restart cannot alter
+	// the bytes. Legacy rows without a Timestamp render unchanged.
+	//
+	// Multimodal turns need the stamp inside ContentBlocks too: providers build
+	// the request exclusively from ContentBlocks when present (agent.go), so a
+	// stamp on Content alone would never reach the model for an image turn. Stamp
+	// the leading text block (deep-copying so the stored row is untouched); if a
+	// turn somehow carries no text block, fall back to a stamp-only Content so
+	// grounding is never silently dropped.
+	if m.Role == "user" && !m.Timestamp.IsZero() {
+		stamp := "[" + m.Timestamp.UTC().Format("Mon 2006-01-02 15:04 MST") + "] "
+		r := *m
+		r.Content = stamp + m.Content
+		if len(m.ContentBlocks) > 0 {
+			r.ContentBlocks = stampLeadingTextBlock(m.ContentBlocks, stamp)
+		}
+		return r
+	}
 	if m.Role != "tool" {
 		return *m
 	}
@@ -191,6 +214,23 @@ func (sm *SegmentedMemory) renderLocked(m *Message, t int64, callName map[string
 	default:
 		return *m
 	}
+}
+
+// stampLeadingTextBlock returns a copy of blocks with stamp prepended to the
+// first text block, so the arrival stamp reaches multimodal providers (which
+// build the request from ContentBlocks). The input slice and its blocks are
+// never mutated — only the compiled view is stamped. If no text block exists,
+// blocks are returned unchanged; renderLocked's stamped Content is the fallback.
+func stampLeadingTextBlock(blocks []ContentBlock, stamp string) []ContentBlock {
+	for i := range blocks {
+		if blocks[i].Type == "text" {
+			out := make([]ContentBlock, len(blocks))
+			copy(out, blocks)
+			out[i].Text = stamp + out[i].Text
+			return out
+		}
+	}
+	return blocks
 }
 
 // offloadStub renders the §5.5 offload stub for a current-turn result strictly

--- a/pkg/agent/context_compilation_test.go
+++ b/pkg/agent/context_compilation_test.go
@@ -27,6 +27,7 @@ import (
 
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
 	"github.com/teradata-labs/loom/pkg/observability"
+	"github.com/teradata-labs/loom/pkg/types"
 )
 
 // --- write rule §4.1: truncation ---------------------------------------------
@@ -109,6 +110,89 @@ func TestCompile_AtThresholdRendersFull(t *testing.T) {
 		if m.Role == "tool" {
 			assert.Equal(t, page, m.Content, "strictly over the threshold, not at it — a page must never stub itself")
 		}
+	}
+}
+
+func TestCompile_UserTurnRendersArrivalStampInViewOnly(t *testing.T) {
+	sm := newCompileMemory(t)
+	ts := time.Date(2026, 8, 10, 14, 5, 0, 0, time.UTC)
+	sm.AddMessage(context.Background(), Message{Role: "user", Content: "what ran today?", Turn: 1, Timestamp: ts})
+
+	out := sm.GetMessagesForLLM()
+	var rendered string
+	for _, m := range out {
+		if m.Role == "user" {
+			rendered = m.Content
+		}
+	}
+	assert.Equal(t, "[Mon 2026-08-10 14:05 UTC] what ran today?", rendered,
+		"the compiled user turn carries the arrival stamp, rendered from Timestamp in UTC")
+
+	// The stored row is untouched — the stamp is a pure render condition.
+	stored := sm.GetRecentConversationTurns(1)
+	require.Len(t, stored, 1)
+	assert.Equal(t, "what ran today?", stored[0].Content,
+		"stored Content stays verbatim; only the view is stamped")
+}
+
+func TestCompile_UserTurnWithoutTimestampRendersVerbatim(t *testing.T) {
+	sm := newCompileMemory(t)
+	// Legacy row with a zero Timestamp must render unchanged.
+	sm.AddMessage(context.Background(), Message{Role: "user", Content: "legacy turn", Turn: 1})
+
+	out := sm.GetMessagesForLLM()
+	for _, m := range out {
+		if m.Role == "user" {
+			assert.Equal(t, "legacy turn", m.Content, "no stamp is invented for a timestamp-less row")
+		}
+	}
+}
+
+// TestCompile_MultimodalUserTurnStampsLeadingTextBlock verifies the arrival
+// stamp reaches multimodal providers: they build the request from ContentBlocks,
+// so the stamp must land on the leading text block too, not just Content. The
+// stored blocks stay verbatim — only the compiled view is stamped.
+func TestCompile_MultimodalUserTurnStampsLeadingTextBlock(t *testing.T) {
+	sm := newCompileMemory(t)
+	ts := time.Date(2026, 8, 10, 14, 5, 0, 0, time.UTC)
+	blocks := []ContentBlock{
+		{Type: "text", Text: "what is in this image?"},
+		{Type: "image", Image: &types.ImageContent{Type: "image", Source: types.ImageSource{Type: "base64", MediaType: "image/png", Data: "aGVsbG8="}}},
+	}
+	sm.AddMessage(context.Background(), Message{Role: "user", Content: "what is in this image?", ContentBlocks: blocks, Turn: 1, Timestamp: ts})
+
+	out := sm.GetMessagesForLLM()
+	var rendered Message
+	for _, m := range out {
+		if m.Role == "user" {
+			rendered = m
+		}
+	}
+	require.Len(t, rendered.ContentBlocks, 2)
+	assert.Equal(t, "[Mon 2026-08-10 14:05 UTC] what is in this image?", rendered.ContentBlocks[0].Text,
+		"the leading text block carries the stamp so multimodal providers see it")
+	assert.Equal(t, "image", rendered.ContentBlocks[1].Type, "the image block is untouched")
+
+	// The stored blocks are untouched — the stamp is a pure render condition.
+	stored := sm.GetRecentConversationTurns(1)
+	require.Len(t, stored, 1)
+	require.Len(t, stored[0].ContentBlocks, 2)
+	assert.Equal(t, "what is in this image?", stored[0].ContentBlocks[0].Text,
+		"stored blocks stay verbatim; only the view is stamped")
+}
+
+func TestCompile_TwoCompilesAreByteIdentical(t *testing.T) {
+	sm := newCompileMemory(t)
+	ts := time.Date(2026, 8, 10, 14, 5, 0, 0, time.UTC)
+	sm.AddMessage(context.Background(), Message{Role: "user", Content: "hello", Turn: 1, Timestamp: ts})
+	sm.AddMessage(context.Background(), Message{Role: "assistant", Content: "hi", Turn: 1})
+
+	first := sm.GetMessagesForLLM()
+	second := sm.GetMessagesForLLM()
+	require.Equal(t, len(first), len(second))
+	for i := range first {
+		assert.Equal(t, first[i].Content, second[i].Content,
+			"the compiled view is byte-stable across calls (Timestamp is write-once)")
 	}
 }
 

--- a/pkg/agent/graph_memory_extractor.go
+++ b/pkg/agent/graph_memory_extractor.go
@@ -112,7 +112,15 @@ func buildConversationBlock(ec extractionContext) string {
 		if msg.Role == "tool" {
 			continue
 		}
-		fmt.Fprintf(&sb, "%d. [%s]: %s\n", i+1, msg.Role, msg.Content)
+		// Render each turn's own arrival date so the extractor anchors relative
+		// phrases ("yesterday", "three days ago") against the turn they were said
+		// in, not the extraction day. Timestamp rides through unchanged from the
+		// stored turn; legacy rows without one fall back to role only.
+		if !msg.Timestamp.IsZero() {
+			fmt.Fprintf(&sb, "%d. [%s @ %s]: %s\n", i+1, msg.Role, msg.Timestamp.UTC().Format("2006-01-02"), msg.Content)
+		} else {
+			fmt.Fprintf(&sb, "%d. [%s]: %s\n", i+1, msg.Role, msg.Content)
+		}
 	}
 
 	return sb.String()
@@ -294,12 +302,17 @@ func (a *Agent) extractGraphMemoryAsync(ctx context.Context, sessionID string) {
 		}
 	}
 
-	// Determine the current date for anchoring relative time references.
-	// Try to extract from conversation content (e.g., "session that took place on 2023/05/24"),
-	// fall back to the current wall clock time.
-	currentDate := extractDateFromMessages(recentMessages)
+	// Determine the current date for anchoring relative time references. Prefer
+	// the newest turn's arrival Timestamp — the durable arrival record that
+	// survives restart — so a session resumed after N days anchors to when the
+	// conversation happened, not extraction day. Fall back to a date embedded in
+	// content (e.g. a benchmark's "took place on 2023/05/24"), then wall clock.
+	currentDate := newestMessageDate(recentMessages)
 	if currentDate == "" {
-		currentDate = time.Now().Format("2006-01-02")
+		currentDate = extractDateFromMessages(recentMessages)
+	}
+	if currentDate == "" {
+		currentDate = time.Now().UTC().Format("2006-01-02")
 	}
 
 	// Use compressorLLM for extraction (cheaper/smaller model), fall back to main LLM.
@@ -485,6 +498,20 @@ func parseExtractionResponse(content string) (ExtractedGraphData, bool) {
 		return data, false
 	}
 	return data, true
+}
+
+// newestMessageDate returns the UTC ISO date (YYYY-MM-DD) of the most recent
+// message that carries a non-zero arrival Timestamp, or "" if none do. This is
+// the durable, restart-surviving anchor for relative time references — strictly
+// more robust than scanning Content, which only worked while a timestamp prefix
+// was baked into the body.
+func newestMessageDate(messages []types.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if !messages[i].Timestamp.IsZero() {
+			return messages[i].Timestamp.UTC().Format("2006-01-02")
+		}
+	}
+	return ""
 }
 
 // extractDateFromMessages scans recent messages for date context.

--- a/pkg/agent/graph_memory_extractor_test.go
+++ b/pkg/agent/graph_memory_extractor_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -638,4 +639,39 @@ func TestExtractedMemory_UnmarshalsEventDateFields(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "2023-03-14", m.EventDate)
 	assert.Equal(t, "approximate", m.EventDateConfidence)
+}
+
+// TestNewestMessageDate_PrefersDurableTimestamp verifies the extractor anchors
+// on the newest turn's arrival Timestamp — the restart-surviving record — so a
+// session resumed after N days anchors to when the conversation happened, not
+// extraction day.
+func TestNewestMessageDate_PrefersDurableTimestamp(t *testing.T) {
+	messages := []types.Message{
+		{Role: "user", Content: "i deployed the service", Timestamp: time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)},
+		{Role: "assistant", Content: "noted"},
+		{Role: "user", Content: "did the deploy finish yesterday?", Timestamp: time.Date(2026, 8, 4, 10, 0, 0, 0, time.UTC)},
+	}
+	assert.Equal(t, "2026-08-04", newestMessageDate(messages), "newest non-zero Timestamp wins")
+
+	// No timestamps: nothing to anchor on from this source.
+	assert.Equal(t, "", newestMessageDate([]types.Message{{Role: "user", Content: "hi"}}))
+}
+
+// TestBuildConversationBlock_RendersPerTurnDates verifies each turn is rendered
+// with its own arrival date so the extractor LLM anchors relative phrases to the
+// turn they were said in, not to the extraction day.
+func TestBuildConversationBlock_RendersPerTurnDates(t *testing.T) {
+	ec := extractionContext{
+		currentDate: "2026-08-04",
+		messages: []types.Message{
+			{Role: "user", Content: "i met alice", Timestamp: time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)},
+			{Role: "user", Content: "legacy line"}, // zero Timestamp
+		},
+	}
+	block := buildConversationBlock(ec)
+	assert.Contains(t, block, "Current date: 2026-08-04")
+	assert.Contains(t, block, "1. [user @ 2026-08-01]: i met alice",
+		"a stamped turn renders its own arrival date")
+	assert.Contains(t, block, "2. [user]: legacy line",
+		"a timestamp-less row renders role only, no invented date")
 }

--- a/pkg/agent/memory_cross_session_test.go
+++ b/pkg/agent/memory_cross_session_test.go
@@ -16,6 +16,7 @@ package agent
 import (
 	"context"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -455,14 +456,24 @@ func TestMemory_SessionHistorySurvivesRestart(t *testing.T) {
 	require.GreaterOrEqual(t, len(llmMsgs), len(msgs),
 		"LLM context must contain prior conversation history after restart")
 
-	// Verify the actual content is present.
+	// Verify the actual content is present. User turns carry the compile-time
+	// arrival stamp in the LLM view (rendered from the persisted Timestamp), so
+	// match them by suffix; the assistant reply is unstamped and matches exactly.
 	var contents []string
 	for _, m := range llmMsgs {
 		contents = append(contents, m.Content)
 	}
-	assert.Contains(t, contents, msgs[0].Content, "first user message must be in LLM context")
+	assertHasSuffix := func(items []string, suffix, msg string) {
+		for _, it := range items {
+			if strings.HasSuffix(it, suffix) {
+				return
+			}
+		}
+		assert.Failf(t, msg, "no compiled message ends with %q; got %v", suffix, items)
+	}
+	assertHasSuffix(contents, msgs[0].Content, "first user message must be in LLM context")
 	assert.Contains(t, contents, msgs[1].Content, "assistant reply must be in LLM context")
-	assert.Contains(t, contents, msgs[2].Content, "second user message must be in LLM context")
+	assertHasSuffix(contents, msgs[2].Content, "second user message must be in LLM context")
 
 	// Also verify a new message can be appended after restore.
 	newMsg := Message{Role: "assistant", Content: "The sky is still blue.", Timestamp: time.Now()}


### PR DESCRIPTION
## Description

Relative phrases like "today", "yesterday", or "this month" need the model to know each user turn's arrival time. The original implementation supplied that by prepending a `[Mon 2006-01-02 15:04 MST] ` stamp directly onto the user-visible `Content` field — leaking a timestamp prefix into every persisted/displayed user message.

The first cut of this PR fixed the leak by moving the anchor into the system prompt/ROM slot. Review (round 1) showed that regressed two downstream consumers and froze the model's "now" at session creation. This PR now adopts the reviewer's suggested direction: keep stored `Content` verbatim, and render the arrival `Timestamp` into the compiled LLM view only — the same "pure render condition" seam the context compiler already uses for tool offload/eviction.

## Type of Change

- 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made

- **`chat()` (`agent.go`)**: `Content` is stored verbatim; arrival time is captured in the existing `Timestamp` field. No stamp is prepended to the persisted body.
- **`renderLocked` (`context_compilation.go`)**: user turns render `"[Mon 2006-01-02 15:04 MST] " + Content` into the compiled view only, guarding a zero `Timestamp` for legacy rows. Rendered in UTC so a server timezone change across restart cannot alter the bytes; `Timestamp` is write-once and persisted as Unix seconds, so every compile — including after restart — is byte-identical and all cache breakpoints hold. The newest user turn always supplies current time, so inter-turn gaps stay visible.
- **Multimodal turns**: providers build the request exclusively from `ContentBlocks` when present, so the stamp is also applied to the leading text block (`stampLeadingTextBlock`, deep-copying so stored blocks stay verbatim). Without this, image turns would silently lose temporal grounding — a gap that existed even in the pre-bug body-prepend code.
- **`getSystemPrompt` (`agent.go`)**: dropped the per-session `CURRENT DATE AND TIME` ROM anchor. It froze the model's "now" at session creation (warm vs DB-restored asymmetry) and its minute-granularity value defeated cross-session ROM prompt-cache reuse. With per-turn stamps it is redundant.
- **Graph memory extractor (`graph_memory_extractor.go`)**: `buildConversationBlock` renders each turn's own arrival date (`[user @ 2026-08-10]`), and `currentDate` is derived from the newest turn's durable `Timestamp` (`newestMessageDate`), falling back to a content-embedded date, then wall clock. A session resumed after N days now anchors relative phrases to the conversation date, not extraction day — fixing a silent regression of the event-date anchoring feature (migration 000006).

## Review items addressed (round 1)

- **F1** (event-date anchoring lost its date source): fixed — extractor anchors on the durable `Timestamp` and renders per-turn dates.
- **F2** (model's "now" froze at session creation, warm-vs-restored asymmetry): fixed — per-turn stamp in the compiled view; ROM anchor removed.
- **F3** (minute-granularity ROM stamp defeated cross-session cache reuse): fixed — ROM anchor dropped.
- **F4** (midnight flake): fixed — the date assertion accepts either day in a `dateBefore`/`dateAfter` band around the call.
- **F5** (nit): the relevant helper usage was replaced with `storedTurns`.

## Testing

```
go test -tags fts5 -race ./pkg/agent/...
go build -tags fts5 ./...
go vet -tags fts5 ./pkg/agent/
```

All pass; 0 race conditions; gofmt clean.

### Test Coverage

- Compiled user turn is stamped while stored `Content` stays verbatim (`TestChat_CompiledUserTurnCarriesTimestamp`, `TestCompile_UserTurnRendersArrivalStampInViewOnly`).
- Multimodal turn stamps the leading text block, stored blocks verbatim (`TestCompile_MultimodalUserTurnStampsLeadingTextBlock`).
- Two consecutive compiles are byte-identical (`TestCompile_TwoCompilesAreByteIdentical`).
- Legacy timestamp-less rows render verbatim (`TestCompile_UserTurnWithoutTimestampRendersVerbatim`).
- Extractor anchors to backdated `Timestamp`s and renders per-turn dates (`TestNewestMessageDate_PrefersDurableTimestamp`, `TestBuildConversationBlock_RendersPerTurnDates`).
- Cross-session restart test updated to match the stamped LLM view.

## Proto Changes

- No proto changes in this PR

## Documentation

- Code comments added/updated
