### PR TITLE
feat(longmemeval): anchor replayed conversations via occurred_at + judge-model backends for the official scorer

### DIFF
--- a/cmd/loom-longmemeval/main.go
+++ b/cmd/loom-longmemeval/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -375,18 +376,21 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 
 	// Run benchmark and collect results
 	resultCh := make(chan EntryResult, len(entries))
+	runErrCh := make(chan error, 1)
 	startTime := time.Now()
 
 	go func() {
-		if err := runner.Run(ctx, entries, resultCh); err != nil {
-			logger.Error("runner error", zap.Error(err))
-		}
+		runErrCh <- runner.Run(ctx, entries, resultCh)
 		close(resultCh)
 	}()
 
 	var results []EntryResult
 	for r := range resultCh {
 		results = append(results, r)
+	}
+	runErr := <-runErrCh
+	if runErr != nil {
+		logger.Error("runner error", zap.Error(runErr))
 	}
 
 	elapsed := time.Since(startTime)
@@ -411,6 +415,14 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 	// Print summary
 	summary := Summarize(results, mode, serverAddr)
 	PrintSummary(summary)
+
+	// An aborted run (e.g. the server rejects occurred_at) must exit
+	// non-zero so callers don't mistake a results file full of failed rows
+	// for a completed run. A user interrupt (SIGINT/SIGTERM) still exits
+	// cleanly with whatever finished.
+	if runErr != nil && !errors.Is(runErr, context.Canceled) {
+		return fmt.Errorf("benchmark run aborted: %w", runErr)
+	}
 
 	return nil
 }

--- a/cmd/loom-longmemeval/main.go
+++ b/cmd/loom-longmemeval/main.go
@@ -63,6 +63,7 @@ var (
 	questionTypes string
 	mode          string
 	isolate       bool
+	useOccurredAt bool
 )
 
 func main() {
@@ -171,6 +172,7 @@ Three benchmark modes:
 	cmd.Flags().StringVar(&questionTypes, "types", "", "Comma-separated question types to include (empty = all)")
 	cmd.Flags().StringVar(&mode, "mode", "ingest", "Run mode: ingest (default), multi-session, or context-stuffing")
 	cmd.Flags().BoolVar(&isolate, "isolate", true, "Create a fresh agent per entry for graph memory isolation (default: true)")
+	cmd.Flags().BoolVar(&useOccurredAt, "occurred-at", true, "Send haystack/question dates as WeaveRequest.occurred_at so memories anchor at historical dates (requires server.allow_time_override: true)")
 
 	return cmd
 }
@@ -341,16 +343,18 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 		zap.Int("entries", len(entries)),
 		zap.Int("concurrency", concurrency),
 		zap.Bool("isolate", isolate),
+		zap.Bool("occurred_at", useOccurredAt),
 	)
 
 	// Create runner (connects to running Loom server via gRPC)
 	runner, err := NewRunner(RunConfig{
-		Mode:        RunMode(mode),
-		ServerAddr:  serverAddr,
-		AgentID:     agentID,
-		Concurrency: concurrency,
-		Verbose:     verbose,
-		Isolate:     isolate,
+		Mode:          RunMode(mode),
+		ServerAddr:    serverAddr,
+		AgentID:       agentID,
+		Concurrency:   concurrency,
+		Verbose:       verbose,
+		Isolate:       isolate,
+		UseOccurredAt: useOccurredAt,
 	}, logger)
 	if err != nil {
 		return err

--- a/cmd/loom-longmemeval/runner.go
+++ b/cmd/loom-longmemeval/runner.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // RunMode determines how conversation history is processed.
@@ -60,6 +61,13 @@ type RunConfig struct {
 	Concurrency int
 	Verbose     bool
 	Isolate     bool // create a fresh agent per entry for graph memory isolation
+
+	// UseOccurredAt sends each haystack session's date (and the question date)
+	// as WeaveRequest.occurred_at. Without it, the server anchors temporal
+	// grounding and graph-memory extraction to the arrival time (the run day),
+	// which contradicts the historical dates inside the replayed conversations.
+	// Requires server.allow_time_override: true on the target server.
+	UseOccurredAt bool
 }
 
 // EntryResult holds the result of evaluating a single entry.
@@ -230,13 +238,26 @@ func (r *Runner) runEntry(ctx context.Context, entry Entry) EntryResult {
 		agentID = tempAgentID
 	}
 
+	// The question turn anchors at the entry's question date, matching the
+	// "Current date:" line in the prompt.
+	var questionAt time.Time
+	if r.config.UseOccurredAt {
+		t, err := ParseDate(entry.QuestionDate)
+		if err != nil {
+			result.Error = fmt.Sprintf("parse question date %q: %v", entry.QuestionDate, err)
+			result.Duration = time.Since(start)
+			return result
+		}
+		questionAt = t
+	}
+
 	switch r.config.Mode {
 	case ModeIngest:
-		result = r.runIngestWith(ctx, entry, sessions, result, agentID)
+		result = r.runIngestWith(ctx, entry, sessions, result, agentID, questionAt)
 	case ModeMultiSession:
-		result = r.runMultiSessionWith(ctx, entry, sessions, result, agentID)
+		result = r.runMultiSessionWith(ctx, entry, sessions, result, agentID, questionAt)
 	case ModeContextStuffing:
-		result = r.runContextStuffingWith(ctx, entry, sessions, result, agentID)
+		result = r.runContextStuffingWith(ctx, entry, sessions, result, agentID, questionAt)
 	default:
 		result.Error = fmt.Sprintf("unknown mode: %s", r.config.Mode)
 	}
@@ -275,14 +296,33 @@ func (r *Runner) deleteTempAgent(ctx context.Context, agentID string) {
 	}
 }
 
