### PR TITLE
fix(agent): load all canonical workflow pattern types in registry

### DIFF
--- a/examples/reference/workflows/orchestration-patterns/README.md
+++ b/examples/reference/workflows/orchestration-patterns/README.md
@@ -103,21 +103,30 @@ spec:
 ### 5. **conditional** - Dynamic Routing
 **File:** `complexity-routing.yaml`
 
-Routes tasks based on classification or conditions.
+Routes tasks based on classification or conditions. The condition agent's
+answer selects a branch by key; each branch is a full nested workflow pattern.
 
 ```yaml
 spec:
   type: conditional
-  agent_ids: [complexity-classifier]
-  # Classification result determines next steps
+  condition_agent_id: complexity-classifier
+  condition_prompt: 'Respond "simple" or "complex": {{input}}'
+  branches:
+    simple:
+      type: pipeline
+      # ... nested pipeline spec
+    complex:
+      type: pipeline
+      # ... nested pipeline spec
+  default_branch:
+    type: fork-join
+    # ... used when no branch key matches
 ```
 
 **Use Cases:**
 - Task routing based on complexity
 - Dynamic workflow selection
 - Classification-based decisions
-
-**Note:** Nested workflows (branches with sub-workflows) are planned for future releases.
 
 ---
 

--- a/examples/reference/workflows/orchestration-patterns/complexity-routing.yaml
+++ b/examples/reference/workflows/orchestration-patterns/complexity-routing.yaml
@@ -1,9 +1,8 @@
 # Complexity-Based Routing Workflow
-# Uses conditional pattern to route tasks based on complexity assessment
-#
-# NOTE: This example shows the conditional pattern structure.
-# Full nested workflow support (branches with sub-workflows) is planned for future releases.
-# For now, conditional patterns work best for simple routing decisions.
+# Uses the conditional pattern to route tasks based on complexity assessment.
+# The condition agent's answer selects a branch by key; each branch is a full
+# nested workflow pattern (pipeline, fork-join, ...) executed by the
+# orchestrator. See workflow-all-fields-reference.yaml for every field.
 
 apiVersion: loom/v1
 kind: Workflow
@@ -15,24 +14,53 @@ metadata:
     complexity: high
 
 spec:
-  type: conditional  # Changed from pattern: conditional
+  type: conditional
 
-  agent_ids:
-    - complexity-classifier
+  # The classifier's output is matched against the branch keys below.
+  condition_agent_id: complexity-classifier
+  condition_prompt: |
+    Classify the complexity of this feature request. Respond with exactly one
+    word, either "simple" or "complex": {{input}}
+
+  branches:
+    simple:
+      type: pipeline
+      initial_prompt: '{{input}}'
+      stages:
+        - agent_id: rapid-implementer
+          prompt_template: 'Implement this small, well-scoped feature: {{input}}'
+    complex:
+      type: pipeline
+      initial_prompt: '{{input}}'
+      stages:
+        - agent_id: solution-architect
+          prompt_template: 'Design the architecture for: {{input}}'
+        - agent_id: rapid-implementer
+          prompt_template: 'Implement according to this design: {{previous_output}}'
+
+  # Used when the classifier's answer matches no branch key after retries.
+  default_branch:
+    type: fork-join
+    prompt: 'Assess complexity yourself, then implement: {{input}}'
+    agent_ids:
+      - solution-architect
+      - rapid-implementer
+    merge_strategy: concatenate
+
+  # Retry when the classifier's output matches no branch key; the retry
+  # prompt lists the valid branch keys.
+  retry_policy:
+    max_retries: 2
 
 # Agent configs used (from $LOOM_DATA_DIR/agents/):
 # - complexity-classifier.yaml: Technical complexity classifier for routing-based decisions
+# - rapid-implementer.yaml: Implementation agent for well-scoped features
+# - solution-architect.yaml: Architecture design agent for complex features
 
 # Example usage:
 #
 # Input: "Add user notification system with email, SMS, and push notifications.
 # Support delivery scheduling, retry logic, template management, and analytics."
 #
-# The classifier will evaluate this and return "complex", which can then be used
-# to route to the appropriate implementation workflow.
-#
-# LIMITATION: Nested workflows (branches with sub-workflows) are not yet supported.
-# For complex routing scenarios, consider:
-# 1. Using separate workflow files for each complexity level
-# 2. Implementing routing logic in the application layer
-# 3. Using the conditional pattern for simple binary decisions
+# The classifier returns "complex", which selects the complex branch:
+# solution-architect designs the system, then rapid-implementer builds it.

--- a/examples/reference/workflows/orchestration-patterns/scheduled-workflows/daily-report.yaml
+++ b/examples/reference/workflows/orchestration-patterns/scheduled-workflows/daily-report.yaml
@@ -10,27 +10,26 @@ metadata:
 
 spec:
   type: pipeline
-  pipeline:
-    initial_prompt: "Generate comprehensive daily sales report for yesterday"
-    stages:
-      - agent_id: data-analyst
-        prompt: |
-          Query the sales database for yesterday's data and generate a summary report.
-          Include:
-          - Total sales revenue
-          - Top performing products
-          - Regional breakdown
-          - Year-over-year comparison
+  initial_prompt: "Generate comprehensive daily sales report for yesterday"
+  stages:
+    - agent_id: data-analyst
+      prompt_template: |
+        Query the sales database for yesterday's data and generate a summary report.
+        Include:
+        - Total sales revenue
+        - Top performing products
+        - Regional breakdown
+        - Year-over-year comparison
 
-      - agent_id: report-formatter
-        prompt: |
-          Format the sales data into a professional HTML report with charts and tables.
-          Ensure the report is visually appealing and easy to read.
+    - agent_id: report-formatter
+      prompt_template: |
+        Format the sales data into a professional HTML report with charts and tables.
+        Ensure the report is visually appealing and easy to read.
 
-      - agent_id: email-sender
-        prompt: |
-          Send the formatted report to the stakeholders distribution list.
-          Subject: Daily Sales Report - {{date}}
+    - agent_id: email-sender
+      prompt_template: |
+        Send the formatted report to the stakeholders distribution list.
+        Subject: Daily Sales Report - {{date}}
 
 # Schedule Configuration
 schedule:

--- a/examples/reference/workflows/orchestration-patterns/scheduled-workflows/frequent-monitor.yaml
+++ b/examples/reference/workflows/orchestration-patterns/scheduled-workflows/frequent-monitor.yaml
@@ -10,32 +10,31 @@ metadata:
 
 spec:
   type: pipeline
-  pipeline:
-    initial_prompt: "Check system health metrics and alert on anomalies"
-    stages:
-      - agent_id: metrics-collector
-        prompt: |
-          Collect current system metrics:
-          - CPU usage
-          - Memory usage
-          - Disk I/O
-          - Network throughput
-          - Database connection pool
-          - API response times
+  initial_prompt: "Check system health metrics and alert on anomalies"
+  stages:
+    - agent_id: metrics-collector
+      prompt_template: |
+        Collect current system metrics:
+        - CPU usage
+        - Memory usage
+        - Disk I/O
+        - Network throughput
+        - Database connection pool
+        - API response times
 
-      - agent_id: anomaly-detector
-        prompt: |
-          Analyze metrics for anomalies:
-          - Compare against baseline
-          - Check for threshold violations
-          - Detect unusual patterns
+    - agent_id: anomaly-detector
+      prompt_template: |
+        Analyze metrics for anomalies:
+        - Compare against baseline
+        - Check for threshold violations
+        - Detect unusual patterns
 
