### PR TITLE
fix(server): judge/registry/eval-store wiring no longer requires a provider pool

### DIFF
--- a/cmd/looms/cmd_serve.go
+++ b/cmd/looms/cmd_serve.go
@@ -373,6 +373,53 @@ type judgeServerSetter interface {
 	SetJudgeServer(js *server.JudgeServer)
 }
 
+// registrySubsystemSink is the subset of *agent.Registry that receives the
+// server-level subsystems. Extracted so wireRegistrySubsystems is unit-testable
+// with a spy.
+type registrySubsystemSink interface {
+	SetTaskManager(manager *task.Manager, decomposer *task.Decomposer)
+	SetGraphMemoryStore(store memory.GraphMemoryStore, embedder memory.Embedder)
+	SetSuppressedBuiltinTools(names []string)
+}
+
+// wireRegistrySubsystems injects the server-level subsystems (task manager,
+// graph-memory store, tool-surface policy) into the agent registry so that
+// registry-built agents — gRPC-created, config-hot-reloaded, or benchmark
+// --isolate temp agents — receive them.
+//
+// This MUST run independently of whether a provider pool is configured. These
+// injections previously lived inside the `providerPool != nil` branch of the
+// serve wiring, so a single-provider server silently gave every registry-built
+// agent a nil graph-memory store (no extraction, no cross-session recall), a
+// nil task manager, and no tool-surface policy. The per-agent YAML flags
+// (memory.graph_memory.enabled, memory.task_board.enabled) still gate behavior;
+// these calls only make the subsystems reachable.
+func wireRegistrySubsystems(
+	reg registrySubsystemSink,
+	taskManager *task.Manager,
+	taskDecomposer *task.Decomposer,
+	graphMemoryStore memory.GraphMemoryStore,
+	memoryEmbedder memory.Embedder,
+	suppressed []string,
+	logger *zap.Logger,
+) {
+	if taskManager != nil {
+		reg.SetTaskManager(taskManager, taskDecomposer)
+		logger.Info("Task manager injected into agent registry",
+			zap.Bool("decomposer_present", taskDecomposer != nil))
+	}
+	if graphMemoryStore != nil {
+		reg.SetGraphMemoryStore(graphMemoryStore, memoryEmbedder)
+		logger.Info("Graph memory store injected into agent registry",
+			zap.Bool("embedder_present", memoryEmbedder != nil))
+	}
+	if len(suppressed) > 0 {
+		reg.SetSuppressedBuiltinTools(suppressed)
+		logger.Info("Suppressed builtin tools propagated to agent registry",
+			zap.Strings("tools", suppressed))
+	}
+}
+
 // buildProviderPool constructs a named provider pool from the server configuration.
 // Each entry in cfg.Providers is created by instantiating a per-entry ProviderFactory
 // buildRateLimiterConfig converts the YAML-sourced LLMRateLimitConfig into the
@@ -2373,36 +2420,10 @@ func runServe(cmd *cobra.Command, args []string) {
 			logger.Info("Provider pool injected into agent registry",
 				zap.Int("providers", len(providerPool)))
 		}
