### PR TITLE
feat(server): occurred_at arrival-time override for replayed/imported conversations

### DIFF
--- a/cmd/looms/cmd_serve.go
+++ b/cmd/looms/cmd_serve.go
@@ -2341,6 +2341,13 @@ func runServe(cmd *cobra.Command, args []string) {
 	// Set logger for server operations
 	loomService.SetLogger(logger)
 
+	// Honor WeaveRequest.occurred_at only when the operator opted in —
+	// replay/import arrival times are rejected otherwise (see applyOccurredAt).
+	loomService.SetAllowTimeOverride(config.Server.AllowTimeOverride)
+	if config.Server.AllowTimeOverride {
+		logger.Info("Arrival-time override enabled (server.allow_time_override): WeaveRequest.occurred_at will be honored")
+	}
+
 	// Set provider factory for dynamic model switching
 	loomService.SetProviderFactory(providerFactory)
 	logger.Info("Provider factory configured on server for model switching")

--- a/cmd/looms/config.go
+++ b/cmd/looms/config.go
@@ -197,15 +197,16 @@ type TUIConfig struct {
 
 // ServerConfig holds server-specific configuration.
 type ServerConfig struct {
-	Port             int                 `mapstructure:"port"`
-	Host             string              `mapstructure:"host"`
-	HTTPPort         int                 `mapstructure:"http_port"` // HTTP/REST+SSE port (default: 5006, 0=disabled)
-	EnableReflection bool                `mapstructure:"enable_reflection"`
-	InsecureAdmin    bool                `mapstructure:"insecure_admin"` // Allow admin endpoints without LOOM_ADMIN_TOKEN (default: false)
-	TLS              TLSConfig           `mapstructure:"tls"`
-	Clarification    ClarificationConfig `mapstructure:"clarification"` // Clarification question timeouts
-	CORS             CORSServerConfig    `mapstructure:"cors"`          // CORS configuration for HTTP endpoints
-	Auth             AuthConfig          `mapstructure:"auth"`          // Endpoint authentication (Supabase JWT)
+	Port              int                 `mapstructure:"port"`
+	Host              string              `mapstructure:"host"`
+	HTTPPort          int                 `mapstructure:"http_port"` // HTTP/REST+SSE port (default: 5006, 0=disabled)
+	EnableReflection  bool                `mapstructure:"enable_reflection"`
+	InsecureAdmin     bool                `mapstructure:"insecure_admin"`      // Allow admin endpoints without LOOM_ADMIN_TOKEN (default: false)
+	AllowTimeOverride bool                `mapstructure:"allow_time_override"` // Honor WeaveRequest.occurred_at for replayed/imported conversations (default: false)
+	TLS               TLSConfig           `mapstructure:"tls"`
+	Clarification     ClarificationConfig `mapstructure:"clarification"` // Clarification question timeouts
+	CORS              CORSServerConfig    `mapstructure:"cors"`          // CORS configuration for HTTP endpoints
+	Auth              AuthConfig          `mapstructure:"auth"`          // Endpoint authentication (Supabase JWT)
 }
 
 // AuthConfig gates JWT authentication of Loom's gRPC/HTTP endpoints. When
@@ -1094,6 +1095,7 @@ func setDefaults() {
 	viper.SetDefault("server.host", "0.0.0.0")
 	viper.SetDefault("server.enable_reflection", true)
 	viper.SetDefault("server.insecure_admin", false)
+	viper.SetDefault("server.allow_time_override", false)
 
 	// Clarification defaults
 	viper.SetDefault("server.clarification.rpc_timeout_seconds", 5)
@@ -1823,6 +1825,7 @@ server:
   host: 0.0.0.0
   enable_reflection: true
   # insecure_admin: false  # Set to true to allow admin endpoints without LOOM_ADMIN_TOKEN (NOT recommended for production)
+  # allow_time_override: false  # Set to true to honor WeaveRequest.occurred_at (replayed/imported conversations only)
 
 llm:
   # Provider options: anthropic, bedrock, ollama, openai, azure-openai, mistral

--- a/docs/reference/CLAUDE.md
+++ b/docs/reference/CLAUDE.md
@@ -353,21 +353,35 @@ rpc Weave(WeaveRequest) returns (WeaveResponse)
 
 **Description**: Single-turn agent interaction.
 
-**Request**:
+**Request** (see `proto/loom/v1/loom.proto` for the authoritative definition):
 ```proto
 message WeaveRequest {
-  string session_id = 1;   // Required: Session identifier
-  string message = 2;      // Required: User message
-  repeated string tools = 3; // Optional: Tool whitelist
+  string query = 1;                    // Required: user's natural language query
+  string session_id = 2;               // Optional: session identifier (auto-generated if empty)
+  map<string, string> backend_config = 3; // Optional: backend configuration overrides
+  int32 max_rounds = 4;                // Optional: maximum execution rounds (default: 3)
+  int32 timeout_seconds = 5;           // Optional: timeout in seconds (default: 300)
+  map<string, string> context = 6;     // Optional: context variables for prompt interpolation
+  string force_pattern = 7;            // Optional: force specific pattern (bypass selection)
+  bool enable_trace = 8;               // Optional: enable tracing for this request
+  string agent_id = 9;                 // Optional: agent to route to (default agent if empty)
+  bool reset_context = 10;             // Optional: clear context window before processing
+  google.protobuf.Timestamp occurred_at = 11; // Optional: historical arrival time (replay/import; requires server.allow_time_override)
 }
 ```
 
 **Response**:
 ```proto
 message WeaveResponse {
-  string message = 1;       // Agent response
-  int64 tokens_used = 2;    // Total tokens consumed
-  repeated ToolCall tools = 3; // Tools executed
+  string text = 1;                     // Generated response text
+  ExecutionResult result = 2;          // Execution result (domain-specific)
+  string session_id = 3;               // Session ID used
+  string trace_id = 4;                 // Trace ID for observability
+  CostInfo cost = 5;                   // Cost attribution
+  ExecutionMetadata metadata = 6;      // Execution metadata
+  repeated SelfCorrectionAttempt corrections = 7; // Self-correction attempts (if any)
+  string agent_id = 8;                 // Agent that handled this request
+  ContextState context_state = 9;      // Context window state after this response
 }
 ```
 
@@ -389,13 +403,13 @@ client := loomv1.NewLoomServiceClient(conn)
 
 resp, err := client.Weave(ctx, &loomv1.WeaveRequest{
     SessionId: "sess_abc123",
-    Message:   "Show sales by region",
+    Query:     "Show sales by region",
 })
 if err != nil {
     log.Fatalf("RPC failed: %v", err)
 }
 
-fmt.Printf("Response: %s\n", resp.Message)
+fmt.Printf("Response: %s\n", resp.Text)
 ```
 
 **Example (HTTP gateway)**:

--- a/docs/reference/streaming.md
+++ b/docs/reference/streaming.md
@@ -492,8 +492,19 @@ message WeaveRequest {
   bool enable_trace = 8;              // Optional: Enable tracing for this request
   string agent_id = 9;               // Optional: Agent ID to route request to (uses default if empty)
   bool reset_context = 10;            // Optional: Clear context window before processing
+  google.protobuf.Timestamp occurred_at = 11; // Optional: historical arrival time for replayed/imported conversations
 }
 ```
+
+**`occurred_at` (replay/import only):** when set, every message persisted
+during the call — user turn, assistant reply, tool rows — carries this
+timestamp instead of the server wall clock, so temporal grounding
+(graph-memory extraction anchoring, arrival stamps) reflects when the
+conversation actually happened. The server rejects the field with
+`FAILED_PRECONDITION` unless `server.allow_time_override: true` is set in
+`looms.yaml` (default: false — client-supplied timestamps can poison temporal
+grounding), and rejects future-dated values with `INVALID_ARGUMENT`. Live
+conversations should leave it unset.
 
 ### Client Example
 

--- a/gen/go/loom/v1/loom.pb.go
+++ b/gen/go/loom/v1/loom.pb.go
@@ -26,6 +26,7 @@ import (
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
 	structpb "google.golang.org/protobuf/types/known/structpb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -298,7 +299,19 @@ type WeaveRequest struct {
 	// Clear context window before processing this message.
 	// When true, the agent's SegmentedMemory is reset (L1/L2/swap cleared)
 	// before the query is processed, giving a fresh context window.
-	ResetContext  bool `protobuf:"varint,10,opt,name=reset_context,json=resetContext,proto3" json:"reset_context,omitempty"`
+	ResetContext bool `protobuf:"varint,10,opt,name=reset_context,json=resetContext,proto3" json:"reset_context,omitempty"`
+	// Historical arrival time for replayed or imported conversations (optional).
+	// When set, every message persisted during this call — the user turn, the
+	// assistant reply, and tool rows — carries this timestamp instead of the
+	// server wall clock, so temporal grounding (compiled-view arrival stamps,
+	// graph-memory extraction anchoring) reflects when the conversation
+	// actually happened rather than when it was ingested.
+	//
+	// Servers reject this field unless server.allow_time_override is enabled
+	// (FAILED_PRECONDITION), and reject values in the future beyond a small
+	// clock-skew allowance (INVALID_ARGUMENT). Live conversations should leave
+	// it unset.
+	OccurredAt    *timestamppb.Timestamp `protobuf:"bytes,11,opt,name=occurred_at,json=occurredAt,proto3" json:"occurred_at,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -401,6 +414,13 @@ func (x *WeaveRequest) GetResetContext() bool {
 		return x.ResetContext
 	}
 	return false
+}
+
+func (x *WeaveRequest) GetOccurredAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.OccurredAt
+	}
+	return nil
 }
 
 // WeaveResponse contains the execution result.
@@ -10700,7 +10720,7 @@ var File_loom_v1_loom_proto protoreflect.FileDescriptor
 
 const file_loom_v1_loom_proto_rawDesc = "" +
 	"\n" +
-	"\x12loom/v1/loom.proto\x12\aloom.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1aloom/v1/agent_config.proto\x1a\x12loom/v1/apps.proto\x1a\x11loom/v1/bus.proto\x1a\x1bloom/v1/communication.proto\x1a\x1bloom/v1/orchestration.proto\x1a\x14loom/v1/server.proto\x1a\x1bloom/v1/shared_memory.proto\x1a\x15loom/v1/storage.proto\x1a\x17loom/v1/templates.proto\x1a\x13loom/v1/tools.proto\"\xa0\x04\n" +
+	"\x12loom/v1/loom.proto\x12\aloom.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1aloom/v1/agent_config.proto\x1a\x12loom/v1/apps.proto\x1a\x11loom/v1/bus.proto\x1a\x1bloom/v1/communication.proto\x1a\x1bloom/v1/orchestration.proto\x1a\x14loom/v1/server.proto\x1a\x1bloom/v1/shared_memory.proto\x1a\x15loom/v1/storage.proto\x1a\x17loom/v1/templates.proto\x1a\x13loom/v1/tools.proto\"\xdd\x04\n" +
 	"\fWeaveRequest\x12\x14\n" +
 	"\x05query\x18\x01 \x01(\tR\x05query\x12\x1d\n" +
 	"\n" +
@@ -10714,7 +10734,9 @@ const file_loom_v1_loom_proto_rawDesc = "" +
 	"\fenable_trace\x18\b \x01(\bR\venableTrace\x12\x19\n" +
 	"\bagent_id\x18\t \x01(\tR\aagentId\x12#\n" +
 	"\rreset_context\x18\n" +
-	" \x01(\bR\fresetContext\x1a@\n" +
+	" \x01(\bR\fresetContext\x12;\n" +
+	"\voccurred_at\x18\v \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"occurredAt\x1a@\n" +
 	"\x12BackendConfigEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a:\n" +
@@ -11914,359 +11936,361 @@ var file_loom_v1_loom_proto_goTypes = []any{
 	nil,                                        // 165: loom.v1.TestMCPServerConnectionRequest.EnvEntry
 	nil,                                        // 166: loom.v1.Artifact.MetadataEntry
 	nil,                                        // 167: loom.v1.CountSessionsByUserResponse.UserCountsEntry
-	(*structpb.Struct)(nil),                    // 168: google.protobuf.Struct
-	(*structpb.Value)(nil),                     // 169: google.protobuf.Value
-	(*ToolExample)(nil),                        // 170: loom.v1.ToolExample
-	(*RateLimitInfo)(nil),                      // 171: loom.v1.RateLimitInfo
-	(*AgentConfig)(nil),                        // 172: loom.v1.AgentConfig
-	(*WorkflowExecution)(nil),                  // 173: loom.v1.WorkflowExecution
-	(*AgentResult)(nil),                        // 174: loom.v1.AgentResult
-	(*WorkflowPattern)(nil),                    // 175: loom.v1.WorkflowPattern
-	(*ScheduleConfig)(nil),                     // 176: loom.v1.ScheduleConfig
-	(*ScheduledWorkflow)(nil),                  // 177: loom.v1.ScheduledWorkflow
-	(*CertificateInfo)(nil),                    // 178: loom.v1.CertificateInfo
-	(LLMRole)(0),                               // 179: loom.v1.LLMRole
-	(*ProviderEntry)(nil),                      // 180: loom.v1.ProviderEntry
-	(*GetStorageStatusRequest)(nil),            // 181: loom.v1.GetStorageStatusRequest
-	(*RunMigrationRequest)(nil),                // 182: loom.v1.RunMigrationRequest
-	(*ExecuteWorkflowRequest)(nil),             // 183: loom.v1.ExecuteWorkflowRequest
-	(*ListWorkflowsRequest)(nil),               // 184: loom.v1.ListWorkflowsRequest
-	(*PublishRequest)(nil),                     // 185: loom.v1.PublishRequest
-	(*SubscribeRequest)(nil),                   // 186: loom.v1.SubscribeRequest
-	(*UnsubscribeRequest)(nil),                 // 187: loom.v1.UnsubscribeRequest
-	(*ListTopicsRequest)(nil),                  // 188: loom.v1.ListTopicsRequest
-	(*GetTopicStatsRequest)(nil),               // 189: loom.v1.GetTopicStatsRequest
-	(*SendAsyncRequest)(nil),                   // 190: loom.v1.SendAsyncRequest
-	(*SendAndReceiveRequest)(nil),              // 191: loom.v1.SendAndReceiveRequest
-	(*PutSharedMemoryRequest)(nil),             // 192: loom.v1.PutSharedMemoryRequest
-	(*GetSharedMemoryRequest)(nil),             // 193: loom.v1.GetSharedMemoryRequest
-	(*DeleteSharedMemoryRequest)(nil),          // 194: loom.v1.DeleteSharedMemoryRequest
-	(*WatchSharedMemoryRequest)(nil),           // 195: loom.v1.WatchSharedMemoryRequest
-	(*ListSharedMemoryKeysRequest)(nil),        // 196: loom.v1.ListSharedMemoryKeysRequest
-	(*GetSharedMemoryStatsRequest)(nil),        // 197: loom.v1.GetSharedMemoryStatsRequest
-	(*ListUIAppsRequest)(nil),                  // 198: loom.v1.ListUIAppsRequest
-	(*GetUIAppRequest)(nil),                    // 199: loom.v1.GetUIAppRequest
-	(*CreateUIAppRequest)(nil),                 // 200: loom.v1.CreateUIAppRequest
-	(*UpdateUIAppRequest)(nil),                 // 201: loom.v1.UpdateUIAppRequest
-	(*DeleteUIAppRequest)(nil),                 // 202: loom.v1.DeleteUIAppRequest
-	(*ListComponentTypesRequest)(nil),          // 203: loom.v1.ListComponentTypesRequest
-	(*ListAgentPresetsRequest)(nil),            // 204: loom.v1.ListAgentPresetsRequest
-	(*ListWorkflowTemplatesRequest)(nil),       // 205: loom.v1.ListWorkflowTemplatesRequest
-	(*CreateWorkflowFromTemplateRequest)(nil),  // 206: loom.v1.CreateWorkflowFromTemplateRequest
-	(*ServerConfig)(nil),                       // 207: loom.v1.ServerConfig
-	(*TLSStatus)(nil),                          // 208: loom.v1.TLSStatus
-	(*GetStorageStatusResponse)(nil),           // 209: loom.v1.GetStorageStatusResponse
-	(*RunMigrationResponse)(nil),               // 210: loom.v1.RunMigrationResponse
-	(*ExecuteWorkflowResponse)(nil),            // 211: loom.v1.ExecuteWorkflowResponse
-	(*ListWorkflowsResponse)(nil),              // 212: loom.v1.ListWorkflowsResponse
-	(*emptypb.Empty)(nil),                      // 213: google.protobuf.Empty
-	(*PublishResponse)(nil),                    // 214: loom.v1.PublishResponse
-	(*BusMessage)(nil),                         // 215: loom.v1.BusMessage
-	(*UnsubscribeResponse)(nil),                // 216: loom.v1.UnsubscribeResponse
-	(*ListTopicsResponse)(nil),                 // 217: loom.v1.ListTopicsResponse
-	(*TopicStats)(nil),                         // 218: loom.v1.TopicStats
-	(*SendAsyncResponse)(nil),                  // 219: loom.v1.SendAsyncResponse
-	(*SendAndReceiveResponse)(nil),             // 220: loom.v1.SendAndReceiveResponse
-	(*PutSharedMemoryResponse)(nil),            // 221: loom.v1.PutSharedMemoryResponse
-	(*GetSharedMemoryResponse)(nil),            // 222: loom.v1.GetSharedMemoryResponse
-	(*DeleteSharedMemoryResponse)(nil),         // 223: loom.v1.DeleteSharedMemoryResponse
-	(*SharedMemoryValue)(nil),                  // 224: loom.v1.SharedMemoryValue
-	(*ListSharedMemoryKeysResponse)(nil),       // 225: loom.v1.ListSharedMemoryKeysResponse
-	(*SharedMemoryStats)(nil),                  // 226: loom.v1.SharedMemoryStats
-	(*ListUIAppsResponse)(nil),                 // 227: loom.v1.ListUIAppsResponse
-	(*GetUIAppResponse)(nil),                   // 228: loom.v1.GetUIAppResponse
-	(*CreateUIAppResponse)(nil),                // 229: loom.v1.CreateUIAppResponse
-	(*UpdateUIAppResponse)(nil),                // 230: loom.v1.UpdateUIAppResponse
-	(*DeleteUIAppResponse)(nil),                // 231: loom.v1.DeleteUIAppResponse
-	(*ListComponentTypesResponse)(nil),         // 232: loom.v1.ListComponentTypesResponse
-	(*ListAgentPresetsResponse)(nil),           // 233: loom.v1.ListAgentPresetsResponse
-	(*ListWorkflowTemplatesResponse)(nil),      // 234: loom.v1.ListWorkflowTemplatesResponse
-	(*CreateWorkflowFromTemplateResponse)(nil), // 235: loom.v1.CreateWorkflowFromTemplateResponse
+	(*timestamppb.Timestamp)(nil),              // 168: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                    // 169: google.protobuf.Struct
+	(*structpb.Value)(nil),                     // 170: google.protobuf.Value
+	(*ToolExample)(nil),                        // 171: loom.v1.ToolExample
+	(*RateLimitInfo)(nil),                      // 172: loom.v1.RateLimitInfo
+	(*AgentConfig)(nil),                        // 173: loom.v1.AgentConfig
+	(*WorkflowExecution)(nil),                  // 174: loom.v1.WorkflowExecution
+	(*AgentResult)(nil),                        // 175: loom.v1.AgentResult
+	(*WorkflowPattern)(nil),                    // 176: loom.v1.WorkflowPattern
+	(*ScheduleConfig)(nil),                     // 177: loom.v1.ScheduleConfig
+	(*ScheduledWorkflow)(nil),                  // 178: loom.v1.ScheduledWorkflow
+	(*CertificateInfo)(nil),                    // 179: loom.v1.CertificateInfo
+	(LLMRole)(0),                               // 180: loom.v1.LLMRole
+	(*ProviderEntry)(nil),                      // 181: loom.v1.ProviderEntry
+	(*GetStorageStatusRequest)(nil),            // 182: loom.v1.GetStorageStatusRequest
+	(*RunMigrationRequest)(nil),                // 183: loom.v1.RunMigrationRequest
+	(*ExecuteWorkflowRequest)(nil),             // 184: loom.v1.ExecuteWorkflowRequest
+	(*ListWorkflowsRequest)(nil),               // 185: loom.v1.ListWorkflowsRequest
+	(*PublishRequest)(nil),                     // 186: loom.v1.PublishRequest
+	(*SubscribeRequest)(nil),                   // 187: loom.v1.SubscribeRequest
+	(*UnsubscribeRequest)(nil),                 // 188: loom.v1.UnsubscribeRequest
+	(*ListTopicsRequest)(nil),                  // 189: loom.v1.ListTopicsRequest
+	(*GetTopicStatsRequest)(nil),               // 190: loom.v1.GetTopicStatsRequest
+	(*SendAsyncRequest)(nil),                   // 191: loom.v1.SendAsyncRequest
+	(*SendAndReceiveRequest)(nil),              // 192: loom.v1.SendAndReceiveRequest
+	(*PutSharedMemoryRequest)(nil),             // 193: loom.v1.PutSharedMemoryRequest
+	(*GetSharedMemoryRequest)(nil),             // 194: loom.v1.GetSharedMemoryRequest
+	(*DeleteSharedMemoryRequest)(nil),          // 195: loom.v1.DeleteSharedMemoryRequest
+	(*WatchSharedMemoryRequest)(nil),           // 196: loom.v1.WatchSharedMemoryRequest
+	(*ListSharedMemoryKeysRequest)(nil),        // 197: loom.v1.ListSharedMemoryKeysRequest
+	(*GetSharedMemoryStatsRequest)(nil),        // 198: loom.v1.GetSharedMemoryStatsRequest
+	(*ListUIAppsRequest)(nil),                  // 199: loom.v1.ListUIAppsRequest
+	(*GetUIAppRequest)(nil),                    // 200: loom.v1.GetUIAppRequest
+	(*CreateUIAppRequest)(nil),                 // 201: loom.v1.CreateUIAppRequest
+	(*UpdateUIAppRequest)(nil),                 // 202: loom.v1.UpdateUIAppRequest
+	(*DeleteUIAppRequest)(nil),                 // 203: loom.v1.DeleteUIAppRequest
+	(*ListComponentTypesRequest)(nil),          // 204: loom.v1.ListComponentTypesRequest
+	(*ListAgentPresetsRequest)(nil),            // 205: loom.v1.ListAgentPresetsRequest
+	(*ListWorkflowTemplatesRequest)(nil),       // 206: loom.v1.ListWorkflowTemplatesRequest
+	(*CreateWorkflowFromTemplateRequest)(nil),  // 207: loom.v1.CreateWorkflowFromTemplateRequest
+	(*ServerConfig)(nil),                       // 208: loom.v1.ServerConfig
+	(*TLSStatus)(nil),                          // 209: loom.v1.TLSStatus
+	(*GetStorageStatusResponse)(nil),           // 210: loom.v1.GetStorageStatusResponse
+	(*RunMigrationResponse)(nil),               // 211: loom.v1.RunMigrationResponse
+	(*ExecuteWorkflowResponse)(nil),            // 212: loom.v1.ExecuteWorkflowResponse
+	(*ListWorkflowsResponse)(nil),              // 213: loom.v1.ListWorkflowsResponse
+	(*emptypb.Empty)(nil),                      // 214: google.protobuf.Empty
+	(*PublishResponse)(nil),                    // 215: loom.v1.PublishResponse
+	(*BusMessage)(nil),                         // 216: loom.v1.BusMessage
+	(*UnsubscribeResponse)(nil),                // 217: loom.v1.UnsubscribeResponse
+	(*ListTopicsResponse)(nil),                 // 218: loom.v1.ListTopicsResponse
+	(*TopicStats)(nil),                         // 219: loom.v1.TopicStats
+	(*SendAsyncResponse)(nil),                  // 220: loom.v1.SendAsyncResponse
+	(*SendAndReceiveResponse)(nil),             // 221: loom.v1.SendAndReceiveResponse
+	(*PutSharedMemoryResponse)(nil),            // 222: loom.v1.PutSharedMemoryResponse
+	(*GetSharedMemoryResponse)(nil),            // 223: loom.v1.GetSharedMemoryResponse
+	(*DeleteSharedMemoryResponse)(nil),         // 224: loom.v1.DeleteSharedMemoryResponse
+	(*SharedMemoryValue)(nil),                  // 225: loom.v1.SharedMemoryValue
+	(*ListSharedMemoryKeysResponse)(nil),       // 226: loom.v1.ListSharedMemoryKeysResponse
+	(*SharedMemoryStats)(nil),                  // 227: loom.v1.SharedMemoryStats
+	(*ListUIAppsResponse)(nil),                 // 228: loom.v1.ListUIAppsResponse
+	(*GetUIAppResponse)(nil),                   // 229: loom.v1.GetUIAppResponse
+	(*CreateUIAppResponse)(nil),                // 230: loom.v1.CreateUIAppResponse
+	(*UpdateUIAppResponse)(nil),                // 231: loom.v1.UpdateUIAppResponse
+	(*DeleteUIAppResponse)(nil),                // 232: loom.v1.DeleteUIAppResponse
+	(*ListComponentTypesResponse)(nil),         // 233: loom.v1.ListComponentTypesResponse
+	(*ListAgentPresetsResponse)(nil),           // 234: loom.v1.ListAgentPresetsResponse
+	(*ListWorkflowTemplatesResponse)(nil),      // 235: loom.v1.ListWorkflowTemplatesResponse
+	(*CreateWorkflowFromTemplateResponse)(nil), // 236: loom.v1.CreateWorkflowFromTemplateResponse
 }
 var file_loom_v1_loom_proto_depIdxs = []int32{
 	147, // 0: loom.v1.WeaveRequest.backend_config:type_name -> loom.v1.WeaveRequest.BackendConfigEntry
 	148, // 1: loom.v1.WeaveRequest.context:type_name -> loom.v1.WeaveRequest.ContextEntry
-	8,   // 2: loom.v1.WeaveResponse.result:type_name -> loom.v1.ExecutionResult
-	14,  // 3: loom.v1.WeaveResponse.cost:type_name -> loom.v1.CostInfo
-	17,  // 4: loom.v1.WeaveResponse.metadata:type_name -> loom.v1.ExecutionMetadata
-	18,  // 5: loom.v1.WeaveResponse.corrections:type_name -> loom.v1.SelfCorrectionAttempt
-	16,  // 6: loom.v1.WeaveResponse.context_state:type_name -> loom.v1.ContextState
-	0,   // 7: loom.v1.WeaveProgress.stage:type_name -> loom.v1.ExecutionStage
-	8,   // 8: loom.v1.WeaveProgress.partial_result:type_name -> loom.v1.ExecutionResult
-	7,   // 9: loom.v1.WeaveProgress.hitl_request:type_name -> loom.v1.HITLRequestInfo
-	14,  // 10: loom.v1.WeaveProgress.cost:type_name -> loom.v1.CostInfo
-	168, // 11: loom.v1.WeaveProgress.tool_input:type_name -> google.protobuf.Struct
-	169, // 12: loom.v1.WeaveProgress.tool_result:type_name -> google.protobuf.Value
-	16,  // 13: loom.v1.WeaveProgress.context_state:type_name -> loom.v1.ContextState
-	149, // 14: loom.v1.ExecutionResult.backend_metadata:type_name -> loom.v1.ExecutionResult.BackendMetadataEntry
-	9,   // 15: loom.v1.ExecutionResult.data_reference:type_name -> loom.v1.DataReference
-	1,   // 16: loom.v1.DataReference.location:type_name -> loom.v1.StorageLocation
-	150, // 17: loom.v1.DataReference.metadata:type_name -> loom.v1.DataReference.MetadataEntry
-	11,  // 18: loom.v1.SharedMemoryConfig.disk_overflow:type_name -> loom.v1.DiskOverflowConfig
-	12,  // 19: loom.v1.SharedMemoryConfig.compression:type_name -> loom.v1.CompressionConfig
-	13,  // 20: loom.v1.SharedMemoryConfig.cleanup:type_name -> loom.v1.CleanupConfig
-	15,  // 21: loom.v1.CostInfo.llm_cost:type_name -> loom.v1.LLMCost
-	15,  // 22: loom.v1.SelfCorrectionAttempt.cost:type_name -> loom.v1.LLMCost
-	30,  // 23: loom.v1.ListPatternsResponse.patterns:type_name -> loom.v1.Pattern
-	2,   // 24: loom.v1.PatternUpdateEvent.type:type_name -> loom.v1.PatternUpdateType
-	31,  // 25: loom.v1.Pattern.parameters:type_name -> loom.v1.PatternParameter
-	32,  // 26: loom.v1.Pattern.examples:type_name -> loom.v1.PatternExample
-	151, // 27: loom.v1.Pattern.backend_hints:type_name -> loom.v1.Pattern.BackendHintsEntry
-	152, // 28: loom.v1.CreateSessionRequest.config:type_name -> loom.v1.CreateSessionRequest.ConfigEntry
-	153, // 29: loom.v1.CreateSessionRequest.metadata:type_name -> loom.v1.CreateSessionRequest.MetadataEntry
-	154, // 30: loom.v1.Session.metadata:type_name -> loom.v1.Session.MetadataEntry
-	34,  // 31: loom.v1.ListSessionsResponse.sessions:type_name -> loom.v1.Session
-	42,  // 32: loom.v1.SessionUpdate.new_message:type_name -> loom.v1.NewMessageUpdate
-	43,  // 33: loom.v1.SessionUpdate.status_change:type_name -> loom.v1.SessionStatusUpdate
-	14,  // 34: loom.v1.NewMessageUpdate.cost:type_name -> loom.v1.CostInfo
-	46,  // 35: loom.v1.ConversationHistory.messages:type_name -> loom.v1.Message
-	47,  // 36: loom.v1.Message.tool_calls:type_name -> loom.v1.ToolCall
-	14,  // 37: loom.v1.Message.cost:type_name -> loom.v1.CostInfo
-	52,  // 38: loom.v1.RegisterToolRequest.tool:type_name -> loom.v1.ToolDefinition
-	52,  // 39: loom.v1.ListToolsResponse.tools:type_name -> loom.v1.ToolDefinition
-	53,  // 40: loom.v1.ToolDefinition.use_cases:type_name -> loom.v1.ToolUseCase
-	54,  // 41: loom.v1.ToolDefinition.conflicts:type_name -> loom.v1.ToolConflict
-	55,  // 42: loom.v1.ToolDefinition.alternatives:type_name -> loom.v1.ToolAlternative
-	170, // 43: loom.v1.ToolDefinition.examples:type_name -> loom.v1.ToolExample
-	57,  // 44: loom.v1.ToolDefinition.prerequisites:type_name -> loom.v1.ToolPrerequisite
-	171, // 45: loom.v1.ToolDefinition.rate_limit:type_name -> loom.v1.RateLimitInfo
-	58,  // 46: loom.v1.ToolDefinition.common_errors:type_name -> loom.v1.ToolCommonError
-	56,  // 47: loom.v1.ToolDefinition.complements:type_name -> loom.v1.ToolComplement
-	61,  // 48: loom.v1.Trace.root_span:type_name -> loom.v1.Span
-	61,  // 49: loom.v1.Trace.spans:type_name -> loom.v1.Span
-	14,  // 50: loom.v1.Trace.total_cost:type_name -> loom.v1.CostInfo
-	155, // 51: loom.v1.Span.attributes:type_name -> loom.v1.Span.AttributesEntry
-	62,  // 52: loom.v1.Span.events:type_name -> loom.v1.SpanEvent
-	156, // 53: loom.v1.SpanEvent.attributes:type_name -> loom.v1.SpanEvent.AttributesEntry
-	157, // 54: loom.v1.HealthStatus.components:type_name -> loom.v1.HealthStatus.ComponentsEntry
-	172, // 55: loom.v1.CreateAgentRequest.config:type_name -> loom.v1.AgentConfig
-	158, // 56: loom.v1.AgentInfo.metadata:type_name -> loom.v1.AgentInfo.MetadataEntry
-	172, // 57: loom.v1.AgentInfo.config:type_name -> loom.v1.AgentConfig
-	67,  // 58: loom.v1.ListAgentsResponse.agents:type_name -> loom.v1.AgentInfo
-	172, // 59: loom.v1.ReloadAgentRequest.config:type_name -> loom.v1.AgentConfig
-	173, // 60: loom.v1.ListWorkflowExecutionsResponse.executions:type_name -> loom.v1.WorkflowExecution
-	174, // 61: loom.v1.WorkflowProgress.partial_results:type_name -> loom.v1.AgentResult
-	175, // 62: loom.v1.ScheduleWorkflowRequest.pattern:type_name -> loom.v1.WorkflowPattern
-	176, // 63: loom.v1.ScheduleWorkflowRequest.schedule:type_name -> loom.v1.ScheduleConfig
-	159, // 64: loom.v1.ScheduleWorkflowRequest.metadata:type_name -> loom.v1.ScheduleWorkflowRequest.MetadataEntry
-	177, // 65: loom.v1.ScheduleWorkflowResponse.schedule:type_name -> loom.v1.ScheduledWorkflow
-	175, // 66: loom.v1.UpdateScheduledWorkflowRequest.pattern:type_name -> loom.v1.WorkflowPattern
-	176, // 67: loom.v1.UpdateScheduledWorkflowRequest.schedule:type_name -> loom.v1.ScheduleConfig
-	177, // 68: loom.v1.ListScheduledWorkflowsResponse.schedules:type_name -> loom.v1.ScheduledWorkflow
-	160, // 69: loom.v1.TriggerScheduledWorkflowRequest.variables:type_name -> loom.v1.TriggerScheduledWorkflowRequest.VariablesEntry
-	92,  // 70: loom.v1.GetScheduleHistoryResponse.executions:type_name -> loom.v1.ScheduleExecution
-	178, // 71: loom.v1.RenewCertificateResponse.certificate:type_name -> loom.v1.CertificateInfo
-	179, // 72: loom.v1.SwitchModelRequest.role:type_name -> loom.v1.LLMRole
-	105, // 73: loom.v1.SwitchModelResponse.previous_model:type_name -> loom.v1.ModelInfo
-	105, // 74: loom.v1.SwitchModelResponse.new_model:type_name -> loom.v1.ModelInfo
-	105, // 75: loom.v1.ListAvailableModelsResponse.models:type_name -> loom.v1.ModelInfo
-	180, // 76: loom.v1.ListProvidersResponse.providers:type_name -> loom.v1.ProviderEntry
-	3,   // 77: loom.v1.ABTestRequest.mode:type_name -> loom.v1.ABTestMode
-	111, // 78: loom.v1.ListMCPServersResponse.servers:type_name -> loom.v1.MCPServerInfo
-	161, // 79: loom.v1.MCPServerInfo.env:type_name -> loom.v1.MCPServerInfo.EnvEntry
-	162, // 80: loom.v1.AddMCPServerRequest.env:type_name -> loom.v1.AddMCPServerRequest.EnvEntry
-	112, // 81: loom.v1.AddMCPServerRequest.tool_filter:type_name -> loom.v1.ToolFilterConfig
-	111, // 82: loom.v1.AddMCPServerResponse.server:type_name -> loom.v1.MCPServerInfo
-	163, // 83: loom.v1.UpdateMCPServerRequest.env:type_name -> loom.v1.UpdateMCPServerRequest.EnvEntry
-	112, // 84: loom.v1.UpdateMCPServerRequest.tool_filter:type_name -> loom.v1.ToolFilterConfig
-	164, // 85: loom.v1.HealthCheckMCPServersResponse.servers:type_name -> loom.v1.HealthCheckMCPServersResponse.ServersEntry
-	165, // 86: loom.v1.TestMCPServerConnectionRequest.env:type_name -> loom.v1.TestMCPServerConnectionRequest.EnvEntry
-	112, // 87: loom.v1.TestMCPServerConnectionRequest.tool_filter:type_name -> loom.v1.ToolFilterConfig
-	52,  // 88: loom.v1.ListMCPServerToolsResponse.tools:type_name -> loom.v1.ToolDefinition
-	166, // 89: loom.v1.Artifact.metadata:type_name -> loom.v1.Artifact.MetadataEntry
-	126, // 90: loom.v1.ListArtifactsResponse.artifacts:type_name -> loom.v1.Artifact
-	126, // 91: loom.v1.GetArtifactResponse.artifact:type_name -> loom.v1.Artifact
-	126, // 92: loom.v1.UploadArtifactResponse.artifact:type_name -> loom.v1.Artifact
-	126, // 93: loom.v1.SearchArtifactsResponse.artifacts:type_name -> loom.v1.Artifact
-	34,  // 94: loom.v1.ListAllSessionsResponse.sessions:type_name -> loom.v1.Session
-	167, // 95: loom.v1.CountSessionsByUserResponse.user_counts:type_name -> loom.v1.CountSessionsByUserResponse.UserCountsEntry
-	65,  // 96: loom.v1.HealthStatus.ComponentsEntry.value:type_name -> loom.v1.ComponentHealth
-	121, // 97: loom.v1.HealthCheckMCPServersResponse.ServersEntry.value:type_name -> loom.v1.MCPServerHealth
-	4,   // 98: loom.v1.LoomService.Weave:input_type -> loom.v1.WeaveRequest
-	4,   // 99: loom.v1.LoomService.StreamWeave:input_type -> loom.v1.WeaveRequest
-	19,  // 100: loom.v1.LoomService.LoadPatterns:input_type -> loom.v1.LoadPatternsRequest
-	21,  // 101: loom.v1.LoomService.ListPatterns:input_type -> loom.v1.ListPatternsRequest
-	23,  // 102: loom.v1.LoomService.GetPattern:input_type -> loom.v1.GetPatternRequest
-	24,  // 103: loom.v1.LoomService.CreatePattern:input_type -> loom.v1.CreatePatternRequest
-	26,  // 104: loom.v1.LoomService.StreamPatternUpdates:input_type -> loom.v1.StreamPatternUpdatesRequest
-	28,  // 105: loom.v1.LoomService.AnswerClarificationQuestion:input_type -> loom.v1.AnswerClarificationRequest
-	33,  // 106: loom.v1.LoomService.CreateSession:input_type -> loom.v1.CreateSessionRequest
-	35,  // 107: loom.v1.LoomService.GetSession:input_type -> loom.v1.GetSessionRequest
-	36,  // 108: loom.v1.LoomService.ListSessions:input_type -> loom.v1.ListSessionsRequest
-	38,  // 109: loom.v1.LoomService.DeleteSession:input_type -> loom.v1.DeleteSessionRequest
-	40,  // 110: loom.v1.LoomService.SubscribeToSession:input_type -> loom.v1.SubscribeToSessionRequest
-	44,  // 111: loom.v1.LoomService.GetConversationHistory:input_type -> loom.v1.GetConversationHistoryRequest
-	48,  // 112: loom.v1.LoomService.RegisterTool:input_type -> loom.v1.RegisterToolRequest
-	50,  // 113: loom.v1.LoomService.ListTools:input_type -> loom.v1.ListToolsRequest
-	59,  // 114: loom.v1.LoomService.GetTrace:input_type -> loom.v1.GetTraceRequest
-	63,  // 115: loom.v1.LoomService.GetHealth:input_type -> loom.v1.GetHealthRequest
-	93,  // 116: loom.v1.LoomService.GetServerConfig:input_type -> loom.v1.GetServerConfigRequest
-	94,  // 117: loom.v1.LoomService.GetTLSStatus:input_type -> loom.v1.GetTLSStatusRequest
-	95,  // 118: loom.v1.LoomService.RenewCertificate:input_type -> loom.v1.RenewCertificateRequest
-	181, // 119: loom.v1.LoomService.GetStorageStatus:input_type -> loom.v1.GetStorageStatusRequest
-	182, // 120: loom.v1.LoomService.RunMigration:input_type -> loom.v1.RunMigrationRequest
-	66,  // 121: loom.v1.LoomService.CreateAgentFromConfig:input_type -> loom.v1.CreateAgentRequest
-	68,  // 122: loom.v1.LoomService.ListAgents:input_type -> loom.v1.ListAgentsRequest
-	70,  // 123: loom.v1.LoomService.GetAgent:input_type -> loom.v1.GetAgentRequest
-	71,  // 124: loom.v1.LoomService.StartAgent:input_type -> loom.v1.StartAgentRequest
-	72,  // 125: loom.v1.LoomService.StopAgent:input_type -> loom.v1.StopAgentRequest
-	73,  // 126: loom.v1.LoomService.DeleteAgent:input_type -> loom.v1.DeleteAgentRequest
-	75,  // 127: loom.v1.LoomService.ReloadAgent:input_type -> loom.v1.ReloadAgentRequest
-	97,  // 128: loom.v1.LoomService.SwitchModel:input_type -> loom.v1.SwitchModelRequest
-	99,  // 129: loom.v1.LoomService.ListAvailableModels:input_type -> loom.v1.ListAvailableModelsRequest
-	101, // 130: loom.v1.LoomService.ListProviders:input_type -> loom.v1.ListProvidersRequest
-	103, // 131: loom.v1.LoomService.ABTest:input_type -> loom.v1.ABTestRequest
-	106, // 132: loom.v1.LoomService.RequestToolPermission:input_type -> loom.v1.ToolPermissionRequest
-	108, // 133: loom.v1.LoomService.ListMCPServers:input_type -> loom.v1.ListMCPServersRequest
-	110, // 134: loom.v1.LoomService.GetMCPServer:input_type -> loom.v1.GetMCPServerRequest
-	113, // 135: loom.v1.LoomService.AddMCPServer:input_type -> loom.v1.AddMCPServerRequest
-	115, // 136: loom.v1.LoomService.UpdateMCPServer:input_type -> loom.v1.UpdateMCPServerRequest
-	116, // 137: loom.v1.LoomService.DeleteMCPServer:input_type -> loom.v1.DeleteMCPServerRequest
-	118, // 138: loom.v1.LoomService.RestartMCPServer:input_type -> loom.v1.RestartMCPServerRequest
-	119, // 139: loom.v1.LoomService.HealthCheckMCPServers:input_type -> loom.v1.HealthCheckMCPServersRequest
-	122, // 140: loom.v1.LoomService.TestMCPServerConnection:input_type -> loom.v1.TestMCPServerConnectionRequest
-	124, // 141: loom.v1.LoomService.ListMCPServerTools:input_type -> loom.v1.ListMCPServerToolsRequest
-	183, // 142: loom.v1.LoomService.ExecuteWorkflow:input_type -> loom.v1.ExecuteWorkflowRequest
-	183, // 143: loom.v1.LoomService.StreamWorkflow:input_type -> loom.v1.ExecuteWorkflowRequest
-	76,  // 144: loom.v1.LoomService.GetWorkflowExecution:input_type -> loom.v1.GetWorkflowExecutionRequest
-	77,  // 145: loom.v1.LoomService.ListWorkflowExecutions:input_type -> loom.v1.ListWorkflowExecutionsRequest
-	184, // 146: loom.v1.LoomService.ListWorkflows:input_type -> loom.v1.ListWorkflowsRequest
-	80,  // 147: loom.v1.LoomService.ScheduleWorkflow:input_type -> loom.v1.ScheduleWorkflowRequest
-	82,  // 148: loom.v1.LoomService.UpdateScheduledWorkflow:input_type -> loom.v1.UpdateScheduledWorkflowRequest
-	83,  // 149: loom.v1.LoomService.GetScheduledWorkflow:input_type -> loom.v1.GetScheduledWorkflowRequest
-	84,  // 150: loom.v1.LoomService.ListScheduledWorkflows:input_type -> loom.v1.ListScheduledWorkflowsRequest
-	86,  // 151: loom.v1.LoomService.DeleteScheduledWorkflow:input_type -> loom.v1.DeleteScheduledWorkflowRequest
-	87,  // 152: loom.v1.LoomService.TriggerScheduledWorkflow:input_type -> loom.v1.TriggerScheduledWorkflowRequest
-	88,  // 153: loom.v1.LoomService.PauseSchedule:input_type -> loom.v1.PauseScheduleRequest
-	89,  // 154: loom.v1.LoomService.ResumeSchedule:input_type -> loom.v1.ResumeScheduleRequest
-	90,  // 155: loom.v1.LoomService.GetScheduleHistory:input_type -> loom.v1.GetScheduleHistoryRequest
-	185, // 156: loom.v1.LoomService.Publish:input_type -> loom.v1.PublishRequest
-	186, // 157: loom.v1.LoomService.Subscribe:input_type -> loom.v1.SubscribeRequest
-	187, // 158: loom.v1.LoomService.Unsubscribe:input_type -> loom.v1.UnsubscribeRequest
-	188, // 159: loom.v1.LoomService.ListTopics:input_type -> loom.v1.ListTopicsRequest
-	189, // 160: loom.v1.LoomService.GetTopicStats:input_type -> loom.v1.GetTopicStatsRequest
-	190, // 161: loom.v1.LoomService.SendAsync:input_type -> loom.v1.SendAsyncRequest
-	191, // 162: loom.v1.LoomService.SendAndReceive:input_type -> loom.v1.SendAndReceiveRequest
-	192, // 163: loom.v1.LoomService.PutSharedMemory:input_type -> loom.v1.PutSharedMemoryRequest
-	193, // 164: loom.v1.LoomService.GetSharedMemory:input_type -> loom.v1.GetSharedMemoryRequest
-	194, // 165: loom.v1.LoomService.DeleteSharedMemory:input_type -> loom.v1.DeleteSharedMemoryRequest
-	195, // 166: loom.v1.LoomService.WatchSharedMemory:input_type -> loom.v1.WatchSharedMemoryRequest
-	196, // 167: loom.v1.LoomService.ListSharedMemoryKeys:input_type -> loom.v1.ListSharedMemoryKeysRequest
-	197, // 168: loom.v1.LoomService.GetSharedMemoryStats:input_type -> loom.v1.GetSharedMemoryStatsRequest
-	127, // 169: loom.v1.LoomService.ListArtifacts:input_type -> loom.v1.ListArtifactsRequest
-	129, // 170: loom.v1.LoomService.GetArtifact:input_type -> loom.v1.GetArtifactRequest
-	131, // 171: loom.v1.LoomService.UploadArtifact:input_type -> loom.v1.UploadArtifactRequest
-	133, // 172: loom.v1.LoomService.DeleteArtifact:input_type -> loom.v1.DeleteArtifactRequest
-	135, // 173: loom.v1.LoomService.SearchArtifacts:input_type -> loom.v1.SearchArtifactsRequest
-	137, // 174: loom.v1.LoomService.GetArtifactContent:input_type -> loom.v1.GetArtifactContentRequest
-	139, // 175: loom.v1.LoomService.GetArtifactStats:input_type -> loom.v1.GetArtifactStatsRequest
-	198, // 176: loom.v1.LoomService.ListUIApps:input_type -> loom.v1.ListUIAppsRequest
-	199, // 177: loom.v1.LoomService.GetUIApp:input_type -> loom.v1.GetUIAppRequest
-	200, // 178: loom.v1.LoomService.CreateUIApp:input_type -> loom.v1.CreateUIAppRequest
-	201, // 179: loom.v1.LoomService.UpdateUIApp:input_type -> loom.v1.UpdateUIAppRequest
-	202, // 180: loom.v1.LoomService.DeleteUIApp:input_type -> loom.v1.DeleteUIAppRequest
-	203, // 181: loom.v1.LoomService.ListComponentTypes:input_type -> loom.v1.ListComponentTypesRequest
-	204, // 182: loom.v1.LoomService.ListAgentPresets:input_type -> loom.v1.ListAgentPresetsRequest
-	205, // 183: loom.v1.LoomService.ListWorkflowTemplates:input_type -> loom.v1.ListWorkflowTemplatesRequest
-	206, // 184: loom.v1.LoomService.CreateWorkflowFromTemplate:input_type -> loom.v1.CreateWorkflowFromTemplateRequest
-	141, // 185: loom.v1.AdminService.ListAllSessions:input_type -> loom.v1.ListAllSessionsRequest
-	143, // 186: loom.v1.AdminService.CountSessionsByUser:input_type -> loom.v1.CountSessionsByUserRequest
-	145, // 187: loom.v1.AdminService.GetSystemStats:input_type -> loom.v1.GetSystemStatsRequest
-	5,   // 188: loom.v1.LoomService.Weave:output_type -> loom.v1.WeaveResponse
-	6,   // 189: loom.v1.LoomService.StreamWeave:output_type -> loom.v1.WeaveProgress
-	20,  // 190: loom.v1.LoomService.LoadPatterns:output_type -> loom.v1.LoadPatternsResponse
-	22,  // 191: loom.v1.LoomService.ListPatterns:output_type -> loom.v1.ListPatternsResponse
-	30,  // 192: loom.v1.LoomService.GetPattern:output_type -> loom.v1.Pattern
-	25,  // 193: loom.v1.LoomService.CreatePattern:output_type -> loom.v1.CreatePatternResponse
-	27,  // 194: loom.v1.LoomService.StreamPatternUpdates:output_type -> loom.v1.PatternUpdateEvent
-	29,  // 195: loom.v1.LoomService.AnswerClarificationQuestion:output_type -> loom.v1.AnswerClarificationResponse
-	34,  // 196: loom.v1.LoomService.CreateSession:output_type -> loom.v1.Session
-	34,  // 197: loom.v1.LoomService.GetSession:output_type -> loom.v1.Session
-	37,  // 198: loom.v1.LoomService.ListSessions:output_type -> loom.v1.ListSessionsResponse
-	39,  // 199: loom.v1.LoomService.DeleteSession:output_type -> loom.v1.DeleteSessionResponse
-	41,  // 200: loom.v1.LoomService.SubscribeToSession:output_type -> loom.v1.SessionUpdate
-	45,  // 201: loom.v1.LoomService.GetConversationHistory:output_type -> loom.v1.ConversationHistory
-	49,  // 202: loom.v1.LoomService.RegisterTool:output_type -> loom.v1.RegisterToolResponse
-	51,  // 203: loom.v1.LoomService.ListTools:output_type -> loom.v1.ListToolsResponse
-	60,  // 204: loom.v1.LoomService.GetTrace:output_type -> loom.v1.Trace
-	64,  // 205: loom.v1.LoomService.GetHealth:output_type -> loom.v1.HealthStatus
-	207, // 206: loom.v1.LoomService.GetServerConfig:output_type -> loom.v1.ServerConfig
-	208, // 207: loom.v1.LoomService.GetTLSStatus:output_type -> loom.v1.TLSStatus
-	96,  // 208: loom.v1.LoomService.RenewCertificate:output_type -> loom.v1.RenewCertificateResponse
-	209, // 209: loom.v1.LoomService.GetStorageStatus:output_type -> loom.v1.GetStorageStatusResponse
-	210, // 210: loom.v1.LoomService.RunMigration:output_type -> loom.v1.RunMigrationResponse
-	67,  // 211: loom.v1.LoomService.CreateAgentFromConfig:output_type -> loom.v1.AgentInfo
-	69,  // 212: loom.v1.LoomService.ListAgents:output_type -> loom.v1.ListAgentsResponse
-	67,  // 213: loom.v1.LoomService.GetAgent:output_type -> loom.v1.AgentInfo
-	67,  // 214: loom.v1.LoomService.StartAgent:output_type -> loom.v1.AgentInfo
-	67,  // 215: loom.v1.LoomService.StopAgent:output_type -> loom.v1.AgentInfo
-	74,  // 216: loom.v1.LoomService.DeleteAgent:output_type -> loom.v1.DeleteAgentResponse
-	67,  // 217: loom.v1.LoomService.ReloadAgent:output_type -> loom.v1.AgentInfo
-	98,  // 218: loom.v1.LoomService.SwitchModel:output_type -> loom.v1.SwitchModelResponse
-	100, // 219: loom.v1.LoomService.ListAvailableModels:output_type -> loom.v1.ListAvailableModelsResponse
-	102, // 220: loom.v1.LoomService.ListProviders:output_type -> loom.v1.ListProvidersResponse
-	104, // 221: loom.v1.LoomService.ABTest:output_type -> loom.v1.ABTestEvent
-	107, // 222: loom.v1.LoomService.RequestToolPermission:output_type -> loom.v1.ToolPermissionResponse
-	109, // 223: loom.v1.LoomService.ListMCPServers:output_type -> loom.v1.ListMCPServersResponse
-	111, // 224: loom.v1.LoomService.GetMCPServer:output_type -> loom.v1.MCPServerInfo
-	114, // 225: loom.v1.LoomService.AddMCPServer:output_type -> loom.v1.AddMCPServerResponse
-	111, // 226: loom.v1.LoomService.UpdateMCPServer:output_type -> loom.v1.MCPServerInfo
-	117, // 227: loom.v1.LoomService.DeleteMCPServer:output_type -> loom.v1.DeleteMCPServerResponse
-	111, // 228: loom.v1.LoomService.RestartMCPServer:output_type -> loom.v1.MCPServerInfo
-	120, // 229: loom.v1.LoomService.HealthCheckMCPServers:output_type -> loom.v1.HealthCheckMCPServersResponse
-	123, // 230: loom.v1.LoomService.TestMCPServerConnection:output_type -> loom.v1.TestMCPServerConnectionResponse
-	125, // 231: loom.v1.LoomService.ListMCPServerTools:output_type -> loom.v1.ListMCPServerToolsResponse
-	211, // 232: loom.v1.LoomService.ExecuteWorkflow:output_type -> loom.v1.ExecuteWorkflowResponse
-	79,  // 233: loom.v1.LoomService.StreamWorkflow:output_type -> loom.v1.WorkflowProgress
-	173, // 234: loom.v1.LoomService.GetWorkflowExecution:output_type -> loom.v1.WorkflowExecution
-	78,  // 235: loom.v1.LoomService.ListWorkflowExecutions:output_type -> loom.v1.ListWorkflowExecutionsResponse
-	212, // 236: loom.v1.LoomService.ListWorkflows:output_type -> loom.v1.ListWorkflowsResponse
-	81,  // 237: loom.v1.LoomService.ScheduleWorkflow:output_type -> loom.v1.ScheduleWorkflowResponse
-	81,  // 238: loom.v1.LoomService.UpdateScheduledWorkflow:output_type -> loom.v1.ScheduleWorkflowResponse
-	177, // 239: loom.v1.LoomService.GetScheduledWorkflow:output_type -> loom.v1.ScheduledWorkflow
-	85,  // 240: loom.v1.LoomService.ListScheduledWorkflows:output_type -> loom.v1.ListScheduledWorkflowsResponse
-	213, // 241: loom.v1.LoomService.DeleteScheduledWorkflow:output_type -> google.protobuf.Empty
-	211, // 242: loom.v1.LoomService.TriggerScheduledWorkflow:output_type -> loom.v1.ExecuteWorkflowResponse
-	213, // 243: loom.v1.LoomService.PauseSchedule:output_type -> google.protobuf.Empty
-	213, // 244: loom.v1.LoomService.ResumeSchedule:output_type -> google.protobuf.Empty
-	91,  // 245: loom.v1.LoomService.GetScheduleHistory:output_type -> loom.v1.GetScheduleHistoryResponse
-	214, // 246: loom.v1.LoomService.Publish:output_type -> loom.v1.PublishResponse
-	215, // 247: loom.v1.LoomService.Subscribe:output_type -> loom.v1.BusMessage
-	216, // 248: loom.v1.LoomService.Unsubscribe:output_type -> loom.v1.UnsubscribeResponse
-	217, // 249: loom.v1.LoomService.ListTopics:output_type -> loom.v1.ListTopicsResponse
-	218, // 250: loom.v1.LoomService.GetTopicStats:output_type -> loom.v1.TopicStats
-	219, // 251: loom.v1.LoomService.SendAsync:output_type -> loom.v1.SendAsyncResponse
-	220, // 252: loom.v1.LoomService.SendAndReceive:output_type -> loom.v1.SendAndReceiveResponse
-	221, // 253: loom.v1.LoomService.PutSharedMemory:output_type -> loom.v1.PutSharedMemoryResponse
-	222, // 254: loom.v1.LoomService.GetSharedMemory:output_type -> loom.v1.GetSharedMemoryResponse
-	223, // 255: loom.v1.LoomService.DeleteSharedMemory:output_type -> loom.v1.DeleteSharedMemoryResponse
-	224, // 256: loom.v1.LoomService.WatchSharedMemory:output_type -> loom.v1.SharedMemoryValue
-	225, // 257: loom.v1.LoomService.ListSharedMemoryKeys:output_type -> loom.v1.ListSharedMemoryKeysResponse
-	226, // 258: loom.v1.LoomService.GetSharedMemoryStats:output_type -> loom.v1.SharedMemoryStats
-	128, // 259: loom.v1.LoomService.ListArtifacts:output_type -> loom.v1.ListArtifactsResponse
-	130, // 260: loom.v1.LoomService.GetArtifact:output_type -> loom.v1.GetArtifactResponse
-	132, // 261: loom.v1.LoomService.UploadArtifact:output_type -> loom.v1.UploadArtifactResponse
-	134, // 262: loom.v1.LoomService.DeleteArtifact:output_type -> loom.v1.DeleteArtifactResponse
-	136, // 263: loom.v1.LoomService.SearchArtifacts:output_type -> loom.v1.SearchArtifactsResponse
-	138, // 264: loom.v1.LoomService.GetArtifactContent:output_type -> loom.v1.GetArtifactContentResponse
-	140, // 265: loom.v1.LoomService.GetArtifactStats:output_type -> loom.v1.GetArtifactStatsResponse
-	227, // 266: loom.v1.LoomService.ListUIApps:output_type -> loom.v1.ListUIAppsResponse
-	228, // 267: loom.v1.LoomService.GetUIApp:output_type -> loom.v1.GetUIAppResponse
-	229, // 268: loom.v1.LoomService.CreateUIApp:output_type -> loom.v1.CreateUIAppResponse
-	230, // 269: loom.v1.LoomService.UpdateUIApp:output_type -> loom.v1.UpdateUIAppResponse
-	231, // 270: loom.v1.LoomService.DeleteUIApp:output_type -> loom.v1.DeleteUIAppResponse
-	232, // 271: loom.v1.LoomService.ListComponentTypes:output_type -> loom.v1.ListComponentTypesResponse
-	233, // 272: loom.v1.LoomService.ListAgentPresets:output_type -> loom.v1.ListAgentPresetsResponse
-	234, // 273: loom.v1.LoomService.ListWorkflowTemplates:output_type -> loom.v1.ListWorkflowTemplatesResponse
-	235, // 274: loom.v1.LoomService.CreateWorkflowFromTemplate:output_type -> loom.v1.CreateWorkflowFromTemplateResponse
-	142, // 275: loom.v1.AdminService.ListAllSessions:output_type -> loom.v1.ListAllSessionsResponse
-	144, // 276: loom.v1.AdminService.CountSessionsByUser:output_type -> loom.v1.CountSessionsByUserResponse
-	146, // 277: loom.v1.AdminService.GetSystemStats:output_type -> loom.v1.GetSystemStatsResponse
-	188, // [188:278] is the sub-list for method output_type
-	98,  // [98:188] is the sub-list for method input_type
-	98,  // [98:98] is the sub-list for extension type_name
-	98,  // [98:98] is the sub-list for extension extendee
-	0,   // [0:98] is the sub-list for field type_name
+	168, // 2: loom.v1.WeaveRequest.occurred_at:type_name -> google.protobuf.Timestamp
+	8,   // 3: loom.v1.WeaveResponse.result:type_name -> loom.v1.ExecutionResult
+	14,  // 4: loom.v1.WeaveResponse.cost:type_name -> loom.v1.CostInfo
+	17,  // 5: loom.v1.WeaveResponse.metadata:type_name -> loom.v1.ExecutionMetadata
+	18,  // 6: loom.v1.WeaveResponse.corrections:type_name -> loom.v1.SelfCorrectionAttempt
+	16,  // 7: loom.v1.WeaveResponse.context_state:type_name -> loom.v1.ContextState
+	0,   // 8: loom.v1.WeaveProgress.stage:type_name -> loom.v1.ExecutionStage
+	8,   // 9: loom.v1.WeaveProgress.partial_result:type_name -> loom.v1.ExecutionResult
+	7,   // 10: loom.v1.WeaveProgress.hitl_request:type_name -> loom.v1.HITLRequestInfo
+	14,  // 11: loom.v1.WeaveProgress.cost:type_name -> loom.v1.CostInfo
+	169, // 12: loom.v1.WeaveProgress.tool_input:type_name -> google.protobuf.Struct
+	170, // 13: loom.v1.WeaveProgress.tool_result:type_name -> google.protobuf.Value
+	16,  // 14: loom.v1.WeaveProgress.context_state:type_name -> loom.v1.ContextState
+	149, // 15: loom.v1.ExecutionResult.backend_metadata:type_name -> loom.v1.ExecutionResult.BackendMetadataEntry
+	9,   // 16: loom.v1.ExecutionResult.data_reference:type_name -> loom.v1.DataReference
+	1,   // 17: loom.v1.DataReference.location:type_name -> loom.v1.StorageLocation
+	150, // 18: loom.v1.DataReference.metadata:type_name -> loom.v1.DataReference.MetadataEntry
+	11,  // 19: loom.v1.SharedMemoryConfig.disk_overflow:type_name -> loom.v1.DiskOverflowConfig
+	12,  // 20: loom.v1.SharedMemoryConfig.compression:type_name -> loom.v1.CompressionConfig
+	13,  // 21: loom.v1.SharedMemoryConfig.cleanup:type_name -> loom.v1.CleanupConfig
+	15,  // 22: loom.v1.CostInfo.llm_cost:type_name -> loom.v1.LLMCost
+	15,  // 23: loom.v1.SelfCorrectionAttempt.cost:type_name -> loom.v1.LLMCost
+	30,  // 24: loom.v1.ListPatternsResponse.patterns:type_name -> loom.v1.Pattern
+	2,   // 25: loom.v1.PatternUpdateEvent.type:type_name -> loom.v1.PatternUpdateType
+	31,  // 26: loom.v1.Pattern.parameters:type_name -> loom.v1.PatternParameter
+	32,  // 27: loom.v1.Pattern.examples:type_name -> loom.v1.PatternExample
+	151, // 28: loom.v1.Pattern.backend_hints:type_name -> loom.v1.Pattern.BackendHintsEntry
+	152, // 29: loom.v1.CreateSessionRequest.config:type_name -> loom.v1.CreateSessionRequest.ConfigEntry
+	153, // 30: loom.v1.CreateSessionRequest.metadata:type_name -> loom.v1.CreateSessionRequest.MetadataEntry
+	154, // 31: loom.v1.Session.metadata:type_name -> loom.v1.Session.MetadataEntry
+	34,  // 32: loom.v1.ListSessionsResponse.sessions:type_name -> loom.v1.Session
+	42,  // 33: loom.v1.SessionUpdate.new_message:type_name -> loom.v1.NewMessageUpdate
+	43,  // 34: loom.v1.SessionUpdate.status_change:type_name -> loom.v1.SessionStatusUpdate
+	14,  // 35: loom.v1.NewMessageUpdate.cost:type_name -> loom.v1.CostInfo
+	46,  // 36: loom.v1.ConversationHistory.messages:type_name -> loom.v1.Message
+	47,  // 37: loom.v1.Message.tool_calls:type_name -> loom.v1.ToolCall
+	14,  // 38: loom.v1.Message.cost:type_name -> loom.v1.CostInfo
+	52,  // 39: loom.v1.RegisterToolRequest.tool:type_name -> loom.v1.ToolDefinition
+	52,  // 40: loom.v1.ListToolsResponse.tools:type_name -> loom.v1.ToolDefinition
+	53,  // 41: loom.v1.ToolDefinition.use_cases:type_name -> loom.v1.ToolUseCase
+	54,  // 42: loom.v1.ToolDefinition.conflicts:type_name -> loom.v1.ToolConflict
+	55,  // 43: loom.v1.ToolDefinition.alternatives:type_name -> loom.v1.ToolAlternative
+	171, // 44: loom.v1.ToolDefinition.examples:type_name -> loom.v1.ToolExample
+	57,  // 45: loom.v1.ToolDefinition.prerequisites:type_name -> loom.v1.ToolPrerequisite
+	172, // 46: loom.v1.ToolDefinition.rate_limit:type_name -> loom.v1.RateLimitInfo
+	58,  // 47: loom.v1.ToolDefinition.common_errors:type_name -> loom.v1.ToolCommonError
+	56,  // 48: loom.v1.ToolDefinition.complements:type_name -> loom.v1.ToolComplement
+	61,  // 49: loom.v1.Trace.root_span:type_name -> loom.v1.Span
+	61,  // 50: loom.v1.Trace.spans:type_name -> loom.v1.Span
+	14,  // 51: loom.v1.Trace.total_cost:type_name -> loom.v1.CostInfo
+	155, // 52: loom.v1.Span.attributes:type_name -> loom.v1.Span.AttributesEntry
+	62,  // 53: loom.v1.Span.events:type_name -> loom.v1.SpanEvent
+	156, // 54: loom.v1.SpanEvent.attributes:type_name -> loom.v1.SpanEvent.AttributesEntry
+	157, // 55: loom.v1.HealthStatus.components:type_name -> loom.v1.HealthStatus.ComponentsEntry
+	173, // 56: loom.v1.CreateAgentRequest.config:type_name -> loom.v1.AgentConfig
+	158, // 57: loom.v1.AgentInfo.metadata:type_name -> loom.v1.AgentInfo.MetadataEntry
+	173, // 58: loom.v1.AgentInfo.config:type_name -> loom.v1.AgentConfig
+	67,  // 59: loom.v1.ListAgentsResponse.agents:type_name -> loom.v1.AgentInfo
+	173, // 60: loom.v1.ReloadAgentRequest.config:type_name -> loom.v1.AgentConfig
+	174, // 61: loom.v1.ListWorkflowExecutionsResponse.executions:type_name -> loom.v1.WorkflowExecution
+	175, // 62: loom.v1.WorkflowProgress.partial_results:type_name -> loom.v1.AgentResult
+	176, // 63: loom.v1.ScheduleWorkflowRequest.pattern:type_name -> loom.v1.WorkflowPattern
+	177, // 64: loom.v1.ScheduleWorkflowRequest.schedule:type_name -> loom.v1.ScheduleConfig
+	159, // 65: loom.v1.ScheduleWorkflowRequest.metadata:type_name -> loom.v1.ScheduleWorkflowRequest.MetadataEntry
+	178, // 66: loom.v1.ScheduleWorkflowResponse.schedule:type_name -> loom.v1.ScheduledWorkflow
+	176, // 67: loom.v1.UpdateScheduledWorkflowRequest.pattern:type_name -> loom.v1.WorkflowPattern
+	177, // 68: loom.v1.UpdateScheduledWorkflowRequest.schedule:type_name -> loom.v1.ScheduleConfig
+	178, // 69: loom.v1.ListScheduledWorkflowsResponse.schedules:type_name -> loom.v1.ScheduledWorkflow
+	160, // 70: loom.v1.TriggerScheduledWorkflowRequest.variables:type_name -> loom.v1.TriggerScheduledWorkflowRequest.VariablesEntry
+	92,  // 71: loom.v1.GetScheduleHistoryResponse.executions:type_name -> loom.v1.ScheduleExecution
+	179, // 72: loom.v1.RenewCertificateResponse.certificate:type_name -> loom.v1.CertificateInfo
+	180, // 73: loom.v1.SwitchModelRequest.role:type_name -> loom.v1.LLMRole
+	105, // 74: loom.v1.SwitchModelResponse.previous_model:type_name -> loom.v1.ModelInfo
+	105, // 75: loom.v1.SwitchModelResponse.new_model:type_name -> loom.v1.ModelInfo
+	105, // 76: loom.v1.ListAvailableModelsResponse.models:type_name -> loom.v1.ModelInfo
+	181, // 77: loom.v1.ListProvidersResponse.providers:type_name -> loom.v1.ProviderEntry
+	3,   // 78: loom.v1.ABTestRequest.mode:type_name -> loom.v1.ABTestMode
+	111, // 79: loom.v1.ListMCPServersResponse.servers:type_name -> loom.v1.MCPServerInfo
+	161, // 80: loom.v1.MCPServerInfo.env:type_name -> loom.v1.MCPServerInfo.EnvEntry
+	162, // 81: loom.v1.AddMCPServerRequest.env:type_name -> loom.v1.AddMCPServerRequest.EnvEntry
+	112, // 82: loom.v1.AddMCPServerRequest.tool_filter:type_name -> loom.v1.ToolFilterConfig
+	111, // 83: loom.v1.AddMCPServerResponse.server:type_name -> loom.v1.MCPServerInfo
+	163, // 84: loom.v1.UpdateMCPServerRequest.env:type_name -> loom.v1.UpdateMCPServerRequest.EnvEntry
+	112, // 85: loom.v1.UpdateMCPServerRequest.tool_filter:type_name -> loom.v1.ToolFilterConfig
+	164, // 86: loom.v1.HealthCheckMCPServersResponse.servers:type_name -> loom.v1.HealthCheckMCPServersResponse.ServersEntry
+	165, // 87: loom.v1.TestMCPServerConnectionRequest.env:type_name -> loom.v1.TestMCPServerConnectionRequest.EnvEntry
+	112, // 88: loom.v1.TestMCPServerConnectionRequest.tool_filter:type_name -> loom.v1.ToolFilterConfig
+	52,  // 89: loom.v1.ListMCPServerToolsResponse.tools:type_name -> loom.v1.ToolDefinition
+	166, // 90: loom.v1.Artifact.metadata:type_name -> loom.v1.Artifact.MetadataEntry
+	126, // 91: loom.v1.ListArtifactsResponse.artifacts:type_name -> loom.v1.Artifact
+	126, // 92: loom.v1.GetArtifactResponse.artifact:type_name -> loom.v1.Artifact
+	126, // 93: loom.v1.UploadArtifactResponse.artifact:type_name -> loom.v1.Artifact
+	126, // 94: loom.v1.SearchArtifactsResponse.artifacts:type_name -> loom.v1.Artifact
+	34,  // 95: loom.v1.ListAllSessionsResponse.sessions:type_name -> loom.v1.Session
+	167, // 96: loom.v1.CountSessionsByUserResponse.user_counts:type_name -> loom.v1.CountSessionsByUserResponse.UserCountsEntry
+	65,  // 97: loom.v1.HealthStatus.ComponentsEntry.value:type_name -> loom.v1.ComponentHealth
+	121, // 98: loom.v1.HealthCheckMCPServersResponse.ServersEntry.value:type_name -> loom.v1.MCPServerHealth
+	4,   // 99: loom.v1.LoomService.Weave:input_type -> loom.v1.WeaveRequest
+	4,   // 100: loom.v1.LoomService.StreamWeave:input_type -> loom.v1.WeaveRequest
+	19,  // 101: loom.v1.LoomService.LoadPatterns:input_type -> loom.v1.LoadPatternsRequest
+	21,  // 102: loom.v1.LoomService.ListPatterns:input_type -> loom.v1.ListPatternsRequest
+	23,  // 103: loom.v1.LoomService.GetPattern:input_type -> loom.v1.GetPatternRequest
+	24,  // 104: loom.v1.LoomService.CreatePattern:input_type -> loom.v1.CreatePatternRequest
+	26,  // 105: loom.v1.LoomService.StreamPatternUpdates:input_type -> loom.v1.StreamPatternUpdatesRequest
+	28,  // 106: loom.v1.LoomService.AnswerClarificationQuestion:input_type -> loom.v1.AnswerClarificationRequest
+	33,  // 107: loom.v1.LoomService.CreateSession:input_type -> loom.v1.CreateSessionRequest
+	35,  // 108: loom.v1.LoomService.GetSession:input_type -> loom.v1.GetSessionRequest
+	36,  // 109: loom.v1.LoomService.ListSessions:input_type -> loom.v1.ListSessionsRequest
+	38,  // 110: loom.v1.LoomService.DeleteSession:input_type -> loom.v1.DeleteSessionRequest
+	40,  // 111: loom.v1.LoomService.SubscribeToSession:input_type -> loom.v1.SubscribeToSessionRequest
+	44,  // 112: loom.v1.LoomService.GetConversationHistory:input_type -> loom.v1.GetConversationHistoryRequest
+	48,  // 113: loom.v1.LoomService.RegisterTool:input_type -> loom.v1.RegisterToolRequest
+	50,  // 114: loom.v1.LoomService.ListTools:input_type -> loom.v1.ListToolsRequest
+	59,  // 115: loom.v1.LoomService.GetTrace:input_type -> loom.v1.GetTraceRequest
+	63,  // 116: loom.v1.LoomService.GetHealth:input_type -> loom.v1.GetHealthRequest
+	93,  // 117: loom.v1.LoomService.GetServerConfig:input_type -> loom.v1.GetServerConfigRequest
+	94,  // 118: loom.v1.LoomService.GetTLSStatus:input_type -> loom.v1.GetTLSStatusRequest
+	95,  // 119: loom.v1.LoomService.RenewCertificate:input_type -> loom.v1.RenewCertificateRequest
+	182, // 120: loom.v1.LoomService.GetStorageStatus:input_type -> loom.v1.GetStorageStatusRequest
+	183, // 121: loom.v1.LoomService.RunMigration:input_type -> loom.v1.RunMigrationRequest
+	66,  // 122: loom.v1.LoomService.CreateAgentFromConfig:input_type -> loom.v1.CreateAgentRequest
+	68,  // 123: loom.v1.LoomService.ListAgents:input_type -> loom.v1.ListAgentsRequest
+	70,  // 124: loom.v1.LoomService.GetAgent:input_type -> loom.v1.GetAgentRequest
+	71,  // 125: loom.v1.LoomService.StartAgent:input_type -> loom.v1.StartAgentRequest
+	72,  // 126: loom.v1.LoomService.StopAgent:input_type -> loom.v1.StopAgentRequest
+	73,  // 127: loom.v1.LoomService.DeleteAgent:input_type -> loom.v1.DeleteAgentRequest
+	75,  // 128: loom.v1.LoomService.ReloadAgent:input_type -> loom.v1.ReloadAgentRequest
+	97,  // 129: loom.v1.LoomService.SwitchModel:input_type -> loom.v1.SwitchModelRequest
+	99,  // 130: loom.v1.LoomService.ListAvailableModels:input_type -> loom.v1.ListAvailableModelsRequest
+	101, // 131: loom.v1.LoomService.ListProviders:input_type -> loom.v1.ListProvidersRequest
+	103, // 132: loom.v1.LoomService.ABTest:input_type -> loom.v1.ABTestRequest
+	106, // 133: loom.v1.LoomService.RequestToolPermission:input_type -> loom.v1.ToolPermissionRequest
+	108, // 134: loom.v1.LoomService.ListMCPServers:input_type -> loom.v1.ListMCPServersRequest
+	110, // 135: loom.v1.LoomService.GetMCPServer:input_type -> loom.v1.GetMCPServerRequest
+	113, // 136: loom.v1.LoomService.AddMCPServer:input_type -> loom.v1.AddMCPServerRequest
+	115, // 137: loom.v1.LoomService.UpdateMCPServer:input_type -> loom.v1.UpdateMCPServerRequest
+	116, // 138: loom.v1.LoomService.DeleteMCPServer:input_type -> loom.v1.DeleteMCPServerRequest
+	118, // 139: loom.v1.LoomService.RestartMCPServer:input_type -> loom.v1.RestartMCPServerRequest
+	119, // 140: loom.v1.LoomService.HealthCheckMCPServers:input_type -> loom.v1.HealthCheckMCPServersRequest
+	122, // 141: loom.v1.LoomService.TestMCPServerConnection:input_type -> loom.v1.TestMCPServerConnectionRequest
+	124, // 142: loom.v1.LoomService.ListMCPServerTools:input_type -> loom.v1.ListMCPServerToolsRequest
+	184, // 143: loom.v1.LoomService.ExecuteWorkflow:input_type -> loom.v1.ExecuteWorkflowRequest
+	184, // 144: loom.v1.LoomService.StreamWorkflow:input_type -> loom.v1.ExecuteWorkflowRequest
+	76,  // 145: loom.v1.LoomService.GetWorkflowExecution:input_type -> loom.v1.GetWorkflowExecutionRequest
+	77,  // 146: loom.v1.LoomService.ListWorkflowExecutions:input_type -> loom.v1.ListWorkflowExecutionsRequest
+	185, // 147: loom.v1.LoomService.ListWorkflows:input_type -> loom.v1.ListWorkflowsRequest
+	80,  // 148: loom.v1.LoomService.ScheduleWorkflow:input_type -> loom.v1.ScheduleWorkflowRequest
+	82,  // 149: loom.v1.LoomService.UpdateScheduledWorkflow:input_type -> loom.v1.UpdateScheduledWorkflowRequest
+	83,  // 150: loom.v1.LoomService.GetScheduledWorkflow:input_type -> loom.v1.GetScheduledWorkflowRequest
+	84,  // 151: loom.v1.LoomService.ListScheduledWorkflows:input_type -> loom.v1.ListScheduledWorkflowsRequest
+	86,  // 152: loom.v1.LoomService.DeleteScheduledWorkflow:input_type -> loom.v1.DeleteScheduledWorkflowRequest
+	87,  // 153: loom.v1.LoomService.TriggerScheduledWorkflow:input_type -> loom.v1.TriggerScheduledWorkflowRequest
+	88,  // 154: loom.v1.LoomService.PauseSchedule:input_type -> loom.v1.PauseScheduleRequest
+	89,  // 155: loom.v1.LoomService.ResumeSchedule:input_type -> loom.v1.ResumeScheduleRequest
+	90,  // 156: loom.v1.LoomService.GetScheduleHistory:input_type -> loom.v1.GetScheduleHistoryRequest
+	186, // 157: loom.v1.LoomService.Publish:input_type -> loom.v1.PublishRequest
+	187, // 158: loom.v1.LoomService.Subscribe:input_type -> loom.v1.SubscribeRequest
+	188, // 159: loom.v1.LoomService.Unsubscribe:input_type -> loom.v1.UnsubscribeRequest
+	189, // 160: loom.v1.LoomService.ListTopics:input_type -> loom.v1.ListTopicsRequest
+	190, // 161: loom.v1.LoomService.GetTopicStats:input_type -> loom.v1.GetTopicStatsRequest
+	191, // 162: loom.v1.LoomService.SendAsync:input_type -> loom.v1.SendAsyncRequest
+	192, // 163: loom.v1.LoomService.SendAndReceive:input_type -> loom.v1.SendAndReceiveRequest
+	193, // 164: loom.v1.LoomService.PutSharedMemory:input_type -> loom.v1.PutSharedMemoryRequest
+	194, // 165: loom.v1.LoomService.GetSharedMemory:input_type -> loom.v1.GetSharedMemoryRequest
+	195, // 166: loom.v1.LoomService.DeleteSharedMemory:input_type -> loom.v1.DeleteSharedMemoryRequest
+	196, // 167: loom.v1.LoomService.WatchSharedMemory:input_type -> loom.v1.WatchSharedMemoryRequest
+	197, // 168: loom.v1.LoomService.ListSharedMemoryKeys:input_type -> loom.v1.ListSharedMemoryKeysRequest
+	198, // 169: loom.v1.LoomService.GetSharedMemoryStats:input_type -> loom.v1.GetSharedMemoryStatsRequest
+	127, // 170: loom.v1.LoomService.ListArtifacts:input_type -> loom.v1.ListArtifactsRequest
+	129, // 171: loom.v1.LoomService.GetArtifact:input_type -> loom.v1.GetArtifactRequest
+	131, // 172: loom.v1.LoomService.UploadArtifact:input_type -> loom.v1.UploadArtifactRequest
+	133, // 173: loom.v1.LoomService.DeleteArtifact:input_type -> loom.v1.DeleteArtifactRequest
+	135, // 174: loom.v1.LoomService.SearchArtifacts:input_type -> loom.v1.SearchArtifactsRequest
+	137, // 175: loom.v1.LoomService.GetArtifactContent:input_type -> loom.v1.GetArtifactContentRequest
+	139, // 176: loom.v1.LoomService.GetArtifactStats:input_type -> loom.v1.GetArtifactStatsRequest
+	199, // 177: loom.v1.LoomService.ListUIApps:input_type -> loom.v1.ListUIAppsRequest
+	200, // 178: loom.v1.LoomService.GetUIApp:input_type -> loom.v1.GetUIAppRequest
+	201, // 179: loom.v1.LoomService.CreateUIApp:input_type -> loom.v1.CreateUIAppRequest
+	202, // 180: loom.v1.LoomService.UpdateUIApp:input_type -> loom.v1.UpdateUIAppRequest
+	203, // 181: loom.v1.LoomService.DeleteUIApp:input_type -> loom.v1.DeleteUIAppRequest
+	204, // 182: loom.v1.LoomService.ListComponentTypes:input_type -> loom.v1.ListComponentTypesRequest
+	205, // 183: loom.v1.LoomService.ListAgentPresets:input_type -> loom.v1.ListAgentPresetsRequest
+	206, // 184: loom.v1.LoomService.ListWorkflowTemplates:input_type -> loom.v1.ListWorkflowTemplatesRequest
+	207, // 185: loom.v1.LoomService.CreateWorkflowFromTemplate:input_type -> loom.v1.CreateWorkflowFromTemplateRequest
+	141, // 186: loom.v1.AdminService.ListAllSessions:input_type -> loom.v1.ListAllSessionsRequest
+	143, // 187: loom.v1.AdminService.CountSessionsByUser:input_type -> loom.v1.CountSessionsByUserRequest
+	145, // 188: loom.v1.AdminService.GetSystemStats:input_type -> loom.v1.GetSystemStatsRequest
+	5,   // 189: loom.v1.LoomService.Weave:output_type -> loom.v1.WeaveResponse
+	6,   // 190: loom.v1.LoomService.StreamWeave:output_type -> loom.v1.WeaveProgress
+	20,  // 191: loom.v1.LoomService.LoadPatterns:output_type -> loom.v1.LoadPatternsResponse
+	22,  // 192: loom.v1.LoomService.ListPatterns:output_type -> loom.v1.ListPatternsResponse
+	30,  // 193: loom.v1.LoomService.GetPattern:output_type -> loom.v1.Pattern
+	25,  // 194: loom.v1.LoomService.CreatePattern:output_type -> loom.v1.CreatePatternResponse
+	27,  // 195: loom.v1.LoomService.StreamPatternUpdates:output_type -> loom.v1.PatternUpdateEvent
+	29,  // 196: loom.v1.LoomService.AnswerClarificationQuestion:output_type -> loom.v1.AnswerClarificationResponse
+	34,  // 197: loom.v1.LoomService.CreateSession:output_type -> loom.v1.Session
+	34,  // 198: loom.v1.LoomService.GetSession:output_type -> loom.v1.Session
+	37,  // 199: loom.v1.LoomService.ListSessions:output_type -> loom.v1.ListSessionsResponse
+	39,  // 200: loom.v1.LoomService.DeleteSession:output_type -> loom.v1.DeleteSessionResponse
+	41,  // 201: loom.v1.LoomService.SubscribeToSession:output_type -> loom.v1.SessionUpdate
+	45,  // 202: loom.v1.LoomService.GetConversationHistory:output_type -> loom.v1.ConversationHistory
+	49,  // 203: loom.v1.LoomService.RegisterTool:output_type -> loom.v1.RegisterToolResponse
+	51,  // 204: loom.v1.LoomService.ListTools:output_type -> loom.v1.ListToolsResponse
+	60,  // 205: loom.v1.LoomService.GetTrace:output_type -> loom.v1.Trace
+	64,  // 206: loom.v1.LoomService.GetHealth:output_type -> loom.v1.HealthStatus
+	208, // 207: loom.v1.LoomService.GetServerConfig:output_type -> loom.v1.ServerConfig
+	209, // 208: loom.v1.LoomService.GetTLSStatus:output_type -> loom.v1.TLSStatus
+	96,  // 209: loom.v1.LoomService.RenewCertificate:output_type -> loom.v1.RenewCertificateResponse
+	210, // 210: loom.v1.LoomService.GetStorageStatus:output_type -> loom.v1.GetStorageStatusResponse
+	211, // 211: loom.v1.LoomService.RunMigration:output_type -> loom.v1.RunMigrationResponse
+	67,  // 212: loom.v1.LoomService.CreateAgentFromConfig:output_type -> loom.v1.AgentInfo
+	69,  // 213: loom.v1.LoomService.ListAgents:output_type -> loom.v1.ListAgentsResponse
+	67,  // 214: loom.v1.LoomService.GetAgent:output_type -> loom.v1.AgentInfo
+	67,  // 215: loom.v1.LoomService.StartAgent:output_type -> loom.v1.AgentInfo
+	67,  // 216: loom.v1.LoomService.StopAgent:output_type -> loom.v1.AgentInfo
+	74,  // 217: loom.v1.LoomService.DeleteAgent:output_type -> loom.v1.DeleteAgentResponse
+	67,  // 218: loom.v1.LoomService.ReloadAgent:output_type -> loom.v1.AgentInfo
+	98,  // 219: loom.v1.LoomService.SwitchModel:output_type -> loom.v1.SwitchModelResponse
+	100, // 220: loom.v1.LoomService.ListAvailableModels:output_type -> loom.v1.ListAvailableModelsResponse
+	102, // 221: loom.v1.LoomService.ListProviders:output_type -> loom.v1.ListProvidersResponse
+	104, // 222: loom.v1.LoomService.ABTest:output_type -> loom.v1.ABTestEvent
+	107, // 223: loom.v1.LoomService.RequestToolPermission:output_type -> loom.v1.ToolPermissionResponse
+	109, // 224: loom.v1.LoomService.ListMCPServers:output_type -> loom.v1.ListMCPServersResponse
+	111, // 225: loom.v1.LoomService.GetMCPServer:output_type -> loom.v1.MCPServerInfo
+	114, // 226: loom.v1.LoomService.AddMCPServer:output_type -> loom.v1.AddMCPServerResponse
+	111, // 227: loom.v1.LoomService.UpdateMCPServer:output_type -> loom.v1.MCPServerInfo
+	117, // 228: loom.v1.LoomService.DeleteMCPServer:output_type -> loom.v1.DeleteMCPServerResponse
+	111, // 229: loom.v1.LoomService.RestartMCPServer:output_type -> loom.v1.MCPServerInfo
+	120, // 230: loom.v1.LoomService.HealthCheckMCPServers:output_type -> loom.v1.HealthCheckMCPServersResponse
+	123, // 231: loom.v1.LoomService.TestMCPServerConnection:output_type -> loom.v1.TestMCPServerConnectionResponse
+	125, // 232: loom.v1.LoomService.ListMCPServerTools:output_type -> loom.v1.ListMCPServerToolsResponse
+	212, // 233: loom.v1.LoomService.ExecuteWorkflow:output_type -> loom.v1.ExecuteWorkflowResponse
+	79,  // 234: loom.v1.LoomService.StreamWorkflow:output_type -> loom.v1.WorkflowProgress
+	174, // 235: loom.v1.LoomService.GetWorkflowExecution:output_type -> loom.v1.WorkflowExecution
+	78,  // 236: loom.v1.LoomService.ListWorkflowExecutions:output_type -> loom.v1.ListWorkflowExecutionsResponse
+	213, // 237: loom.v1.LoomService.ListWorkflows:output_type -> loom.v1.ListWorkflowsResponse
+	81,  // 238: loom.v1.LoomService.ScheduleWorkflow:output_type -> loom.v1.ScheduleWorkflowResponse
+	81,  // 239: loom.v1.LoomService.UpdateScheduledWorkflow:output_type -> loom.v1.ScheduleWorkflowResponse
+	178, // 240: loom.v1.LoomService.GetScheduledWorkflow:output_type -> loom.v1.ScheduledWorkflow
+	85,  // 241: loom.v1.LoomService.ListScheduledWorkflows:output_type -> loom.v1.ListScheduledWorkflowsResponse
+	214, // 242: loom.v1.LoomService.DeleteScheduledWorkflow:output_type -> google.protobuf.Empty
+	212, // 243: loom.v1.LoomService.TriggerScheduledWorkflow:output_type -> loom.v1.ExecuteWorkflowResponse
+	214, // 244: loom.v1.LoomService.PauseSchedule:output_type -> google.protobuf.Empty
+	214, // 245: loom.v1.LoomService.ResumeSchedule:output_type -> google.protobuf.Empty
+	91,  // 246: loom.v1.LoomService.GetScheduleHistory:output_type -> loom.v1.GetScheduleHistoryResponse
+	215, // 247: loom.v1.LoomService.Publish:output_type -> loom.v1.PublishResponse
+	216, // 248: loom.v1.LoomService.Subscribe:output_type -> loom.v1.BusMessage
+	217, // 249: loom.v1.LoomService.Unsubscribe:output_type -> loom.v1.UnsubscribeResponse
+	218, // 250: loom.v1.LoomService.ListTopics:output_type -> loom.v1.ListTopicsResponse
+	219, // 251: loom.v1.LoomService.GetTopicStats:output_type -> loom.v1.TopicStats
+	220, // 252: loom.v1.LoomService.SendAsync:output_type -> loom.v1.SendAsyncResponse
+	221, // 253: loom.v1.LoomService.SendAndReceive:output_type -> loom.v1.SendAndReceiveResponse
+	222, // 254: loom.v1.LoomService.PutSharedMemory:output_type -> loom.v1.PutSharedMemoryResponse
+	223, // 255: loom.v1.LoomService.GetSharedMemory:output_type -> loom.v1.GetSharedMemoryResponse
+	224, // 256: loom.v1.LoomService.DeleteSharedMemory:output_type -> loom.v1.DeleteSharedMemoryResponse
+	225, // 257: loom.v1.LoomService.WatchSharedMemory:output_type -> loom.v1.SharedMemoryValue
+	226, // 258: loom.v1.LoomService.ListSharedMemoryKeys:output_type -> loom.v1.ListSharedMemoryKeysResponse
+	227, // 259: loom.v1.LoomService.GetSharedMemoryStats:output_type -> loom.v1.SharedMemoryStats
+	128, // 260: loom.v1.LoomService.ListArtifacts:output_type -> loom.v1.ListArtifactsResponse
+	130, // 261: loom.v1.LoomService.GetArtifact:output_type -> loom.v1.GetArtifactResponse
+	132, // 262: loom.v1.LoomService.UploadArtifact:output_type -> loom.v1.UploadArtifactResponse
+	134, // 263: loom.v1.LoomService.DeleteArtifact:output_type -> loom.v1.DeleteArtifactResponse
+	136, // 264: loom.v1.LoomService.SearchArtifacts:output_type -> loom.v1.SearchArtifactsResponse
+	138, // 265: loom.v1.LoomService.GetArtifactContent:output_type -> loom.v1.GetArtifactContentResponse
+	140, // 266: loom.v1.LoomService.GetArtifactStats:output_type -> loom.v1.GetArtifactStatsResponse
+	228, // 267: loom.v1.LoomService.ListUIApps:output_type -> loom.v1.ListUIAppsResponse
+	229, // 268: loom.v1.LoomService.GetUIApp:output_type -> loom.v1.GetUIAppResponse
+	230, // 269: loom.v1.LoomService.CreateUIApp:output_type -> loom.v1.CreateUIAppResponse
+	231, // 270: loom.v1.LoomService.UpdateUIApp:output_type -> loom.v1.UpdateUIAppResponse
+	232, // 271: loom.v1.LoomService.DeleteUIApp:output_type -> loom.v1.DeleteUIAppResponse
+	233, // 272: loom.v1.LoomService.ListComponentTypes:output_type -> loom.v1.ListComponentTypesResponse
+	234, // 273: loom.v1.LoomService.ListAgentPresets:output_type -> loom.v1.ListAgentPresetsResponse
+	235, // 274: loom.v1.LoomService.ListWorkflowTemplates:output_type -> loom.v1.ListWorkflowTemplatesResponse
+	236, // 275: loom.v1.LoomService.CreateWorkflowFromTemplate:output_type -> loom.v1.CreateWorkflowFromTemplateResponse
+	142, // 276: loom.v1.AdminService.ListAllSessions:output_type -> loom.v1.ListAllSessionsResponse
+	144, // 277: loom.v1.AdminService.CountSessionsByUser:output_type -> loom.v1.CountSessionsByUserResponse
+	146, // 278: loom.v1.AdminService.GetSystemStats:output_type -> loom.v1.GetSystemStatsResponse
+	189, // [189:279] is the sub-list for method output_type
+	99,  // [99:189] is the sub-list for method input_type
+	99,  // [99:99] is the sub-list for extension type_name
+	99,  // [99:99] is the sub-list for extension extendee
+	0,   // [0:99] is the sub-list for field type_name
 }
 
 func init() { file_loom_v1_loom_proto_init() }

--- a/gen/openapiv2/loom/v1/loom.swagger.json
+++ b/gen/openapiv2/loom/v1/loom.swagger.json
@@ -10110,6 +10110,11 @@
         "resetContext": {
           "type": "boolean",
           "description": "Clear context window before processing this message.\nWhen true, the agent's SegmentedMemory is reset (L1/L2/swap cleared)\nbefore the query is processed, giving a fresh context window."
+        },
+        "occurredAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Historical arrival time for replayed or imported conversations (optional).\nWhen set, every message persisted during this call — the user turn, the\nassistant reply, and tool rows — carries this timestamp instead of the\nserver wall clock, so temporal grounding (compiled-view arrival stamps,\ngraph-memory extraction anchoring) reflects when the conversation\nactually happened rather than when it was ingested.\n\nServers reject this field unless server.allow_time_override is enabled\n(FAILED_PRECONDITION), and reject values in the future beyond a small\nclock-skew allowance (INVALID_ARGUMENT). Live conversations should leave\nit unset."
         }
       },
       "description": "WeaveRequest initiates a query execution."

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1988,6 +1988,13 @@ func (a *Agent) chat(ctx context.Context, sessionID string, userMessage string, 
 // arrival. turnStart is true only at the Chat() entry — the only
 // turn-incrementing event (HLD §4.5). Persist failures are logged, never fatal.
 func (a *Agent) appendMessage(ctx context.Context, session *Session, msg Message, turnStart bool) Message {
+	// A replay/import override (WeaveRequest.occurred_at → WithOccurredAt)
+	// anchors every row persisted during the call at the conversation's
+	// historical time; without one, the caller-stamped wall clock stands.
+	if at, ok := occurredAtFromContext(ctx); ok {
+		msg.Timestamp = at
+	}
+
 	// In-memory derivation, identical arithmetic to the store's subquery — the
 	// only derivation for storeless sessions and unpersisted rows.
 	t := sessionCurrentTurn(session)

--- a/pkg/agent/occurred_at.go
+++ b/pkg/agent/occurred_at.go
@@ -1,0 +1,34 @@
+// Copyright © 2026 Teradata Corporation - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package agent
+
+import (
+	"context"
+	"time"
+)
+
+// occurredAtKey carries a historical arrival-time override through the
+// conversation call chain (server Weave handler → Chat entry points →
+// appendMessage). Follows the same context-key pattern as progressCallbackKey.
+type occurredAtKey struct{}
+
+// WithOccurredAt returns a context that overrides the arrival timestamp of
+// every message persisted during the conversation call — the user turn, the
+// assistant reply, and tool rows. It exists for replayed or imported
+// conversations (WeaveRequest.occurred_at), where the wall clock at ingestion
+// is not when the conversation happened: temporal grounding (compiled-view
+// arrival stamps, graph-memory extraction anchoring) reads Message.Timestamp,
+// so the override keeps all of those signals anchored to the conversation's
+// real time. Live conversations must not use this.
+func WithOccurredAt(ctx context.Context, t time.Time) context.Context {
+	return context.WithValue(ctx, occurredAtKey{}, t)
+}
+
+// occurredAtFromContext reports the arrival-time override, if any.
+func occurredAtFromContext(ctx context.Context) (time.Time, bool) {
+	t, ok := ctx.Value(occurredAtKey{}).(time.Time)
+	return t, ok
+}

--- a/pkg/agent/occurred_at_test.go
+++ b/pkg/agent/occurred_at_test.go
@@ -1,0 +1,66 @@
+// Copyright © 2026 Teradata Corporation - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestChat_OccurredAtOverride_AnchorsAllRows verifies WithOccurredAt threads a
+// replay/import arrival time through the whole conversation call: every row
+// appendMessage persists — the user turn and the assistant reply — carries the
+// override instead of the wall clock, so temporal grounding reads the
+// conversation's historical time.
+func TestChat_OccurredAtOverride_AnchorsAllRows(t *testing.T) {
+	llm := &capturingLLM{response: "ok"}
+	ag := contentBlocksTestAgent(llm)
+
+	occurred := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+	ctx := WithOccurredAt(context.Background(), occurred)
+
+	_, err := ag.Chat(ctx, "occurred-at-session", "what ran that day?")
+	require.NoError(t, err)
+
+	session, ok := ag.GetSession("occurred-at-session")
+	require.True(t, ok)
+	messages := session.GetMessages()
+	require.NotEmpty(t, messages)
+
+	var stamped int
+	for _, m := range messages {
+		if m.Role != "user" && m.Role != "assistant" {
+			continue
+		}
+		require.True(t, m.Timestamp.Equal(occurred),
+			"%s row Timestamp = %s, want the occurred_at override %s", m.Role, m.Timestamp, occurred)
+		stamped++
+	}
+	require.GreaterOrEqual(t, stamped, 2, "user turn and assistant reply should both be anchored")
+}
+
+// TestChat_NoOverride_KeepsWallClock pins the default: without WithOccurredAt,
+// rows keep their wall-clock arrival timestamps.
+func TestChat_NoOverride_KeepsWallClock(t *testing.T) {
+	llm := &capturingLLM{response: "ok"}
+	ag := contentBlocksTestAgent(llm)
+
+	before := time.Now().Add(-time.Minute)
+	_, err := ag.Chat(context.Background(), "wall-clock-session", "hello")
+	require.NoError(t, err)
+
+	session, ok := ag.GetSession("wall-clock-session")
+	require.True(t, ok)
+	for _, m := range session.GetMessages() {
+		if m.Role == "user" {
+			require.True(t, m.Timestamp.After(before),
+				"user row keeps its wall-clock arrival time without an override")
+		}
+	}
+}

--- a/pkg/server/multi_agent.go
+++ b/pkg/server/multi_agent.go
@@ -53,6 +53,12 @@ type MultiAgentServer struct {
 	sessionStore agent.SessionStorage
 	mu           sync.RWMutex
 
+	// allowTimeOverride accepts WeaveRequest.occurred_at (replay/import arrival
+	// times). Default false: client-supplied timestamps can poison temporal
+	// grounding, so honoring them is an explicit operator decision
+	// (server.allow_time_override). Set via SetAllowTimeOverride.
+	allowTimeOverride bool
+
 	defaultAgentID     string                           // Agent to use when no agent_id specified
 	patternBroadcaster *PatternEventBroadcaster         // Broadcasts pattern update events
 	hotReloaders       map[string]*patterns.HotReloader // Hot-reloaders for each agent's patterns
@@ -275,6 +281,15 @@ func (s *MultiAgentServer) SetMCPManager(mgr *manager.Manager, configPath string
 		logger = zap.NewNop()
 	}
 	s.logger = logger
+}
+
+// SetAllowTimeOverride configures whether WeaveRequest.occurred_at is honored
+// (server.allow_time_override). See applyOccurredAt for the gate semantics.
+// This should be called after NewMultiAgentServer(), before serving.
+func (s *MultiAgentServer) SetAllowTimeOverride(allow bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.allowTimeOverride = allow
 }
 
 // SetLogger injects the logger for server operations.
@@ -691,12 +706,18 @@ func (s *MultiAgentServer) Weave(ctx context.Context, req *loomv1.WeaveRequest) 
 		return nil, status.Error(codes.InvalidArgument, "query is required")
 	}
 
+	// Replay/import support: validate occurred_at and thread it through the
+	// context so persisted rows anchor at the conversation's historical time.
+	ctx, err := applyOccurredAt(ctx, req, s.allowTimeOverride)
+	if err != nil {
+		return nil, err
+	}
+
 	// Get agent: if no agent_id specified but session_id is, look up which agent owns the session.
 	// This fixes the bug where Weave(session_id=X) without agent_id falls through to the
 	// default agent instead of the agent that created/owns the session.
 	var ag *agent.Agent
 	var agentID string
-	var err error
 
 	if req.AgentId == "" && req.SessionId != "" {
 		if found, foundID, ok := s.findAgentBySession(req.SessionId); ok {
@@ -841,10 +862,16 @@ func (s *MultiAgentServer) StreamWeave(req *loomv1.WeaveRequest, stream loomv1.L
 		return status.Error(codes.InvalidArgument, "query cannot be empty")
 	}
 
+	// Replay/import support: validate occurred_at and thread it through the
+	// context used for the agent call (see applyOccurredAt).
+	ctx, err := applyOccurredAt(stream.Context(), req, s.allowTimeOverride)
+	if err != nil {
+		return err
+	}
+
 	// Get agent: if no agent_id specified but session_id is, look up which agent owns the session.
 	var ag *agent.Agent
 	var resolvedAgentID string
-	var err error
 
 	if req.AgentId == "" && req.SessionId != "" {
 		if found, foundID, ok := s.findAgentBySession(req.SessionId); ok {
@@ -938,7 +965,7 @@ func (s *MultiAgentServer) StreamWeave(req *loomv1.WeaveRequest, stream loomv1.L
 
 	// Execute agent with progress callback
 	go func() {
-		resp, err := ag.ChatWithProgress(stream.Context(), sessionID, req.Query, progressCallback)
+		resp, err := ag.ChatWithProgress(ctx, sessionID, req.Query, progressCallback)
 		resultChan <- agentResult{resp: resp, err: err}
 		close(progressChan)
 	}()

--- a/pkg/server/occurred_at.go
+++ b/pkg/server/occurred_at.go
@@ -1,0 +1,50 @@
+// Copyright © 2026 Teradata Corporation - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package server
+
+import (
+	"context"
+	"time"
+
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"github.com/teradata-labs/loom/pkg/agent"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// occurredAtMaxSkew is the clock-skew allowance when validating that an
+// occurred_at override is not in the future. Client and server clocks are
+// rarely perfectly aligned; a few minutes of tolerance avoids rejecting
+// legitimate "just now" imports without opening the door to future-dated rows.
+const occurredAtMaxSkew = 5 * time.Minute
+
+// applyOccurredAt validates WeaveRequest.occurred_at and, when present and
+// allowed, threads it through the context so agent.appendMessage anchors every
+// row persisted during the call at the conversation's historical time.
+//
+// Client-supplied timestamps can poison temporal grounding (compiled-view
+// arrival stamps, graph-memory extraction anchoring), so the override is
+// opt-in per server: requests carrying occurred_at are rejected with
+// FAILED_PRECONDITION unless allow is true (server.allow_time_override).
+// Future-dated values are rejected with INVALID_ARGUMENT regardless.
+func applyOccurredAt(ctx context.Context, req *loomv1.WeaveRequest, allow bool) (context.Context, error) {
+	if req.GetOccurredAt() == nil {
+		return ctx, nil
+	}
+	if !allow {
+		return nil, status.Error(codes.FailedPrecondition,
+			"occurred_at override is disabled on this server (set server.allow_time_override: true to accept replayed/imported conversations)")
+	}
+	if err := req.GetOccurredAt().CheckValid(); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid occurred_at: %v", err)
+	}
+	t := req.GetOccurredAt().AsTime()
+	if t.After(time.Now().Add(occurredAtMaxSkew)) {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"occurred_at is in the future: %s", t.Format(time.RFC3339))
+	}
+	return agent.WithOccurredAt(ctx, t), nil
+}

--- a/pkg/server/occurred_at_test.go
+++ b/pkg/server/occurred_at_test.go
@@ -1,0 +1,169 @@
+// Copyright © 2026 Teradata Corporation - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"github.com/teradata-labs/loom/pkg/agent"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// TestWeave_OccurredAt_DisabledByDefault pins the security default: a request
+// carrying occurred_at must be rejected unless the operator explicitly opted
+// in via server.allow_time_override — client-supplied arrival times can poison
+// temporal grounding (compiled-view stamps, extraction anchoring).
+func TestWeave_OccurredAt_DisabledByDefault(t *testing.T) {
+	llm := &countingLLM{name: "mock", model: "mock-model"}
+	ag := agent.NewAgent(&mockBackend{}, llm)
+	srv := NewMultiAgentServer(map[string]*agent.Agent{"agent1": ag}, nil)
+
+	_, err := srv.Weave(context.Background(), &loomv1.WeaveRequest{
+		Query:      "hello",
+		OccurredAt: timestamppb.New(time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)),
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	assert.Equal(t, int64(0), llm.calls.Load(), "the agent must not run when occurred_at is rejected")
+}
+
+// TestWeave_OccurredAt_RejectsFutureTimestamp verifies future-dated overrides
+// are rejected even when the override gate is enabled.
+func TestWeave_OccurredAt_RejectsFutureTimestamp(t *testing.T) {
+	llm := &countingLLM{name: "mock", model: "mock-model"}
+	ag := agent.NewAgent(&mockBackend{}, llm)
+	srv := NewMultiAgentServer(map[string]*agent.Agent{"agent1": ag}, nil)
+	srv.SetAllowTimeOverride(true)
+
+	_, err := srv.Weave(context.Background(), &loomv1.WeaveRequest{
+		Query:      "hello",
+		OccurredAt: timestamppb.New(time.Now().Add(2 * time.Hour)),
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+// TestWeave_OccurredAt_AnchorsPersistedRows verifies the accepted path: every
+// row persisted during the call — the user turn and the assistant reply —
+// carries the override instead of the ingestion wall clock, so replayed or
+// imported conversations anchor temporal grounding at the conversation's
+// historical time.
+func TestWeave_OccurredAt_AnchorsPersistedRows(t *testing.T) {
+	llm := &countingLLM{name: "mock", model: "mock-model"}
+	ag := agent.NewAgent(&mockBackend{}, llm)
+	srv := NewMultiAgentServer(map[string]*agent.Agent{"agent1": ag}, nil)
+	srv.SetAllowTimeOverride(true)
+
+	occurred := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+	const sessionID = "occurred-at-session"
+
+	_, err := srv.Weave(context.Background(), &loomv1.WeaveRequest{
+		Query:      "what did i deploy?",
+		SessionId:  sessionID,
+		OccurredAt: timestamppb.New(occurred),
+	})
+	require.NoError(t, err)
+
+	session, ok := ag.GetSession(sessionID)
+	require.True(t, ok, "session should exist after Weave")
+	messages := session.GetMessages()
+	require.NotEmpty(t, messages)
+
+	var stamped int
+	for _, m := range messages {
+		if m.Role != "user" && m.Role != "assistant" {
+			continue
+		}
+		assert.True(t, m.Timestamp.Equal(occurred),
+			"%s row Timestamp = %s, want the occurred_at override %s", m.Role, m.Timestamp, occurred)
+		stamped++
+	}
+	assert.GreaterOrEqual(t, stamped, 2, "both the user turn and the assistant reply should be anchored")
+}
+
+// TestWeave_OccurredAt_UnsetLeavesWallClock verifies the default path is
+// untouched: without occurred_at, rows keep their ingestion wall-clock
+// timestamps even when the override gate is enabled.
+func TestWeave_OccurredAt_UnsetLeavesWallClock(t *testing.T) {
+	llm := &countingLLM{name: "mock", model: "mock-model"}
+	ag := agent.NewAgent(&mockBackend{}, llm)
+	srv := NewMultiAgentServer(map[string]*agent.Agent{"agent1": ag}, nil)
+	srv.SetAllowTimeOverride(true)
+
+	const sessionID = "wall-clock-session"
+	before := time.Now().Add(-time.Minute)
+
+	_, err := srv.Weave(context.Background(), &loomv1.WeaveRequest{
+		Query:     "hello",
+		SessionId: sessionID,
+	})
+	require.NoError(t, err)
+
+	session, ok := ag.GetSession(sessionID)
+	require.True(t, ok)
+	for _, m := range session.GetMessages() {
+		if m.Role == "user" {
+			assert.True(t, m.Timestamp.After(before),
+				"user row keeps its wall-clock arrival time when no override is supplied")
+		}
+	}
+}
+
+// TestServer_Weave_OccurredAt_DisabledByDefault mirrors the multi-agent gating
+// test for the single-agent Server.
+func TestServer_Weave_OccurredAt_DisabledByDefault(t *testing.T) {
+	llm := &countingLLM{name: "mock", model: "mock-model"}
+	ag := agent.NewAgent(&mockBackend{}, llm)
+	srv := NewServer(ag, nil)
+
+	_, err := srv.Weave(context.Background(), &loomv1.WeaveRequest{
+		Query:      "hello",
+		OccurredAt: timestamppb.New(time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)),
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+// TestServer_Weave_OccurredAt_AnchorsPersistedRows mirrors the accepted-path
+// test for the single-agent Server.
+func TestServer_Weave_OccurredAt_AnchorsPersistedRows(t *testing.T) {
+	llm := &countingLLM{name: "mock", model: "mock-model"}
+	ag := agent.NewAgent(&mockBackend{}, llm)
+	srv := NewServer(ag, nil)
+	srv.SetAllowTimeOverride(true)
+
+	occurred := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+	const sessionID = "single-occurred-at-session"
+
+	_, err := srv.Weave(context.Background(), &loomv1.WeaveRequest{
+		Query:      "what did i deploy?",
+		SessionId:  sessionID,
+		OccurredAt: timestamppb.New(occurred),
+	})
+	require.NoError(t, err)
+
+	session, ok := ag.GetSession(sessionID)
+	require.True(t, ok)
+	for _, m := range session.GetMessages() {
+		if m.Role == "user" || m.Role == "assistant" {
+			assert.True(t, m.Timestamp.Equal(occurred),
+				"%s row Timestamp = %s, want %s", m.Role, m.Timestamp, occurred)
+		}
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -60,6 +60,18 @@ type Server struct {
 	activeProviderName string                       // currently active pool provider
 	evalStore          *evals.Store                 // optional; nil means no persistence
 	judgeServer        *JudgeServer                 // optional; nil means use hardcoded judge
+
+	// allowTimeOverride accepts WeaveRequest.occurred_at (replay/import arrival
+	// times). Default false: client-supplied timestamps can poison temporal
+	// grounding, so honoring them is an explicit operator decision
+	// (server.allow_time_override). Set via SetAllowTimeOverride.
+	allowTimeOverride bool
+}
+
+// SetAllowTimeOverride configures whether WeaveRequest.occurred_at is honored
+// (server.allow_time_override). See applyOccurredAt for the gate semantics.
+func (s *Server) SetAllowTimeOverride(allow bool) {
+	s.allowTimeOverride = allow
 }
 
 // SetJudgeServer wires an in-memory JudgeServer so that ABTest can resolve req.JudgeId.
@@ -107,6 +119,13 @@ func (s *Server) SetActiveProviderName(name string) {
 func (s *Server) Weave(ctx context.Context, req *loomv1.WeaveRequest) (*loomv1.WeaveResponse, error) {
 	if req.Query == "" {
 		return nil, status.Error(codes.InvalidArgument, "query is required")
+	}
+
+	// Replay/import support: validate occurred_at and thread it through the
+	// context so persisted rows anchor at the conversation's historical time.
+	ctx, err := applyOccurredAt(ctx, req, s.allowTimeOverride)
+	if err != nil {
+		return nil, err
 	}
 
 	// Get or create session
@@ -166,6 +185,13 @@ func (s *Server) StreamWeave(req *loomv1.WeaveRequest, stream loomv1.LoomService
 		return status.Error(codes.InvalidArgument, "query cannot be empty")
 	}
 
+	// Replay/import support: validate occurred_at and thread it through the
+	// context used for the agent call (see applyOccurredAt).
+	ctx, err := applyOccurredAt(stream.Context(), req, s.allowTimeOverride)
+	if err != nil {
+		return err
+	}
+
 	// Generate session ID if not provided
 	sessionID := req.SessionId
 	if sessionID == "" {
@@ -198,7 +224,7 @@ func (s *Server) StreamWeave(req *loomv1.WeaveRequest, stream loomv1.LoomService
 
 	// Execute agent with progress callback
 	go func() {
-		resp, err := s.agent.ChatWithProgress(stream.Context(), sessionID, req.Query, progressCallback)
+		resp, err := s.agent.ChatWithProgress(ctx, sessionID, req.Query, progressCallback)
 		resultChan <- agentResult{resp: resp, err: err}
 		close(progressChan) // Signal no more progress events
 	}()

--- a/proto/loom/v1/loom.proto
+++ b/proto/loom/v1/loom.proto
@@ -18,6 +18,7 @@ package loom.v1;
 import "google/api/annotations.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
 import "loom/v1/agent_config.proto";
 import "loom/v1/apps.proto";
 import "loom/v1/bus.proto";
@@ -680,6 +681,19 @@ message WeaveRequest {
   // When true, the agent's SegmentedMemory is reset (L1/L2/swap cleared)
   // before the query is processed, giving a fresh context window.
   bool reset_context = 10;
+
+  // Historical arrival time for replayed or imported conversations (optional).
+  // When set, every message persisted during this call — the user turn, the
+  // assistant reply, and tool rows — carries this timestamp instead of the
+  // server wall clock, so temporal grounding (compiled-view arrival stamps,
+  // graph-memory extraction anchoring) reflects when the conversation
+  // actually happened rather than when it was ingested.
+  //
+  // Servers reject this field unless server.allow_time_override is enabled
+  // (FAILED_PRECONDITION), and reject values in the future beyond a small
+  // clock-skew allowance (INVALID_ARGUMENT). Live conversations should leave
+  // it unset.
+  google.protobuf.Timestamp occurred_at = 11;
 }
 
 // WeaveResponse contains the execution result.


### PR DESCRIPTION
## Description

Adds `WeaveRequest.occurred_at` — a proto-first arrival-time override so replayed or imported conversations anchor temporal grounding at their historical time instead of the ingestion wall clock.

### Motivation

PR #306 (approved) anchors graph-memory extraction on the durable `Message.Timestamp` and renders per-turn arrival dates. That is strictly more correct for live sessions, but replayed histories — e.g. the LongMemEval harness, which ingests haystack sessions over gRPC with "took place on YYYY/MM/DD" in the content — get `Timestamp = time.Now()` at ingestion, so post-#306 they would anchor to the benchmark run day and every turn would carry a run-day date contradicting the inline historical date. This PR makes historical arrival time a first-class capability of the public API instead of a content-scanning hack.

### What's included

**Proto (law first)**
- `google.protobuf.Timestamp occurred_at = 11` on `WeaveRequest` — `buf lint`, `buf breaking`, `buf generate` all clean

**Server gate** (`pkg/server/occurred_at.go`)
- `applyOccurredAt` wired into `Weave` + `StreamWeave` on both `Server` and `MultiAgentServer`
- Rejected with `FAILED_PRECONDITION` unless the operator sets `server.allow_time_override: true` (default **false** — client-supplied timestamps can poison temporal grounding, so honoring them is an explicit operator decision)
- Future-dated values beyond a 5-minute clock-skew allowance rejected with `INVALID_ARGUMENT`

**Agent** (`pkg/agent/occurred_at.go`)
- `WithOccurredAt` context override applied centrally in `appendMessage`: the user turn, assistant reply, and tool rows persisted during the call all carry the historical time, so extraction anchoring (`newestMessageDate`), per-turn dates, and compiled-view arrival stamps stay mutually consistent

**Config**
- `server.allow_time_override` (viper default false), wired in `cmd_serve` via `SetAllowTimeOverride`, documented in the example config

**Docs**
- `docs/reference/streaming.md`: field + gate semantics
- `docs/reference/CLAUDE.md`: corrected the `WeaveRequest`/`WeaveResponse` listings and client example, which documented fields that don't exist in the real proto (`message`, `tokens_used`, `resp.Message`)

### Tests

8 new tests, all passing with `-tags fts5 -race`:
- Gating default (reject with `FAILED_PRECONDITION`, agent never runs) — both servers
- Future timestamp rejection (`INVALID_ARGUMENT`)
- Accepted path anchors user + assistant rows at the override — both servers
- No-override path keeps wall-clock timestamps (gate enabled but field unset)
- Agent-level: `WithOccurredAt` anchors all rows; absence keeps wall clock

### Verification

- [x] `just check` passes ("All checks passed! (matches GitHub CI)")
- [x] `buf breaking --against origin/main` — no breaking changes
- [x] `gofmt -l` clean
- [x] New tests run with `-race`, 0 race conditions

### Follow-up (separate branch)

The LongMemEval harness (`feat/longmemeval-benchmark`) should pass each haystack session's date as `occurred_at` and enable `server.allow_time_override` in its benchmark deployment — that closes the post-#306 anchoring gap for replayed histories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