-      - agent_id: alerting
-        prompt: |
-          If anomalies detected:
-          - Send alerts to on-call engineer
-          - Create incident ticket
-          - Log to monitoring dashboard
+    - agent_id: alerting
+      prompt_template: |
+        If anomalies detected:
+        - Send alerts to on-call engineer
+        - Create incident ticket
+        - Log to monitoring dashboard
 
 # Schedule Configuration
 schedule:

--- a/examples/reference/workflows/orchestration-patterns/scheduled-workflows/hourly-sync.yaml
+++ b/examples/reference/workflows/orchestration-patterns/scheduled-workflows/hourly-sync.yaml
@@ -10,23 +10,22 @@ metadata:
 
 spec:
   type: pipeline
-  pipeline:
-    initial_prompt: "Synchronize customer data from CRM to data warehouse"
-    stages:
-      - agent_id: data-extractor
-        prompt: |
-          Extract new and updated customer records from the CRM system
-          since the last sync timestamp.
+  initial_prompt: "Synchronize customer data from CRM to data warehouse"
+  stages:
+    - agent_id: data-extractor
+      prompt_template: |
+        Extract new and updated customer records from the CRM system
+        since the last sync timestamp.
 
-      - agent_id: data-transformer
-        prompt: |
-          Transform the extracted data to match the warehouse schema.
-          Apply data quality rules and validation.
+    - agent_id: data-transformer
+      prompt_template: |
+        Transform the extracted data to match the warehouse schema.
+        Apply data quality rules and validation.
 
-      - agent_id: data-loader
-        prompt: |
-          Load the transformed data into the data warehouse.
-          Update the last sync timestamp on success.
+    - agent_id: data-loader
+      prompt_template: |
+        Load the transformed data into the data warehouse.
+        Update the last sync timestamp on success.
 
 # Schedule Configuration
 schedule:

--- a/examples/reference/workflows/orchestration-patterns/scheduled-workflows/weekly-backup.yaml
+++ b/examples/reference/workflows/orchestration-patterns/scheduled-workflows/weekly-backup.yaml
@@ -10,41 +10,40 @@ metadata:
 
 spec:
   type: pipeline
-  pipeline:
-    initial_prompt: "Execute weekly full backup of all production systems"
-    stages:
-      - agent_id: backup-coordinator
-        prompt: |
-          Initialize backup process for all registered systems.
-          Verify all systems are in backup-ready state.
+  initial_prompt: "Execute weekly full backup of all production systems"
+  stages:
+    - agent_id: backup-coordinator
+      prompt_template: |
+        Initialize backup process for all registered systems.
+        Verify all systems are in backup-ready state.
 
-      - agent_id: database-backup
-        prompt: |
-          Execute full database backups:
-          - PostgreSQL production database
-          - MongoDB customer data
-          - Redis cache state
-          Create backup manifests with checksums.
+    - agent_id: database-backup
+      prompt_template: |
+        Execute full database backups:
+        - PostgreSQL production database
+        - MongoDB customer data
+        - Redis cache state
+        Create backup manifests with checksums.
 
-      - agent_id: storage-backup
-        prompt: |
-          Backup file storage systems:
-          - Document storage (S3)
-          - Image assets
-          - Configuration files
-          Verify integrity of all backups.
+    - agent_id: storage-backup
+      prompt_template: |
+        Backup file storage systems:
+        - Document storage (S3)
+        - Image assets
+        - Configuration files
+        Verify integrity of all backups.
 
-      - agent_id: backup-validator
-        prompt: |
-          Validate all backups:
-          - Verify checksums
-          - Test restore capability (sample)
-          - Generate backup report
+    - agent_id: backup-validator
+      prompt_template: |
+        Validate all backups:
+        - Verify checksums
+        - Test restore capability (sample)
+        - Generate backup report
 
-      - agent_id: notification
-        prompt: |
-          Send backup completion report to operations team.
-          Include backup size, duration, and validation results.
+    - agent_id: notification
+      prompt_template: |
+        Send backup completion report to operations team.
+        Include backup size, duration, and validation results.
 
 # Schedule Configuration
 schedule:

--- a/examples/reference/workflows/orchestration-patterns/technology-swarm.yaml
+++ b/examples/reference/workflows/orchestration-patterns/technology-swarm.yaml
@@ -12,6 +12,9 @@ metadata:
 
 spec:
   type: swarm  # Changed from pattern: swarm
+  # The question all agents vote on; {{input}} is replaced with the user's
+  # message at execution time.
+  question: '{{input}}'
   strategy: majority
   confidence_threshold: 0.7
   share_votes: false