-		// Inject the task subsystem so registry-built agents reach Phase D
-		// (skills-overhaul task emission) and the sticky-while-open-tasks
-		// eviction checker. The per-agent memory.task_board.enabled flag
-		// still controls task_board tool surfacing; emission is always-on.
-		if registry != nil && taskManager != nil {
-			registry.SetTaskManager(taskManager, taskDecomposer)
-			logger.Info("Task manager injected into agent registry",
-				zap.Bool("decomposer_present", taskDecomposer != nil))
-		}
-		// Inject the graph memory subsystem so registry-built agents
-		// (gRPC-created or config-hot-reloaded) get the extractor. The
-		// per-agent memory.graph_memory.enabled flag in YAML can still
-		// opt out for a specific agent; the suppressed-tools list below
-		// controls tool surfacing independently.
-		if registry != nil && graphMemoryStore != nil {
-			registry.SetGraphMemoryStore(graphMemoryStore, memoryEmbedder)
-			logger.Info("Graph memory store injected into agent registry",
-				zap.Bool("embedder_present", memoryEmbedder != nil))
-		}
-		// Push the server-level tool-surface policy into the registry so
-		// gRPC-created agents see the same hidden-tools list as the
-		// statically-loaded ones. See builtinToolsToSuppress().
-		if registry != nil {
-			suppressed := builtinToolsToSuppress()
-			if len(suppressed) > 0 {
-				registry.SetSuppressedBuiltinTools(suppressed)
-				logger.Info("Suppressed builtin tools propagated to agent registry",
-					zap.Strings("tools", suppressed))
-			}
-		}
+		// NOTE: the task-manager, graph-memory, and tool-surface registry
+		// injections were moved OUT of this pool-gated branch to an
+		// unconditional block after the if/else — they must run whenever a
+		// registry exists, not only when a provider pool is configured.
 		// Wire the eval store for ABTest result persistence.
 		if ess, ok := interface{}(loomService).(evalStoreSetter); ok {
 			evalDBPath := config.Database.Path
@@ -2425,6 +2446,15 @@ func runServe(cmd *cobra.Command, args []string) {
 			jss.SetJudgeServer(judgeServer)
 			logger.Info("Judge server wired into loom service for ABTest judge_id resolution")
 		}
+	}
+
+	// Inject server subsystems into the agent registry UNCONDITIONALLY (not gated
+	// on a provider pool) so registry-built agents on a single-provider server
+	// still receive the graph-memory store, task manager, and tool-surface
+	// policy. See wireRegistrySubsystems for the regression this guards.
+	if registry != nil {
+		wireRegistrySubsystems(registry, taskManager, taskDecomposer,
+			graphMemoryStore, memoryEmbedder, builtinToolsToSuppress(), logger)
 	}
 
 	// Set agent registry for workflow execution

--- a/cmd/looms/cmd_serve.go
+++ b/cmd/looms/cmd_serve.go
@@ -382,6 +382,18 @@ type registrySubsystemSink interface {
 	SetSuppressedBuiltinTools(names []string)
 }
 
+// resolveJudgeFallback picks the judge's fallback LLM: the pool's active
+// provider when one is configured and names a real pool entry, else the
+// server's default provider — so judge evaluations work identically on
+// pooled and single-provider servers. A misspelled active_provider falls
+// back instead of handing the judge a nil provider.
+func resolveJudgeFallback(pool map[string]agent.LLMProvider, active string, fallback agent.LLMProvider) agent.LLMProvider {
+	if p, ok := pool[active]; ok && p != nil {
+		return p
+	}
+	return fallback
+}
+
 // wireRegistrySubsystems injects the server-level subsystems (task manager,
 // graph-memory store, tool-surface policy) into the agent registry so that
 // registry-built agents — gRPC-created, config-hot-reloaded, or benchmark