-// weave sends a Weave RPC and accumulates token usage into result.
-func (r *Runner) weave(ctx context.Context, sessionID, query, agentID string, result *EntryResult) (*loomv1.WeaveResponse, error) {
+// buildWeaveRequest constructs a Weave request, attaching occurred_at when
+// a non-zero time is given so replayed turns anchor at their historical date.
+func buildWeaveRequest(sessionID, query, agentID string, occurredAt time.Time) *loomv1.WeaveRequest {
 	req := &loomv1.WeaveRequest{
 		Query:          query,
 		SessionId:      sessionID,
 		TimeoutSeconds: 120,
 		AgentId:        agentID,
 	}
+	if !occurredAt.IsZero() {
+		req.OccurredAt = timestamppb.New(occurredAt)
+	}
+	return req
+}
+
+// sessionOccurredAt returns the haystack session's date as the occurred_at
+// override, or the zero time when the override is disabled.
+func (r *Runner) sessionOccurredAt(s SessionWithDate) time.Time {
+	if r.config.UseOccurredAt {
+		return s.ParsedAt
+	}
+	return time.Time{}
+}
+
+// weave sends a Weave RPC and accumulates token usage into result.
+func (r *Runner) weave(ctx context.Context, sessionID, query, agentID string, occurredAt time.Time, result *EntryResult) (*loomv1.WeaveResponse, error) {
+	req := buildWeaveRequest(sessionID, query, agentID, occurredAt)
 
 	resp, err := r.client.Weave(ctx, req)
 	if err != nil {
@@ -321,7 +361,7 @@ func (r *Runner) deleteSession(ctx context.Context, sessionID string) {
 // runIngestWith processes an entry by feeding sessions through Weave, then querying.
 // All turns happen in a single session so the conversation history accumulates,
 // compression triggers, and the agent can search back through everything.
-func (r *Runner) runIngestWith(ctx context.Context, entry Entry, sessions []SessionWithDate, result EntryResult, agentID string) EntryResult {
+func (r *Runner) runIngestWith(ctx context.Context, entry Entry, sessions []SessionWithDate, result EntryResult, agentID string, questionAt time.Time) EntryResult {
 	sessionID, err := r.createSession(ctx, fmt.Sprintf("lme-%s", entry.QuestionID), agentID)
 	if err != nil {
 		result.Error = fmt.Sprintf("create session: %v", err)
@@ -337,7 +377,7 @@ func (r *Runner) runIngestWith(ctx context.Context, entry Entry, sessions []Sess
 			i+1, sess.Date, FormatSession(sess),
 		)
 
-		_, err = r.weave(ctx, sessionID, ingestMsg, agentID, &result)
+		_, err = r.weave(ctx, sessionID, ingestMsg, agentID, r.sessionOccurredAt(sess), &result)
 		if err != nil {
 			result.Error = fmt.Sprintf("ingest session %d: %v", i, err)
 			return result
@@ -354,7 +394,7 @@ func (r *Runner) runIngestWith(ctx context.Context, entry Entry, sessions []Sess
 		entry.QuestionDate, entry.Question,
 	)
 
-	resp, err := r.weave(ctx, sessionID, questionMsg, agentID, &result)
+	resp, err := r.weave(ctx, sessionID, questionMsg, agentID, questionAt, &result)
 	if err != nil {
 		result.Error = fmt.Sprintf("ask question: %v", err)
 		return result
@@ -368,7 +408,7 @@ func (r *Runner) runIngestWith(ctx context.Context, entry Entry, sessions []Sess
 // haystack session. Each session is ingested, then ended so its messages are
 // persisted to the DB and become FTS5-searchable. The question is asked in a
 // fresh session — the agent must use graph_memory + conversation_memory to recall.
-func (r *Runner) runMultiSessionWith(ctx context.Context, entry Entry, sessions []SessionWithDate, result EntryResult, agentID string) EntryResult {
+func (r *Runner) runMultiSessionWith(ctx context.Context, entry Entry, sessions []SessionWithDate, result EntryResult, agentID string, questionAt time.Time) EntryResult {
 	// Phase 1: Ingest each haystack session in its own agent session.
 	for i, sess := range sessions {
 		sessName := fmt.Sprintf("lme-%s-s%d", entry.QuestionID, i+1)
@@ -386,7 +426,7 @@ func (r *Runner) runMultiSessionWith(ctx context.Context, entry Entry, sessions 
 			sess.Date, FormatSession(sess),
 		)
 
-		_, err = r.weave(ctx, sessionID, ingestMsg, agentID, &result)
+		_, err = r.weave(ctx, sessionID, ingestMsg, agentID, r.sessionOccurredAt(sess), &result)
 		if err != nil {
 			result.Error = fmt.Sprintf("ingest session %d: %v", i, err)
 			return result
@@ -412,7 +452,7 @@ func (r *Runner) runMultiSessionWith(ctx context.Context, entry Entry, sessions 
 		entry.QuestionDate, entry.Question,
 	)
 
-	resp, err := r.weave(ctx, questionSessionID, questionMsg, agentID, &result)
+	resp, err := r.weave(ctx, questionSessionID, questionMsg, agentID, questionAt, &result)
 	if err != nil {
 		result.Error = fmt.Sprintf("ask question: %v", err)
 		return result
@@ -423,7 +463,7 @@ func (r *Runner) runMultiSessionWith(ctx context.Context, entry Entry, sessions 
 }
 
 // runContextStuffingWith processes an entry by stuffing all sessions into one Weave call.
-func (r *Runner) runContextStuffingWith(ctx context.Context, entry Entry, sessions []SessionWithDate, result EntryResult, agentID string) EntryResult {
+func (r *Runner) runContextStuffingWith(ctx context.Context, entry Entry, sessions []SessionWithDate, result EntryResult, agentID string, questionAt time.Time) EntryResult {
 	sessionID, err := r.createSession(ctx, fmt.Sprintf("lme-%s-cs", entry.QuestionID), agentID)
 	if err != nil {
 		result.Error = fmt.Sprintf("create session: %v", err)
@@ -443,7 +483,7 @@ func (r *Runner) runContextStuffingWith(ctx context.Context, entry Entry, sessio
 		allSessions, entry.QuestionDate, entry.Question,
 	)
 
-	resp, err := r.weave(ctx, sessionID, prompt, agentID, &result)
+	resp, err := r.weave(ctx, sessionID, prompt, agentID, questionAt, &result)
 	if err != nil {
 		result.Error = fmt.Sprintf("ask question: %v", err)
 		return result

--- a/cmd/loom-longmemeval/runner.go
+++ b/cmd/loom-longmemeval/runner.go
@@ -18,7 +18,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -165,10 +167,17 @@ func (r *Runner) Run(ctx context.Context, entries []Entry, resultCh chan<- Entry
 	var completed atomic.Int64
 	total := len(entries)
 
+	// A server without allow_time_override rejects EVERY entry identically:
+	// abort the run on the first such rejection instead of burning one futile
+	// temp-agent create/weave/delete cycle per entry (500 on a full set).
+	runCtx, abort := context.WithCancel(ctx)
+	defer abort()
+	var abortErr atomic.Pointer[string]
+
 loop:
 	for i, entry := range entries {
 		select {
-		case <-ctx.Done():
+		case <-runCtx.Done():
 			break loop
 		case sem <- struct{}{}:
 		}
@@ -178,7 +187,14 @@ loop:
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			result := r.runEntry(ctx, e)
+			result := r.runEntry(runCtx, e)
+			if strings.Contains(result.Error, "allow_time_override") {
+				msg := "server rejects occurred_at (server.allow_time_override is not enabled); aborting the run — enable it in looms.yaml or pass --occurred-at=false"
+				if abortErr.CompareAndSwap(nil, &msg) {
+					r.logger.Error(msg, zap.String("first_failed_entry", e.QuestionID))
+					abort()
+				}
+			}
 			done := completed.Add(1)
 			r.logger.Info("entry completed",
 				zap.String("question_id", e.QuestionID),
@@ -197,6 +213,9 @@ loop:
 	}
 
 	wg.Wait()
+	if msg := abortErr.Load(); msg != nil {
+		return errors.New(*msg)
+	}
 	return ctx.Err()
 }
 

--- a/cmd/loom-longmemeval/runner.go
+++ b/cmd/loom-longmemeval/runner.go
@@ -28,7 +28,9 @@ import (
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -84,6 +86,11 @@ type EntryResult struct {
 	OutputTokens int           `json:"output_tokens"`
 	Sessions     int           `json:"sessions_ingested"`
 	Error        string        `json:"error,omitempty"`
+
+	// grpcCode carries the gRPC status code of a failed Weave call so the
+	// runner can decide whether to abort the whole run. Unexported — never
+	// serialized to results.
+	grpcCode codes.Code
 }
 
 // Runner orchestrates the benchmark execution against a running Loom server.
@@ -188,7 +195,7 @@ loop:
 			defer func() { <-sem }()
 
 			result := r.runEntry(runCtx, e)
-			if strings.Contains(result.Error, "allow_time_override") {
+			if isTimeOverrideRejection(result) {
 				msg := "server rejects occurred_at (server.allow_time_override is not enabled); aborting the run — enable it in looms.yaml or pass --occurred-at=false"
 				if abortErr.CompareAndSwap(nil, &msg) {
 					r.logger.Error(msg, zap.String("first_failed_entry", e.QuestionID))
@@ -217,6 +224,18 @@ loop:
 		return errors.New(*msg)
 	}
 	return ctx.Err()
+}
+
+// isTimeOverrideRejection reports whether an entry failed because the server
+// rejects WeaveRequest.occurred_at (server.allow_time_override disabled). The
+// primary signal is the gRPC FailedPrecondition code from the Weave call
+// paired with a mention of occurred_at; the bare flag-name substring is kept
+// as a fallback for servers whose status code was lost in transit.
+func isTimeOverrideRejection(result EntryResult) bool {
+	if result.grpcCode == codes.FailedPrecondition && strings.Contains(result.Error, "occurred_at") {
+		return true
+	}
+	return strings.Contains(result.Error, "allow_time_override")
 }
 
 // runEntry evaluates a single LongMemEval entry.
@@ -248,7 +267,14 @@ func (r *Runner) runEntry(ctx context.Context, entry Entry) EntryResult {
 			return result
 		}
 		tempAgentID = id
-		defer r.deleteTempAgent(ctx, tempAgentID)
+		defer func() {
+			// Cleanup must survive cancellation of the run context —
+			// otherwise an abort strands the sibling goroutines' temp
+			// agents (and their graph-memory stores) server-side.
+			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+			defer cancel()
+			r.deleteTempAgent(cleanupCtx, tempAgentID)
+		}()
 	}
 
 	// Use temp agent if available, otherwise the configured agent.
@@ -260,7 +286,7 @@ func (r *Runner) runEntry(ctx context.Context, entry Entry) EntryResult {
 	// The question turn anchors at the entry's question date, matching the
 	// "Current date:" line in the prompt.
 	var questionAt time.Time
-	if r.config.UseOccurredAt {
+	if r.occurredAtEnabled() {
 		t, err := ParseDate(entry.QuestionDate)
 		if err != nil {
 			result.Error = fmt.Sprintf("parse question date %q: %v", entry.QuestionDate, err)
@@ -330,10 +356,17 @@ func buildWeaveRequest(sessionID, query, agentID string, occurredAt time.Time) *
 	return req
 }
 
+// occurredAtEnabled reports whether occurred_at overrides should be sent.
+// Context-stuffing is the no-memory baseline and must run unchanged against
+// a stock server (allow_time_override off), so it never sends occurred_at.
+func (r *Runner) occurredAtEnabled() bool {
+	return r.config.UseOccurredAt && r.config.Mode != ModeContextStuffing
+}
+
 // sessionOccurredAt returns the haystack session's date as the occurred_at
 // override, or the zero time when the override is disabled.
 func (r *Runner) sessionOccurredAt(s SessionWithDate) time.Time {
-	if r.config.UseOccurredAt {
+	if r.occurredAtEnabled() {
 		return s.ParsedAt
 	}
 	return time.Time{}
@@ -345,6 +378,7 @@ func (r *Runner) weave(ctx context.Context, sessionID, query, agentID string, oc
 
 	resp, err := r.client.Weave(ctx, req)
 	if err != nil {
+		result.grpcCode = status.Code(err)
 		return nil, err
 	}
 

--- a/cmd/loom-longmemeval/runner_test.go
+++ b/cmd/loom-longmemeval/runner_test.go
@@ -17,11 +17,18 @@
 package main
 
 import (
+	"context"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestBuildWeaveRequest(t *testing.T) {
@@ -66,7 +73,7 @@ func TestBuildWeaveRequestFromDatasetDate(t *testing.T) {
 
 	req := buildWeaveRequest("sess-1", "query", "agent-1", parsed)
 	require.NotNil(t, req.OccurredAt)
-	assert.Equal(t, parsed.UTC(), req.OccurredAt.AsTime())
+	assert.True(t, parsed.Equal(req.OccurredAt.AsTime()))
 }
 
 func TestSessionOccurredAt(t *testing.T) {
@@ -75,9 +82,205 @@ func TestSessionOccurredAt(t *testing.T) {
 		ParsedAt: time.Date(2023, 4, 10, 17, 50, 0, 0, time.UTC),
 	}
 
-	enabled := &Runner{config: RunConfig{UseOccurredAt: true}}
+	enabled := &Runner{config: RunConfig{Mode: ModeIngest, UseOccurredAt: true}}
 	assert.True(t, sess.ParsedAt.Equal(enabled.sessionOccurredAt(sess)))
 
-	disabled := &Runner{config: RunConfig{UseOccurredAt: false}}
+	disabled := &Runner{config: RunConfig{Mode: ModeIngest, UseOccurredAt: false}}
 	assert.True(t, disabled.sessionOccurredAt(sess).IsZero())
+
+	// Context-stuffing is the no-memory baseline: never sends occurred_at.
+	stuffing := &Runner{config: RunConfig{Mode: ModeContextStuffing, UseOccurredAt: true}}
+	assert.True(t, stuffing.sessionOccurredAt(sess).IsZero())
+}
+
+func TestOccurredAtEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  RunConfig
+		want bool
+	}{
+		{"ingest with flag", RunConfig{Mode: ModeIngest, UseOccurredAt: true}, true},
+		{"multi-session with flag", RunConfig{Mode: ModeMultiSession, UseOccurredAt: true}, true},
+		{"context-stuffing with flag", RunConfig{Mode: ModeContextStuffing, UseOccurredAt: true}, false},
+		{"ingest without flag", RunConfig{Mode: ModeIngest, UseOccurredAt: false}, false},
+		{"context-stuffing without flag", RunConfig{Mode: ModeContextStuffing, UseOccurredAt: false}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Runner{config: tt.cfg}
+			assert.Equal(t, tt.want, r.occurredAtEnabled())
+		})
+	}
+}
+
+func TestIsTimeOverrideRejection(t *testing.T) {
+	tests := []struct {
+		name   string
+		result EntryResult
+		want   bool
+	}{
+		{
+			name: "failed precondition mentioning occurred_at",
+			result: EntryResult{
+				Error:    "ingest session 0: rpc error: code = FailedPrecondition desc = occurred_at override is disabled on this server",
+				grpcCode: codes.FailedPrecondition,
+			},
+			want: true,
+		},
+		{
+			name:   "flag-name substring without a status code",
+			result: EntryResult{Error: "server refused: enable allow_time_override"},
+			want:   true,
+		},
+		{
+			name: "unrelated failed precondition",
+			result: EntryResult{
+				Error:    "ask question: agent is busy",
+				grpcCode: codes.FailedPrecondition,
+			},
+			want: false,
+		},
+		{
+			name: "unrelated error",
+			result: EntryResult{
+				Error:    "ingest session 0: connection reset",
+				grpcCode: codes.Unavailable,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isTimeOverrideRejection(tt.result))
+		})
+	}
+}
+
+// fakeLoomClient stubs the subset of LoomServiceClient the runner touches.
+// Calls to any other method panic via the embedded nil interface.
+type fakeLoomClient struct {
+	loomv1.LoomServiceClient
+
+	mu                 sync.Mutex
+	weaveReqs          []*loomv1.WeaveRequest
+	weaveErr           error
+	deleteAgentCtxErrs []error
+}
+
+func (f *fakeLoomClient) CreateSession(_ context.Context, _ *loomv1.CreateSessionRequest, _ ...grpc.CallOption) (*loomv1.Session, error) {
+	return &loomv1.Session{Id: "sess-fake"}, nil
+}
+
+func (f *fakeLoomClient) DeleteSession(_ context.Context, _ *loomv1.DeleteSessionRequest, _ ...grpc.CallOption) (*loomv1.DeleteSessionResponse, error) {
+	return &loomv1.DeleteSessionResponse{}, nil
+}
+
+func (f *fakeLoomClient) CreateAgentFromConfig(_ context.Context, _ *loomv1.CreateAgentRequest, _ ...grpc.CallOption) (*loomv1.AgentInfo, error) {
+	return &loomv1.AgentInfo{Id: "agent-fake"}, nil
+}
+
+func (f *fakeLoomClient) DeleteAgent(ctx context.Context, _ *loomv1.DeleteAgentRequest, _ ...grpc.CallOption) (*loomv1.DeleteAgentResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deleteAgentCtxErrs = append(f.deleteAgentCtxErrs, ctx.Err())
+	return &loomv1.DeleteAgentResponse{}, nil
+}
+
+func (f *fakeLoomClient) Weave(_ context.Context, in *loomv1.WeaveRequest, _ ...grpc.CallOption) (*loomv1.WeaveResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.weaveReqs = append(f.weaveReqs, in)
+	if f.weaveErr != nil {
+		return nil, f.weaveErr
+	}
+	return &loomv1.WeaveResponse{Text: "answer"}, nil
+}
+
+func (f *fakeLoomClient) snapshotWeaveReqs() []*loomv1.WeaveRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]*loomv1.WeaveRequest(nil), f.weaveReqs...)
+}
+
+func testEntry(qid string) Entry {
+	return Entry{
+		QuestionID:       qid,
+		QuestionType:     "temporal-reasoning",
+		Question:         "When did the trip happen?",
+		QuestionDate:     "2023/05/20 (Sat) 02:21",
+		HaystackDates:    []string{"2023/04/10 (Mon) 17:50"},
+		HaystackSessions: [][]Turn{{{Role: "user", Content: "I went on a trip today."}}},
+	}
+}
+
+func TestRunEntryContextStuffingSendsNoOccurredAt(t *testing.T) {
+	fake := &fakeLoomClient{}
+	r := &Runner{
+		config: RunConfig{Mode: ModeContextStuffing, UseOccurredAt: true},
+		logger: zap.NewNop(),
+		client: fake,
+	}
+
+	result := r.runEntry(context.Background(), testEntry("q-cs"))
+	require.Empty(t, result.Error)
+
+	reqs := fake.snapshotWeaveReqs()
+	require.NotEmpty(t, reqs)
+	for _, req := range reqs {
+		assert.Nil(t, req.OccurredAt, "context-stuffing must never send occurred_at")
+	}
+}
+
+func TestRunEntryIngestSendsOccurredAt(t *testing.T) {
+	fake := &fakeLoomClient{}
+	r := &Runner{
+		config: RunConfig{Mode: ModeIngest, UseOccurredAt: true},
+		logger: zap.NewNop(),
+		client: fake,
+	}
+
+	result := r.runEntry(context.Background(), testEntry("q-ingest"))
+	require.Empty(t, result.Error)
+
+	reqs := fake.snapshotWeaveReqs()
+	require.Len(t, reqs, 2) // one haystack session + the question
+	for _, req := range reqs {
+		require.NotNil(t, req.OccurredAt)
+	}
+}
+
+func TestRunAbortsOnTimeOverrideRejection(t *testing.T) {
+	fake := &fakeLoomClient{
+		weaveErr: status.Error(codes.FailedPrecondition,
+			"occurred_at override is disabled on this server (set server.allow_time_override: true to accept replayed/imported conversations)"),
+	}
+	r := &Runner{
+		config: RunConfig{
+			Mode:          ModeIngest,
+			UseOccurredAt: true,
+			Isolate:       true,
+			Concurrency:   3,
+		},
+		logger:    zap.NewNop(),
+		client:    fake,
+		baseAgent: &loomv1.AgentConfig{Name: "lme-base"},
+	}
+
+	entries := []Entry{testEntry("q1"), testEntry("q2"), testEntry("q3")}
+	resultCh := make(chan EntryResult, len(entries))
+
+	err := r.Run(context.Background(), entries, resultCh)
+	require.Error(t, err, "an aborted run must surface a non-nil error")
+	assert.Contains(t, err.Error(), "allow_time_override")
+
+	// Every entry that created a temp agent must have deleted it on a live
+	// context, even though the abort cancelled the run context.
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	require.NotEmpty(t, fake.deleteAgentCtxErrs)
+	for i, ctxErr := range fake.deleteAgentCtxErrs {
+		assert.NoError(t, ctxErr, "temp-agent cleanup %d ran on a cancelled context", i)
+	}
 }

--- a/cmd/loom-longmemeval/runner_test.go
+++ b/cmd/loom-longmemeval/runner_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build fts5
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildWeaveRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		occurredAt time.Time
+		wantSet    bool
+	}{
+		{
+			name:       "zero time omits occurred_at",
+			occurredAt: time.Time{},
+			wantSet:    false,
+		},
+		{
+			name:       "historical date sets occurred_at",
+			occurredAt: time.Date(2023, 4, 10, 17, 50, 0, 0, time.UTC),
+			wantSet:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := buildWeaveRequest("sess-1", "query", "agent-1", tt.occurredAt)
+			assert.Equal(t, "sess-1", req.SessionId)
+			assert.Equal(t, "query", req.Query)
+			assert.Equal(t, "agent-1", req.AgentId)
+
+			if !tt.wantSet {
+				assert.Nil(t, req.OccurredAt)
+				return
+			}
+			require.NotNil(t, req.OccurredAt)
+			assert.True(t, tt.occurredAt.Equal(req.OccurredAt.AsTime()))
+		})
+	}
+}
+
+func TestBuildWeaveRequestFromDatasetDate(t *testing.T) {
+	// The exact format the LongMemEval dataset uses for haystack/question dates.
+	parsed, err := ParseDate("2023/04/10 (Mon) 17:50")
+	require.NoError(t, err)
+
+	req := buildWeaveRequest("sess-1", "query", "agent-1", parsed)
+	require.NotNil(t, req.OccurredAt)
+	assert.Equal(t, parsed.UTC(), req.OccurredAt.AsTime())
+}
+
+func TestSessionOccurredAt(t *testing.T) {
+	sess := SessionWithDate{
+		Date:     "2023/04/10 (Mon) 17:50",
+		ParsedAt: time.Date(2023, 4, 10, 17, 50, 0, 0, time.UTC),
+	}
+
+	enabled := &Runner{config: RunConfig{UseOccurredAt: true}}
+	assert.True(t, sess.ParsedAt.Equal(enabled.sessionOccurredAt(sess)))
+
+	disabled := &Runner{config: RunConfig{UseOccurredAt: false}}
+	assert.True(t, disabled.sessionOccurredAt(sess).IsZero())
+}

--- a/docs/guides/longmemeval-benchmark.md
+++ b/docs/guides/longmemeval-benchmark.md
@@ -37,9 +37,29 @@ The six question categories are:
 
 - Loom server running (`just build-server && ./bin/looms serve`)
 - An LLM provider configured in `~/.loom/looms.yaml` with judge access (examples in this guide use Bedrock Opus 4.6)
-- `server.allow_time_override: true` in `~/.loom/looms.yaml`. The harness sends each haystack session's date as `WeaveRequest.occurred_at` so extraction anchors memories at the historical date instead of the run day. Without the flag, every entry fails with `FAILED_PRECONDITION` (pass `--occurred-at=false` to run without the override, but expect temporal-reasoning to degrade — memories then anchor to the run date, contradicting the dates inside the replayed conversations)
+- `server.allow_time_override: true` in `~/.loom/looms.yaml`. The harness sends each haystack session's date as `WeaveRequest.occurred_at` so extraction anchors memories at the historical date instead of the run day. Without the flag, every entry fails with `FAILED_PRECONDITION` (pass `--occurred-at=false` to run without the override; memories then anchor to the run date instead of the historical session date. Note: the only A/B measured so far — oracle x30, temporal-reasoning — scored slightly HIGHER with the override off (100% vs 93.3%), because the extractor also reads dates from the conversation text itself; the override's value is mechanism correctness on full haystacks where the text cue may be absent, not a measured accuracy win)
 - Benchmark binary built: `just build-longmemeval`
 - Network access to `huggingface.co` for the one-time dataset download (~285 MB for the oracle set)
+
+## Scoring with the official LongMemEval judge
+
+The official metric comes from `scripts/longmemeval-eval/evaluate_qa.py` (adapted from
+[xiaowu0162/LongMemEval](https://github.com/xiaowu0162/LongMemEval); judge prompts are byte-identical to upstream):
+
+```bash
+pip install -r scripts/longmemeval-eval/requirements.txt
+# judge model backends: gpt-5.1 (OpenAI, OPENAI_API_KEY), azure-gpt
+# (AZURE_OPENAI_ENDPOINT/_API_KEY/_DEPLOYMENT_ID), or
+# claude-opus-4-6-bedrock (AWS default credential chain)
+python3 scripts/longmemeval-eval/evaluate_qa.py claude-opus-4-6-bedrock \
+    results/hypotheses.jsonl data/longmemeval_oracle.json
+```
+
+Known deviation from upstream, disclosed: the judge reply budget is 64 tokens
+(upstream: `max_tokens: 10`); the verdict check is upstream's substring
+`'yes' in response`, so a verbose judge has marginally more room to emit an
+incidental "yes". Kept for parity with the runs published on the PRs; flip a
+single constant in the script to reproduce upstream exactly.
 
 ## Quick Start
 

--- a/docs/guides/longmemeval-benchmark.md
+++ b/docs/guides/longmemeval-benchmark.md
@@ -37,6 +37,7 @@ The six question categories are:
 
 - Loom server running (`just build-server && ./bin/looms serve`)
 - An LLM provider configured in `~/.loom/looms.yaml` with judge access (examples in this guide use Bedrock Opus 4.6)
+- `server.allow_time_override: true` in `~/.loom/looms.yaml`. The harness sends each haystack session's date as `WeaveRequest.occurred_at` so extraction anchors memories at the historical date instead of the run day. Without the flag, every entry fails with `FAILED_PRECONDITION` (pass `--occurred-at=false` to run without the override, but expect temporal-reasoning to degrade — memories then anchor to the run date, contradicting the dates inside the replayed conversations)
 - Benchmark binary built: `just build-longmemeval`
 - Network access to `huggingface.co` for the one-time dataset download (~285 MB for the oracle set)
 
@@ -182,6 +183,7 @@ Additional run flags:
 | Flag | Default | What it does |
 |------|---------|--------------|
 | `--isolate` | `true` | Create a fresh `lme-tmp-<qid>` agent per entry; delete it afterward. Ensures no cross-entry memory bleed. |
+| `--occurred-at` | `true` | Send haystack/question dates as `WeaveRequest.occurred_at` so memories anchor at historical dates. Requires `server.allow_time_override: true` on the server. |
 | `--concurrency` | `3` | Number of entries processed in parallel. Lower to `2` if you see Bedrock throttling. |
 | `--server` | `localhost:60051` | Loom gRPC address. |
 | `--agent` | `""` | Use a specific agent ID instead of cloning the default. |

--- a/docs/guides/longmemeval-benchmark.md
+++ b/docs/guides/longmemeval-benchmark.md
@@ -37,7 +37,7 @@ The six question categories are:
 
 - Loom server running (`just build-server && ./bin/looms serve`)
 - An LLM provider configured in `~/.loom/looms.yaml` with judge access (examples in this guide use Bedrock Opus 4.6)
-- `server.allow_time_override: true` in `~/.loom/looms.yaml`. The harness sends each haystack session's date as `WeaveRequest.occurred_at` so extraction anchors memories at the historical date instead of the run day. Without the flag, every entry fails with `FAILED_PRECONDITION` (pass `--occurred-at=false` to run without the override; memories then anchor to the run date instead of the historical session date. Note: the only A/B measured so far — oracle x30, temporal-reasoning — scored slightly HIGHER with the override off (100% vs 93.3%), because the extractor also reads dates from the conversation text itself; the override's value is mechanism correctness on full haystacks where the text cue may be absent, not a measured accuracy win)
+- `server.allow_time_override: true` in `~/.loom/looms.yaml`. In the memory modes (`ingest`, `multi-session`) the harness sends each haystack session's date as `WeaveRequest.occurred_at` so extraction anchors memories at the historical date instead of the run day; `context-stuffing` never sends it, so the baseline runs on a stock server. Without the flag, every memory-mode entry fails with `FAILED_PRECONDITION` (pass `--occurred-at=false` to run without the override; memories then anchor to the run date instead of the historical session date. Note: the only A/B measured so far — oracle x30, temporal-reasoning — scored slightly HIGHER with the override off (100% vs 93.3%), because the extractor also reads dates from the conversation text itself; the override's value is mechanism correctness on full haystacks where the text cue may be absent, not a measured accuracy win)
 - Benchmark binary built: `just build-longmemeval`
 - Network access to `huggingface.co` for the one-time dataset download (~285 MB for the oracle set)
 
@@ -51,15 +51,16 @@ pip install -r scripts/longmemeval-eval/requirements.txt
 # judge model backends: gpt-5.1 (OpenAI, OPENAI_API_KEY), azure-gpt
 # (AZURE_OPENAI_ENDPOINT/_API_KEY/_DEPLOYMENT_ID), or
 # claude-opus-4-6-bedrock (AWS default credential chain)
-python3 scripts/longmemeval-eval/evaluate_qa.py claude-opus-4-6-bedrock \
-    results/hypotheses.jsonl data/longmemeval_oracle.json
+python3 scripts/longmemeval-eval/evaluate_qa.py \
+    results/hypotheses.jsonl data/longmemeval_oracle.json claude-opus-4-6-bedrock
 ```
 
 Known deviation from upstream, disclosed: the judge reply budget is 64 tokens
 (upstream: `max_tokens: 10`); the verdict check is upstream's substring
 `'yes' in response`, so a verbose judge has marginally more room to emit an
-incidental "yes". Kept for parity with the runs published on the PRs; flip a
-single constant in the script to reproduce upstream exactly.
+incidental "yes". Kept for parity with the runs published on the PRs; flip the
+`JUDGE_MAX_TOKENS` constant at the top of the script to 10 to reproduce
+upstream exactly.
 
 ## Quick Start
 
@@ -203,7 +204,7 @@ Additional run flags:
 | Flag | Default | What it does |
 |------|---------|--------------|
 | `--isolate` | `true` | Create a fresh `lme-tmp-<qid>` agent per entry; delete it afterward. Ensures no cross-entry memory bleed. |
-| `--occurred-at` | `true` | Send haystack/question dates as `WeaveRequest.occurred_at` so memories anchor at historical dates. Requires `server.allow_time_override: true` on the server. |
+| `--occurred-at` | `true` | Send haystack/question dates as `WeaveRequest.occurred_at` so memories anchor at historical dates. Requires `server.allow_time_override: true` on the server. Ignored in `context-stuffing` mode — the no-memory baseline never sends `occurred_at` and runs on a stock server. |
 | `--concurrency` | `3` | Number of entries processed in parallel. Lower to `2` if you see Bedrock throttling. |
 | `--server` | `localhost:60051` | Loom gRPC address. |
 | `--agent` | `""` | Use a specific agent ID instead of cloning the default. |

--- a/scripts/longmemeval-eval/evaluate_qa.py
+++ b/scripts/longmemeval-eval/evaluate_qa.py
@@ -27,6 +27,12 @@ from openai import OpenAI
 import numpy as np
 
 
+# Judge reply budget, shared by every backend. Upstream uses max_tokens=10;
+# flip this single constant to 10 to reproduce upstream exactly (see the
+# module docstring for why 64 is kept here).
+JUDGE_MAX_TOKENS = 64
+
+
 model_zoo = {
     'llama-3.1-70b-instruct': ('meta-llama/Meta-Llama-3.1-70B-Instruct', 'local'),
     'gpt-4o-mini': ('gpt-4o-mini-2024-07-18', 'openai'),
@@ -47,7 +53,7 @@ def bedrock_converse_with_backoff(client, model_id, prompt, max_tries=5):
             resp = client.converse(
                 modelId=model_id,
                 messages=[{'role': 'user', 'content': [{'text': prompt}]}],
-                inferenceConfig={'maxTokens': 64, 'temperature': 0},
+                inferenceConfig={'maxTokens': JUDGE_MAX_TOKENS, 'temperature': 0},
             )
             return resp['output']['message']['content'][0]['text']
         except ClientError as e:
@@ -172,7 +178,7 @@ if __name__ == '__main__':
                     ],
                     'n': 1,
                     'temperature': 0,
-                    'max_completion_tokens': 64
+                    'max_completion_tokens': JUDGE_MAX_TOKENS
                 }
                 completion = chat_completions_with_backoff(metric_client, **kwargs)
                 eval_response = completion.choices[0].message.content.strip()

--- a/scripts/longmemeval-eval/evaluate_qa.py
+++ b/scripts/longmemeval-eval/evaluate_qa.py
@@ -6,6 +6,10 @@ Adapted from https://github.com/xiaowu0162/LongMemEval/blob/main/src/evaluation/
 Changes from upstream:
   - Added gpt-5.1 to model_zoo (gpt-4o retired Feb 2026)
   - Default metric model changed to gpt-5.1
+  - Added 'bedrock' backend (boto3 converse; credentials/region from the AWS
+    default chain, region override via AWS_REGION) and 'azure' backend
+    (AzureOpenAI; needs AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY, and
+    AZURE_OPENAI_DEPLOYMENT_ID). Judge prompts are unchanged from the paper.
 """
 
 import os
@@ -23,7 +27,31 @@ model_zoo = {
     'gpt-4o-mini': ('gpt-4o-mini-2024-07-18', 'openai'),
     'gpt-4o': ('gpt-4o-2024-08-06', 'openai'),
     'gpt-5.1': ('gpt-5.1', 'openai'),
+    'claude-opus-4-6-bedrock': ('global.anthropic.claude-opus-4-6-v1', 'bedrock'),
+    'azure-gpt': (os.getenv('AZURE_OPENAI_DEPLOYMENT_ID', ''), 'azure'),
 }
+
+
+def bedrock_converse_with_backoff(client, model_id, prompt, max_tries=5):
+    import random
+    import time
+    from botocore.exceptions import ClientError
+    retryable = ('ThrottlingException', 'ServiceUnavailableException', 'ModelNotReadyException')
+    for attempt in range(max_tries):
+        try:
+            resp = client.converse(
+                modelId=model_id,
+                messages=[{'role': 'user', 'content': [{'text': prompt}]}],
+                inferenceConfig={'maxTokens': 64, 'temperature': 0},
+            )
+            return resp['output']['message']['content'][0]['text']
+        except ClientError as e:
+            code = e.response.get('Error', {}).get('Code', '')
+            if code in retryable and attempt < max_tries - 1:
+                time.sleep(min(2 ** attempt + random.random(), 30))
+                continue
+            raise
+    raise RuntimeError('bedrock converse retries exhausted')
 
 
 @backoff.on_exception(backoff.expo, (openai.RateLimitError,
@@ -75,18 +103,30 @@ if __name__ == '__main__':
         print('Available:', ', '.join(model_zoo.keys()))
         exit()
     metric_model, metric_model_source = model_zoo[metric_model_short]
+    metric_client = None
+    bedrock_client = None
     if metric_model_source == 'openai':
         openai.organization = os.getenv('OPENAI_ORGANIZATION')
-        openai_api_key = os.getenv('OPENAI_API_KEY')
-        openai_api_base = None
+        metric_client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+    elif metric_model_source == 'azure':
+        from openai import AzureOpenAI
+        endpoint = os.getenv('AZURE_OPENAI_ENDPOINT')
+        if not endpoint or not metric_model:
+            print('azure backend requires AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_DEPLOYMENT_ID')
+            exit(1)
+        metric_client = AzureOpenAI(
+            azure_endpoint=endpoint,
+            api_key=os.getenv('AZURE_OPENAI_API_KEY'),
+            api_version=os.getenv('AZURE_OPENAI_API_VERSION', '2024-10-21'),
+        )
+    elif metric_model_source == 'bedrock':
+        import boto3
+        bedrock_client = boto3.client(
+            'bedrock-runtime',
+            region_name=os.getenv('AWS_REGION', 'us-west-2'),
+        )
     else:
-        openai_api_key = "EMPTY"
-        openai_api_base = "http://localhost:8001/v1"
-
-    metric_client = OpenAI(
-        api_key=openai_api_key,
-        base_url=openai_api_base,
-    )
+        metric_client = OpenAI(api_key="EMPTY", base_url="http://localhost:8001/v1")
 
     try:
         hypotheses = [json.loads(line) for line in open(hyp_file).readlines()]
@@ -115,17 +155,20 @@ if __name__ == '__main__':
             hyp = entry['hypothesis']
 
             prompt = get_anscheck_prompt(qtype, q, ans, hyp, abstention='_abs' in entry['question_id'])
-            kwargs = {
-                'model': metric_model,
-                'messages': [
-                    {"role": "user", "content": prompt}
-                ],
-                'n': 1,
-                'temperature': 0,
-                'max_completion_tokens': 64
-            }
-            completion = chat_completions_with_backoff(metric_client, **kwargs)
-            eval_response = completion.choices[0].message.content.strip()
+            if metric_model_source == 'bedrock':
+                eval_response = bedrock_converse_with_backoff(bedrock_client, metric_model, prompt).strip()
+            else:
+                kwargs = {
+                    'model': metric_model,
+                    'messages': [
+                        {"role": "user", "content": prompt}
+                    ],
+                    'n': 1,
+                    'temperature': 0,
+                    'max_completion_tokens': 64
+                }
+                completion = chat_completions_with_backoff(metric_client, **kwargs)
+                eval_response = completion.choices[0].message.content.strip()
             label = 'yes' in eval_response.lower()
             entry['autoeval_label'] = {
                 'model': metric_model,

--- a/scripts/longmemeval-eval/evaluate_qa.py
+++ b/scripts/longmemeval-eval/evaluate_qa.py
@@ -6,8 +6,13 @@ Adapted from https://github.com/xiaowu0162/LongMemEval/blob/main/src/evaluation/
 Changes from upstream:
   - Added gpt-5.1 to model_zoo (gpt-4o retired Feb 2026)
   - Default metric model changed to gpt-5.1
-  - Added 'bedrock' backend (boto3 converse; credentials/region from the AWS
-    default chain, region override via AWS_REGION) and 'azure' backend
+  - Judge reply budget is 64 tokens (upstream: max_tokens=10). With the
+    upstream substring check ('yes' in response) a verbose judge has more
+    room to emit an incidental "yes"; disclosed here, kept for parity with
+    published runs.
+  - Added 'bedrock' backend (boto3 converse; credentials AND region from the
+    AWS default chain — AWS_REGION/AWS_DEFAULT_REGION/profile — with
+    us-west-2 only as the last-resort default) and 'azure' backend
     (AzureOpenAI; needs AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY, and
     AZURE_OPENAI_DEPLOYMENT_ID). Judge prompts are unchanged from the paper.
 """
@@ -123,7 +128,9 @@ if __name__ == '__main__':
         import boto3
         bedrock_client = boto3.client(
             'bedrock-runtime',
-            region_name=os.getenv('AWS_REGION', 'us-west-2'),
+            # Respect the full default chain (env, profile, SSO); only fall
+            # back to us-west-2 when nothing in the chain names a region.
+            region_name=os.getenv('AWS_REGION') or os.getenv('AWS_DEFAULT_REGION') or boto3.session.Session().region_name or 'us-west-2',
         )
     else:
         metric_client = OpenAI(api_key="EMPTY", base_url="http://localhost:8001/v1")

--- a/scripts/longmemeval-eval/requirements.txt
+++ b/scripts/longmemeval-eval/requirements.txt
@@ -1,0 +1,5 @@
+backoff>=2.2
+boto3>=1.34
+numpy>=1.26
+openai>=1.50
+tqdm>=4.66


### PR DESCRIPTION
## Summary
- Wire `WeaveRequest.occurred_at` (added in #308) into the LongMemEval harness: haystack session dates on ingest Weaves, question date on the question Weave, all three modes. Without this, post-#306 arrival-time anchoring stamps every replayed memory with the run date.
- `--occurred-at` flag (default `true`); server must set `server.allow_time_override: true` (documented in the guide).
- Extend the vendored official scorer with `bedrock` (boto3 converse) and `azure` (AzureOpenAI) judge backends — the paper's judge prompts are unchanged; the judge model is a disclosed parameter. Add `requirements.txt`.

## Validation
- `go test -tags fts5 -race ./cmd/loom-longmemeval/` passes; gofmt clean.
- Fresh temporal-reasoning x30 (oracle, ingest, Bedrock Opus 4.6, post-#306 main): 93.3% on the official metric — no regression vs the April 80% baseline, and anchored runs answer ~6x faster (51s vs ~5min/entry) with far less answer-time tool use.
- A/B with `--occurred-at=false` on the same 30: 100% official metric, confirming the delta is answer-time efficiency, not accuracy, on the oracle set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)