--- a/pkg/agent/config_loader.go
+++ b/pkg/agent/config_loader.go
@@ -1602,8 +1602,15 @@ func (c *workflowAgentCollector) collect(spec map[string]interface{}) error {
 		c.addPipelineStages(pipelineSpec)
 
 	case "conditional":
-		if conditionAgent, ok := spec["condition_agent_id"].(string); ok {
-			c.add(conditionAgent)
+		// convertConditionalPattern requires both fields; rejecting them here
+		// keeps the registry from registering a workflow that can never run.
+		conditionAgent, ok := spec["condition_agent_id"].(string)
+		if !ok || strings.TrimSpace(conditionAgent) == "" {
+			return fmt.Errorf("conditional workflow requires non-empty 'condition_agent_id'")
+		}
+		c.add(conditionAgent)
+		if prompt, ok := spec["condition_prompt"].(string); !ok || strings.TrimSpace(prompt) == "" {
+			return fmt.Errorf("conditional workflow requires non-empty 'condition_prompt'")
 		}
 		branches, ok := spec["branches"].(map[string]interface{})
 		if !ok {

--- a/pkg/agent/config_loader.go
+++ b/pkg/agent/config_loader.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
@@ -1410,83 +1411,11 @@ func loadOrchestrationWorkflow(path string, data map[string]interface{}, llmProv
 		return nil, fmt.Errorf("orchestration workflow missing 'spec.type' (or use spec.entrypoint for agent-reference workflows)")
 	}
 
-	// Extract agent IDs based on pattern type
-	var agentIDs []string
-	switch patternType {
-	case "debate":
-		if ids, ok := spec["agent_ids"].([]interface{}); ok {
-			for _, id := range ids {
-				if idStr, ok := id.(string); ok {
-					agentIDs = append(agentIDs, idStr)
-				}
-			}
-		}
-		// Include optional moderator
-		if moderator, ok := spec["moderator_agent_id"].(string); ok && moderator != "" {
-			agentIDs = append(agentIDs, moderator)
-		}
-
-	case "fork-join":
-		if ids, ok := spec["agent_ids"].([]interface{}); ok {
-			for _, id := range ids {
-				if idStr, ok := id.(string); ok {
-					agentIDs = append(agentIDs, idStr)
-				}
-			}
-		}
-
-	case "parallel":
-		tasks, ok := spec["tasks"].([]interface{})
-		if !ok {
-			return nil, fmt.Errorf("parallel workflow requires 'spec.tasks' array")
-		}
-
-		seen := make(map[string]bool)
-		for i, task := range tasks {
-			taskMap, ok := task.(map[string]interface{})
-			if !ok {
-				return nil, fmt.Errorf("parallel workflow task %d must be an object", i)
-			}
-
-			agentID, ok := taskMap["agent_id"].(string)
-			if !ok || strings.TrimSpace(agentID) == "" {
-				return nil, fmt.Errorf("parallel workflow task %d missing non-empty 'agent_id'", i)
-			}
-
-			if !seen[agentID] {
-				agentIDs = append(agentIDs, agentID)
-				seen[agentID] = true
-			}
-		}
-
-	case "pipeline", "iterative_pipeline":
-		if stages, ok := spec["stages"].([]interface{}); ok {
-			seen := make(map[string]bool)
-			for _, stage := range stages {
-				if stageMap, ok := stage.(map[string]interface{}); ok {
-					if agentID, ok := stageMap["agent_id"].(string); ok && !seen[agentID] {
-						agentIDs = append(agentIDs, agentID)
-						seen[agentID] = true
-					}
-				}
-			}
-		}
-
-	case "conditional":
-		if branches, ok := spec["branches"].(map[string]interface{}); ok {
-			seen := make(map[string]bool)
-			for _, branch := range branches {
-				if branchMap, ok := branch.(map[string]interface{}); ok {
-					if agentID, ok := branchMap["agent_id"].(string); ok && !seen[agentID] {
-						agentIDs = append(agentIDs, agentID)
-						seen[agentID] = true
-					}
-				}
-			}
-		}
-
-	default:
-		return nil, fmt.Errorf("unsupported workflow pattern type: %s", patternType)
+	// Collect every agent ID the workflow references, recursing into nested
+	// patterns (conditional branches, iterative base pipelines).
+	agentIDs, err := workflowAgentIDs(spec)
+	if err != nil {
+		return nil, err
 	}
 
 	if len(agentIDs) == 0 {
@@ -1572,6 +1501,145 @@ Sub-agents: %s`,
 	}
 
 	return configs, nil
+}
+
+// workflowAgentIDs extracts the ordered, de-duplicated set of agent IDs a
+// canonical orchestration workflow references, recursing into nested patterns
+// (conditional branches and default_branch, the iterative base pipeline). The
+// accepted spec.type vocabulary is exactly the canonical hyphenated set shared
+// with pkg/validation and pkg/orchestration — pinned by the loader contract
+// test so it cannot drift from the validator again.
+func workflowAgentIDs(spec map[string]interface{}) ([]string, error) {
+	c := &workflowAgentCollector{seen: make(map[string]bool)}
+	if err := c.collect(spec); err != nil {
+		return nil, err
+	}
+	return c.ids, nil
+}
+
+// workflowAgentCollector accumulates agent IDs in first-seen order across a
+// (possibly nested) workflow spec.
+type workflowAgentCollector struct {
+	seen map[string]bool
+	ids  []string
+}
+
+func (c *workflowAgentCollector) add(id string) {
+	if strings.TrimSpace(id) == "" || c.seen[id] {
+		return
+	}
+	c.seen[id] = true
+	c.ids = append(c.ids, id)
+}
+
+func (c *workflowAgentCollector) addList(raw interface{}) {
+	items, _ := raw.([]interface{})
+	for _, item := range items {
+		if id, ok := item.(string); ok {
+			c.add(id)
+		}
+	}
+}
+
+func (c *workflowAgentCollector) addPipelineStages(spec map[string]interface{}) {
+	stages, _ := spec["stages"].([]interface{})
+	for _, stage := range stages {
+		if stageMap, ok := stage.(map[string]interface{}); ok {
+			if agentID, ok := stageMap["agent_id"].(string); ok {
+				c.add(agentID)
+			}
+		}
+	}
+}
+
+func (c *workflowAgentCollector) collect(spec map[string]interface{}) error {
+	patternType, _ := spec["type"].(string)
+	if patternType == "" {
+		return fmt.Errorf("workflow pattern spec missing 'type' field")
+	}
+
+	switch patternType {
+	case "debate":
+		c.addList(spec["agent_ids"])
+		if moderator, ok := spec["moderator_agent_id"].(string); ok {
+			c.add(moderator)
+		}
+
+	case "fork-join":
+		c.addList(spec["agent_ids"])
+
+	case "swarm":
+		c.addList(spec["agent_ids"])
+		if judge, ok := spec["judge_agent_id"].(string); ok {
+			c.add(judge)
+		}
+
+	case "parallel":
+		tasks, ok := spec["tasks"].([]interface{})
+		if !ok {
+			return fmt.Errorf("parallel workflow requires 'spec.tasks' array")
+		}
+		for i, task := range tasks {
+			taskMap, ok := task.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("parallel workflow task %d must be an object", i)
+			}
+			agentID, ok := taskMap["agent_id"].(string)
+			if !ok || strings.TrimSpace(agentID) == "" {
+				return fmt.Errorf("parallel workflow task %d missing non-empty 'agent_id'", i)
+			}
+			c.add(agentID)
+		}
+
+	case "pipeline":
+		c.addPipelineStages(spec)
+
+	case "iterative":
+		pipelineSpec, ok := spec["pipeline"].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("iterative workflow requires 'spec.pipeline' object")
+		}
+		c.addPipelineStages(pipelineSpec)
+
+	case "conditional":
+		if conditionAgent, ok := spec["condition_agent_id"].(string); ok {
+			c.add(conditionAgent)
+		}
+		branches, ok := spec["branches"].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("conditional workflow requires 'spec.branches' map")
+		}
+		// Branches are nested workflow patterns; iterate in sorted order so
+		// sub-agent registration order is deterministic across runs.
+		branchNames := make([]string, 0, len(branches))
+		for name := range branches {
+			branchNames = append(branchNames, name)
+		}
+		sort.Strings(branchNames)
+		for _, name := range branchNames {
+			branchSpec, ok := branches[name].(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("conditional branch %q must be an object with a 'type' field", name)
+			}
+			if err := c.collect(branchSpec); err != nil {
+				return fmt.Errorf("conditional branch %q: %w", name, err)
+			}
+		}
+		if defaultRaw, hasDefault := spec["default_branch"]; hasDefault {
+			defaultSpec, ok := defaultRaw.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("conditional default_branch must be an object with a 'type' field")
+			}
+			if err := c.collect(defaultSpec); err != nil {
+				return fmt.Errorf("conditional default_branch: %w", err)
+			}
+		}
+
+	default:
+		return fmt.Errorf("unsupported workflow pattern type: %s", patternType)
+	}
+
+	return nil
 }
 
 // loadWeaverWorkflow parses weaver-generated workflows (agent config with embedded workflow section)

--- a/pkg/agent/config_loader_workflow_test.go
+++ b/pkg/agent/config_loader_workflow_test.go
@@ -633,6 +633,32 @@ func TestLoadWorkflowAgents_ConditionalRejectsMalformedSpecs(t *testing.T) {
 		wantErr string
 	}{
 		{
+			name: "missing condition_agent_id",
+			spec: `  type: conditional
+  condition_prompt: 'Classify: {{input}}'
+  branches:
+    ok:
+      type: fork-join
+      prompt: 'Handle: {{input}}'
+      agent_ids:
+        - handler
+`,
+			wantErr: "conditional workflow requires non-empty 'condition_agent_id'",
+		},
+		{
+			name: "missing condition_prompt",
+			spec: `  type: conditional
+  condition_agent_id: classifier
+  branches:
+    ok:
+      type: fork-join
+      prompt: 'Handle: {{input}}'
+      agent_ids:
+        - handler
+`,
+			wantErr: "conditional workflow requires non-empty 'condition_prompt'",
+		},
+		{
 			name: "missing branches",
 			spec: `  type: conditional
   condition_agent_id: classifier

--- a/pkg/agent/config_loader_workflow_test.go
+++ b/pkg/agent/config_loader_workflow_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"github.com/teradata-labs/loom/pkg/validation"
 )
 
 // TestLoadWorkflowAgents_WeaverFormat tests loading a weaver-generated workflow
@@ -360,4 +361,404 @@ spec:
 			assert.Nil(t, configs)
 		})
 	}
+}
+
+// TestLoadWorkflowAgents_CanonicalPatternContract pins the registry loader's
+// accepted spec.type vocabulary to validation.CanonicalWorkflowPatternTypes.
+// Every canonical pattern type must both pass pkg/validation and load through
+// LoadWorkflowAgents with all referenced agents registered, so a vocabulary
+// or schema split between the validator and the loader (the fork-join bug,
+// #307) fails here instead of surfacing as silently skipped workflows.
+func TestLoadWorkflowAgents_CanonicalPatternContract(t *testing.T) {
+	type contractCase struct {
+		yaml       string
+		wantAgents []string
+	}
+
+	cases := map[string]contractCase{
+		"debate": {
+			yaml: `apiVersion: loom/v1
+kind: Workflow
+metadata:
+  name: contract-debate
+  description: Canonical debate spec
+spec:
+  type: debate
+  topic: 'Monolith or microservices?'
+  agent_ids:
+    - architect
+    - pragmatist
+  rounds: 1
+  moderator_agent_id: moderator
+`,
+			wantAgents: []string{"architect", "pragmatist", "moderator"},
+		},
+		"fork-join": {
+			yaml: `apiVersion: loom/v1
+kind: Workflow
+metadata:
+  name: contract-fork-join
+  description: Canonical fork-join spec
+spec:
+  type: fork-join
+  prompt: 'Research the target: {{input}}'
+  agent_ids:
+    - researcher-a
+    - researcher-b
+  merge_strategy: concatenate
+`,
+			wantAgents: []string{"researcher-a", "researcher-b"},
+		},
+		"pipeline": {
+			yaml: `apiVersion: loom/v1
+kind: Workflow
+metadata:
+  name: contract-pipeline
+  description: Canonical pipeline spec
+spec:
+  type: pipeline
+  initial_prompt: '{{input}}'
+  stages:
+    - agent_id: spec-writer
+      prompt_template: 'Write the spec: {{input}}'
+    - agent_id: implementer
+      prompt_template: 'Implement: {{previous_output}}'
+`,
+			wantAgents: []string{"spec-writer", "implementer"},
+		},
+		"parallel": {
+			yaml: `apiVersion: loom/v1
+kind: Workflow
+metadata:
+  name: contract-parallel
+  description: Canonical parallel spec
+spec:
+  type: parallel
+  tasks:
+    - agent_id: task-a
+      prompt: 'Do task A'
+    - agent_id: task-b
+      prompt: 'Do task B'
+  merge_strategy: concatenate
+`,
+			wantAgents: []string{"task-a", "task-b"},
+		},
+		"conditional": {
+			yaml: `apiVersion: loom/v1
+kind: Workflow
+metadata:
+  name: contract-conditional
+  description: Canonical conditional spec with nested branch patterns
+spec:
+  type: conditional
+  condition_agent_id: classifier
+  condition_prompt: 'Is this a bug report? {{input}}'
+  branches:
+    bug:
+      type: pipeline
+      initial_prompt: '{{input}}'
+      stages:
+        - agent_id: bug-triager
+          prompt_template: 'Triage: {{input}}'
+    feature:
+      type: fork-join
+      prompt: 'Assess: {{input}}'
+      agent_ids:
+        - feature-assessor
+  default_branch:
+    type: fork-join
+    prompt: 'Fallback: {{input}}'
+    agent_ids:
+      - generalist
+  retry_policy:
+    max_retries: 2
+`,
+			wantAgents: []string{"classifier", "bug-triager", "feature-assessor", "generalist"},
+		},
+		"iterative": {
+			yaml: `apiVersion: loom/v1
+kind: Workflow
+metadata:
+  name: contract-iterative
+  description: Canonical iterative spec wrapping a base pipeline
+spec:
+  type: iterative
+  max_iterations: 2
+  pipeline:
+    initial_prompt: '{{input}}'
+    stages:
+      - agent_id: drafter
+        prompt_template: 'Draft: {{input}}'
+      - agent_id: reviewer
+        prompt_template: 'Review: {{previous_output}}'
+`,
+			wantAgents: []string{"drafter", "reviewer"},
+		},
+		"swarm": {
+			yaml: `apiVersion: loom/v1
+kind: Workflow
+metadata:
+  name: contract-swarm
+  description: Canonical swarm spec
+spec:
+  type: swarm
+  question: 'Best approach for {{input}}?'
+  agent_ids:
+    - voter-a
+    - voter-b
+    - voter-c
+  strategy: majority
+  judge_agent_id: judge
+  retry_policy:
+    max_retries: 1
+`,
+			wantAgents: []string{"voter-a", "voter-b", "voter-c", "judge"},
+		},
+	}
+
+	// The table must cover the canonical vocabulary exactly: adding a type to
+	// validation.CanonicalWorkflowPatternTypes without teaching the loader
+	// (and this table) about it fails here.
+	canonical := validation.CanonicalWorkflowPatternTypes()
+	tableTypes := make([]string, 0, len(cases))
+	for typ := range cases {
+		tableTypes = append(tableTypes, typ)
+	}
+	require.ElementsMatch(t, canonical, tableTypes,
+		"contract table out of sync with validation.CanonicalWorkflowPatternTypes — add a spec for the new pattern type")
+
+	for _, patternType := range canonical {
+		t.Run(patternType, func(t *testing.T) {
+			tc := cases[patternType]
+			workflowName := "contract-" + patternType
+
+			// The canonical validator accepts the spec.
+			result := validation.ValidateYAMLContent(tc.yaml, workflowName+".yaml")
+			require.True(t, result.Valid, "validator rejected canonical %s spec: %+v", patternType, result.Errors)
+
+			// The registry loader loads the same spec and registers every
+			// referenced agent.
+			workflowPath := filepath.Join(t.TempDir(), workflowName+".yaml")
+			require.NoError(t, os.WriteFile(workflowPath, []byte(tc.yaml), 0600))
+
+			configs, err := LoadWorkflowAgents(workflowPath, &mockLLMProvider{})
+			require.NoError(t, err, "registry loader rejected canonical %s workflow", patternType)
+
+			var coordinator *loomv1.AgentConfig
+			var subAgents []string
+			for _, config := range configs {
+				if config.Metadata["role"] == "coordinator" {
+					coordinator = config
+					continue
+				}
+				subAgents = append(subAgents, config.Name)
+			}
+
+			require.NotNil(t, coordinator, "no coordinator generated for %s", patternType)
+			assert.Equal(t, workflowName, coordinator.Name)
+			assert.Equal(t, patternType, coordinator.Metadata["pattern"])
+
+			wantSubAgents := make([]string, 0, len(tc.wantAgents))
+			for _, agentID := range tc.wantAgents {
+				wantSubAgents = append(wantSubAgents, workflowName+":"+agentID)
+			}
+			assert.ElementsMatch(t, wantSubAgents, subAgents)
+		})
+	}
+}
+
+// TestLoadWorkflowAgents_ConditionalNestedPatterns exercises recursive agent
+// collection: a conditional branch holding another conditional, and an agent
+// shared across branches that must register exactly once.
+func TestLoadWorkflowAgents_ConditionalNestedPatterns(t *testing.T) {
+	workflowYAML := `apiVersion: loom/v1
+kind: Workflow
+metadata:
+  name: nested-conditional
+spec:
+  type: conditional
+  condition_agent_id: router
+  condition_prompt: 'Route: {{input}}'
+  branches:
+    simple:
+      type: fork-join
+      prompt: 'Handle: {{input}}'
+      agent_ids:
+        - handler
+        - escalation
+    complex:
+      type: conditional
+      condition_agent_id: sub-router
+      condition_prompt: 'Sub-route: {{input}}'
+      branches:
+        deep:
+          type: pipeline
+          initial_prompt: '{{input}}'
+          stages:
+            - agent_id: specialist
+              prompt_template: 'Deep dive: {{input}}'
+            - agent_id: escalation
+              prompt_template: 'Escalate: {{previous_output}}'
+`
+
+	workflowPath := filepath.Join(t.TempDir(), "nested-conditional.yaml")
+	require.NoError(t, os.WriteFile(workflowPath, []byte(workflowYAML), 0600))
+
+	configs, err := LoadWorkflowAgents(workflowPath, &mockLLMProvider{})
+	require.NoError(t, err)
+
+	var subAgents []string
+	for _, config := range configs {
+		if config.Metadata["role"] != "coordinator" {
+			subAgents = append(subAgents, config.Name)
+		}
+	}
+
+	// escalation appears in two branches but registers once.
+	assert.ElementsMatch(t, []string{
+		"nested-conditional:router",
+		"nested-conditional:sub-router",
+		"nested-conditional:specialist",
+		"nested-conditional:escalation",
+		"nested-conditional:handler",
+	}, subAgents)
+}
+
+// TestLoadWorkflowAgents_ConditionalRejectsMalformedSpecs covers the strict
+// errors for canonical conditional workflows.
+func TestLoadWorkflowAgents_ConditionalRejectsMalformedSpecs(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    string
+		wantErr string
+	}{
+		{
+			name: "missing branches",
+			spec: `  type: conditional
+  condition_agent_id: classifier
+  condition_prompt: 'Classify: {{input}}'
+`,
+			wantErr: "conditional workflow requires 'spec.branches' map",
+		},
+		{
+			name: "branch is not an object",
+			spec: `  type: conditional
+  condition_agent_id: classifier
+  condition_prompt: 'Classify: {{input}}'
+  branches:
+    broken: just-a-string
+`,
+			wantErr: `conditional branch "broken" must be an object with a 'type' field`,
+		},
+		{
+			name: "branch missing type",
+			spec: `  type: conditional
+  condition_agent_id: classifier
+  condition_prompt: 'Classify: {{input}}'
+  branches:
+    untyped:
+      agent_id: orphan
+`,
+			wantErr: `conditional branch "untyped": workflow pattern spec missing 'type' field`,
+		},
+		{
+			name: "default_branch is not an object",
+			spec: `  type: conditional
+  condition_agent_id: classifier
+  condition_prompt: 'Classify: {{input}}'
+  branches:
+    ok:
+      type: fork-join
+      prompt: 'Handle: {{input}}'
+      agent_ids:
+        - handler
+  default_branch: nope
+`,
+			wantErr: "conditional default_branch must be an object with a 'type' field",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workflowYAML := `apiVersion: loom/v1
+kind: Workflow
+metadata:
+  name: invalid-conditional
+spec:
+` + tt.spec
+
+			workflowPath := filepath.Join(t.TempDir(), "invalid-conditional.yaml")
+			require.NoError(t, os.WriteFile(workflowPath, []byte(workflowYAML), 0600))
+
+			configs, err := LoadWorkflowAgents(workflowPath, &mockLLMProvider{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.Nil(t, configs)
+		})
+	}
+}
+
+// TestLoadWorkflowAgents_ShippedOrchestrationExamples loads every shipped
+// orchestration example through the registry loader. Before the canonical
+// pattern-type work, several of these (swarm, conditional) validated but were
+// silently skipped by the registry at startup.
+func TestLoadWorkflowAgents_ShippedOrchestrationExamples(t *testing.T) {
+	examplesDir := filepath.Join("..", "..", "examples", "reference", "workflows", "orchestration-patterns")
+
+	var files []string
+	err := filepath.WalkDir(examplesDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && filepath.Ext(path) == ".yaml" {
+			files = append(files, path)
+		}
+		return nil
+	})
+	require.NoError(t, err, "examples directory missing (update the path)")
+	require.NotEmpty(t, files)
+
+	for _, file := range files {
+		t.Run(filepath.Base(file), func(t *testing.T) {
+			configs, err := LoadWorkflowAgents(file, &mockLLMProvider{})
+			require.NoError(t, err, "shipped example failed to load in the registry: %s", file)
+
+			var coordinator *loomv1.AgentConfig
+			subAgents := 0
+			for _, config := range configs {
+				if config.Metadata["role"] == "coordinator" {
+					coordinator = config
+					continue
+				}
+				subAgents++
+			}
+			require.NotNil(t, coordinator, "no coordinator generated for %s", file)
+			assert.Greater(t, subAgents, 0, "no sub-agents registered for %s", file)
+		})
+	}
+}
+
+// TestLoadWorkflowAgents_LoaderOnlySpellingsRejected locks out spec.type
+// spellings that only the registry loader ever accepted. They were never
+// valid for the validator or the canonical converter, so accepting them here
+// reintroduces the vocabulary split fixed for fork_join in #307.
+func TestLoadWorkflowAgents_LoaderOnlySpellingsRejected(t *testing.T) {
+	workflowYAML := `apiVersion: loom/v1
+kind: Workflow
+metadata:
+  name: loader-only-spelling
+spec:
+  type: iterative_pipeline
+  stages:
+    - agent_id: stage-agent
+      prompt_template: 'Run: {{input}}'
+`
+
+	workflowPath := filepath.Join(t.TempDir(), "loader-only-spelling.yaml")
+	require.NoError(t, os.WriteFile(workflowPath, []byte(workflowYAML), 0600))
+
+	configs, err := LoadWorkflowAgents(workflowPath, &mockLLMProvider{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported workflow pattern type: iterative_pipeline")
+	assert.Nil(t, configs)
 }

--- a/pkg/orchestration/workflow_config.go
+++ b/pkg/orchestration/workflow_config.go
@@ -12,6 +12,7 @@ import (
 
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
 	"github.com/teradata-labs/loom/pkg/types"
+	"github.com/teradata-labs/loom/pkg/validation"
 	"gopkg.in/yaml.v3"
 )
 
@@ -164,7 +165,7 @@ func validateWorkflowStructure(config *WorkflowConfig) error {
 	}
 
 	// Validate pattern type
-	validTypes := []string{"debate", "fork-join", "pipeline", "parallel", "conditional", "iterative", "swarm"}
+	validTypes := validation.CanonicalWorkflowPatternTypes()
 	isValid := false
 	for _, validType := range validTypes {
 		if patternType == validType {

--- a/pkg/orchestration/workflow_config_examples_test.go
+++ b/pkg/orchestration/workflow_config_examples_test.go
@@ -1,0 +1,45 @@
+// Copyright © 2026 Teradata Corporation - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package orchestration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadWorkflowFromYAML_ShippedOrchestrationExamples parses every shipped
+// orchestration example through the canonical converter — the path
+// `looms workflow validate` and ExecuteWorkflow use. This is the runnability
+// side of the shipped-example contract: pkg/agent's example sweep proves the
+// registry can load these files, and this sweep proves the converter can
+// execute them, so an example can't be registry-loadable but not runnable.
+func TestLoadWorkflowFromYAML_ShippedOrchestrationExamples(t *testing.T) {
+	examplesDir := filepath.Join("..", "..", "examples", "reference", "workflows", "orchestration-patterns")
+
+	var files []string
+	err := filepath.WalkDir(examplesDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && filepath.Ext(path) == ".yaml" {
+			files = append(files, path)
+		}
+		return nil
+	})
+	require.NoError(t, err, "examples directory missing (update the path)")
+	require.NotEmpty(t, files)
+
+	for _, file := range files {
+		t.Run(filepath.Base(file), func(t *testing.T) {
+			pattern, err := LoadWorkflowFromYAML(file)
+			require.NoError(t, err, "shipped example failed canonical conversion: %s", file)
+			require.NotNil(t, pattern.GetPattern(), "no pattern produced for %s", file)
+		})
+	}
+}

--- a/pkg/validation/real_workflows_test.go
+++ b/pkg/validation/real_workflows_test.go
@@ -68,7 +68,6 @@ func TestRealWorkflowExamples(t *testing.T) {
 			// every subtest here rot away unnoticed when examples/ moved.
 			if _, err := os.Stat(fullPath); os.IsNotExist(err) {
 				t.Fatalf("Workflow file not found (update the path): %s", fullPath)
-				return
 			}
 
 			// Validate the file
@@ -140,7 +139,6 @@ func TestWorkflowTypeDetectionOnRealFiles(t *testing.T) {
 			// every subtest here rot away unnoticed when examples/ moved.
 			if _, err := os.Stat(fullPath); os.IsNotExist(err) {
 				t.Fatalf("Workflow file not found (update the path): %s", fullPath)
-				return
 			}
 
 			// Read and parse file

--- a/pkg/validation/real_workflows_test.go
+++ b/pkg/validation/real_workflows_test.go
@@ -30,19 +30,31 @@ func TestRealWorkflowExamples(t *testing.T) {
 	}{
 		{
 			name:         "architecture_debate_orchestration",
-			path:         "examples/reference/workflows/architecture-debate.yaml",
+			path:         "examples/reference/workflows/orchestration-patterns/architecture-debate.yaml",
 			workflowType: "orchestration",
 			shouldPass:   true,
 		},
 		{
 			name:         "dungeon_crawl_multi_agent",
-			path:         "examples/dungeon-crawler/workflows/dungeon-crawl.yaml",
+			path:         "examples/reference/workflows/event-driven/dungeon-crawler/workflows/dungeon-crawl.yaml",
 			workflowType: "multi-agent",
 			shouldPass:   true,
 		},
 		{
 			name:         "security_analysis_fork_join",
-			path:         "examples/reference/workflows/security-analysis.yaml",
+			path:         "examples/reference/workflows/orchestration-patterns/security-analysis.yaml",
+			workflowType: "orchestration",
+			shouldPass:   true,
+		},
+		{
+			name:         "complexity_routing_conditional",
+			path:         "examples/reference/workflows/orchestration-patterns/complexity-routing.yaml",
+			workflowType: "orchestration",
+			shouldPass:   true,
+		},
+		{
+			name:         "technology_swarm",
+			path:         "examples/reference/workflows/orchestration-patterns/technology-swarm.yaml",
 			workflowType: "orchestration",
 			shouldPass:   true,
 		},
@@ -52,9 +64,10 @@ func TestRealWorkflowExamples(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fullPath := filepath.Join(projectRoot, tt.path)
 
-			// Check if file exists
+			// A moved or deleted example must fail loudly: silent skips let
+			// every subtest here rot away unnoticed when examples/ moved.
 			if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-				t.Skipf("Workflow file not found: %s", fullPath)
+				t.Fatalf("Workflow file not found (update the path): %s", fullPath)
 				return
 			}
 
@@ -104,17 +117,17 @@ func TestWorkflowTypeDetectionOnRealFiles(t *testing.T) {
 	}{
 		{
 			name:         "debate_is_orchestration",
-			path:         "examples/reference/workflows/architecture-debate.yaml",
+			path:         "examples/reference/workflows/orchestration-patterns/architecture-debate.yaml",
 			expectedType: "orchestration",
 		},
 		{
-			name:         "vacation_is_multi_agent",
-			path:         "examples/vacation-planner/workflows/vacation-planning-workflow.yaml",
+			name:         "brainstorm_is_multi_agent",
+			path:         "examples/reference/workflows/event-driven/brainstorm-session/workflows/brainstorm-session.yaml",
 			expectedType: "multi-agent",
 		},
 		{
 			name:         "security_analysis_is_orchestration",
-			path:         "examples/reference/workflows/security-analysis.yaml",
+			path:         "examples/reference/workflows/orchestration-patterns/security-analysis.yaml",
 			expectedType: "orchestration",
 		},
 	}
@@ -123,9 +136,10 @@ func TestWorkflowTypeDetectionOnRealFiles(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fullPath := filepath.Join(projectRoot, tt.path)
 
-			// Check if file exists
+			// A moved or deleted example must fail loudly: silent skips let
+			// every subtest here rot away unnoticed when examples/ moved.
 			if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-				t.Skipf("Workflow file not found: %s", fullPath)
+				t.Fatalf("Workflow file not found (update the path): %s", fullPath)
 				return
 			}
 

--- a/pkg/validation/required_fields_test.go
+++ b/pkg/validation/required_fields_test.go
@@ -1,0 +1,108 @@
+// Copyright © 2026 Teradata Corporation - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOrchestrationRequiredFieldsMatchConverter pins the validator's
+// per-pattern required-field checks to what the canonical converter
+// (pkg/orchestration convert*Pattern) actually rejects. Before these checks,
+// a swarm spec without 'question' validated cleanly but failed at
+// LoadWorkflowFromYAML — the required-field flavor of the vocabulary drift
+// fixed by the canonical pattern-type contract.
+func TestOrchestrationRequiredFieldsMatchConverter(t *testing.T) {
+	tests := []struct {
+		name      string
+		spec      string
+		wantField string
+	}{
+		{
+			name: "swarm missing question",
+			spec: `  type: swarm
+  agent_ids:
+    - voter-a
+    - voter-b
+`,
+			wantField: "spec.question",
+		},
+		{
+			name: "swarm missing agent_ids",
+			spec: `  type: swarm
+  question: '{{input}}'
+`,
+			wantField: "spec.agent_ids",
+		},
+		{
+			name: "conditional missing condition_agent_id",
+			spec: `  type: conditional
+  condition_prompt: 'Classify: {{input}}'
+  branches:
+    ok:
+      type: fork-join
+      prompt: 'Handle: {{input}}'
+      agent_ids:
+        - handler
+`,
+			wantField: "spec.condition_agent_id",
+		},
+		{
+			name: "conditional missing condition_prompt",
+			spec: `  type: conditional
+  condition_agent_id: classifier
+  branches:
+    ok:
+      type: fork-join
+      prompt: 'Handle: {{input}}'
+      agent_ids:
+        - handler
+`,
+			wantField: "spec.condition_prompt",
+		},
+		{
+			name: "conditional missing branches",
+			spec: `  type: conditional
+  condition_agent_id: classifier
+  condition_prompt: 'Classify: {{input}}'
+`,
+			wantField: "spec.branches",
+		},
+		{
+			name: "iterative missing pipeline",
+			spec: `  type: iterative
+  max_iterations: 2
+`,
+			wantField: "spec.pipeline",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workflowYAML := `apiVersion: loom/v1
+kind: Workflow
+metadata:
+  name: required-fields
+spec:
+` + tt.spec
+
+			result := ValidateYAMLContent(workflowYAML, "required-fields.yaml")
+			require.False(t, result.Valid, "expected validation to fail")
+
+			found := false
+			for _, e := range result.Errors {
+				if e.Field == tt.wantField {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "expected an error on %s, got: %+v", tt.wantField, result.Errors)
+		})
+	}
+}

--- a/pkg/validation/validator.go
+++ b/pkg/validation/validator.go
@@ -311,6 +311,14 @@ func validateWorkflowStructure(content string) []ValidationError {
 	return errors
 }
 
+// CanonicalWorkflowPatternTypes returns the canonical spec.type vocabulary
+// for orchestration workflows. This is the single source of truth: the
+// validator, pkg/orchestration's converter guard, and the agent registry
+// loader (pinned by its contract test) all accept exactly this set.
+func CanonicalWorkflowPatternTypes() []string {
+	return []string{"debate", "fork-join", "pipeline", "parallel", "conditional", "iterative", "swarm"}
+}
+
 // validateOrchestrationWorkflowStructure validates structure for orchestration workflows.
 func validateOrchestrationWorkflowStructure(spec map[string]interface{}) []ValidationError {
 	var errors []ValidationError
@@ -382,7 +390,7 @@ func validateOrchestrationWorkflowStructure(spec map[string]interface{}) []Valid
 	}
 
 	// Validate pattern/type value
-	validPatterns := []string{"debate", "fork-join", "pipeline", "parallel", "conditional", "iterative", "swarm"}
+	validPatterns := CanonicalWorkflowPatternTypes()
 	isValidPattern := false
 	for _, valid := range validPatterns {
 		if patternValue == valid {
@@ -436,6 +444,7 @@ func validateOrchestrationSchema(spec map[string]interface{}, patternType string
 		"conditional": {
 			"pattern", "type", // Pattern identifier
 			"condition_agent_id", "condition_prompt", "branches", "default_branch", // Conditional specific
+			"retry_policy", // Optional output retry (parsed by convertConditionalPattern)
 		},
 		"iterative": {
 			"pattern", "type", // Pattern identifier
@@ -444,6 +453,7 @@ func validateOrchestrationSchema(spec map[string]interface{}, patternType string
 		"swarm": {
 			"pattern", "type", // Pattern identifier
 			"question", "agent_ids", "strategy", "confidence_threshold", "share_votes", "judge_agent_id", // Swarm specific
+			"retry_policy", // Optional output retry (parsed by convertSwarmPattern)
 		},
 	}
 

--- a/pkg/validation/validator.go
+++ b/pkg/validation/validator.go
@@ -637,6 +637,78 @@ func validatePatternSpecificFields(spec map[string]interface{}, patternType stri
 				Fix:      "Add at least 2 agents for debate",
 			})
 		}
+
+	case "swarm":
+		// swarm requires: question, agent_ids (convertSwarmPattern)
+		if _, hasQuestion := spec["question"]; !hasQuestion {
+			errors = append(errors, ValidationError{
+				Level:    LevelStructure,
+				Field:    "spec.question",
+				Message:  "Missing required field for swarm pattern",
+				Expected: "question: string (what the agents vote on)",
+				Fix:      "Add 'question: \"{{input}}\"' (or a literal question) under spec",
+			})
+		}
+		if agentIds, hasAgentIds := spec["agent_ids"]; !hasAgentIds {
+			errors = append(errors, ValidationError{
+				Level:    LevelStructure,
+				Field:    "spec.agent_ids",
+				Message:  "Missing required field for swarm pattern",
+				Expected: "agent_ids: [agent1, agent2]",
+				Fix:      "Add 'agent_ids: [database-expert, cost-analyst]' under spec",
+			})
+		} else if agentList, ok := agentIds.([]interface{}); ok && len(agentList) == 0 {
+			errors = append(errors, ValidationError{
+				Level:    LevelStructure,
+				Field:    "spec.agent_ids",
+				Message:  "agent_ids cannot be empty",
+				Expected: "At least one agent ID",
+				Fix:      "Add agent IDs to the list",
+			})
+		}
+
+	case "conditional":
+		// conditional requires: condition_agent_id, condition_prompt, branches
+		// (convertConditionalPattern)
+		if _, hasAgent := spec["condition_agent_id"]; !hasAgent {
+			errors = append(errors, ValidationError{
+				Level:    LevelStructure,
+				Field:    "spec.condition_agent_id",
+				Message:  "Missing required field for conditional pattern",
+				Expected: "condition_agent_id: string (agent whose answer selects a branch)",
+				Fix:      "Add 'condition_agent_id: classifier' under spec",
+			})
+		}
+		if _, hasPrompt := spec["condition_prompt"]; !hasPrompt {
+			errors = append(errors, ValidationError{
+				Level:    LevelStructure,
+				Field:    "spec.condition_prompt",
+				Message:  "Missing required field for conditional pattern",
+				Expected: "condition_prompt: string",
+				Fix:      "Add 'condition_prompt: \"Is this simple or complex? {{input}}\"' under spec",
+			})
+		}
+		if _, hasBranches := spec["branches"]; !hasBranches {
+			errors = append(errors, ValidationError{
+				Level:    LevelStructure,
+				Field:    "spec.branches",
+				Message:  "Missing required field for conditional pattern",
+				Expected: "branches: map of branch key -> nested workflow pattern",
+				Fix:      "Add 'branches:' with one nested workflow spec per branch key",
+			})
+		}
+
+	case "iterative":
+		// iterative requires: pipeline (convertIterativePattern)
+		if _, hasPipeline := spec["pipeline"]; !hasPipeline {
+			errors = append(errors, ValidationError{
+				Level:    LevelStructure,
+				Field:    "spec.pipeline",
+				Message:  "Missing required field for iterative pattern",
+				Expected: "pipeline: nested pipeline spec (initial_prompt + stages)",
+				Fix:      "Add 'pipeline:' with initial_prompt and stages under spec",
+			})
+		}
 	}
 
 	return errors


### PR DESCRIPTION
## Description

Follow-up to #307, which fixed the fork-join instance of a broader defect: the registry loader (`loadOrchestrationWorkflow`) accepted only a subset of the canonical `spec.type` vocabulary, so workflows that `looms workflow validate` reported **valid** were **silently skipped** by the agent registry at startup and on reload (logged at ERROR, execution continued). After #307, three canonical types were still affected:

- **`iterative`** — no loader case at all
- **`swarm`** — no loader case at all (the shipped example `technology-swarm.yaml` validated but never loaded)
- **`conditional`** — the loader read `branches[*].agent_id`, but canonical branches are *nested workflow patterns* (`convertConditionalPattern` recurses into them); canonical files died with "no agents found in workflow". The loader also never collected `condition_agent_id`, so even under its old wrong schema the condition agent was never registered.

The loader also accepted **`iterative_pipeline`** — the exact mirror image of the `fork_join` bug: a loader-only spelling the validator and canonical converter reject, never usable end to end.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update (shipped example YAMLs corrected)
- [ ] 🔧 Refactoring
- [x] 🧪 Test update

## Changes Made

### Loader (`pkg/agent/config_loader.go`)

- Replaced the per-type agent-ID switch with `workflowAgentIDs`, a recursive collector covering all 7 canonical types (`debate`, `fork-join`, `pipeline`, `parallel`, `conditional`, `iterative`, `swarm`).
- `conditional`: recurses into `branches` and `default_branch` (nested patterns of any type, including nested conditionals), collects `condition_agent_id`, iterates branches in sorted order so registration order is deterministic, and de-duplicates agents shared across branches.
- `iterative`: collects agents from the base pipeline under `spec.pipeline`.
- `swarm`: `agent_ids` plus optional `judge_agent_id`.
- `debate`: moderator is now de-duplicated when it also appears in `agent_ids` (previously produced a duplicate namespaced sub-agent config).
- Dropped `iterative_pipeline` from the case label. All remaining `iterative_pipeline` occurrences in the repo are internal executor/checkpoint identifiers, not YAML `spec.type` values — the same removal rationale as #307's `fork_join`.
- Exact error strings for the existing `parallel` and `fork_join` regression tests are preserved.

### Vocabulary contract (the part that keeps this class of bug from recurring)

- `validation.CanonicalWorkflowPatternTypes()` is now the single exported source of truth for the canonical vocabulary. The validator and `pkg/orchestration`'s converter guard (`validateSpec`) both consume it — previously three hand-maintained copies existed (`validator.go:385`, `workflow_config.go:167`, and the loader switch).
- `TestLoadWorkflowAgents_CanonicalPatternContract` pins the loader to it: for every canonical type, a minimal canonical spec must pass `pkg/validation` **and** load through `LoadWorkflowAgents` with the expected coordinator + namespaced sub-agents. The table is asserted with `ElementsMatch` against `CanonicalWorkflowPatternTypes()`, so adding a type to the vocabulary without teaching the loader (and the table) fails the test.

### Validator allowlists (`pkg/validation/validator.go`)

- `conditional` and `swarm` now allow `spec.retry_policy`, which their converters parse (`parseOutputRetryPolicy` calls at `workflow_config.go:512` and `:690`) and which `workflow-all-fields-reference.yaml` documents. Previously the reference file's own conditional/swarm sections failed schema validation. (Pipeline retry is per-stage and unaffected.)

### Shipped examples — all orchestration examples now validate AND load

- `complexity-routing.yaml`: rewritten to canonical conditional with nested branch patterns. Its "nested workflows (branches with sub-workflows) are planned for future releases" note was stale — `conditional_executor.go:137` executes the selected branch via `orchestrator.ExecutePattern` and the converter has recursed into branches all along. The old file (`type: conditional` + bare `agent_ids`) failed the validator, the converter, and the loader.
- `scheduled-workflows/{daily-report,frequent-monitor,hourly-sync,weekly-backup}.yaml`: flattened the non-canonical `spec.pipeline.{initial_prompt,stages}` nesting to canonical `spec.initial_prompt` / `spec.stages`, and renamed stage `prompt:` to `prompt_template:`. These four never validated or loaded. (`heartbeat-new.yaml` / `heartbeat-resume.yaml` were already canonical.)
- `orchestration-patterns/README.md`: conditional section now shows the canonical shape; stale limitation note removed.
- `pkg/validation/real_workflows_test.go`: all five example paths in this sweep were stale (files moved into `orchestration-patterns/`, two examples deleted), so **every subtest silently skipped** via `t.Skipf`. Paths fixed, missing files now `t.Fatalf` so path rot can't disable the sweep again, and the conditional + swarm examples were added to it.
- `TestLoadWorkflowAgents_ShippedOrchestrationExamples`: loads every YAML under `examples/reference/workflows/orchestration-patterns/` through the registry loader (13 files). This is the test that caught the four broken scheduled examples.

## Out of scope (verified, deliberately not fixed here)

**Weaver's `apply_template` emits `spec.schedule`, but the scheduler reads top-level `schedule`.** `buildWorkflowYAMLFromTemplate` (`agent_management_templates.go:437`) writes the suggested schedule under `spec`, while `pkg/scheduler/loader.go:120` reads `config.Schedule` (top-level, matching `WorkflowConfig.Schedule` and the shipped scheduled examples) and the validator allowlists reject `spec.schedule`. Three shipped templates set `Schedulable: true`, so template-emitted schedules are currently invisible to the scheduler. That's a Weaver emitter fix with its own regression test — separate PR.

## Related Issues

Follow-up to #307 (announced in its review). No tracking issue; root-cause analysis is inline above.

## Testing

- `TestLoadWorkflowAgents_CanonicalPatternContract` — all 7 canonical types validate + load (fails on main for `iterative`, `swarm`, `conditional`)
- `TestLoadWorkflowAgents_ConditionalNestedPatterns` — nested conditional recursion + cross-branch de-duplication
- `TestLoadWorkflowAgents_ConditionalRejectsMalformedSpecs` — strict errors for missing/malformed branches and default_branch
- `TestLoadWorkflowAgents_LoaderOnlySpellingsRejected` — `iterative_pipeline` rejected
- `TestLoadWorkflowAgents_ShippedOrchestrationExamples` — every shipped orchestration example loads (fails on main for 6 of 13 files)
- Existing regression tests preserved and passing: `TestLoadWorkflowAgents_ForkJoinPatternType` (#307), `TestLoadWorkflowAgents_ParallelTasks` / `_ParallelRejectsMalformedTasks` (#298), exact error strings unchanged
- Full `just check` (lint + `go test -tags fts5 -race ./...` + build) green locally

### Test Checklist

- [x] All new and existing tests pass
- [x] Race detector shows zero race conditions (`-race` on the full suite via `just check`)
- [x] Code builds successfully (`go build -tags fts5 ./...`)
- [x] All checks pass (`just check`)

### Test Coverage

- [x] Added tests for new functionality
- [x] Updated tests for modified functionality

## Proto Changes

- [x] No proto changes in this PR

## Documentation

- [ ] README.md updated (top-level: not needed)
- [x] Shipped example YAMLs + `orchestration-patterns/README.md` corrected to canonical shapes
- [x] Code comments added/updated
- [x] No `docs/` changes needed — the hyphenated canonical vocabulary was already the documented behavior; this makes the loader match it

## Security

- [x] No security implications

## Performance

- [x] No performance impact (loader runs once per file at startup/reload)

## Deployment Notes

Workflows using `spec.type: iterative_pipeline` are now rejected by the loader. Like #307's `fork_join`, that spelling was never accepted by the validator or the canonical converter, so no working configuration existed to migrate. Users with old-format conditional files (`branches[*].agent_id`) now get a clear error (`conditional branch "x": workflow pattern spec missing 'type' field`) instead of a silent partial load that dropped the condition agent.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
