### PR TITLE
fix(security): guard tainted path values directly with filepath.IsLocal (CodeQL #666–#670)

### DIFF
--- a/docs/reference/security-scan-triage.md
+++ b/docs/reference/security-scan-triage.md
@@ -1,9 +1,9 @@
-# Security Scan Triage — Snyk Findings (2026-07)
+# Security Scan Triage
 
-Triage record for the Snyk SAST/SCA findings reported against `teradata-labs/loom:main`
-via ArmorCode as of 2026-07-22. Each class of finding was verified against the code
-before being classified. This document exists so future scans don't re-litigate the
-same findings from scratch.
+Triage record for security-scanner findings against `teradata-labs/loom:main` —
+Snyk SAST/SCA via ArmorCode (2026-07-22) and GitHub CodeQL (2026-07/08). Each class
+of finding was verified against the code before being classified. This document
+exists so future scans don't re-litigate the same findings from scratch.
 
 ## Fixed
 
@@ -20,10 +20,53 @@ The PR #271 hardening itself surfaced three `go/path-injection` CodeQL alerts
 (#666–668) in `pkg/artifacts/session_metadata.go` (`WriteSessionArtifactMetadata`:
 `os.MkdirAll`, `os.CreateTemp`, `os.Rename`). Not exploitable — `ValidateSessionID`
 already allowlists `[A-Za-z0-9._-]` and rejects `..` — but CodeQL doesn't model that
-function as a sanitizer. Fixed by adding the CodeQL-recognized containment pattern
-(`filepath.Clean` + `filepath.Rel` + `filepath.IsLocal`) inside `SessionArtifactsRoot`,
-the single choke point every session metadata path derives from;
-`ReadSessionArtifactMetadata`'s duplicate inline check was folded into it.
+function as a sanitizer. A containment pattern (`filepath.Clean` + `filepath.Rel` +
+`filepath.IsLocal`) was added inside `SessionArtifactsRoot`, the single choke point
+every session metadata path derives from; `ReadSessionArtifactMetadata`'s duplicate
+inline check was folded into it. **Correction (2026-08-11): that pattern did not
+close the alerts** — the guard was applied to a derived value CodeQL doesn't track
+back to the sink. See the next section for the root cause and the fix that worked.
+
+## CodeQL go/path-injection + go/zipslip (2026-08-11)
+
+Triage of the five open CodeQL alerts on `main`: #666–669 (`go/path-injection`,
+`pkg/artifacts/session_metadata.go` — `os.MkdirAll`/`os.CreateTemp`/`os.Rename` in
+`WriteSessionArtifactMetadata`, `os.ReadFile` in `ReadSessionArtifactMetadata`) and
+#670 (`go/zipslip`, `pkg/server/skills_import.go` `extractZipToTempDir`).
+
+**Assessment: all five not exploitable.**
+
+- #666–669: every flagged path derives from `SessionArtifactsRoot`, gated by
+  `ValidateSessionID` (strict `[A-Za-z0-9._-]` allowlist — no separators, no `..`).
+  Hostile IDs (`../x`, `a/b`, `/etc`, …) are covered by
+  `TestSessionArtifactsRoot_rejectsBadPath`. The metadata feature is also
+  default-off (`SessionMetadataEnabled`).
+- #670: `extractZipToTempDir` cleans each entry name, rejects escapes, extracts
+  into a fresh `MkdirTemp` dir, writes only regular files (Go `archive/zip` never
+  materializes symlinks through this path), and caps decompression at 64MB.
+  `TestAddSkill_RejectsHostileZip` covers escaping entries.
+
+**Why the 2026-07 guards didn't register** (verified against the query sources,
+[`TaintedPathCustomizations.qll`](https://github.com/github/codeql/blob/main/go/ql/lib/semmle/go/security/TaintedPathCustomizations.qll)
+and
+[`ZipSlipCustomizations.qll`](https://github.com/github/codeql/blob/main/go/ql/lib/semmle/go/security/ZipSlipCustomizations.qll)):
+
+- CodeQL models `filepath.IsLocal` as a barrier guard (`IsLocalCheck`), but a guard
+  sanitizes only the exact expression it checks. Both sites guarded a derived
+  `rel` value while the tainted `root`/`dest` flowed on to the sinks untouched.
+- The zip check `strings.HasPrefix(rel, ".."+string(filepath.Separator))` also
+  fails CodeQL's `DotDotCheck`, which requires a string literal (`".."`, `"../"`,
+  `"..\\"`); its generic `PrefixCheck` sanitizes on the *true* branch (the
+  `HasPrefix(path, safeDir)` idiom) — the opposite polarity.
+
+**Fix.** Guard the tainted value itself with `filepath.IsLocal` before it is joined:
+`SessionArtifactsRoot` now checks `filepath.IsLocal(sessionID)` (one shared choke
+point closes #666–669), and `extractZipToTempDir` checks `filepath.IsLocal(name)`
+right after `filepath.Clean`, replacing the `IsAbs` + `Rel`/`HasPrefix` block it
+strictly subsumes (closes #670). Semantics are equal-or-stricter: the only newly
+rejected inputs are Windows drive-relative paths (`C:x`) and reserved device names
+(`NUL`). Lesson for future scans: **place the analyzer-modeled check on the exact
+variable that reaches the sink**, not on a value derived from it.
 
 ## No fix available upstream
 

--- a/pkg/artifacts/session_metadata.go
+++ b/pkg/artifacts/session_metadata.go
@@ -117,25 +117,21 @@ func validateSessionArtifactPathSegment(sessionID string) error {
 }
 
 // SessionArtifactsRoot returns $LOOM_DATA_DIR/artifacts/sessions/<sessionID>.
-// The joined path is verified to stay inside the sessions directory, so the
-// returned root is safe to use in filesystem operations even though sessionID
-// originates from API callers. ValidateSessionID already rejects separators
-// and traversal sequences; the Rel/IsLocal check makes that containment
-// explicit at the path level.
+// sessionID originates from API callers: ValidateSessionID enforces a strict
+// [A-Za-z0-9._-] allowlist (no separators, no ".."), and filepath.IsLocal
+// additionally rejects anything absolute, escaping, or reserved (Windows).
+// IsLocal must guard sessionID itself, not a value derived from it — CodeQL
+// credits the barrier only on the exact guarded expression, which is why an
+// earlier filepath.Rel-based containment check left go/path-injection alerts
+// (#666-#669) open.
 func SessionArtifactsRoot(sessionID string) (string, error) {
 	if err := validateSessionArtifactPathSegment(sessionID); err != nil {
 		return "", err
 	}
-	base := filepath.Join(config.GetLoomDataDir(), "artifacts", "sessions")
-	root := filepath.Clean(filepath.Join(base, sessionID))
-	rel, err := filepath.Rel(base, root)
-	if err != nil {
-		return "", fmt.Errorf("invalid session artifact path: %w", err)
-	}
-	if !filepath.IsLocal(rel) {
+	if !filepath.IsLocal(sessionID) {
 		return "", fmt.Errorf("invalid session artifact path")
 	}
-	return root, nil
+	return filepath.Join(config.GetLoomDataDir(), "artifacts", "sessions", sessionID), nil
 }
 
 // sessionMetadataPath returns the path to metadata.json for a session.

--- a/pkg/server/skills_import.go
+++ b/pkg/server/skills_import.go
@@ -533,9 +533,10 @@ func (s *SkillsImportServer) materializeSingleSource(
 // directory plus a cleanup function that removes it.
 //
 // Security:
-//   - Rejects entries with absolute paths or "..", which would let a
-//     hostile zip escape the temp dir. (zip slip — CVE-2018-1002200
-//     class.)
+//   - Rejects non-local entry names via filepath.IsLocal (absolute
+//     paths, ".." escapes, Windows drive-relative/reserved names),
+//     which would let a hostile zip escape the temp dir. (zip slip —
+//     CVE-2018-1002200 class.)
 //   - Rejects entries whose decompressed name is empty.
 //   - Caps total decompressed size at 64MB so a zip-bomb can't OOM
 //     the server.
@@ -561,19 +562,18 @@ func (s *SkillsImportServer) extractZipToTempDir(data []byte, prefix string) (st
 		if name == "." || name == "" {
 			continue
 		}
-		// Reject absolute archive paths.
-		if filepath.IsAbs(name) {
+		// IsLocal rejects absolute paths, ".." escapes, and Windows
+		// drive-relative/reserved names. It must guard name itself (the
+		// value joined into dest below) — CodeQL credits the barrier only
+		// on the exact guarded expression, which is why an earlier
+		// filepath.Rel-based containment check left the go/zipslip alert
+		// (#670) open.
+		if !filepath.IsLocal(name) {
 			cleanup()
 			return "", noopCleanup, fmt.Errorf("zip entry %q escapes archive root", f.Name)
 		}
 
 		dest := filepath.Join(tempDir, name)
-		// Resolve destination relative to tempDir and ensure it does not escape.
-		rel, err := filepath.Rel(tempDir, dest)
-		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			cleanup()
-			return "", noopCleanup, fmt.Errorf("zip entry %q escapes archive root", f.Name)
-		}
 
 		if f.FileInfo().IsDir() {
 			if err := os.MkdirAll(dest, 0o750); err != nil {

--- a/pkg/server/skills_import_test.go
+++ b/pkg/server/skills_import_test.go
@@ -80,13 +80,13 @@ func buildFixtureZip(t *testing.T, name, body string) []byte {
 	return buf.Bytes()
 }
 
-// buildHostileZip produces a zip that tries to escape the temp dir
-// via a path-traversal entry. Used to verify zip-slip rejection.
-func buildHostileZip(t *testing.T) []byte {
+// buildHostileZip produces a zip whose single entry has the given
+// name, used to verify zip-slip rejection of escaping entry names.
+func buildHostileZip(t *testing.T, entryName string) []byte {
 	t.Helper()
 	var buf bytes.Buffer
 	zw := zip.NewWriter(&buf)
-	w, err := zw.Create("../etc/escape.txt")
+	w, err := zw.Create(entryName)
 	require.NoError(t, err)
 	_, err = w.Write([]byte("hostile"))
 	require.NoError(t, err)
@@ -246,15 +246,28 @@ func TestAddSkill_FromInline(t *testing.T) {
 }
 
 func TestAddSkill_RejectsHostileZip(t *testing.T) {
-	srv := makeServer(t)
-	zipBytes := buildHostileZip(t)
+	tests := []struct {
+		name      string
+		entryName string
+	}{
+		{name: "parent traversal", entryName: "../etc/escape.txt"},
+		{name: "absolute path", entryName: "/etc/escape.txt"},
+		{name: "nested traversal", entryName: "skill/../../etc/escape.txt"},
+		{name: "bare dot dot", entryName: ".."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := makeServer(t)
+			zipBytes := buildHostileZip(t, tt.entryName)
 
-	_, err := srv.AddSkill(context.Background(), &loomv1.AddSkillRequest{
-		Source: &loomv1.AddSkillRequest_ZipArchive{ZipArchive: zipBytes},
-	})
-	require.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, status.Code(err))
-	assert.Contains(t, err.Error(), "escapes archive root")
+			_, err := srv.AddSkill(context.Background(), &loomv1.AddSkillRequest{
+				Source: &loomv1.AddSkillRequest_ZipArchive{ZipArchive: zipBytes},
+			})
+			require.Error(t, err)
+			assert.Equal(t, codes.InvalidArgument, status.Code(err))
+			assert.Contains(t, err.Error(), "escapes archive root")
+		})
+	}
 }
 
 func TestAddSkill_RejectsEmptyZip(t *testing.T) {


### PR DESCRIPTION
## Summary

Triage + fix for the five open CodeQL alerts on `main`:

| Alert | Rule | Location | Assessment |
|---|---|---|---|
| #666–#668 | `go/path-injection` | `pkg/artifacts/session_metadata.go` (`WriteSessionArtifactMetadata`: `MkdirAll`/`CreateTemp`/`Rename`) | Not exploitable — false positive |
| #669 | `go/path-injection` | `pkg/artifacts/session_metadata.go` (`ReadSessionArtifactMetadata`: `ReadFile`) | Not exploitable — false positive |
| #670 | `go/zipslip` | `pkg/server/skills_import.go` (`extractZipToTempDir`) | Not exploitable — false positive |

All flagged paths were already gated: `ValidateSessionID` enforces a strict `[A-Za-z0-9._-]` allowlist (no separators, no `..`) on every session-metadata path, and the zip extractor had `Clean` + `IsAbs` + `Rel`-prefix containment, a fresh temp dir target, no symlink materialization, and a 64MB decompression cap. Hostile inputs are covered by existing tests.

## Why the alerts stayed open (root cause)

The 2026-07 hardening placed the analyzer-visible check on the wrong variable. Verified against CodeQL's query sources ([TaintedPathCustomizations.qll](https://github.com/github/codeql/blob/main/go/ql/lib/semmle/go/security/TaintedPathCustomizations.qll), [ZipSlipCustomizations.qll](https://github.com/github/codeql/blob/main/go/ql/lib/semmle/go/security/ZipSlipCustomizations.qll)):

- `filepath.IsLocal` **is** modeled (`IsLocalCheck`), but a barrier guard sanitizes only the exact expression it checks. Both sites guarded a derived `rel` value while the tainted `root`/`dest` flowed to the sinks.
- The zip check `strings.HasPrefix(rel, ".."+string(filepath.Separator))` fails `DotDotCheck` (requires a string literal) and has the opposite polarity of `PrefixCheck` (which models the `HasPrefix(path, safeDir)` idiom).

## Fix

Guard the tainted value itself, before it is joined:

- `SessionArtifactsRoot`: `filepath.IsLocal(sessionID)` — one shared choke point closes #666–#669.
- `extractZipToTempDir`: `filepath.IsLocal(name)` right after `filepath.Clean`, replacing the `IsAbs` + `Rel`/`HasPrefix` block it strictly subsumes — closes #670.

Semantics are equal-or-stricter: the only newly rejected inputs are Windows drive-relative paths (`C:x`) and reserved device names (`NUL`).

## Tests & docs

- `TestAddSkill_RejectsHostileZip` is now table-driven: parent traversal, absolute path, nested traversal, bare `..`.
- Existing `TestSessionArtifactsRoot_rejectsBadPath` hostile-ID table unchanged and green.
- `just check` passes (lint + full `-tags fts5 -race` suite + build; gosec 0 issues).
- `docs/reference/security-scan-triage.md`: corrected the 2026-07-23 entry (it claimed #666–#668 were fixed; they weren't) and recorded this triage with the guard-placement lesson.

**Verification**: this PR's CodeQL check should report all five alerts as fixed; they auto-close on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)