@@ -2404,10 +2416,18 @@ func runServe(cmd *cobra.Command, args []string) {
 	logger.Info("Provider factory configured on server for model switching")
 
 	// Wire provider pool from config.
-	if providerPool, err := buildProviderPool(config, providerFactory, logger); err != nil {
+	// The pool is optional: only the two SetProviderPool calls are inherently
+	// pool features. Everything else below runs regardless, so a
+	// single-provider server still gets its eval store and judge (the
+	// regression this hoisting fixes).
+	providerPool, poolErr := buildProviderPool(config, providerFactory, logger)
+	if poolErr != nil {
 		logger.Warn("Failed to build provider pool from config; pool-based features will be unavailable",
-			zap.String("reason", "provider pool configuration error; check LLM provider settings"))
-	} else if providerPool != nil {
+			zap.String("reason", "provider pool configuration error; check LLM provider settings"),
+			zap.Error(poolErr))
+		providerPool = nil
+	}
+	if providerPool != nil {
 		if pps, ok := interface{}(loomService).(providerPoolSetter); ok {
 			pps.SetProviderPool(providerPool, config.ActiveProvider)
 			logger.Info("Provider pool configured on server",
@@ -2420,32 +2440,10 @@ func runServe(cmd *cobra.Command, args []string) {
 			logger.Info("Provider pool injected into agent registry",
 				zap.Int("providers", len(providerPool)))
 		}
-		// NOTE: the task-manager, graph-memory, and tool-surface registry
-		// injections were moved OUT of this pool-gated branch to an
-		// unconditional block after the if/else — they must run whenever a
-		// registry exists, not only when a provider pool is configured.
-		// Wire the eval store for ABTest result persistence.
-		if ess, ok := interface{}(loomService).(evalStoreSetter); ok {
-			evalDBPath := config.Database.Path
-			if evalDBPath == "" {
-				evalDBPath = "./evals.db"
-			}
-			if store, storeErr := evals.NewStore(evalDBPath); storeErr != nil {
-				logger.Warn("Failed to create eval store; ABTest results will not be persisted",
-					zap.Error(storeErr))
-			} else {
-				ess.SetEvalStore(store)
-				logger.Info("Eval store configured for ABTest persistence", zap.String("path", evalDBPath))
-			}
-		}
-		// Wire judgeServer into loomService so ABTest can resolve judge_id.
-		// Provide the active pool provider as the fallback LLM for evaluations.
-		activeProvider := providerPool[config.ActiveProvider]
-		judgeServer.SetProviderPool(providerPool, activeProvider)
-		if jss, ok := interface{}(loomService).(judgeServerSetter); ok {
-			jss.SetJudgeServer(judgeServer)
-			logger.Info("Judge server wired into loom service for ABTest judge_id resolution")
-		}
+		// NOTE: the task-manager, graph-memory, tool-surface, eval-store, and
+		// judge wiring all moved OUT of this pool-gated branch to the
+		// unconditional blocks after it — they must run whenever their
+		// subsystems exist, not only when a provider pool is configured.
 	}
 
 	// Inject server subsystems into the agent registry UNCONDITIONALLY (not gated
@@ -2455,6 +2453,29 @@ func runServe(cmd *cobra.Command, args []string) {
 	if registry != nil {
 		wireRegistrySubsystems(registry, taskManager, taskDecomposer,
 			graphMemoryStore, memoryEmbedder, builtinToolsToSuppress(), logger)
+	}
+
+	// Wire the eval store for ABTest result persistence — pool-independent.
+	if ess, ok := interface{}(loomService).(evalStoreSetter); ok {
+		evalDBPath := config.Database.Path
+		if evalDBPath == "" {
+			evalDBPath = "./evals.db"
+		}
+		if store, storeErr := evals.NewStore(evalDBPath); storeErr != nil {
+			logger.Warn("Failed to create eval store; ABTest results will not be persisted",
+				zap.Error(storeErr))
+		} else {
+			ess.SetEvalStore(store)
+			logger.Info("Eval store configured for ABTest persistence", zap.String("path", evalDBPath))
+		}
+	}
+	// Wire judgeServer into loomService so ABTest can resolve judge_id —
+	// pool-independent: without a pool the server's default provider judges,
+	// so single-provider servers get working evaluations too.
+	judgeServer.SetProviderPool(providerPool, resolveJudgeFallback(providerPool, config.ActiveProvider, llmProvider))
+	if jss, ok := interface{}(loomService).(judgeServerSetter); ok {
+		jss.SetJudgeServer(judgeServer)
+		logger.Info("Judge server wired into loom service for ABTest judge_id resolution")
 	}
 
 	// Set agent registry for workflow execution

--- a/cmd/looms/judge_wiring_test.go
+++ b/cmd/looms/judge_wiring_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/teradata-labs/loom/pkg/agent"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+	"github.com/teradata-labs/loom/pkg/types"
+)
+
+// fakeJudgeLLM is the minimal types.LLMProvider for identity assertions.
+type fakeJudgeLLM struct{ name string }
+
+func (f *fakeJudgeLLM) Chat(context.Context, []types.Message, []shuttle.Tool) (*types.LLMResponse, error) {
+	return nil, nil
+}
+func (f *fakeJudgeLLM) Name() string  { return f.name }
+func (f *fakeJudgeLLM) Model() string { return "fake" }
+
+// TestResolveJudgeFallback is the regression guard for judge wiring on
+// single-provider servers: the judge's fallback LLM must resolve without any
+// provider pool, and a misconfigured active_provider must fall back to the
+// server default instead of handing the judge a nil provider.
+func TestResolveJudgeFallback(t *testing.T) {
+	def := &fakeJudgeLLM{name: "default"}
+	pooled := &fakeJudgeLLM{name: "pooled"}
+
+	t.Run("no pool at all → server default", func(t *testing.T) {
+		assert.Same(t, agent.LLMProvider(def), resolveJudgeFallback(nil, "anthropic", def))
+	})
+	t.Run("pool hit → active pool provider", func(t *testing.T) {
+		pool := map[string]agent.LLMProvider{"anthropic": pooled}
+		assert.Same(t, agent.LLMProvider(pooled), resolveJudgeFallback(pool, "anthropic", def))
+	})
+	t.Run("misspelled active_provider → server default, never nil", func(t *testing.T) {
+		pool := map[string]agent.LLMProvider{"anthropic": pooled}
+		got := resolveJudgeFallback(pool, "antropic", def)
+		assert.Same(t, agent.LLMProvider(def), got)
+		assert.NotNil(t, got)
+	})
+	t.Run("pool entry explicitly nil → server default", func(t *testing.T) {
+		pool := map[string]agent.LLMProvider{"anthropic": nil}
+		assert.Same(t, agent.LLMProvider(def), resolveJudgeFallback(pool, "anthropic", def))
+	})
+}

--- a/cmd/looms/registry_subsystems_test.go
+++ b/cmd/looms/registry_subsystems_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/teradata-labs/loom/pkg/memory"
+	"github.com/teradata-labs/loom/pkg/task"
+)
+
+// spyRegistrySink records which subsystem setters were invoked.
+type spyRegistrySink struct {
+	taskManagerSet bool
+	graphStoreSet  bool
+	suppressedSet  []string
+}
+
+func (s *spyRegistrySink) SetTaskManager(*task.Manager, *task.Decomposer) { s.taskManagerSet = true }
+func (s *spyRegistrySink) SetGraphMemoryStore(memory.GraphMemoryStore, memory.Embedder) {
+	s.graphStoreSet = true
+}
+func (s *spyRegistrySink) SetSuppressedBuiltinTools(names []string) { s.suppressedSet = names }
+
+// stubGraphStore is a non-nil memory.GraphMemoryStore whose methods are never
+// invoked here (the helper only checks for nil). Embedding the interface
+// satisfies all ~29 methods without hand-stubbing them.
+type stubGraphStore struct{ memory.GraphMemoryStore }
+
+// TestWireRegistrySubsystems is the regression guard for the single-provider
+// nil-graph-store bug: the registry subsystem injections must run whenever the
+// subsystems are present, with no dependence on a provider pool. This helper
+// has no pool parameter at all — that is the point. Previously these calls were
+// nested inside `providerPool != nil`, so a single-provider server left every
+// registry-built agent (including benchmark --isolate temp agents) with a nil
+// graph-memory store, disabling extraction and cross-session recall.
+func TestWireRegistrySubsystems(t *testing.T) {
+	t.Run("present subsystems are all wired (no pool involved)", func(t *testing.T) {
+		spy := &spyRegistrySink{}
+		// Non-nil task manager and graph store; a nil provider pool is not even
+		// expressible here because the helper takes none.
+		tm := &task.Manager{}
+		gm := memory.GraphMemoryStore(&stubGraphStore{})
+		wireRegistrySubsystems(spy, tm, nil, gm, nil, []string{"graph_memory", "task_board"}, zap.NewNop())
+
+		assert.True(t, spy.taskManagerSet, "task manager must be injected")
+		assert.True(t, spy.graphStoreSet, "graph memory store must be injected")
+		assert.Equal(t, []string{"graph_memory", "task_board"}, spy.suppressedSet,
+			"tool-surface policy must be propagated")
+	})
+
+	t.Run("nil subsystems are skipped, empty suppression is a no-op", func(t *testing.T) {
+		spy := &spyRegistrySink{}
+		wireRegistrySubsystems(spy, nil, nil, nil, nil, nil, zap.NewNop())
+
+		assert.False(t, spy.taskManagerSet, "nil task manager must not be injected")
+		assert.False(t, spy.graphStoreSet, "nil graph store must not be injected")
+		assert.Nil(t, spy.suppressedSet, "empty suppression list must not call the setter")
+	})
+}


### PR DESCRIPTION
## Summary
`cmd_serve.go` gated judge wiring — plus registry task-manager, graph-memory, suppressed-tools, and eval-store injection — inside `if providerPool != nil` (introduced with #100's pool refactor; later PRs appended more wiring inside the gate). Servers configured with only the standard `llm:` block get `FAILED_PRECONDITION: no LLM provider available for evaluation` on every judge call, and registry-built agents silently miss the task/graph-memory/eval subsystems.

This hoists the non-pool-specific wiring out of the gate. The judge falls back to the server's default provider when no `providers:` pool exists; the active pool provider still wins when configured.

## How found
LongMemEval scoring (`loom-longmemeval score`) failed with the FAILED_PRECONDITION above on a single-provider (Bedrock-only) server. April's benchmark runs predate the gating, which is why this wasn't seen earlier.

## Validation
- `go test -tags fts5 -race ./cmd/looms/` passes; gofmt clean.
- On a single-provider server: startup now logs "Judge server wired into loom service"; `score` over a 30-entry result set completes with zero judge errors (previously 30/30 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)