### PR TITLE
feat(longmemeval): AKS rig for the full 500-question LongMemEval_S run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,16 @@ jobs:
         with:
           version: v2.9.0
 
+      # The only regression tests for a runner that spends real Bedrock money
+      # on multi-day runs. STRICT so a missing jq/pyyaml fails the job instead
+      # of printing SKIP and going green.
+      - name: LongMemEval rig regression tests
+        env:
+          LME_RIG_STRICT: "1"
+        run: |
+          bash deploy/longmemeval/render-test.sh
+          bash deploy/longmemeval/slice-loop-test.sh
+
   # ============================================================================
   # Job 3: Unit Tests with Race Detection
   # ============================================================================

--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,7 @@ generate-weaver
 # LongMemEval benchmark downloaded dataset (~285MB, fetched by
 # `loom-longmemeval download`). Not for source control.
 /data/longmemeval/
+
+# Local operator overrides for the LongMemEval rig (may hold model, cluster,
+# or credential values). The generic .env rules do not match this name.
+lme.env.local

--- a/Justfile
+++ b/Justfile
@@ -407,6 +407,12 @@ dev-full: build-server
 interop:
     go test -tags "fts5 interop" -race -run Interop ./pkg/mcp/conformance/
 
+# Offline regression tests for the LongMemEval AKS rig (no cluster, no spend)
+lme-rig-test:
+    @echo "Testing the LongMemEval rig..."
+    LME_RIG_STRICT=1 bash deploy/longmemeval/render-test.sh
+    LME_RIG_STRICT=1 bash deploy/longmemeval/slice-loop-test.sh
+
 check: proto-lint proto-format-check proto-gen-check generate-weaver fmt-check vet lint test build security interop
     @echo "✅ All checks passed! (matches GitHub CI)"
 

--- a/cmd/loom-longmemeval/info_test.go
+++ b/cmd/loom-longmemeval/info_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build fts5
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func statsFixture() []Entry {
+	turn := []Turn{{Role: "user", Content: "hi"}, {Role: "assistant", Content: "hello"}}
+	return []Entry{
+		{QuestionID: "q1", QuestionType: "temporal-reasoning", HaystackSessions: [][]Turn{turn, turn}},
+		{QuestionID: "q2", QuestionType: "temporal-reasoning", HaystackSessions: [][]Turn{turn}},
+		{QuestionID: "q3", QuestionType: "multi-session", HaystackSessions: [][]Turn{turn}},
+		{QuestionID: "q4", QuestionType: "knowledge-update"},
+	}
+}
+
+func TestComputeDatasetStats(t *testing.T) {
+	stats := ComputeDatasetStats("/data/lme.json", statsFixture())
+
+	assert.Equal(t, "/data/lme.json", stats.Dataset)
+	assert.Equal(t, 4, stats.Entries)
+	assert.Equal(t, 4, stats.TotalSessions)
+	assert.Equal(t, 8, stats.TotalTurns)
+
+	// Ordering follows QuestionTypes() (sorted), so the slice loop that
+	// consumes this iterates deterministically across invocations.
+	assert.Equal(t, []DatasetTypeCount{
+		{Type: "knowledge-update", Count: 1},
+		{Type: "multi-session", Count: 1},
+		{Type: "temporal-reasoning", Count: 2},
+	}, stats.QuestionTypes)
+}
+
+// The per-type counts must sum to the entry count: the slice loop walks each
+// type to its count, so an under-count would silently omit questions from a
+// published number and an over-count would run the harness past its last entry.
+func TestComputeDatasetStats_CountsCoverEveryEntry(t *testing.T) {
+	stats := ComputeDatasetStats("d.json", statsFixture())
+
+	total := 0
+	for _, tc := range stats.QuestionTypes {
+		assert.NotEmpty(t, tc.Type)
+		assert.Positive(t, tc.Count)
+		total += tc.Count
+	}
+	assert.Equal(t, stats.Entries, total)
+}
+
+func TestComputeDatasetStats_Empty(t *testing.T) {
+	stats := ComputeDatasetStats("empty.json", nil)
+
+	assert.Equal(t, 0, stats.Entries)
+	assert.Empty(t, stats.QuestionTypes)
+	// Marshals as [] rather than null, so `jq '.question_types[]'` on an
+	// empty dataset yields no rows instead of erroring.
+	blob, err := json.Marshal(stats)
+	require.NoError(t, err)
+	assert.Contains(t, string(blob), `"question_types":[]`)
+}
+
+// ratio must not emit NaN/Inf into the human-readable output for a dataset
+// with no entries or no sessions.
+func TestRatio(t *testing.T) {
+	assert.Equal(t, "2.0", ratio(4, 2))
+	assert.Equal(t, "n/a", ratio(4, 0))
+	assert.Equal(t, "n/a", ratio(0, 0))
+}
+
+// The JSON emitted by `info --json` is what the AKS slice loop parses with
+// jq, so pin the field names and the shape end-to-end.
+func TestInfoCmd_JSONOutput(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dataset.json")
+	blob, err := json.Marshal(statsFixture())
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, blob, 0o600))
+
+	cmd := infoCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{path, "--json"})
+	require.NoError(t, cmd.Execute())
+
+	var got DatasetStats
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+
+	assert.Equal(t, path, got.Dataset)
+	assert.Equal(t, 4, got.Entries)
+	assert.Equal(t, 4, got.TotalSessions)
+	assert.Equal(t, 8, got.TotalTurns)
+	assert.Equal(t, []DatasetTypeCount{
+		{Type: "knowledge-update", Count: 1},
+		{Type: "multi-session", Count: 1},
+		{Type: "temporal-reasoning", Count: 2},
+	}, got.QuestionTypes)
+}

--- a/cmd/loom-longmemeval/main.go
+++ b/cmd/loom-longmemeval/main.go
@@ -249,8 +249,54 @@ PASS/PARTIAL/FAIL verdicts with scores and explanations.`,
 	return cmd
 }
 
+// DatasetTypeCount is one question type and how many entries carry it.
+type DatasetTypeCount struct {
+	Type  string `json:"type"`
+	Count int    `json:"count"`
+}
+
+// DatasetStats is the machine-readable form of `info`. The AKS slice loop
+// (deploy/longmemeval/runner-script.yaml) derives its per-type chunk counts
+// from this instead of hardcoding them, so a dataset revision that shifts a
+// count cannot silently drive the loop past the last entry (a hard error) or
+// stop it early and omit questions from a published number.
+//
+// QuestionTypes is ordered by QuestionTypes(), so consumers iterate
+// deterministically.
+type DatasetStats struct {
+	Dataset       string             `json:"dataset"`
+	Entries       int                `json:"entries"`
+	QuestionTypes []DatasetTypeCount `json:"question_types"`
+	TotalSessions int                `json:"total_sessions"`
+	TotalTurns    int                `json:"total_turns"`
+}
+
+// ComputeDatasetStats summarizes a loaded dataset.
+func ComputeDatasetStats(path string, entries []Entry) DatasetStats {
+	stats := DatasetStats{
+		Dataset:       path,
+		Entries:       len(entries),
+		QuestionTypes: []DatasetTypeCount{},
+	}
+
+	typeCounts := make(map[string]int)
+	for _, e := range entries {
+		typeCounts[e.QuestionType]++
+		stats.TotalSessions += len(e.HaystackSessions)
+		for _, s := range e.HaystackSessions {
+			stats.TotalTurns += len(s)
+		}
+	}
+	for _, t := range QuestionTypes(entries) {
+		stats.QuestionTypes = append(stats.QuestionTypes, DatasetTypeCount{Type: t, Count: typeCounts[t]})
+	}
+	return stats
+}
+
 func infoCmd() *cobra.Command {
-	return &cobra.Command{
+	var asJSON bool
+
+	cmd := &cobra.Command{
 		Use:   "info [dataset-path]",
 		Short: "Show dataset statistics",
 		Args:  cobra.MaximumNArgs(1),
@@ -264,38 +310,43 @@ func infoCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			stats := ComputeDatasetStats(path, entries)
 
-			fmt.Printf("Dataset:  %s\n", path)
-			fmt.Printf("Entries:  %d\n", len(entries))
+			if asJSON {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(stats)
+			}
+
+			fmt.Printf("Dataset:  %s\n", stats.Dataset)
+			fmt.Printf("Entries:  %d\n", stats.Entries)
 			fmt.Println()
 
-			types := QuestionTypes(entries)
-			typeCounts := make(map[string]int)
-			for _, e := range entries {
-				typeCounts[e.QuestionType]++
-			}
-
 			fmt.Println("Question Types:")
-			for _, t := range types {
-				fmt.Printf("  %-30s %d\n", t, typeCounts[t])
+			for _, tc := range stats.QuestionTypes {
+				fmt.Printf("  %-30s %d\n", tc.Type, tc.Count)
 			}
 
-			// Session stats
-			var totalSessions, totalTurns int
-			for _, e := range entries {
-				totalSessions += len(e.HaystackSessions)
-				for _, s := range e.HaystackSessions {
-					totalTurns += len(s)
-				}
-			}
-			fmt.Printf("\nTotal sessions: %d (avg %.1f/entry)\n",
-				totalSessions, float64(totalSessions)/float64(len(entries)))
-			fmt.Printf("Total turns:    %d (avg %.1f/session)\n",
-				totalTurns, float64(totalTurns)/float64(totalSessions))
+			fmt.Printf("\nTotal sessions: %d (avg %s/entry)\n",
+				stats.TotalSessions, ratio(stats.TotalSessions, stats.Entries))
+			fmt.Printf("Total turns:    %d (avg %s/session)\n",
+				stats.TotalTurns, ratio(stats.TotalTurns, stats.TotalSessions))
 
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit statistics as JSON (used by the AKS slice loop to derive per-type counts)")
+	return cmd
+}
+
+// ratio formats an average, reporting "n/a" rather than NaN when the
+// denominator is zero (an empty or session-less dataset).
+func ratio(num, denom int) string {
+	if denom == 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.1f", float64(num)/float64(denom))
 }
 
 func runBenchmark(cmd *cobra.Command, args []string) error {

--- a/deploy/longmemeval/Dockerfile
+++ b/deploy/longmemeval/Dockerfile
@@ -1,0 +1,31 @@
+# Builds the real loom server + LongMemEval harness for the AKS rig.
+# Unlike deploy/Dockerfile (mock-LLM bench, CGO off), these binaries need
+# CGO for sqlite FTS5, so the build stage is debian-based and the runtime
+# keeps glibc + bash (the runner job is a shell slice-loop).
+FROM golang:1.26-bookworm AS builder
+
+ARG GIT_COMMIT=unknown
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=1 GOOS=linux go build -tags fts5 \
+    -ldflags="-s -w -X main.gitCommit=${GIT_COMMIT}" \
+    -o /looms ./cmd/looms
+
+RUN CGO_ENABLED=1 GOOS=linux go build -tags fts5 \
+    -ldflags="-s -w -X main.gitCommit=${GIT_COMMIT}" \
+    -o /loom-longmemeval ./cmd/loom-longmemeval
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /looms /looms
+COPY --from=builder /loom-longmemeval /loom-longmemeval

--- a/deploy/longmemeval/Dockerfile
+++ b/deploy/longmemeval/Dockerfile
@@ -23,8 +23,9 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags fts5 \
 
 FROM debian:bookworm-slim
 
+# jq is required by the runner's chunk validation (deploy/longmemeval/runner-script.yaml)
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates \
+    && apt-get install -y --no-install-recommends ca-certificates jq \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /looms /looms

--- a/deploy/longmemeval/README.md
+++ b/deploy/longmemeval/README.md
@@ -1,0 +1,107 @@
+# LongMemEval on AKS
+
+Runs the full LongMemEval benchmark (500 questions, `LongMemEval_S`) against a
+real Loom server + Bedrock on Azure Kubernetes Service. Modeled on
+`deploy/benchmark/` (the mock-LLM load-test rig), with the differences a real-LLM,
+multi-day run requires: small nodes, real credentials, resumable chunked execution,
+and results that survive pod restarts.
+
+**Why not a laptop:** a multi-day run dies on sleep/network blips. This rig's
+runner is a k8s Job that resumes at chunk granularity after any interruption.
+
+## Quick start
+
+```bash
+# 1. One-time: create the small cluster (~$0.55/hr; scale-down when idle)
+bash deploy/longmemeval/setup-cluster.sh
+
+# 2. Launch (builds the image in ACR, deploys server, starts the runner job)
+LME_BEDROCK_BEARER_TOKEN=ABSK... bash deploy/longmemeval/run-500.sh
+
+# 3. Watch
+kubectl logs -f job/lme-runner -n loom-lme
+
+# 4. Snapshot or collect results (works mid-run)
+bash deploy/longmemeval/pull-results.sh
+
+# 5. When finished
+bash deploy/longmemeval/scale-down.sh
+```
+
+Configuration lives in `lme.env` (override with `lme.env.local`): dataset variant,
+run mode, concurrency, chunk size, VM sizes.
+
+## Architecture
+
+```
+          AKS loom-lme-aks (D8s_v5 workload pool)
+   ┌───────────────┐        ┌─────────────────────────┐
+   │ lme-server     │◄─gRPC──┤ lme-runner (Job)         │
+   │ (looms, fts5,  │        │ chunked slice loop,      │
+   │  graph memory) │        │ resume via results PVC   │
+   └───────┬───────┘        └───────────┬─────────────┘
+           │ HTTPS                       │
+           ▼                             ▼
+   AWS Bedrock (Opus 4.6)     PVCs: lme-results (RWX, KEEP),
+                                    lme-data (dataset cache)
+```
+
+- **Auth:** a Bedrock API key (`ABSK...`) in the `lme-bedrock` Secret, injected as
+  `LOOM_LLM_BEDROCK_BEARER_TOKEN`. Loom's Bedrock client uses bearer auth only when
+  configured explicitly (ambient `AWS_BEARER_TOKEN_BEDROCK` is deliberately ignored).
+- **Time anchoring:** the server config sets `server.allow_time_override: true`; the
+  runner passes `--occurred-at=true` so replayed conversations anchor at their
+  historical dates (see `docs/guides/longmemeval-benchmark.md`).
+- **Resume:** the runner writes one output pair per `(type, offset)` chunk. On any
+  restart it skips chunks whose `.jsonl` exists. Failed chunks are cleaned and retried
+  by the Job's backoff. Individual errored entries *inside* a completed chunk are
+  visible in the `-detailed.json` (non-empty `error` field); repair them with a
+  targeted `--offset/--limit` run against the same output naming.
+
+## Time and cost — read before launching
+
+The run is LLM-bound; wall-clock scales with Bedrock quota, not node size.
+Observed on the 2026-08 pilot (multi-session mode, `_S` set, Opus 4.6):
+~60 min/entry serial, so:
+
+| Concurrency | Est. wall-clock (500 q, multi-session) |
+|---|---|
+| 6 (default) | ~3.5 days |
+| 10 | ~2 days |
+| 16 | ~1.3 days (watch for throttling) |
+
+LLM spend is the dominant cost — expect **high hundreds to low thousands USD**
+for the full 500 in multi-session mode (measure on a small chunk first; the
+pilot slices are the calibration data). Cluster cost is noise by comparison
+(~$0.55/hr active). `ingest` mode is cheaper and faster but is a weaker claim
+than multi-session for a memory system.
+
+Raise `LME_CONCURRENCY` only alongside your Bedrock TPM/RPM quota; the harness
+retries transient throttles but sustained 429s stall entries.
+
+## Scoring
+
+Scoring runs **off-cluster** on pulled results (raw LongMemEval-compatible JSONL):
+
+```bash
+bash deploy/longmemeval/pull-results.sh ./results/s500
+cat ./results/s500/results/s500-*.jsonl > ./results/s500/s500-all.jsonl
+
+# Official evaluator (paper prompts). Judge model is a disclosed parameter:
+#   gpt-5.1 (needs OPENAI_API_KEY)  | azure-gpt (needs AZURE_OPENAI_* env)
+#   claude-opus-4-6-bedrock (same-family judge — internal use, disclose if published)
+python scripts/longmemeval-eval/evaluate_qa.py \
+    ./results/s500/s500-all.jsonl data/longmemeval/longmemeval_s_cleaned.json gpt-5.1
+python scripts/longmemeval-eval/print_qa_metrics.py \
+    ./results/s500/s500-all.jsonl.eval-results-gpt-5.1 \
+    data/longmemeval/longmemeval_s_cleaned.json
+```
+
+For a public claim, report: dataset variant (`_S`), all 500 questions including
+the 30 abstention questions, mode, model, judge model, commit, and raw results.
+
+## Teardown
+
+`teardown-cluster.sh` destroys the results PVC with the cluster — it refuses to
+run until you confirm results are pulled (`LME_CONFIRM_RESULTS_PULLED=1`).
+Prefer `scale-down.sh` between runs.

--- a/deploy/longmemeval/README.md
+++ b/deploy/longmemeval/README.md
@@ -29,7 +29,11 @@ bash deploy/longmemeval/scale-down.sh
 ```
 
 Configuration lives in `lme.env` (override with `lme.env.local`): dataset variant,
-run mode, concurrency, chunk size, VM sizes.
+run mode, concurrency, chunk size, VM sizes, namespace, port, model. Every
+manifest is a template rendered by `run-500.sh` (allowlisted `envsubst` via
+`render-common.sh`), so overrides apply consistently across the namespace,
+server, service, config, and runner job. `bash deploy/longmemeval/render-test.sh`
+renders everything with nondefault values and asserts the manifests agree.
 
 ## Architecture
 
@@ -52,11 +56,23 @@ run mode, concurrency, chunk size, VM sizes.
 - **Time anchoring:** the server config sets `server.allow_time_override: true`; the
   runner passes `--occurred-at=true` so replayed conversations anchor at their
   historical dates (see `docs/guides/longmemeval-benchmark.md`).
-- **Resume:** the runner writes one output pair per `(type, offset)` chunk. On any
-  restart it skips chunks whose `.jsonl` exists. Failed chunks are cleaned and retried
-  by the Job's backoff. Individual errored entries *inside* a completed chunk are
-  visible in the `-detailed.json` (non-empty `error` field); repair them with a
-  targeted `--offset/--limit` run against the same output naming.
+- **Run identity:** `run-500.sh` derives a run id from a manifest of everything
+  that determines what the benchmark measures (dataset, mode, occurred_at, model,
+  pinned image tag, chunk size). Chunk outputs live under
+  `/results/runs/<run-id>/`, and the runner verifies the stored `manifest.txt`
+  before resuming — a changed configuration gets a fresh run directory instead of
+  silently reusing chunks. To knowingly continue a run after e.g. an image
+  rebuild: `LME_RUN_ID=<id> LME_ALLOW_MANIFEST_DRIFT=1` (drift is logged to the
+  run's `manifest-drift.log`; nothing is ever deleted). Workload images are
+  pinned to the immutable commit tag the build pushes, never `:latest`.
+- **Resume:** the runner writes each `(type, offset)` chunk to `*.tmp`, validates
+  it (exact entry count, every line parses as JSON, zero errored entries in the
+  `-detailed.json`), promotes it with an atomic rename, and only then writes a
+  `.done` marker. The marker — not file nonemptiness — is the resume signal, so a
+  killed or partial chunk is always redone. A failed attempt removes only its own
+  unpromoted `.tmp` files; promoted results are never deleted. Individual errored
+  entries can no longer hide inside a "completed" chunk — validation rejects them
+  and the Job's backoff retries the chunk.
 
 ## Time and cost — read before launching
 
@@ -85,7 +101,8 @@ Scoring runs **off-cluster** on pulled results (raw LongMemEval-compatible JSONL
 
 ```bash
 bash deploy/longmemeval/pull-results.sh ./results/s500
-cat ./results/s500/results/s500-*.jsonl > ./results/s500/s500-all.jsonl
+# Chunks live under runs/<run-id>/ — concatenate ONE run, don't mix runs:
+cat ./results/s500/results/runs/<run-id>/s500-*.jsonl > ./results/s500/s500-all.jsonl
 
 # Official evaluator (paper prompts). Judge model is a disclosed parameter:
 #   gpt-5.1 (needs OPENAI_API_KEY)  | azure-gpt (needs AZURE_OPENAI_* env)

--- a/deploy/longmemeval/README.md
+++ b/deploy/longmemeval/README.md
@@ -37,16 +37,20 @@ server, service, config, and runner job.
 Two offline tests cover the rig itself (no cluster, no Bedrock, no spend):
 
 ```bash
-bash deploy/longmemeval/render-test.sh      # manifests agree on nondefault values
-bash deploy/longmemeval/slice-loop-test.sh  # drives the real slice loop with a stub harness
+just lme-rig-test   # both, in strict mode — what CI runs
 ```
+
+CI runs these on every PR (`LME_RIG_STRICT=1`, so a missing prerequisite fails
+rather than printing SKIP and going green).
 
 `slice-loop-test.sh` extracts the runner script from the rendered ConfigMap and
 runs it against a synthetic dataset, asserting the behaviours a paid multi-day
 run depends on: counts derived from the dataset, resume skipping only completed
 chunks, a deterministically-failing entry quarantining its chunk instead of
-re-billing the run, rejected output preserved outside the scorer's glob, and a
-revised dataset refused on resume.
+re-billing the run, rejected output preserved outside the scorer's glob, a
+failed results-volume write stopping the run instead of reporting success, the
+incomplete-run sentinel clearing once every chunk completes, and a revised
+dataset refused on resume.
 
 ## Architecture
 
@@ -84,7 +88,10 @@ revised dataset refused on resume.
   `:latest`. `az acr build` uploads the working tree rather than the commit, so
   a dirty tree is tagged `<commit>-dirty-<fingerprint>` and gets its own run id
   — a build with uncommitted edits can never resume a clean commit's chunks
-  under the same name. `run-500.sh` warns when it does this.
+  under the same name. `run-500.sh` warns when it does this. Because ACR tags
+  are mutable, the run identity also records the image's immutable **digest**,
+  and both workloads pull with `imagePullPolicy: Always`, so a rebuilt or
+  retagged image yields a new run id instead of quietly serving a resume.
 - **Per-type counts:** the slice loop derives them from
   `loom-longmemeval info --json` on the dataset it is about to run, so a dataset
   revision cannot silently drive the final chunk past the last entry or stop the
@@ -104,7 +111,11 @@ revised dataset refused on resume.
   that question's text, say) would otherwise re-bill its ~9 healthy neighbours on
   every one of the Job's restarts and still never complete. Each chunk gets
   `LME_MAX_CHUNK_ATTEMPTS` tries (default 3), counted on the PVC so the budget
-  spans pod restarts. Past that the chunk is quarantined with a `.failed` marker
+  spans pod restarts. Only *deterministic* failures count — a chunk that ran
+  and produced output failing validation. A harness that could not run at all
+  (provider outage, server restart, transport error) says nothing about the
+  chunk's entries, so it leaves the budget untouched and is bounded by the
+  Job's `backoffLimit` instead. Past that the chunk is quarantined with a `.failed` marker
   naming the failing entries and how to retry it (`rm` the marker), and later
   passes skip it so the remaining chunks can finish. A quarantined chunk never
   turns a partial run into a passing one: the run exits nonzero and writes

--- a/deploy/longmemeval/README.md
+++ b/deploy/longmemeval/README.md
@@ -32,8 +32,21 @@ Configuration lives in `lme.env` (override with `lme.env.local`): dataset varian
 run mode, concurrency, chunk size, VM sizes, namespace, port, model. Every
 manifest is a template rendered by `run-500.sh` (allowlisted `envsubst` via
 `render-common.sh`), so overrides apply consistently across the namespace,
-server, service, config, and runner job. `bash deploy/longmemeval/render-test.sh`
-renders everything with nondefault values and asserts the manifests agree.
+server, service, config, and runner job.
+
+Two offline tests cover the rig itself (no cluster, no Bedrock, no spend):
+
+```bash
+bash deploy/longmemeval/render-test.sh      # manifests agree on nondefault values
+bash deploy/longmemeval/slice-loop-test.sh  # drives the real slice loop with a stub harness
+```
+
+`slice-loop-test.sh` extracts the runner script from the rendered ConfigMap and
+runs it against a synthetic dataset, asserting the behaviours a paid multi-day
+run depends on: counts derived from the dataset, resume skipping only completed
+chunks, a deterministically-failing entry quarantining its chunk instead of
+re-billing the run, rejected output preserved outside the scorer's glob, and a
+revised dataset refused on resume.
 
 ## Architecture
 
@@ -63,16 +76,41 @@ renders everything with nondefault values and asserts the manifests agree.
   before resuming — a changed configuration gets a fresh run directory instead of
   silently reusing chunks. To knowingly continue a run after e.g. an image
   rebuild: `LME_RUN_ID=<id> LME_ALLOW_MANIFEST_DRIFT=1` (drift is logged to the
-  run's `manifest-drift.log`; nothing is ever deleted). Workload images are
-  pinned to the immutable commit tag the build pushes, never `:latest`.
+  run's `manifest-drift.log`; nothing is ever deleted). The runner also pins the
+  dataset's own statistics (entry count and per-type counts) in
+  `dataset-stats.json`, so a dataset revised underneath a resume is refused
+  rather than mixed with chunks that answered different questions.
+- **Build identity:** workloads are pinned to the tag the build pushes, never
+  `:latest`. `az acr build` uploads the working tree rather than the commit, so
+  a dirty tree is tagged `<commit>-dirty-<fingerprint>` and gets its own run id
+  — a build with uncommitted edits can never resume a clean commit's chunks
+  under the same name. `run-500.sh` warns when it does this.
+- **Per-type counts:** the slice loop derives them from
+  `loom-longmemeval info --json` on the dataset it is about to run, so a dataset
+  revision cannot silently drive the final chunk past the last entry or stop the
+  loop early and omit questions from a published number.
 - **Resume:** the runner writes each `(type, offset)` chunk to `*.tmp`, validates
   it (exact entry count, every line parses as JSON, zero errored entries in the
   `-detailed.json`), promotes it with an atomic rename, and only then writes a
   `.done` marker. The marker — not file nonemptiness — is the resume signal, so a
-  killed or partial chunk is always redone. A failed attempt removes only its own
-  unpromoted `.tmp` files; promoted results are never deleted. Individual errored
-  entries can no longer hide inside a "completed" chunk — validation rejects them
-  and the Job's backoff retries the chunk.
+  killed or partial chunk is always redone. Promoted results are never deleted,
+  and a rejected attempt's output is moved to `runs/<run-id>/rejected/` (outside
+  the `s500-*.jsonl` glob the scorer reads) rather than discarded — it cost real
+  spend and names the entries that failed. Individual errored entries can no
+  longer hide inside a "completed" chunk: validation rejects them and the Job's
+  backoff retries the chunk.
+- **Attempt budget:** validation is all-or-nothing but resume granularity is the
+  whole chunk, so an entry that fails *deterministically* (a content filter on
+  that question's text, say) would otherwise re-bill its ~9 healthy neighbours on
+  every one of the Job's restarts and still never complete. Each chunk gets
+  `LME_MAX_CHUNK_ATTEMPTS` tries (default 3), counted on the PVC so the budget
+  spans pod restarts. Past that the chunk is quarantined with a `.failed` marker
+  naming the failing entries and how to retry it (`rm` the marker), and later
+  passes skip it so the remaining chunks can finish. A quarantined chunk never
+  turns a partial run into a passing one: the run exits nonzero and writes
+  `RUN-INCOMPLETE.txt` listing what is missing. Once only quarantined chunks
+  remain, further Job restarts are no-op passes that cost nothing, and the Job
+  ends `Failed` when it exhausts `backoffLimit` — which is the honest outcome.
 
 ## Time and cost — read before launching
 
@@ -102,6 +140,7 @@ Scoring runs **off-cluster** on pulled results (raw LongMemEval-compatible JSONL
 ```bash
 bash deploy/longmemeval/pull-results.sh ./results/s500
 # Chunks live under runs/<run-id>/ — concatenate ONE run, don't mix runs:
+# (check for RUN-INCOMPLETE.txt first — it means entries are missing)
 cat ./results/s500/results/runs/<run-id>/s500-*.jsonl > ./results/s500/s500-all.jsonl
 
 # Official evaluator (paper prompts). Judge model is a disclosed parameter:

--- a/deploy/longmemeval/lme.env
+++ b/deploy/longmemeval/lme.env
@@ -1,0 +1,43 @@
+# lme.env — Environment-specific configuration for the LongMemEval AKS rig.
+# Copy to lme.env.local and customize. All deploy/longmemeval scripts source this file.
+
+# Azure resource group for the LongMemEval cluster
+LME_RESOURCE_GROUP="loom-lme"
+
+# AKS cluster name
+LME_CLUSTER_NAME="loom-lme-aks"
+
+# Azure region
+LME_LOCATION="eastus"
+
+# Azure Container Registry name (must already exist; shared with deploy/benchmark)
+LME_ACR_NAME="loomcloudacr"
+LME_ACR_LOGIN_SERVER="${LME_ACR_NAME}.azurecr.io"
+
+# Docker image name
+LME_IMAGE="${LME_ACR_LOGIN_SERVER}/loom-longmemeval"
+
+# Workload node pool VM size. The run is LLM-bound (Bedrock latency dominates),
+# so small nodes suffice — this is not the load-test rig.
+LME_WORK_VM_SIZE="Standard_D8s_v5"
+
+# System node pool VM size (kube-system only)
+LME_SYSTEM_VM_SIZE="Standard_D2s_v5"
+
+# K8s namespace
+LME_NAMESPACE="loom-lme"
+
+# gRPC port for the loom server
+LME_GRPC_PORT="60051"
+
+# ── Run parameters (consumed by run-500.sh → runner-job env) ─────────────────
+# Dataset variant: small = LongMemEval_S (the publishable benchmark set)
+LME_DATASET="small"
+# Run mode: multi-session (production-faithful) | ingest | context-stuffing
+LME_MODE="multi-session"
+# Concurrent entries. The ceiling is your Bedrock TPM/RPM quota, not CPU.
+LME_CONCURRENCY="6"
+# Questions per resumable chunk (per type). Smaller = finer resume granularity.
+LME_CHUNK="10"
+# Send historical dates as WeaveRequest.occurred_at (requires allow_time_override)
+LME_OCCURRED_AT="true"

--- a/deploy/longmemeval/lme.env
+++ b/deploy/longmemeval/lme.env
@@ -27,8 +27,12 @@ LME_SYSTEM_VM_SIZE="Standard_D2s_v5"
 # K8s namespace
 LME_NAMESPACE="loom-lme"
 
-# gRPC port for the loom server
+# gRPC port for the loom server (rendered into the server config, Deployment,
+# Service, and the runner's SERVER address)
 LME_GRPC_PORT="60051"
+
+# Bedrock model id served by looms (also part of the run identity manifest)
+LME_MODEL="global.anthropic.claude-opus-4-6-v1"
 
 # ── Run parameters (consumed by run-500.sh → runner-job env) ─────────────────
 # Dataset variant: small = LongMemEval_S (the publishable benchmark set)
@@ -41,3 +45,14 @@ LME_CONCURRENCY="6"
 LME_CHUNK="10"
 # Send historical dates as WeaveRequest.occurred_at (requires allow_time_override)
 LME_OCCURRED_AT="true"
+
+# ── Optional overrides (set in lme.env.local or the environment) ─────────────
+# LME_IMAGE_TAG   — pin workloads to a specific pushed image tag instead of the
+#                   current git commit (useful with --skip-build after new commits).
+# LME_RUN_ID      — resume a specific existing run directory instead of the
+#                   config-hash default. The runner still verifies the stored
+#                   manifest and rejects drift unless LME_ALLOW_MANIFEST_DRIFT=1.
+# LME_ALLOW_MANIFEST_DRIFT — set to 1 to knowingly resume a run whose stored
+#                   manifest no longer matches (e.g. same benchmark, rebuilt
+#                   image). Drift is appended to the run's manifest-drift.log;
+#                   existing outputs are never deleted either way.

--- a/deploy/longmemeval/lme.env
+++ b/deploy/longmemeval/lme.env
@@ -45,6 +45,12 @@ LME_CONCURRENCY="6"
 LME_CHUNK="10"
 # Send historical dates as WeaveRequest.occurred_at (requires allow_time_override)
 LME_OCCURRED_AT="true"
+# Tries a chunk gets before it is quarantined and later passes skip it. Chunk
+# validation is all-or-nothing, so one deterministically-failing entry would
+# otherwise re-bill its ~9 healthy neighbours on every Job restart and still
+# never complete. A quarantined chunk leaves the run incomplete (nonzero exit
+# + RUN-INCOMPLETE.txt); it never turns a partial result into a passing one.
+LME_MAX_CHUNK_ATTEMPTS="3"
 
 # ── Optional overrides (set in lme.env.local or the environment) ─────────────
 # LME_IMAGE_TAG   — pin workloads to a specific pushed image tag instead of the

--- a/deploy/longmemeval/namespace.yaml
+++ b/deploy/longmemeval/namespace.yaml
@@ -1,4 +1,5 @@
+# Template — rendered by run-500.sh (render-common.sh, allowlisted envsubst).
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: loom-lme
+  name: ${LME_NAMESPACE}

--- a/deploy/longmemeval/namespace.yaml
+++ b/deploy/longmemeval/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: loom-lme

--- a/deploy/longmemeval/pull-results.sh
+++ b/deploy/longmemeval/pull-results.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# pull-results.sh — Copy LongMemEval results from the AKS PVC to local disk.
+# The results PVC is RWX (azurefile), so this works mid-run without
+# disturbing the runner.
+#
+# Usage: bash deploy/longmemeval/pull-results.sh [LOCAL_DIR]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lme.env
+source "${SCRIPT_DIR}/lme.env"
+[[ -f "${SCRIPT_DIR}/lme.env.local" ]] && source "${SCRIPT_DIR}/lme.env.local"
+
+TIMESTAMP="$(date -u +%Y%m%d-%H%M%S)"
+LOCAL_DIR="${1:-./results/lme-pulled-${TIMESTAMP}}"
+POD_NAME="lme-results-puller-${TIMESTAMP}"
+
+if ! kubectl get pvc lme-results -n "${LME_NAMESPACE}" &>/dev/null; then
+    echo "ERROR: PVC lme-results not found in namespace ${LME_NAMESPACE}"
+    exit 1
+fi
+
+echo "Creating temporary puller pod..."
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${POD_NAME}
+  namespace: ${LME_NAMESPACE}
+spec:
+  restartPolicy: Never
+  containers:
+    - name: puller
+      image: alpine:3.21
+      command: ["sleep", "3600"]
+      volumeMounts:
+        - name: results
+          mountPath: /results
+          readOnly: true
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "128Mi"
+        limits:
+          cpu: "500m"
+          memory: "256Mi"
+  volumes:
+    - name: results
+      persistentVolumeClaim:
+        claimName: lme-results
+EOF
+
+kubectl wait --for=condition=Ready "pod/${POD_NAME}" -n "${LME_NAMESPACE}" --timeout=120s
+
+echo ""
+echo "=== Files on PVC ==="
+kubectl exec "${POD_NAME}" -n "${LME_NAMESPACE}" -- sh -c 'ls -lh /results/ | tail -20; echo; echo "chunks: $(ls /results/*.jsonl 2>/dev/null | wc -l)"'
+
+mkdir -p "${LOCAL_DIR}"
+kubectl cp "${LME_NAMESPACE}/${POD_NAME}:/results" "${LOCAL_DIR}"
+kubectl delete pod "${POD_NAME}" -n "${LME_NAMESPACE}" --grace-period=5
+
+echo ""
+echo "Saved to: ${LOCAL_DIR} ($(du -sh "${LOCAL_DIR}" | cut -f1))"
+echo "Score with the official evaluator (see README.md § Scoring)."

--- a/deploy/longmemeval/pull-results.sh
+++ b/deploy/longmemeval/pull-results.sh
@@ -21,6 +21,13 @@ if ! kubectl get pvc lme-results -n "${LME_NAMESPACE}" &>/dev/null; then
     exit 1
 fi
 
+# Under set -e, any failure below (wait, exec, cp) would otherwise skip the
+# final delete and leak the pod — always delete exactly the pod we generated.
+cleanup() {
+    kubectl delete pod "${POD_NAME}" -n "${LME_NAMESPACE}" --ignore-not-found --grace-period=5
+}
+trap cleanup EXIT
+
 echo "Creating temporary puller pod..."
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
@@ -55,11 +62,10 @@ kubectl wait --for=condition=Ready "pod/${POD_NAME}" -n "${LME_NAMESPACE}" --tim
 
 echo ""
 echo "=== Files on PVC ==="
-kubectl exec "${POD_NAME}" -n "${LME_NAMESPACE}" -- sh -c 'ls -lh /results/ | tail -20; echo; echo "chunks: $(ls /results/*.jsonl 2>/dev/null | wc -l)"'
+kubectl exec "${POD_NAME}" -n "${LME_NAMESPACE}" -- sh -c 'ls -lhR /results/ | tail -40; echo; echo "completed chunks (all runs): $(find /results -name "*.done" 2>/dev/null | wc -l)"'
 
 mkdir -p "${LOCAL_DIR}"
 kubectl cp "${LME_NAMESPACE}/${POD_NAME}:/results" "${LOCAL_DIR}"
-kubectl delete pod "${POD_NAME}" -n "${LME_NAMESPACE}" --grace-period=5
 
 echo ""
 echo "Saved to: ${LOCAL_DIR} ($(du -sh "${LOCAL_DIR}" | cut -f1))"

--- a/deploy/longmemeval/pvcs.yaml
+++ b/deploy/longmemeval/pvcs.yaml
@@ -1,0 +1,29 @@
+# lme-results holds benchmark outputs — NEVER auto-delete; these represent
+# days of paid LLM compute. teardown-cluster.sh refuses to run while it exists.
+# azurefile (RWX) so pull-results.sh can mount read-only mid-run.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lme-results
+  namespace: loom-lme
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: azurefile-csi
+  resources:
+    requests:
+      storage: 10Gi
+---
+# lme-data caches the HuggingFace dataset download (~285 MB) across job runs.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lme-data
+  namespace: loom-lme
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: azurefile-csi
+  resources:
+    requests:
+      storage: 5Gi

--- a/deploy/longmemeval/pvcs.yaml
+++ b/deploy/longmemeval/pvcs.yaml
@@ -1,3 +1,5 @@
+# Template — rendered by run-500.sh (render-common.sh, allowlisted envsubst).
+#
 # lme-results holds benchmark outputs — NEVER auto-delete; these represent
 # days of paid LLM compute. teardown-cluster.sh refuses to run while it exists.
 # azurefile (RWX) so pull-results.sh can mount read-only mid-run.
@@ -5,7 +7,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: lme-results
-  namespace: loom-lme
+  namespace: ${LME_NAMESPACE}
 spec:
   accessModes:
     - ReadWriteMany
@@ -19,7 +21,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: lme-data
-  namespace: loom-lme
+  namespace: ${LME_NAMESPACE}
 spec:
   accessModes:
     - ReadWriteMany

--- a/deploy/longmemeval/render-common.sh
+++ b/deploy/longmemeval/render-common.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# render-common.sh — shared manifest rendering for the LongMemEval rig.
+# Sourced by run-500.sh and render-test.sh (not executed directly).
+#
+# Manifest templates use ${LME_*} placeholders. envsubst runs with an explicit
+# allowlist so shell syntax inside embedded scripts (the runner ConfigMap's
+# slice loop) is never touched, and rendering fails loudly if a required
+# variable is unset or an unknown ${LME_*} placeholder survives.
+
+# Every LME_* placeholder that may appear in a manifest template.
+LME_RENDER_VARS='${LME_NAMESPACE} ${LME_IMAGE} ${LME_IMAGE_TAG} ${LME_GRPC_PORT} ${LME_MODEL} ${LME_DATASET} ${LME_DATASET_FILE} ${LME_MODE} ${LME_CONCURRENCY} ${LME_CHUNK} ${LME_OCCURRED_AT} ${LME_RUN_ID} ${LME_RUN_MANIFEST} ${LME_ALLOW_MANIFEST_DRIFT}'
+
+# lme_render <template> — render a manifest template to stdout.
+# Fails if any allowlisted variable is unset/empty, or if any ${LME_*}
+# placeholder survives rendering (a variable name missing from the allowlist).
+lme_render() {
+    local tpl="$1" rendered var
+    for var in ${LME_RENDER_VARS}; do
+        var="${var#\$\{}"
+        var="${var%\}}"
+        if [[ -z "${!var:-}" ]]; then
+            echo "lme_render: required variable ${var} is unset or empty (rendering ${tpl})" >&2
+            return 1
+        fi
+    done
+    rendered="$(envsubst "${LME_RENDER_VARS}" < "${tpl}")" || return 1
+    if grep -q '\${LME_' <<< "${rendered}"; then
+        echo "lme_render: unrendered LME_* placeholder in ${tpl} (add it to LME_RENDER_VARS):" >&2
+        grep -n '\${LME_' <<< "${rendered}" >&2
+        return 1
+    fi
+    printf '%s\n' "${rendered}"
+}
+
+# lme_sha256_12 <string> — first 12 hex chars of sha256 (portable macOS/Linux).
+lme_sha256_12() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        printf '%s' "$1" | sha256sum | cut -c1-12
+    else
+        printf '%s' "$1" | shasum -a 256 | cut -c1-12
+    fi
+}

--- a/deploy/longmemeval/render-common.sh
+++ b/deploy/longmemeval/render-common.sh
@@ -8,7 +8,7 @@
 # variable is unset or an unknown ${LME_*} placeholder survives.
 
 # Every LME_* placeholder that may appear in a manifest template.
-LME_RENDER_VARS='${LME_NAMESPACE} ${LME_IMAGE} ${LME_IMAGE_TAG} ${LME_GRPC_PORT} ${LME_MODEL} ${LME_DATASET} ${LME_DATASET_FILE} ${LME_MODE} ${LME_CONCURRENCY} ${LME_CHUNK} ${LME_OCCURRED_AT} ${LME_RUN_ID} ${LME_RUN_MANIFEST} ${LME_ALLOW_MANIFEST_DRIFT}'
+LME_RENDER_VARS='${LME_NAMESPACE} ${LME_IMAGE} ${LME_IMAGE_TAG} ${LME_GRPC_PORT} ${LME_MODEL} ${LME_DATASET} ${LME_DATASET_FILE} ${LME_MODE} ${LME_CONCURRENCY} ${LME_CHUNK} ${LME_OCCURRED_AT} ${LME_RUN_ID} ${LME_RUN_MANIFEST} ${LME_ALLOW_MANIFEST_DRIFT} ${LME_MAX_CHUNK_ATTEMPTS}'
 
 # lme_render <template> — render a manifest template to stdout.
 # Fails if any allowlisted variable is unset/empty, or if any ${LME_*}
@@ -32,11 +32,42 @@ lme_render() {
     printf '%s\n' "${rendered}"
 }
 
+# lme_sha256_12_stdin — first 12 hex chars of sha256 over stdin (portable).
+lme_sha256_12_stdin() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum | cut -c1-12
+    else
+        shasum -a 256 | cut -c1-12
+    fi
+}
+
 # lme_sha256_12 <string> — first 12 hex chars of sha256 (portable macOS/Linux).
 lme_sha256_12() {
-    if command -v sha256sum >/dev/null 2>&1; then
-        printf '%s' "$1" | sha256sum | cut -c1-12
-    else
-        printf '%s' "$1" | shasum -a 256 | cut -c1-12
+    printf '%s' "$1" | lme_sha256_12_stdin
+}
+
+# lme_build_id <repo-root> — the image tag identifying what will actually be
+# built. `az acr build` uploads the working tree, not the commit, so a commit
+# hash alone does not identify a build: a dirty tree would be tagged with a
+# name a clean build of that commit may already own, and ACR tags are mutable.
+# A clean tree yields the short commit; a dirty one yields
+# <commit>-dirty-<fingerprint>, where the fingerprint covers the uncommitted
+# tracked changes and the contents of every untracked, non-ignored file — the
+# parts of the upload that differ from the commit.
+lme_build_id() {
+    local root="$1" commit fingerprint f
+    commit="$(git -C "${root}" rev-parse --short HEAD)"
+    if [[ -z "$(git -C "${root}" status --porcelain)" ]]; then
+        printf '%s' "${commit}"
+        return 0
     fi
+    fingerprint="$( {
+        git -C "${root}" diff HEAD --binary
+        git -C "${root}" ls-files --others --exclude-standard -z |
+            while IFS= read -r -d '' f; do
+                printf '%s\n' "${f}"
+                cat "${root}/${f}" 2>/dev/null
+            done
+    } | lme_sha256_12_stdin )"
+    printf '%s-dirty-%s' "${commit}" "${fingerprint}"
 }

--- a/deploy/longmemeval/render-common.sh
+++ b/deploy/longmemeval/render-common.sh
@@ -8,7 +8,7 @@
 # variable is unset or an unknown ${LME_*} placeholder survives.
 
 # Every LME_* placeholder that may appear in a manifest template.
-LME_RENDER_VARS='${LME_NAMESPACE} ${LME_IMAGE} ${LME_IMAGE_TAG} ${LME_GRPC_PORT} ${LME_MODEL} ${LME_DATASET} ${LME_DATASET_FILE} ${LME_MODE} ${LME_CONCURRENCY} ${LME_CHUNK} ${LME_OCCURRED_AT} ${LME_RUN_ID} ${LME_RUN_MANIFEST} ${LME_ALLOW_MANIFEST_DRIFT} ${LME_MAX_CHUNK_ATTEMPTS}'
+LME_RENDER_VARS='${LME_NAMESPACE} ${LME_IMAGE} ${LME_IMAGE_TAG} ${LME_GRPC_PORT} ${LME_MODEL} ${LME_DATASET} ${LME_DATASET_FILE} ${LME_MODE} ${LME_CONCURRENCY} ${LME_CHUNK} ${LME_OCCURRED_AT} ${LME_RUN_ID} ${LME_RUN_MANIFEST} ${LME_ALLOW_MANIFEST_DRIFT} ${LME_MAX_CHUNK_ATTEMPTS} ${LME_CONFIG_HASH}'
 
 # lme_render <template> — render a manifest template to stdout.
 # Fails if any allowlisted variable is unset/empty, or if any ${LME_*}

--- a/deploy/longmemeval/render-common.sh
+++ b/deploy/longmemeval/render-common.sh
@@ -18,6 +18,13 @@ lme_render() {
     for var in ${LME_RENDER_VARS}; do
         var="${var#\$\{}"
         var="${var%\}}"
+        # Require only what THIS template references. The allowlist is global,
+        # so demanding every entry made it impossible to render one template
+        # in order to compute a value another template needs — which is
+        # exactly what run-500.sh does for LME_CONFIG_HASH, and it died on the
+        # documented invocation. A variable that never appears here cannot
+        # affect this render.
+        grep -qF "\${${var}}" "${tpl}" || continue
         if [[ -z "${!var:-}" ]]; then
             echo "lme_render: required variable ${var} is unset or empty (rendering ${tpl})" >&2
             return 1

--- a/deploy/longmemeval/render-test.sh
+++ b/deploy/longmemeval/render-test.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# render-test.sh — Renders every manifest template with NONDEFAULT
+# namespace/image/port/model values and asserts the manifests agree, so a
+# hardcoded value can never desync the workloads when lme.env is overridden.
+# No cluster access needed. Usage:
+#   bash deploy/longmemeval/render-test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=render-common.sh
+source "${SCRIPT_DIR}/render-common.sh"
+
+# Deliberately nondefault values for every rendered field.
+export LME_NAMESPACE="lme-render-test"
+export LME_IMAGE="testreg.azurecr.io/lme-render-test"
+export LME_IMAGE_TAG="cafef00d"
+export LME_GRPC_PORT="51234"
+export LME_MODEL="test.model-v9"
+export LME_DATASET="small"
+export LME_DATASET_FILE="test_dataset.json"
+export LME_MODE="ingest"
+export LME_CONCURRENCY="3"
+export LME_CHUNK="7"
+export LME_OCCURRED_AT="false"
+export LME_RUN_ID="runid0123abcd"
+export LME_RUN_MANIFEST="dataset=test_dataset.json mode=ingest occurred_at=false model=test.model-v9 image=testreg.azurecr.io/lme-render-test:cafef00d chunk=7"
+export LME_ALLOW_MANIFEST_DRIFT="0"
+
+MANIFESTS=(namespace pvcs server-config runner-script server-deployment runner-job)
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+failures=0
+fail() { echo "FAIL: $*"; failures=$((failures + 1)); }
+
+for m in "${MANIFESTS[@]}"; do
+    lme_render "${SCRIPT_DIR}/${m}.yaml" > "${TMP_DIR}/${m}.yaml" \
+        || fail "${m}.yaml did not render"
+done
+
+# 1. Every rendered manifest parses as YAML.
+if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' 2>/dev/null; then
+    for m in "${MANIFESTS[@]}"; do
+        python3 -c 'import sys, yaml; list(yaml.safe_load_all(open(sys.argv[1])))' "${TMP_DIR}/${m}.yaml" \
+            || fail "${m}.yaml does not parse as YAML after rendering"
+    done
+else
+    echo "NOTE: python3+pyyaml not available; skipping YAML parse assertions"
+fi
+
+# 2. The embedded runner script parses as bash.
+if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' 2>/dev/null; then
+    python3 -c 'import sys, yaml; sys.stdout.write(yaml.safe_load(open(sys.argv[1]))["data"]["run-slices.sh"])' \
+        "${TMP_DIR}/runner-script.yaml" > "${TMP_DIR}/run-slices.sh" \
+        || fail "could not extract run-slices.sh from rendered runner-script.yaml"
+    bash -n "${TMP_DIR}/run-slices.sh" || fail "rendered run-slices.sh has bash syntax errors"
+fi
+
+# 3. Namespace: the Namespace object and every metadata.namespace agree.
+grep -q "name: ${LME_NAMESPACE}\$" "${TMP_DIR}/namespace.yaml" \
+    || fail "namespace.yaml does not create ${LME_NAMESPACE}"
+for m in pvcs server-config runner-script server-deployment runner-job; do
+    grep -q "namespace: ${LME_NAMESPACE}\$" "${TMP_DIR}/${m}.yaml" \
+        || fail "${m}.yaml missing namespace ${LME_NAMESPACE}"
+    if grep -n '^[[:space:]]*namespace: ' "${TMP_DIR}/${m}.yaml" | grep -v "namespace: ${LME_NAMESPACE}\$"; then
+        fail "${m}.yaml has a namespace other than ${LME_NAMESPACE}"
+    fi
+done
+
+# 4. Images: every image reference is the pinned nondefault tag; never :latest.
+for m in server-deployment runner-job; do
+    grep -q "image: ${LME_IMAGE}:${LME_IMAGE_TAG}\$" "${TMP_DIR}/${m}.yaml" \
+        || fail "${m}.yaml missing pinned image ${LME_IMAGE}:${LME_IMAGE_TAG}"
+    if grep -n '^[[:space:]]*image: ' "${TMP_DIR}/${m}.yaml" | grep -v "image: ${LME_IMAGE}:${LME_IMAGE_TAG}\$"; then
+        fail "${m}.yaml has an image other than ${LME_IMAGE}:${LME_IMAGE_TAG}"
+    fi
+done
+if grep -rn ':latest' "${TMP_DIR}"/*.yaml; then
+    fail "a rendered manifest still references :latest"
+fi
+
+# 5. Port: server config, containerPort, Service port, and the runner's SERVER
+# address must all agree; the old default must not survive anywhere.
+grep -q "port: ${LME_GRPC_PORT}\$" "${TMP_DIR}/server-config.yaml" \
+    || fail "server-config.yaml port != ${LME_GRPC_PORT}"
+grep -q "containerPort: ${LME_GRPC_PORT}\$" "${TMP_DIR}/server-deployment.yaml" \
+    || fail "server-deployment.yaml containerPort != ${LME_GRPC_PORT}"
+grep -q "port: ${LME_GRPC_PORT}\$" "${TMP_DIR}/server-deployment.yaml" \
+    || fail "server-deployment.yaml Service port != ${LME_GRPC_PORT}"
+grep -q "value: \"lme-server:${LME_GRPC_PORT}\"" "${TMP_DIR}/runner-job.yaml" \
+    || fail "runner-job.yaml SERVER != lme-server:${LME_GRPC_PORT}"
+if grep -rn '60051' "${TMP_DIR}"/*.yaml; then
+    fail "a rendered manifest still hardcodes port 60051"
+fi
+
+# 6. Model, dataset, and run identity land where they must.
+grep -q "bedrock_model_id: ${LME_MODEL}\$" "${TMP_DIR}/server-config.yaml" \
+    || fail "server-config.yaml model != ${LME_MODEL}"
+grep -q "value: \"/data/longmemeval/${LME_DATASET_FILE}\"" "${TMP_DIR}/runner-job.yaml" \
+    || fail "runner-job.yaml DATASET_FILE not rendered"
+grep -q "value: \"${LME_RUN_ID}\"" "${TMP_DIR}/runner-job.yaml" \
+    || fail "runner-job.yaml RUN_ID not rendered"
+grep -q "value: \"${LME_RUN_MANIFEST}\"" "${TMP_DIR}/runner-job.yaml" \
+    || fail "runner-job.yaml RUN_MANIFEST not rendered"
+
+# 7. No unrendered placeholders (lme_render also guards; belt and suspenders).
+if grep -rn '\${LME_' "${TMP_DIR}"/*.yaml; then
+    fail "unrendered LME_* placeholder in rendered output"
+fi
+
+if [[ "${failures}" -gt 0 ]]; then
+    echo ""
+    echo "render-test: ${failures} failure(s)"
+    exit 1
+fi
+echo "render-test: OK — all manifests agree on nondefault namespace/image/port/model/run-id"

--- a/deploy/longmemeval/render-test.sh
+++ b/deploy/longmemeval/render-test.sh
@@ -27,6 +27,7 @@ export LME_RUN_ID="runid0123abcd"
 export LME_RUN_MANIFEST="dataset=test_dataset.json mode=ingest occurred_at=false model=test.model-v9 image=testreg.azurecr.io/lme-render-test:cafef00d chunk=7"
 export LME_ALLOW_MANIFEST_DRIFT="0"
 export LME_MAX_CHUNK_ATTEMPTS="4"
+export LME_CONFIG_HASH="cfg123456789"
 
 MANIFESTS=(namespace pvcs server-config runner-script server-deployment runner-job)
 
@@ -47,6 +48,8 @@ if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' 2>/dev/null; t
         python3 -c 'import sys, yaml; list(yaml.safe_load_all(open(sys.argv[1])))' "${TMP_DIR}/${m}.yaml" \
             || fail "${m}.yaml does not parse as YAML after rendering"
     done
+elif [[ "${LME_RIG_STRICT:-0}" == "1" ]]; then
+    fail "python3+pyyaml is required to validate rendered manifests (LME_RIG_STRICT=1)"
 else
     echo "NOTE: python3+pyyaml not available; skipping YAML parse assertions"
 fi
@@ -107,6 +110,10 @@ grep -q "value: \"${LME_RUN_MANIFEST}\"" "${TMP_DIR}/runner-job.yaml" \
     || fail "runner-job.yaml RUN_MANIFEST not rendered"
 grep -q "value: \"${LME_MAX_CHUNK_ATTEMPTS}\"" "${TMP_DIR}/runner-job.yaml" \
     || fail "runner-job.yaml MAX_CHUNK_ATTEMPTS not rendered"
+# A config-only change must roll the server pod: looms reads its config once
+# at startup, so without this a new model would never actually be served.
+grep -q "loom.dev/config-checksum: \"${LME_CONFIG_HASH}\"" "${TMP_DIR}/server-deployment.yaml" \
+    || fail "server-deployment.yaml pod template missing the config checksum annotation"
 
 # 7. No unrendered placeholders (lme_render also guards; belt and suspenders).
 if grep -rn '\${LME_' "${TMP_DIR}"/*.yaml; then

--- a/deploy/longmemeval/render-test.sh
+++ b/deploy/longmemeval/render-test.sh
@@ -115,6 +115,22 @@ grep -q "value: \"${LME_MAX_CHUNK_ATTEMPTS}\"" "${TMP_DIR}/runner-job.yaml" \
 grep -q "loom.dev/config-checksum: \"${LME_CONFIG_HASH}\"" "${TMP_DIR}/server-deployment.yaml" \
     || fail "server-deployment.yaml pod template missing the config checksum annotation"
 
+# 6b. run-500.sh computes LME_CONFIG_HASH by rendering server-config.yaml
+# BEFORE that variable exists. lme_render must therefore require only the
+# variables a given template references — requiring the whole global allowlist
+# broke the documented invocation, and every test here pre-seeding the value
+# is precisely why CI stayed green through it.
+(
+    unset LME_CONFIG_HASH
+    lme_render "${SCRIPT_DIR}/server-config.yaml" >/dev/null 2>&1
+) || fail "server-config.yaml must render with LME_CONFIG_HASH unset (run-500.sh's hash step)"
+
+# ...but a variable the template DOES reference must still be required.
+(
+    unset LME_MODEL
+    lme_render "${SCRIPT_DIR}/server-config.yaml" >/dev/null 2>&1
+) && fail "lme_render accepted server-config.yaml with LME_MODEL unset" || true
+
 # 7. No unrendered placeholders (lme_render also guards; belt and suspenders).
 if grep -rn '\${LME_' "${TMP_DIR}"/*.yaml; then
     fail "unrendered LME_* placeholder in rendered output"

--- a/deploy/longmemeval/render-test.sh
+++ b/deploy/longmemeval/render-test.sh
@@ -26,6 +26,7 @@ export LME_OCCURRED_AT="false"
 export LME_RUN_ID="runid0123abcd"
 export LME_RUN_MANIFEST="dataset=test_dataset.json mode=ingest occurred_at=false model=test.model-v9 image=testreg.azurecr.io/lme-render-test:cafef00d chunk=7"
 export LME_ALLOW_MANIFEST_DRIFT="0"
+export LME_MAX_CHUNK_ATTEMPTS="4"
 
 MANIFESTS=(namespace pvcs server-config runner-script server-deployment runner-job)
 
@@ -104,6 +105,8 @@ grep -q "value: \"${LME_RUN_ID}\"" "${TMP_DIR}/runner-job.yaml" \
     || fail "runner-job.yaml RUN_ID not rendered"
 grep -q "value: \"${LME_RUN_MANIFEST}\"" "${TMP_DIR}/runner-job.yaml" \
     || fail "runner-job.yaml RUN_MANIFEST not rendered"
+grep -q "value: \"${LME_MAX_CHUNK_ATTEMPTS}\"" "${TMP_DIR}/runner-job.yaml" \
+    || fail "runner-job.yaml MAX_CHUNK_ATTEMPTS not rendered"
 
 # 7. No unrendered placeholders (lme_render also guards; belt and suspenders).
 if grep -rn '\${LME_' "${TMP_DIR}"/*.yaml; then

--- a/deploy/longmemeval/run-500.sh
+++ b/deploy/longmemeval/run-500.sh
@@ -8,7 +8,7 @@
 #
 # Usage:
 #   LME_BEDROCK_BEARER_TOKEN=ABSK... bash deploy/longmemeval/run-500.sh
-#   bash deploy/longmemeval/run-500.sh --skip-build   # reuse the pushed image
+#   bash deploy/longmemeval/run-500.sh --skip-build   # reuse a pushed image tag
 
 set -euo pipefail
 
@@ -17,6 +17,8 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 # shellcheck source=lme.env
 source "${SCRIPT_DIR}/lme.env"
 [[ -f "${SCRIPT_DIR}/lme.env.local" ]] && source "${SCRIPT_DIR}/lme.env.local"
+# shellcheck source=render-common.sh
+source "${SCRIPT_DIR}/render-common.sh"
 
 SKIP_BUILD=0
 [[ "${1:-}" == "--skip-build" ]] && SKIP_BUILD=1
@@ -27,25 +29,51 @@ case "${LME_DATASET}" in
   medium) LME_DATASET_FILE="longmemeval_m_cleaned.json" ;;
   *) echo "Unknown LME_DATASET: ${LME_DATASET}"; exit 1 ;;
 esac
-export LME_IMAGE LME_GRPC_PORT LME_DATASET LME_DATASET_FILE LME_MODE LME_CONCURRENCY LME_CHUNK LME_OCCURRED_AT
+
+# Workloads are pinned to an immutable commit tag — never :latest — and the
+# tag is part of the run's identity manifest below.
+GIT_COMMIT="$(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
+LME_IMAGE_TAG="${LME_IMAGE_TAG:-${GIT_COMMIT}}"
+LME_IMAGE_REPO="${LME_IMAGE#*/}"
 
 if [[ "${SKIP_BUILD}" -eq 0 ]]; then
-    GIT_COMMIT="$(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
-    echo "=== Building image in ACR (${LME_IMAGE}:latest @ ${GIT_COMMIT}) ==="
+    echo "=== Building image in ACR (${LME_IMAGE}:${LME_IMAGE_TAG}) ==="
     az acr build \
         --registry "${LME_ACR_NAME}" \
-        --image "loom-longmemeval:latest" \
-        --image "loom-longmemeval:${GIT_COMMIT}" \
+        --image "${LME_IMAGE_REPO}:${LME_IMAGE_TAG}" \
         --file "${SCRIPT_DIR}/Dockerfile" \
         --build-arg "GIT_COMMIT=${GIT_COMMIT}" \
         "${REPO_ROOT}"
+else
+    echo "=== Skipping build; verifying ${LME_IMAGE}:${LME_IMAGE_TAG} exists in ACR ==="
+    if ! az acr repository show --name "${LME_ACR_NAME}" --image "${LME_IMAGE_REPO}:${LME_IMAGE_TAG}" -o none; then
+        echo "ERROR: ${LME_IMAGE}:${LME_IMAGE_TAG} not found in ACR."
+        echo "Run without --skip-build, or set LME_IMAGE_TAG to a tag that was pushed."
+        exit 1
+    fi
 fi
 
-echo "=== Applying namespace, PVCs, config ==="
-kubectl apply -f "${SCRIPT_DIR}/namespace.yaml"
-kubectl apply -f "${SCRIPT_DIR}/pvcs.yaml"
-kubectl apply -f "${SCRIPT_DIR}/server-config.yaml"
-kubectl apply -f "${SCRIPT_DIR}/runner-script.yaml"
+# Run identity: a manifest of every input that determines what the benchmark
+# measures. Chunk outputs are namespaced by its hash on the results PVC, so a
+# configuration change can never silently reuse chunks from a different run;
+# the runner also verifies the stored manifest before resuming.
+LME_RUN_MANIFEST="dataset=${LME_DATASET_FILE} mode=${LME_MODE} occurred_at=${LME_OCCURRED_AT} model=${LME_MODEL} image=${LME_IMAGE}:${LME_IMAGE_TAG} chunk=${LME_CHUNK}"
+LME_RUN_ID="${LME_RUN_ID:-$(lme_sha256_12 "${LME_RUN_MANIFEST}")}"
+LME_ALLOW_MANIFEST_DRIFT="${LME_ALLOW_MANIFEST_DRIFT:-0}"
+
+export LME_NAMESPACE LME_IMAGE LME_IMAGE_TAG LME_GRPC_PORT LME_MODEL \
+    LME_DATASET LME_DATASET_FILE LME_MODE LME_CONCURRENCY LME_CHUNK \
+    LME_OCCURRED_AT LME_RUN_ID LME_RUN_MANIFEST LME_ALLOW_MANIFEST_DRIFT
+
+echo "=== Run identity ==="
+echo "  run id:   ${LME_RUN_ID}"
+echo "  manifest: ${LME_RUN_MANIFEST}"
+echo "  outputs:  PVC lme-results:/results/runs/${LME_RUN_ID}/"
+
+echo "=== Applying namespace, PVCs, config (namespace=${LME_NAMESPACE}) ==="
+for manifest in namespace pvcs server-config runner-script; do
+    lme_render "${SCRIPT_DIR}/${manifest}.yaml" | kubectl apply -f -
+done
 
 echo "=== Ensuring Bedrock secret ==="
 if ! kubectl get secret lme-bedrock -n "${LME_NAMESPACE}" &>/dev/null; then
@@ -59,15 +87,15 @@ if ! kubectl get secret lme-bedrock -n "${LME_NAMESPACE}" &>/dev/null; then
         --from-literal=bearer-token="${LME_BEDROCK_BEARER_TOKEN}"
 fi
 
-echo "=== Deploying server ==="
-kubectl apply -f "${SCRIPT_DIR}/server-deployment.yaml"
+echo "=== Deploying server (${LME_IMAGE}:${LME_IMAGE_TAG}, port ${LME_GRPC_PORT}) ==="
+lme_render "${SCRIPT_DIR}/server-deployment.yaml" | kubectl apply -f -
 kubectl rollout status deployment/lme-server -n "${LME_NAMESPACE}" --timeout=300s
 
-echo "=== Launching runner job (mode=${LME_MODE}, concurrency=${LME_CONCURRENCY}, chunk=${LME_CHUNK}) ==="
-# Delete any previous job (results on the PVC are untouched; completed chunks
-# are skipped on the next run — this is the resume path).
+echo "=== Launching runner job (mode=${LME_MODE}, concurrency=${LME_CONCURRENCY}, chunk=${LME_CHUNK}, run=${LME_RUN_ID}) ==="
+# Delete any previous job object (results on the PVC are untouched; chunks
+# with a .done marker are skipped on the next run — this is the resume path).
 kubectl delete job lme-runner -n "${LME_NAMESPACE}" --ignore-not-found
-envsubst < "${SCRIPT_DIR}/runner-job.yaml" | kubectl apply -f -
+lme_render "${SCRIPT_DIR}/runner-job.yaml" | kubectl apply -f -
 
 echo ""
 echo "=== Running. Monitor with: ==="

--- a/deploy/longmemeval/run-500.sh
+++ b/deploy/longmemeval/run-500.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# run-500.sh — Build, deploy, and launch the full LongMemEval run on AKS.
+#
+# Prerequisites:
+#   - setup-cluster.sh has been run (or kubectl context points at the cluster)
+#   - LME_BEDROCK_BEARER_TOKEN exported (an ABSK... Bedrock API key), OR the
+#     lme-bedrock secret already exists in the namespace
+#
+# Usage:
+#   LME_BEDROCK_BEARER_TOKEN=ABSK... bash deploy/longmemeval/run-500.sh
+#   bash deploy/longmemeval/run-500.sh --skip-build   # reuse the pushed image
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=lme.env
+source "${SCRIPT_DIR}/lme.env"
+[[ -f "${SCRIPT_DIR}/lme.env.local" ]] && source "${SCRIPT_DIR}/lme.env.local"
+
+SKIP_BUILD=0
+[[ "${1:-}" == "--skip-build" ]] && SKIP_BUILD=1
+
+case "${LME_DATASET}" in
+  oracle) LME_DATASET_FILE="longmemeval_oracle.json" ;;
+  small)  LME_DATASET_FILE="longmemeval_s_cleaned.json" ;;
+  medium) LME_DATASET_FILE="longmemeval_m_cleaned.json" ;;
+  *) echo "Unknown LME_DATASET: ${LME_DATASET}"; exit 1 ;;
+esac
+export LME_IMAGE LME_GRPC_PORT LME_DATASET LME_DATASET_FILE LME_MODE LME_CONCURRENCY LME_CHUNK LME_OCCURRED_AT
+
+if [[ "${SKIP_BUILD}" -eq 0 ]]; then
+    GIT_COMMIT="$(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
+    echo "=== Building image in ACR (${LME_IMAGE}:latest @ ${GIT_COMMIT}) ==="
+    az acr build \
+        --registry "${LME_ACR_NAME}" \
+        --image "loom-longmemeval:latest" \
+        --image "loom-longmemeval:${GIT_COMMIT}" \
+        --file "${SCRIPT_DIR}/Dockerfile" \
+        --build-arg "GIT_COMMIT=${GIT_COMMIT}" \
+        "${REPO_ROOT}"
+fi
+
+echo "=== Applying namespace, PVCs, config ==="
+kubectl apply -f "${SCRIPT_DIR}/namespace.yaml"
+kubectl apply -f "${SCRIPT_DIR}/pvcs.yaml"
+kubectl apply -f "${SCRIPT_DIR}/server-config.yaml"
+kubectl apply -f "${SCRIPT_DIR}/runner-script.yaml"
+
+echo "=== Ensuring Bedrock secret ==="
+if ! kubectl get secret lme-bedrock -n "${LME_NAMESPACE}" &>/dev/null; then
+    if [[ -z "${LME_BEDROCK_BEARER_TOKEN:-}" ]]; then
+        echo "ERROR: secret lme-bedrock not found and LME_BEDROCK_BEARER_TOKEN not set."
+        echo "Export a Bedrock API key (ABSK...) and re-run."
+        exit 1
+    fi
+    kubectl create secret generic lme-bedrock \
+        -n "${LME_NAMESPACE}" \
+        --from-literal=bearer-token="${LME_BEDROCK_BEARER_TOKEN}"
+fi
+
+echo "=== Deploying server ==="
+kubectl apply -f "${SCRIPT_DIR}/server-deployment.yaml"
+kubectl rollout status deployment/lme-server -n "${LME_NAMESPACE}" --timeout=300s
+
+echo "=== Launching runner job (mode=${LME_MODE}, concurrency=${LME_CONCURRENCY}, chunk=${LME_CHUNK}) ==="
+# Delete any previous job (results on the PVC are untouched; completed chunks
+# are skipped on the next run — this is the resume path).
+kubectl delete job lme-runner -n "${LME_NAMESPACE}" --ignore-not-found
+envsubst < "${SCRIPT_DIR}/runner-job.yaml" | kubectl apply -f -
+
+echo ""
+echo "=== Running. Monitor with: ==="
+echo "  kubectl logs -f job/lme-runner -n ${LME_NAMESPACE}"
+echo "  bash ${SCRIPT_DIR}/pull-results.sh   # snapshot results mid-run"

--- a/deploy/longmemeval/run-500.sh
+++ b/deploy/longmemeval/run-500.sh
@@ -67,11 +67,28 @@ else
     fi
 fi
 
+# ACR tags are mutable, and Kubernetes defaults a non-:latest tag to
+# imagePullPolicy: IfNotPresent — so a rebuilt or retagged image can serve a
+# run whose manifest records the same tag string. Resolve the tag to its
+# immutable digest and make THAT part of the run identity, so a moved tag
+# yields a new run id instead of silently resuming onto chunks produced by
+# different bytes. Empty (older az, or no permission) degrades to tag-only
+# identity rather than blocking the run.
+LME_IMAGE_DIGEST="$(az acr repository show \
+    --name "${LME_ACR_NAME}" \
+    --image "${LME_IMAGE_REPO}:${LME_IMAGE_TAG}" \
+    --query digest -o tsv 2>/dev/null || true)"
+if [[ -z "${LME_IMAGE_DIGEST}" ]]; then
+    echo "WARNING: could not resolve the image digest; run identity falls back to the"
+    echo "         tag alone, which ACR allows to move. Resume cannot detect a rebuild."
+    LME_IMAGE_DIGEST="unresolved"
+fi
+
 # Run identity: a manifest of every input that determines what the benchmark
 # measures. Chunk outputs are namespaced by its hash on the results PVC, so a
 # configuration change can never silently reuse chunks from a different run;
 # the runner also verifies the stored manifest before resuming.
-LME_RUN_MANIFEST="dataset=${LME_DATASET_FILE} mode=${LME_MODE} occurred_at=${LME_OCCURRED_AT} model=${LME_MODEL} image=${LME_IMAGE}:${LME_IMAGE_TAG} chunk=${LME_CHUNK}"
+LME_RUN_MANIFEST="dataset=${LME_DATASET_FILE} mode=${LME_MODE} occurred_at=${LME_OCCURRED_AT} model=${LME_MODEL} image=${LME_IMAGE}:${LME_IMAGE_TAG} digest=${LME_IMAGE_DIGEST} chunk=${LME_CHUNK}"
 LME_RUN_ID="${LME_RUN_ID:-$(lme_sha256_12 "${LME_RUN_MANIFEST}")}"
 LME_ALLOW_MANIFEST_DRIFT="${LME_ALLOW_MANIFEST_DRIFT:-0}"
 
@@ -83,9 +100,16 @@ export LME_NAMESPACE LME_IMAGE LME_IMAGE_TAG LME_GRPC_PORT LME_MODEL \
 echo "=== Run identity ==="
 echo "  run id:   ${LME_RUN_ID}"
 echo "  manifest: ${LME_RUN_MANIFEST}"
+echo "  digest:   ${LME_IMAGE_DIGEST}"
 echo "  outputs:  PVC lme-results:/results/runs/${LME_RUN_ID}/"
 
-echo "=== Applying namespace, PVCs, config (namespace=${LME_NAMESPACE}) ==="
+# Hash the rendered server config so a config-only change (model, port,
+# anything in looms.yaml) rolls the server pod. Computed BEFORE the config is
+# applied, from exactly the bytes that will be applied.
+LME_CONFIG_HASH="$(lme_render "${SCRIPT_DIR}/server-config.yaml" | lme_sha256_12_stdin)"
+export LME_CONFIG_HASH
+
+echo "=== Applying namespace, PVCs, config (namespace=${LME_NAMESPACE}, config ${LME_CONFIG_HASH}) ==="
 for manifest in namespace pvcs server-config runner-script; do
     lme_render "${SCRIPT_DIR}/${manifest}.yaml" | kubectl apply -f -
 done

--- a/deploy/longmemeval/run-500.sh
+++ b/deploy/longmemeval/run-500.sh
@@ -30,11 +30,25 @@ case "${LME_DATASET}" in
   *) echo "Unknown LME_DATASET: ${LME_DATASET}"; exit 1 ;;
 esac
 
-# Workloads are pinned to an immutable commit tag — never :latest — and the
-# tag is part of the run's identity manifest below.
+# Workloads are pinned to a tag that identifies the *build context* — never
+# :latest — and the tag is part of the run's identity manifest below.
+#
+# az acr build uploads the working tree, not the commit, and ACR tags are
+# mutable: a dirty tree at commit abc123 would otherwise be pushed as :abc123,
+# a name a clean build of abc123 may already own. The manifest would then
+# match and the runner would happily resume chunks produced by a different
+# binary — exactly the cross-run contamination the run identity exists to
+# prevent. A dirty tree therefore gets its own tag and its own run id.
 GIT_COMMIT="$(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
-LME_IMAGE_TAG="${LME_IMAGE_TAG:-${GIT_COMMIT}}"
+GIT_BUILD_ID="$(lme_build_id "${REPO_ROOT}")"
+if [[ "${GIT_BUILD_ID}" != "${GIT_COMMIT}" ]]; then
+    echo "WARNING: the working tree is dirty; az acr build uploads it as-is."
+    echo "         Tagging this build ${GIT_BUILD_ID} so it cannot be confused"
+    echo "         with a clean build of ${GIT_COMMIT} (it gets its own run id)."
+fi
+LME_IMAGE_TAG="${LME_IMAGE_TAG:-${GIT_BUILD_ID}}"
 LME_IMAGE_REPO="${LME_IMAGE#*/}"
+LME_MAX_CHUNK_ATTEMPTS="${LME_MAX_CHUNK_ATTEMPTS:-3}"
 
 if [[ "${SKIP_BUILD}" -eq 0 ]]; then
     echo "=== Building image in ACR (${LME_IMAGE}:${LME_IMAGE_TAG}) ==="
@@ -42,7 +56,7 @@ if [[ "${SKIP_BUILD}" -eq 0 ]]; then
         --registry "${LME_ACR_NAME}" \
         --image "${LME_IMAGE_REPO}:${LME_IMAGE_TAG}" \
         --file "${SCRIPT_DIR}/Dockerfile" \
-        --build-arg "GIT_COMMIT=${GIT_COMMIT}" \
+        --build-arg "GIT_COMMIT=${GIT_BUILD_ID}" \
         "${REPO_ROOT}"
 else
     echo "=== Skipping build; verifying ${LME_IMAGE}:${LME_IMAGE_TAG} exists in ACR ==="
@@ -63,7 +77,8 @@ LME_ALLOW_MANIFEST_DRIFT="${LME_ALLOW_MANIFEST_DRIFT:-0}"
 
 export LME_NAMESPACE LME_IMAGE LME_IMAGE_TAG LME_GRPC_PORT LME_MODEL \
     LME_DATASET LME_DATASET_FILE LME_MODE LME_CONCURRENCY LME_CHUNK \
-    LME_OCCURRED_AT LME_RUN_ID LME_RUN_MANIFEST LME_ALLOW_MANIFEST_DRIFT
+    LME_OCCURRED_AT LME_RUN_ID LME_RUN_MANIFEST LME_ALLOW_MANIFEST_DRIFT \
+    LME_MAX_CHUNK_ATTEMPTS
 
 echo "=== Run identity ==="
 echo "  run id:   ${LME_RUN_ID}"

--- a/deploy/longmemeval/runner-job.yaml
+++ b/deploy/longmemeval/runner-job.yaml
@@ -1,12 +1,13 @@
-# Template — applied by run-500.sh via envsubst (LME_* variables from lme.env).
+# Template — rendered by run-500.sh (render-common.sh, allowlisted envsubst;
+# LME_* variables from lme.env / lme.env.local).
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: lme-runner
-  namespace: loom-lme
+  namespace: ${LME_NAMESPACE}
 spec:
-  # Multi-day run: pod restarts are the resume mechanism (completed chunks
-  # are skipped from the results PVC), so allow generous retries.
+  # Multi-day run: pod restarts are the resume mechanism (chunks with a .done
+  # marker on the results PVC are skipped), so allow generous retries.
   backoffLimit: 30
   template:
     metadata:
@@ -23,7 +24,7 @@ spec:
       initContainers:
         # One-time (cached on the data PVC): fetch the dataset from HuggingFace.
         - name: download-dataset
-          image: ${LME_IMAGE}:latest
+          image: ${LME_IMAGE}:${LME_IMAGE_TAG}
           command: ["/loom-longmemeval"]
           args: ["download", "--datasets", "${LME_DATASET}", "--data-dir", "/data/longmemeval"]
           volumeMounts:
@@ -31,7 +32,7 @@ spec:
               mountPath: /data
       containers:
         - name: runner
-          image: ${LME_IMAGE}:latest
+          image: ${LME_IMAGE}:${LME_IMAGE_TAG}
           command: ["/bin/bash", "/scripts/run-slices.sh"]
           env:
             - name: SERVER
@@ -48,6 +49,12 @@ spec:
               value: "${LME_OCCURRED_AT}"
             - name: RESULTS_DIR
               value: "/results"
+            - name: RUN_ID
+              value: "${LME_RUN_ID}"
+            - name: RUN_MANIFEST
+              value: "${LME_RUN_MANIFEST}"
+            - name: ALLOW_MANIFEST_DRIFT
+              value: "${LME_ALLOW_MANIFEST_DRIFT}"
           volumeMounts:
             - name: results
               mountPath: /results

--- a/deploy/longmemeval/runner-job.yaml
+++ b/deploy/longmemeval/runner-job.yaml
@@ -1,0 +1,75 @@
+# Template — applied by run-500.sh via envsubst (LME_* variables from lme.env).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: lme-runner
+  namespace: loom-lme
+spec:
+  # Multi-day run: pod restarts are the resume mechanism (completed chunks
+  # are skipped from the results PVC), so allow generous retries.
+  backoffLimit: 30
+  template:
+    metadata:
+      labels:
+        app: lme-runner
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        loom-role: lme
+      tolerations:
+        - key: loom-role
+          value: lme
+          effect: NoSchedule
+      initContainers:
+        # One-time (cached on the data PVC): fetch the dataset from HuggingFace.
+        - name: download-dataset
+          image: ${LME_IMAGE}:latest
+          command: ["/loom-longmemeval"]
+          args: ["download", "--datasets", "${LME_DATASET}", "--data-dir", "/data/longmemeval"]
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      containers:
+        - name: runner
+          image: ${LME_IMAGE}:latest
+          command: ["/bin/bash", "/scripts/run-slices.sh"]
+          env:
+            - name: SERVER
+              value: "lme-server:${LME_GRPC_PORT}"
+            - name: DATASET_FILE
+              value: "/data/longmemeval/${LME_DATASET_FILE}"
+            - name: MODE
+              value: "${LME_MODE}"
+            - name: CONCURRENCY
+              value: "${LME_CONCURRENCY}"
+            - name: CHUNK
+              value: "${LME_CHUNK}"
+            - name: OCCURRED_AT
+              value: "${LME_OCCURRED_AT}"
+            - name: RESULTS_DIR
+              value: "/results"
+          volumeMounts:
+            - name: results
+              mountPath: /results
+            - name: data
+              mountPath: /data
+            - name: scripts
+              mountPath: /scripts
+          resources:
+            requests:
+              cpu: "1"
+              memory: "2Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+      volumes:
+        - name: results
+          persistentVolumeClaim:
+            claimName: lme-results
+        - name: data
+          persistentVolumeClaim:
+            claimName: lme-data
+        - name: scripts
+          configMap:
+            name: lme-runner-script
+            defaultMode: 0755

--- a/deploy/longmemeval/runner-job.yaml
+++ b/deploy/longmemeval/runner-job.yaml
@@ -7,7 +7,10 @@ metadata:
   namespace: ${LME_NAMESPACE}
 spec:
   # Multi-day run: pod restarts are the resume mechanism (chunks with a .done
-  # marker on the results PVC are skipped), so allow generous retries.
+  # marker on the results PVC are skipped), so allow generous retries. A chunk
+  # that keeps failing does not consume them all: after LME_MAX_CHUNK_ATTEMPTS
+  # it is quarantined and later passes skip it, so restarts always make
+  # progress on the chunks that can still complete.
   backoffLimit: 30
   template:
     metadata:
@@ -55,6 +58,8 @@ spec:
               value: "${LME_RUN_MANIFEST}"
             - name: ALLOW_MANIFEST_DRIFT
               value: "${LME_ALLOW_MANIFEST_DRIFT}"
+            - name: MAX_CHUNK_ATTEMPTS
+              value: "${LME_MAX_CHUNK_ATTEMPTS}"
           volumeMounts:
             - name: results
               mountPath: /results

--- a/deploy/longmemeval/runner-job.yaml
+++ b/deploy/longmemeval/runner-job.yaml
@@ -28,6 +28,10 @@ spec:
         # One-time (cached on the data PVC): fetch the dataset from HuggingFace.
         - name: download-dataset
           image: ${LME_IMAGE}:${LME_IMAGE_TAG}
+          # Any tag other than the floating default pulls IfNotPresent, so a
+          # node with a cached layer under a moved tag would keep serving the
+          # old bytes.
+          imagePullPolicy: Always
           command: ["/loom-longmemeval"]
           args: ["download", "--datasets", "${LME_DATASET}", "--data-dir", "/data/longmemeval"]
           volumeMounts:
@@ -36,6 +40,10 @@ spec:
       containers:
         - name: runner
           image: ${LME_IMAGE}:${LME_IMAGE_TAG}
+          # Any tag other than the floating default pulls IfNotPresent, so a
+          # node with a cached layer under a moved tag would keep serving the
+          # old bytes.
+          imagePullPolicy: Always
           command: ["/bin/bash", "/scripts/run-slices.sh"]
           env:
             - name: SERVER

--- a/deploy/longmemeval/runner-script.yaml
+++ b/deploy/longmemeval/runner-script.yaml
@@ -1,23 +1,106 @@
+# Template — rendered by run-500.sh (render-common.sh, allowlisted envsubst).
+# Only allowlisted LME_* placeholders are substituted; the embedded script's
+# own shell variables pass through untouched.
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: lme-runner-script
-  namespace: loom-lme
+  namespace: ${LME_NAMESPACE}
 data:
   run-slices.sh: |
     #!/bin/bash
-    # Drives the full LongMemEval run in resumable chunks. Each chunk's output
-    # lands on the results PVC; chunks whose output already exists are skipped,
-    # so a pod restart (node reboot, transient failure, job re-run) resumes
-    # instead of restarting. Failed chunks have partial output removed so the
-    # next attempt redoes them; a non-zero exit makes the Job retry the pod.
+    # Drives the full LongMemEval run in resumable, validated chunks.
+    #
+    # Durability model (per chunk):
+    #   1. the harness writes to *.tmp paths on the results PVC
+    #   2. the chunk is validated: exact entry count, every line parses as
+    #      JSON with a unique non-empty question_id, and the detailed output
+    #      shows zero missing/errored entries (the harness skips errored
+    #      entries in the .jsonl and exits 0 even after a partial/cancelled
+    #      run, so a nonempty file alone proves nothing)
+    #   3. only then is the output promoted via atomic rename and a .done
+    #      marker written; the marker — never file nonemptiness — is the
+    #      resume signal, so a killed or partial attempt is always redone
+    #
+    # Run identity: outputs live under RESULTS_DIR/runs/RUN_ID and the stored
+    # manifest.txt must match RUN_MANIFEST before resuming, so chunks from a
+    # different configuration are never silently reused.
+    #
+    # Results are never deleted: a failed attempt removes only its own
+    # unpromoted *.tmp files; promoted outputs and other runs are untouched.
     set -uo pipefail
 
-    : "${SERVER:?}" "${DATASET_FILE:?}" "${MODE:?}" "${CONCURRENCY:?}" "${CHUNK:?}" "${OCCURRED_AT:?}" "${RESULTS_DIR:?}"
+    : "${SERVER:?}" "${DATASET_FILE:?}" "${MODE:?}" "${CONCURRENCY:?}" "${CHUNK:?}" "${OCCURRED_AT:?}" "${RESULTS_DIR:?}" "${RUN_ID:?}" "${RUN_MANIFEST:?}"
+    ALLOW_MANIFEST_DRIFT="${ALLOW_MANIFEST_DRIFT:-0}"
+
+    command -v jq >/dev/null 2>&1 || { echo "FATAL: jq not present in runner image (required for chunk validation)"; exit 1; }
+
+    run_dir="${RESULTS_DIR}/runs/${RUN_ID}"
+    mkdir -p "${run_dir}"
+
+    # Verify run identity before touching anything. A mismatch means this run
+    # directory was produced by a different configuration (dataset, mode,
+    # occurred_at, model, image, chunking) — resuming would mix results.
+    manifest_file="${run_dir}/manifest.txt"
+    if [ -f "${manifest_file}" ]; then
+      stored="$(cat "${manifest_file}")"
+      if [ "${stored}" != "${RUN_MANIFEST}" ]; then
+        if [ "${ALLOW_MANIFEST_DRIFT}" = "1" ]; then
+          echo "WARNING: resuming run ${RUN_ID} despite manifest drift (LME_ALLOW_MANIFEST_DRIFT=1)"
+          echo "  stored:  ${stored}"
+          echo "  current: ${RUN_MANIFEST}"
+          echo "$(date -u '+%FT%TZ') ${RUN_MANIFEST}" >> "${run_dir}/manifest-drift.log"
+        else
+          echo "FATAL: refusing to resume run ${RUN_ID}: this run directory was produced by a"
+          echo "different configuration. Existing outputs are preserved and untouched."
+          echo "  stored:  ${stored}"
+          echo "  current: ${RUN_MANIFEST}"
+          echo "A configuration change normally yields a new run id (fresh directory); to"
+          echo "knowingly continue THIS run — e.g. same benchmark on a rebuilt image —"
+          echo "re-run run-500.sh with LME_RUN_ID=${RUN_ID} LME_ALLOW_MANIFEST_DRIFT=1."
+          exit 1
+        fi
+      fi
+    else
+      printf '%s' "${RUN_MANIFEST}" > "${manifest_file}.tmp"
+      mv "${manifest_file}.tmp" "${manifest_file}"
+    fi
 
     # Per-type question counts in LongMemEval (oracle and _S share them).
     types=(temporal-reasoning multi-session knowledge-update single-session-user single-session-assistant single-session-preference)
     counts=(133 133 78 70 56 30)
+
+    # validate_chunk <jsonl> <detailed.json> <expected-entries>
+    # Complete = the .jsonl holds exactly the expected number of well-formed
+    # entries (unique non-empty question_id, hypothesis string) AND the
+    # detailed output holds the same number of results, none with an error
+    # (the harness marks per-entry failures via a non-empty "error" field
+    # there and omits them from the .jsonl).
+    validate_chunk() {
+      local out="$1" det="$2" want="$3"
+      if [ ! -s "${out}" ] || [ ! -s "${det}" ]; then
+        echo "  invalid chunk: missing or empty output (${out} / ${det})"
+        return 1
+      fi
+      if ! jq -e -s --argjson want "${want}" '
+            length == $want
+            and (map(.question_id) | unique | length) == $want
+            and all(.[]; type == "object"
+                    and (.question_id | type == "string" and length > 0)
+                    and (.hypothesis | type == "string"))' \
+            "${out}" >/dev/null; then
+        echo "  invalid chunk: ${out} is not exactly ${want} well-formed JSONL entries"
+        return 1
+      fi
+      if ! jq -e --argjson want "${want}" '
+            type == "array" and length == $want
+            and all(.[]; (.error // "") == "")' \
+            "${det}" >/dev/null; then
+        echo "  invalid chunk: ${det} reports missing or errored entries"
+        return 1
+      fi
+      return 0
+    }
 
     failed=0
     for i in "${!types[@]}"; do
@@ -26,15 +109,16 @@ data:
       while [ "$offset" -lt "$n" ]; do
         lim="$CHUNK"
         [ $((offset + lim)) -gt "$n" ] && lim=$((n - offset))
-        out="${RESULTS_DIR}/s500-${t}-o$(printf '%03d' "$offset").jsonl"
-        det="${out%.jsonl}-detailed.json"
-        if [ -s "$out" ]; then
-          echo "skip completed chunk: $out"
+        base="${run_dir}/s500-${t}-o$(printf '%03d' "$offset")"
+        out="${base}.jsonl"; det="${base}-detailed.json"; marker="${base}.done"
+        tmp_out="${out}.tmp"; tmp_det="${det}.tmp"
+        if [ -f "${marker}" ]; then
+          echo "skip completed chunk: ${out}"
           offset=$((offset + CHUNK))
           continue
         fi
-        echo "=== [$(date -u '+%F %T')] run: ${t} offset=${offset} limit=${lim} conc=${CONCURRENCY} mode=${MODE} ==="
-        if ! /loom-longmemeval run \
+        echo "=== [$(date -u '+%F %T')] run: ${t} offset=${offset} limit=${lim} conc=${CONCURRENCY} mode=${MODE} run_id=${RUN_ID} ==="
+        if /loom-longmemeval run \
             --server "$SERVER" \
             --dataset "$DATASET_FILE" \
             --mode "$MODE" \
@@ -43,15 +127,22 @@ data:
             --limit "$lim" \
             --concurrency "$CONCURRENCY" \
             --occurred-at="$OCCURRED_AT" \
-            --output "$out" \
-            --detailed "$det"; then
-          echo "CHUNK FAILED: ${t} offset=${offset} (removing partial output for retry)"
-          rm -f "$out" "$det"
+            --output "$tmp_out" \
+            --detailed "$tmp_det" \
+            && validate_chunk "$tmp_out" "$tmp_det" "$lim"; then
+          mv "$tmp_det" "$det"
+          mv "$tmp_out" "$out"
+          printf 'run_id=%s entries=%s completed=%s\n' "${RUN_ID}" "${lim}" "$(date -u '+%FT%TZ')" > "${marker}.tmp"
+          mv "${marker}.tmp" "${marker}"
+          echo "chunk complete: ${out} (${lim} entries)"
+        else
+          echo "CHUNK FAILED: ${t} offset=${offset} (removing unpromoted .tmp output; promoted results are never touched)"
+          rm -f "$tmp_out" "$tmp_det"
           failed=1
         fi
         offset=$((offset + CHUNK))
       done
     done
 
-    echo "=== run complete (failed=${failed}) ==="
+    echo "=== run complete (failed=${failed}, run_id=${RUN_ID}) ==="
     exit "$failed"

--- a/deploy/longmemeval/runner-script.yaml
+++ b/deploy/longmemeval/runner-script.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lme-runner-script
+  namespace: loom-lme
+data:
+  run-slices.sh: |
+    #!/bin/bash
+    # Drives the full LongMemEval run in resumable chunks. Each chunk's output
+    # lands on the results PVC; chunks whose output already exists are skipped,
+    # so a pod restart (node reboot, transient failure, job re-run) resumes
+    # instead of restarting. Failed chunks have partial output removed so the
+    # next attempt redoes them; a non-zero exit makes the Job retry the pod.
+    set -uo pipefail
+
+    : "${SERVER:?}" "${DATASET_FILE:?}" "${MODE:?}" "${CONCURRENCY:?}" "${CHUNK:?}" "${OCCURRED_AT:?}" "${RESULTS_DIR:?}"
+
+    # Per-type question counts in LongMemEval (oracle and _S share them).
+    types=(temporal-reasoning multi-session knowledge-update single-session-user single-session-assistant single-session-preference)
+    counts=(133 133 78 70 56 30)
+
+    failed=0
+    for i in "${!types[@]}"; do
+      t="${types[$i]}"; n="${counts[$i]}"
+      offset=0
+      while [ "$offset" -lt "$n" ]; do
+        lim="$CHUNK"
+        [ $((offset + lim)) -gt "$n" ] && lim=$((n - offset))
+        out="${RESULTS_DIR}/s500-${t}-o$(printf '%03d' "$offset").jsonl"
+        det="${out%.jsonl}-detailed.json"
+        if [ -s "$out" ]; then
+          echo "skip completed chunk: $out"
+          offset=$((offset + CHUNK))
+          continue
+        fi
+        echo "=== [$(date -u '+%F %T')] run: ${t} offset=${offset} limit=${lim} conc=${CONCURRENCY} mode=${MODE} ==="
+        if ! /loom-longmemeval run \
+            --server "$SERVER" \
+            --dataset "$DATASET_FILE" \
+            --mode "$MODE" \
+            --types "$t" \
+            --offset "$offset" \
+            --limit "$lim" \
+            --concurrency "$CONCURRENCY" \
+            --occurred-at="$OCCURRED_AT" \
+            --output "$out" \
+            --detailed "$det"; then
+          echo "CHUNK FAILED: ${t} offset=${offset} (removing partial output for retry)"
+          rm -f "$out" "$det"
+          failed=1
+        fi
+        offset=$((offset + CHUNK))
+      done
+    done
+
+    echo "=== run complete (failed=${failed}) ==="
+    exit "$failed"

--- a/deploy/longmemeval/runner-script.yaml
+++ b/deploy/longmemeval/runner-script.yaml
@@ -22,21 +22,47 @@ data:
     #      marker written; the marker — never file nonemptiness — is the
     #      resume signal, so a killed or partial attempt is always redone
     #
-    # Run identity: outputs live under RESULTS_DIR/runs/RUN_ID and the stored
-    # manifest.txt must match RUN_MANIFEST before resuming, so chunks from a
-    # different configuration are never silently reused.
+    # Attempt budget: validation is all-or-nothing but resume granularity is
+    # the whole chunk, so an entry that fails *deterministically* (a content
+    # filter on that question's text, an oversized session that always fails
+    # ingest) would otherwise re-bill its healthy neighbours on every one of
+    # the Job's restarts and still never complete. Each chunk therefore gets
+    # MAX_CHUNK_ATTEMPTS tries, counted on the PVC so the budget spans pod
+    # restarts; past that the chunk is quarantined (.failed marker) and later
+    # passes skip it, leaving the remaining chunks free to finish. The run
+    # still exits nonzero and writes RUN-INCOMPLETE.txt — a quarantined chunk
+    # means the published number would be missing entries.
     #
-    # Results are never deleted: a failed attempt removes only its own
-    # unpromoted *.tmp files; promoted outputs and other runs are untouched.
+    # Run identity: outputs live under RESULTS_DIR/runs/RUN_ID and both the
+    # stored manifest and the dataset's own statistics must match before
+    # resuming, so chunks from a different configuration or a revised dataset
+    # are never silently reused.
+    #
+    # Results are never deleted: a rejected attempt's output is moved into
+    # runs/RUN_ID/rejected/ (outside the s500-*.jsonl glob the scorer reads),
+    # never removed; promoted outputs and other runs are untouched.
     set -uo pipefail
 
     : "${SERVER:?}" "${DATASET_FILE:?}" "${MODE:?}" "${CONCURRENCY:?}" "${CHUNK:?}" "${OCCURRED_AT:?}" "${RESULTS_DIR:?}" "${RUN_ID:?}" "${RUN_MANIFEST:?}"
     ALLOW_MANIFEST_DRIFT="${ALLOW_MANIFEST_DRIFT:-0}"
+    MAX_CHUNK_ATTEMPTS="${MAX_CHUNK_ATTEMPTS:-3}"
 
     command -v jq >/dev/null 2>&1 || { echo "FATAL: jq not present in runner image (required for chunk validation)"; exit 1; }
 
+    # The harness binary. In the Job this is always the image's own copy; the
+    # seam exists so slice-loop-test.sh can drive this exact script offline,
+    # with a stub standing in for the paid Bedrock calls.
+    HARNESS="${HARNESS_BIN:-/loom-longmemeval}"
+
     run_dir="${RESULTS_DIR}/runs/${RUN_ID}"
+    reject_dir="${run_dir}/rejected"
     mkdir -p "${run_dir}"
+
+    # write_atomic <path> — persist stdin to path via a .tmp + rename, so a
+    # kill mid-write can never leave a half-written marker on the PVC.
+    write_atomic() {
+      cat > "$1.tmp" && mv "$1.tmp" "$1"
+    }
 
     # Verify run identity before touching anything. A mismatch means this run
     # directory was produced by a different configuration (dataset, mode,
@@ -62,13 +88,64 @@ data:
         fi
       fi
     else
-      printf '%s' "${RUN_MANIFEST}" > "${manifest_file}.tmp"
-      mv "${manifest_file}.tmp" "${manifest_file}"
+      printf '%s' "${RUN_MANIFEST}" | write_atomic "${manifest_file}"
     fi
 
-    # Per-type question counts in LongMemEval (oracle and _S share them).
-    types=(temporal-reasoning multi-session knowledge-update single-session-user single-session-assistant single-session-preference)
-    counts=(133 133 78 70 56 30)
+    # Per-type question counts come from the dataset, never a hardcoded table.
+    # A dataset revision that shifts a count would otherwise drive the final
+    # chunk past the last entry (the harness errors on offset >= entry count,
+    # failing every retry) or stop the loop early and quietly omit questions
+    # from a published number.
+    if ! stats="$("${HARNESS}" info --json "${DATASET_FILE}")" || [ -z "${stats}" ]; then
+      echo "FATAL: could not read dataset statistics from ${DATASET_FILE}"
+      exit 1
+    fi
+
+    types=(); counts=()
+    while IFS="$(printf '\t')" read -r t n; do
+      [ -n "${t}" ] || continue
+      types+=("${t}"); counts+=("${n}")
+    done < <(printf '%s' "${stats}" | jq -r '.question_types[] | [.type, .count] | @tsv')
+
+    if [ "${#types[@]}" -eq 0 ]; then
+      echo "FATAL: dataset ${DATASET_FILE} reports no question types"
+      exit 1
+    fi
+    total_entries="$(printf '%s' "${stats}" | jq -r '.entries')"
+    sum=0
+    for n in "${counts[@]}"; do sum=$((sum + n)); done
+    if [ "${sum}" -ne "${total_entries}" ]; then
+      echo "FATAL: per-type counts sum to ${sum} but the dataset holds ${total_entries} entries"
+      exit 1
+    fi
+
+    # The counts are part of what the run measures, so pin them the same way
+    # the manifest pins the configuration: a dataset swapped underneath a
+    # resume would otherwise reuse chunks answering different questions.
+    stats_id="$(printf '%s' "${stats}" | jq -cS '{entries, question_types}')"
+    stats_file="${run_dir}/dataset-stats.json"
+    if [ -f "${stats_file}" ]; then
+      stored_stats="$(cat "${stats_file}")"
+      if [ "${stored_stats}" != "${stats_id}" ]; then
+        if [ "${ALLOW_MANIFEST_DRIFT}" = "1" ]; then
+          echo "WARNING: resuming run ${RUN_ID} despite dataset drift (LME_ALLOW_MANIFEST_DRIFT=1)"
+          echo "$(date -u '+%FT%TZ') ${stats_id}" >> "${run_dir}/manifest-drift.log"
+        else
+          echo "FATAL: refusing to resume run ${RUN_ID}: ${DATASET_FILE} no longer holds the"
+          echo "questions this run's completed chunks answered. Existing outputs are preserved."
+          echo "  stored:  ${stored_stats}"
+          echo "  current: ${stats_id}"
+          exit 1
+        fi
+      fi
+    else
+      printf '%s' "${stats_id}" | write_atomic "${stats_file}"
+    fi
+
+    echo "=== dataset plan (${total_entries} entries, derived from ${DATASET_FILE}) ==="
+    for i in "${!types[@]}"; do
+      echo "  ${types[$i]}: ${counts[$i]}"
+    done
 
     # validate_chunk <jsonl> <detailed.json> <expected-entries>
     # Complete = the .jsonl holds exactly the expected number of well-formed
@@ -79,7 +156,7 @@ data:
     validate_chunk() {
       local out="$1" det="$2" want="$3"
       if [ ! -s "${out}" ] || [ ! -s "${det}" ]; then
-        echo "  invalid chunk: missing or empty output (${out} / ${det})"
+        echo "invalid chunk: missing or empty output (${out} / ${det})"
         return 1
       fi
       if ! jq -e -s --argjson want "${want}" '
@@ -89,20 +166,33 @@ data:
                     and (.question_id | type == "string" and length > 0)
                     and (.hypothesis | type == "string"))' \
             "${out}" >/dev/null; then
-        echo "  invalid chunk: ${out} is not exactly ${want} well-formed JSONL entries"
+        echo "invalid chunk: ${out} is not exactly ${want} well-formed JSONL entries"
         return 1
       fi
       if ! jq -e --argjson want "${want}" '
             type == "array" and length == $want
             and all(.[]; (.error // "") == "")' \
             "${det}" >/dev/null; then
-        echo "  invalid chunk: ${det} reports missing or errored entries"
+        echo "invalid chunk: ${det} reports missing or errored entries"
         return 1
       fi
       return 0
     }
 
+    # errored_entries <detailed.json> — the question ids the harness recorded
+    # a per-entry failure for, so a quarantine marker names the poison entry
+    # instead of only the chunk.
+    errored_entries() {
+      [ -s "$1" ] || { echo "  (no detailed output produced)"; return 0; }
+      jq -r 'if type == "array"
+             then (.[] | select((.error // "") != "") | "  \(.question_id): \(.error)")
+             else "  (detailed output is not a JSON array)" end' "$1" 2>/dev/null |
+        head -20
+    }
+
     failed=0
+    quarantined=()
+    completed=0
     for i in "${!types[@]}"; do
       t="${types[$i]}"; n="${counts[$i]}"
       offset=0
@@ -110,15 +200,29 @@ data:
         lim="$CHUNK"
         [ $((offset + lim)) -gt "$n" ] && lim=$((n - offset))
         base="${run_dir}/s500-${t}-o$(printf '%03d' "$offset")"
+        name="$(basename "${base}")"
         out="${base}.jsonl"; det="${base}-detailed.json"; marker="${base}.done"
+        attempts_file="${base}.attempts"; quarantine="${base}.failed"
         tmp_out="${out}.tmp"; tmp_det="${det}.tmp"
         if [ -f "${marker}" ]; then
           echo "skip completed chunk: ${out}"
+          completed=$((completed + 1))
           offset=$((offset + CHUNK))
           continue
         fi
-        echo "=== [$(date -u '+%F %T')] run: ${t} offset=${offset} limit=${lim} conc=${CONCURRENCY} mode=${MODE} run_id=${RUN_ID} ==="
-        if /loom-longmemeval run \
+        if [ -f "${quarantine}" ]; then
+          echo "skip quarantined chunk: ${name} (see ${quarantine})"
+          quarantined+=("${name}")
+          failed=1
+          offset=$((offset + CHUNK))
+          continue
+        fi
+
+        attempt=$(( $(cat "${attempts_file}" 2>/dev/null || echo 0) + 1 ))
+        printf '%s' "${attempt}" | write_atomic "${attempts_file}"
+
+        echo "=== [$(date -u '+%F %T')] run: ${t} offset=${offset} limit=${lim} conc=${CONCURRENCY} mode=${MODE} run_id=${RUN_ID} attempt=${attempt}/${MAX_CHUNK_ATTEMPTS} ==="
+        if "${HARNESS}" run \
             --server "$SERVER" \
             --dataset "$DATASET_FILE" \
             --mode "$MODE" \
@@ -128,21 +232,67 @@ data:
             --concurrency "$CONCURRENCY" \
             --occurred-at="$OCCURRED_AT" \
             --output "$tmp_out" \
-            --detailed "$tmp_det" \
-            && validate_chunk "$tmp_out" "$tmp_det" "$lim"; then
+            --detailed "$tmp_det"; then
+          reason="$(validate_chunk "$tmp_out" "$tmp_det" "$lim")"
+          ok=$?
+        else
+          reason="harness exited $?"
+          ok=1
+        fi
+
+        if [ "${ok}" -eq 0 ]; then
           mv "$tmp_det" "$det"
           mv "$tmp_out" "$out"
-          printf 'run_id=%s entries=%s completed=%s\n' "${RUN_ID}" "${lim}" "$(date -u '+%FT%TZ')" > "${marker}.tmp"
-          mv "${marker}.tmp" "${marker}"
-          echo "chunk complete: ${out} (${lim} entries)"
+          printf 'run_id=%s entries=%s attempts=%s completed=%s\n' \
+            "${RUN_ID}" "${lim}" "${attempt}" "$(date -u '+%FT%TZ')" | write_atomic "${marker}"
+          rm -f "${attempts_file}"
+          completed=$((completed + 1))
+          echo "chunk complete: ${out} (${lim} entries, attempt ${attempt})"
         else
-          echo "CHUNK FAILED: ${t} offset=${offset} (removing unpromoted .tmp output; promoted results are never touched)"
-          rm -f "$tmp_out" "$tmp_det"
           failed=1
+          echo "  ${reason}"
+          # Keep the rejected attempt: it cost real Bedrock spend and names
+          # the failing entries. It lands in rejected/ so the scorer's
+          # s500-*.jsonl glob can never pick it up as a result.
+          mkdir -p "${reject_dir}"
+          [ -f "$tmp_out" ] && mv -f "$tmp_out" "${reject_dir}/${name}.jsonl"
+          [ -f "$tmp_det" ] && mv -f "$tmp_det" "${reject_dir}/${name}-detailed.json"
+          if [ "${attempt}" -ge "${MAX_CHUNK_ATTEMPTS}" ]; then
+            {
+              printf 'run_id=%s type=%s offset=%s limit=%s attempts=%s quarantined=%s\n' \
+                "${RUN_ID}" "${t}" "${offset}" "${lim}" "${attempt}" "$(date -u '+%FT%TZ')"
+              printf 'last failure: %s\n' "${reason}"
+              printf 'last attempt output: rejected/%s.jsonl, rejected/%s-detailed.json\n' "${name}" "${name}"
+              printf 'entries the harness reported an error for:\n'
+              errored_entries "${reject_dir}/${name}-detailed.json"
+              printf 'to retry this chunk: rm %s %s\n' "${quarantine}" "${attempts_file}"
+            } | write_atomic "${quarantine}"
+            quarantined+=("${name}")
+            echo "CHUNK QUARANTINED after ${attempt} attempts: ${name} — later passes will skip it so the remaining chunks can finish. See ${quarantine}."
+          else
+            echo "CHUNK FAILED (attempt ${attempt}/${MAX_CHUNK_ATTEMPTS}): ${name} — retried on the next pod restart."
+          fi
         fi
         offset=$((offset + CHUNK))
       done
     done
 
+    echo "=== run summary (run_id=${RUN_ID}) ==="
+    echo "  completed chunks:   ${completed}"
+    echo "  quarantined chunks: ${#quarantined[@]}"
+    if [ "${#quarantined[@]}" -gt 0 ]; then
+      {
+        printf 'run_id=%s written=%s\n' "${RUN_ID}" "$(date -u '+%FT%TZ')"
+        printf 'This run is INCOMPLETE: %s chunk(s) exhausted MAX_CHUNK_ATTEMPTS=%s and were\n' "${#quarantined[@]}" "${MAX_CHUNK_ATTEMPTS}"
+        printf 'skipped. Scoring s500-*.jsonl will omit their entries, so any number derived\n'
+        printf 'from this run is not the full benchmark. Each chunk has a .failed marker\n'
+        printf 'naming the entries that failed and how to retry it.\n'
+        printf 'quarantined chunks:\n'
+        for q in "${quarantined[@]}"; do printf '  %s\n' "${q}"; done
+      } | write_atomic "${run_dir}/RUN-INCOMPLETE.txt"
+      echo "  wrote ${run_dir}/RUN-INCOMPLETE.txt"
+      echo "  NOTE: the Job will keep restarting until backoffLimit is reached; later"
+      echo "        passes are no-ops (every chunk is done or quarantined) and cost nothing."
+    fi
     echo "=== run complete (failed=${failed}, run_id=${RUN_ID}) ==="
     exit "$failed"

--- a/deploy/longmemeval/runner-script.yaml
+++ b/deploy/longmemeval/runner-script.yaml
@@ -60,8 +60,24 @@ data:
 
     # write_atomic <path> — persist stdin to path via a .tmp + rename, so a
     # kill mid-write can never leave a half-written marker on the PVC.
+    # Returns nonzero if EITHER step fails; every caller must check it. The
+    # script runs without `set -e`, so an unchecked write on a full or
+    # flaking Azure Files volume would otherwise be silently ignored and the
+    # chunk reported complete with nothing durable behind it.
     write_atomic() {
-      cat > "$1.tmp" && mv "$1.tmp" "$1"
+      cat > "$1.tmp" || { echo "  PVC WRITE FAILED: $1.tmp"; rm -f "$1.tmp"; return 1; }
+      mv "$1.tmp" "$1" || { echo "  PVC RENAME FAILED: $1.tmp -> $1"; rm -f "$1.tmp"; return 1; }
+      return 0
+    }
+
+    # fatal_pvc <message> — a persistence failure is never a chunk-level
+    # problem to retry past: durable state is uncertain, so stop the pass
+    # immediately and let the Job restart rather than continue writing more
+    # results into a volume that just failed.
+    fatal_pvc() {
+      echo "FATAL: results PVC write failed: $*"
+      echo "Refusing to continue: completed chunks cannot be trusted while the volume is failing."
+      exit 1
     }
 
     # Verify run identity before touching anything. A mismatch means this run
@@ -88,7 +104,7 @@ data:
         fi
       fi
     else
-      printf '%s' "${RUN_MANIFEST}" | write_atomic "${manifest_file}"
+      printf '%s' "${RUN_MANIFEST}" | write_atomic "${manifest_file}" || fatal_pvc "${manifest_file}"
     fi
 
     # Per-type question counts come from the dataset, never a hardcoded table.
@@ -122,7 +138,16 @@ data:
     # The counts are part of what the run measures, so pin them the same way
     # the manifest pins the configuration: a dataset swapped underneath a
     # resume would otherwise reuse chunks answering different questions.
-    stats_id="$(printf '%s' "${stats}" | jq -cS '{entries, question_types}')"
+    # Summary statistics do not identify a dataset: a revision that keeps the
+    # same entry count and type distribution but changes question text or
+    # answers would resume onto chunks that answered different questions.
+    # Hash the file itself.
+    if command -v sha256sum >/dev/null 2>&1; then
+      dataset_digest="$(sha256sum "${DATASET_FILE}" | cut -d' ' -f1)"
+    else
+      dataset_digest="$(shasum -a 256 "${DATASET_FILE}" | cut -d' ' -f1)"
+    fi
+    stats_id="$(printf '%s' "${stats}" | jq -cS --arg d "${dataset_digest}" '{entries, question_types, dataset_sha256: $d}')"
     stats_file="${run_dir}/dataset-stats.json"
     if [ -f "${stats_file}" ]; then
       stored_stats="$(cat "${stats_file}")"
@@ -139,7 +164,7 @@ data:
         fi
       fi
     else
-      printf '%s' "${stats_id}" | write_atomic "${stats_file}"
+      printf '%s' "${stats_id}" | write_atomic "${stats_file}" || fatal_pvc "${stats_file}"
     fi
 
     echo "=== dataset plan (${total_entries} entries, derived from ${DATASET_FILE}) ==="
@@ -218,10 +243,16 @@ data:
           continue
         fi
 
-        attempt=$(( $(cat "${attempts_file}" 2>/dev/null || echo 0) + 1 ))
-        printf '%s' "${attempt}" | write_atomic "${attempts_file}"
+        # The quarantine budget counts DETERMINISTIC failures only — a chunk
+        # that ran and produced output which failed validation. A harness
+        # that could not run at all (provider outage, server restart,
+        # transport error) says nothing about the chunk's entries, and
+        # burning the budget on it would quarantine ~9 healthy entries over
+        # three unlucky minutes. Infrastructure retries are bounded by the
+        # Job's backoffLimit instead.
+        attempt=$(cat "${attempts_file}" 2>/dev/null || echo 0)
 
-        echo "=== [$(date -u '+%F %T')] run: ${t} offset=${offset} limit=${lim} conc=${CONCURRENCY} mode=${MODE} run_id=${RUN_ID} attempt=${attempt}/${MAX_CHUNK_ATTEMPTS} ==="
+        echo "=== [$(date -u '+%F %T')] run: ${t} offset=${offset} limit=${lim} conc=${CONCURRENCY} mode=${MODE} run_id=${RUN_ID} deterministic_failures=${attempt}/${MAX_CHUNK_ATTEMPTS} ==="
         if "${HARNESS}" run \
             --server "$SERVER" \
             --dataset "$DATASET_FILE" \
@@ -233,18 +264,28 @@ data:
             --occurred-at="$OCCURRED_AT" \
             --output "$tmp_out" \
             --detailed "$tmp_det"; then
+          harness_rc=0
           reason="$(validate_chunk "$tmp_out" "$tmp_det" "$lim")"
           ok=$?
         else
-          reason="harness exited $?"
+          harness_rc=$?
+          reason="harness exited ${harness_rc}"
           ok=1
         fi
 
         if [ "${ok}" -eq 0 ]; then
-          mv "$tmp_det" "$det"
-          mv "$tmp_out" "$out"
-          printf 'run_id=%s entries=%s attempts=%s completed=%s\n' \
-            "${RUN_ID}" "${lim}" "${attempt}" "$(date -u '+%FT%TZ')" | write_atomic "${marker}"
+          # Promotion is the only point where a validated chunk becomes
+          # durable, so every step is checked and the .done marker is written
+          # LAST, after both promoted files are confirmed present. An
+          # unchecked rename here would report "chunk complete" for a chunk
+          # that is not on the volume — the run would then skip it forever
+          # and score a benchmark that silently lost those entries.
+          mv "$tmp_det" "$det" || fatal_pvc "promote ${det}"
+          mv "$tmp_out" "$out" || fatal_pvc "promote ${out}"
+          [ -s "$det" ] && [ -s "$out" ] || fatal_pvc "promoted outputs missing after rename (${out})"
+          printf 'run_id=%s entries=%s deterministic_failures=%s completed=%s\n' \
+            "${RUN_ID}" "${lim}" "${attempt}" "$(date -u '+%FT%TZ')" | write_atomic "${marker}" \
+            || fatal_pvc "completion marker ${marker}"
           rm -f "${attempts_file}"
           completed=$((completed + 1))
           echo "chunk complete: ${out} (${lim} entries, attempt ${attempt})"
@@ -257,20 +298,34 @@ data:
           mkdir -p "${reject_dir}"
           [ -f "$tmp_out" ] && mv -f "$tmp_out" "${reject_dir}/${name}.jsonl"
           [ -f "$tmp_det" ] && mv -f "$tmp_det" "${reject_dir}/${name}-detailed.json"
+          if [ "${harness_rc}" -ne 0 ]; then
+            # The harness could not run. That is infrastructure, not a
+            # verdict on these entries, so the deterministic budget is
+            # untouched and the Job's backoffLimit bounds the retries.
+            echo "CHUNK FAILED (infrastructure, budget untouched): ${name} — harness exited ${harness_rc}; retried on the next pod restart."
+            offset=$((offset + CHUNK))
+            continue
+          fi
+
+          # The chunk ran and produced output that failed validation: a
+          # deterministic problem with these entries. Consume the budget.
+          attempt=$((attempt + 1))
+          printf '%s' "${attempt}" | write_atomic "${attempts_file}" || fatal_pvc "${attempts_file}"
+
           if [ "${attempt}" -ge "${MAX_CHUNK_ATTEMPTS}" ]; then
             {
-              printf 'run_id=%s type=%s offset=%s limit=%s attempts=%s quarantined=%s\n' \
+              printf 'run_id=%s type=%s offset=%s limit=%s deterministic_failures=%s quarantined=%s\n' \
                 "${RUN_ID}" "${t}" "${offset}" "${lim}" "${attempt}" "$(date -u '+%FT%TZ')"
               printf 'last failure: %s\n' "${reason}"
               printf 'last attempt output: rejected/%s.jsonl, rejected/%s-detailed.json\n' "${name}" "${name}"
               printf 'entries the harness reported an error for:\n'
               errored_entries "${reject_dir}/${name}-detailed.json"
               printf 'to retry this chunk: rm %s %s\n' "${quarantine}" "${attempts_file}"
-            } | write_atomic "${quarantine}"
+            } | write_atomic "${quarantine}" || fatal_pvc "${quarantine}"
             quarantined+=("${name}")
-            echo "CHUNK QUARANTINED after ${attempt} attempts: ${name} — later passes will skip it so the remaining chunks can finish. See ${quarantine}."
+            echo "CHUNK QUARANTINED after ${attempt} deterministic failures: ${name} — later passes will skip it so the remaining chunks can finish. See ${quarantine}."
           else
-            echo "CHUNK FAILED (attempt ${attempt}/${MAX_CHUNK_ATTEMPTS}): ${name} — retried on the next pod restart."
+            echo "CHUNK FAILED (deterministic ${attempt}/${MAX_CHUNK_ATTEMPTS}): ${name} — retried on the next pod restart."
           fi
         fi
         offset=$((offset + CHUNK))
@@ -289,10 +344,17 @@ data:
         printf 'naming the entries that failed and how to retry it.\n'
         printf 'quarantined chunks:\n'
         for q in "${quarantined[@]}"; do printf '  %s\n' "${q}"; done
-      } | write_atomic "${run_dir}/RUN-INCOMPLETE.txt"
+      } | write_atomic "${run_dir}/RUN-INCOMPLETE.txt" || fatal_pvc "RUN-INCOMPLETE.txt"
       echo "  wrote ${run_dir}/RUN-INCOMPLETE.txt"
       echo "  NOTE: the Job will keep restarting until backoffLimit is reached; later"
       echo "        passes are no-ops (every chunk is done or quarantined) and cost nothing."
+    elif [ -f "${run_dir}/RUN-INCOMPLETE.txt" ]; then
+      # A quarantined chunk was recovered (operator removed its .failed and
+      # .attempts markers) and the run has since completed. Leaving the
+      # sentinel behind would tell the next reader — and the README tells
+      # them to believe it — that a complete run is missing entries.
+      rm -f "${run_dir}/RUN-INCOMPLETE.txt"
+      echo "  cleared a stale RUN-INCOMPLETE.txt: every chunk is now complete"
     fi
     echo "=== run complete (failed=${failed}, run_id=${RUN_ID}) ==="
     exit "$failed"

--- a/deploy/longmemeval/scale-down.sh
+++ b/deploy/longmemeval/scale-down.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# scale-down.sh — Scale the workload node pool to 0 when idle.
+# The results and data PVCs survive; scale back up with:
+#   az aks nodepool scale ... --node-count 1
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lme.env
+source "${SCRIPT_DIR}/lme.env"
+[[ -f "${SCRIPT_DIR}/lme.env.local" ]] && source "${SCRIPT_DIR}/lme.env.local"
+
+echo "Scaling workload pool to 0 (server and any running job will stop)..."
+az aks nodepool scale \
+    --cluster-name "${LME_CLUSTER_NAME}" \
+    --resource-group "${LME_RESOURCE_GROUP}" \
+    --name loomlme \
+    --node-count 0 \
+    -o none
+
+echo "Done. Idle cost is the system pool + storage only."

--- a/deploy/longmemeval/server-config.yaml
+++ b/deploy/longmemeval/server-config.yaml
@@ -1,18 +1,19 @@
+# Template — rendered by run-500.sh (render-common.sh, allowlisted envsubst).
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: lme-server-config
-  namespace: loom-lme
+  namespace: ${LME_NAMESPACE}
 data:
   looms.yaml: |
     llm:
       provider: bedrock
-      bedrock_model_id: global.anthropic.claude-opus-4-6-v1
+      bedrock_model_id: ${LME_MODEL}
       bedrock_region: us-west-2
       # bedrock_bearer_token comes from LOOM_LLM_BEDROCK_BEARER_TOKEN (Secret lme-bedrock)
     server:
       host: 0.0.0.0
-      port: 60051
+      port: ${LME_GRPC_PORT}
       # Required: the harness replays historical conversations and anchors
       # them via WeaveRequest.occurred_at.
       allow_time_override: true

--- a/deploy/longmemeval/server-config.yaml
+++ b/deploy/longmemeval/server-config.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lme-server-config
+  namespace: loom-lme
+data:
+  looms.yaml: |
+    llm:
+      provider: bedrock
+      bedrock_model_id: global.anthropic.claude-opus-4-6-v1
+      bedrock_region: us-west-2
+      # bedrock_bearer_token comes from LOOM_LLM_BEDROCK_BEARER_TOKEN (Secret lme-bedrock)
+    server:
+      host: 0.0.0.0
+      port: 60051
+      # Required: the harness replays historical conversations and anchors
+      # them via WeaveRequest.occurred_at.
+      allow_time_override: true
+    database:
+      path: /var/lib/loom/loom.db
+    observability:
+      enabled: true
+      mode: embedded
+      storage_type: sqlite
+      sqlite_path: /var/lib/loom/observability.db

--- a/deploy/longmemeval/server-deployment.yaml
+++ b/deploy/longmemeval/server-deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lme-server
+  namespace: loom-lme
+  labels:
+    app: lme-server
+spec:
+  replicas: 1
+  # The server holds per-run sqlite state on an emptyDir; never run two at once.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: lme-server
+  template:
+    metadata:
+      labels:
+        app: lme-server
+    spec:
+      nodeSelector:
+        loom-role: lme
+      tolerations:
+        - key: loom-role
+          value: lme
+          effect: NoSchedule
+      containers:
+        - name: server
+          image: loomcloudacr.azurecr.io/loom-longmemeval:latest
+          command: ["/looms"]
+          args: ["serve", "--config", "/etc/loom/looms.yaml"]
+          ports:
+            - name: grpc
+              containerPort: 60051
+              protocol: TCP
+          env:
+            - name: HOME
+              value: /var/lib/loom
+            - name: LOOM_LLM_BEDROCK_BEARER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: lme-bedrock
+                  key: bearer-token
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loom
+              readOnly: true
+            - name: state
+              mountPath: /var/lib/loom
+          resources:
+            requests:
+              cpu: "3"
+              memory: "8Gi"
+            limits:
+              cpu: "6"
+              memory: "16Gi"
+          readinessProbe:
+            tcpSocket:
+              port: grpc
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: grpc
+            initialDelaySeconds: 15
+            periodSeconds: 20
+      volumes:
+        - name: config
+          configMap:
+            name: lme-server-config
+        - name: state
+          emptyDir:
+            sizeLimit: 20Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: lme-server
+  namespace: loom-lme
+spec:
+  selector:
+    app: lme-server
+  ports:
+    - name: grpc
+      port: 60051
+      targetPort: grpc

--- a/deploy/longmemeval/server-deployment.yaml
+++ b/deploy/longmemeval/server-deployment.yaml
@@ -1,8 +1,9 @@
+# Template — rendered by run-500.sh (render-common.sh, allowlisted envsubst).
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: lme-server
-  namespace: loom-lme
+  namespace: ${LME_NAMESPACE}
   labels:
     app: lme-server
 spec:
@@ -26,12 +27,12 @@ spec:
           effect: NoSchedule
       containers:
         - name: server
-          image: loomcloudacr.azurecr.io/loom-longmemeval:latest
+          image: ${LME_IMAGE}:${LME_IMAGE_TAG}
           command: ["/looms"]
           args: ["serve", "--config", "/etc/loom/looms.yaml"]
           ports:
             - name: grpc
-              containerPort: 60051
+              containerPort: ${LME_GRPC_PORT}
               protocol: TCP
           env:
             - name: HOME
@@ -76,11 +77,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: lme-server
-  namespace: loom-lme
+  namespace: ${LME_NAMESPACE}
 spec:
   selector:
     app: lme-server
   ports:
     - name: grpc
-      port: 60051
+      port: ${LME_GRPC_PORT}
       targetPort: grpc

--- a/deploy/longmemeval/server-deployment.yaml
+++ b/deploy/longmemeval/server-deployment.yaml
@@ -18,6 +18,14 @@ spec:
     metadata:
       labels:
         app: lme-server
+      annotations:
+        # looms reads its config once at startup (cobra.OnInitialize) and has
+        # no watcher, so a ConfigMap-only change — a different LME_MODEL, say
+        # — would leave the OLD model serving while the run manifest claims
+        # the new one. Stamping the rendered config's hash into the pod
+        # template makes such a change roll the pod, so the server that
+        # answers is always the one this run's identity records.
+        loom.dev/config-checksum: "${LME_CONFIG_HASH}"
     spec:
       nodeSelector:
         loom-role: lme
@@ -28,6 +36,10 @@ spec:
       containers:
         - name: server
           image: ${LME_IMAGE}:${LME_IMAGE_TAG}
+          # Any tag other than the floating default pulls IfNotPresent, so a
+          # node with a cached layer under a moved tag would keep serving the
+          # old bytes.
+          imagePullPolicy: Always
           command: ["/looms"]
           args: ["serve", "--config", "/etc/loom/looms.yaml"]
           ports:

--- a/deploy/longmemeval/setup-cluster.sh
+++ b/deploy/longmemeval/setup-cluster.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# setup-cluster.sh — Create a small AKS cluster for the LongMemEval run.
+#
+# Unlike deploy/benchmark (CPU-bound load tests on big nodes), this run is
+# LLM-bound: the pods mostly wait on Bedrock, so nodes are small and cheap
+# (~$0.55/hr total). Sources lme.env; override via lme.env.local.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lme.env
+source "${SCRIPT_DIR}/lme.env"
+[[ -f "${SCRIPT_DIR}/lme.env.local" ]] && source "${SCRIPT_DIR}/lme.env.local"
+
+echo "=== Step 1/5: Creating resource group ${LME_RESOURCE_GROUP} ==="
+az group create --name "${LME_RESOURCE_GROUP}" --location "${LME_LOCATION}" -o none
+
+echo "=== Step 2/5: Creating AKS cluster ${LME_CLUSTER_NAME} ==="
+az aks create \
+    --resource-group "${LME_RESOURCE_GROUP}" \
+    --name "${LME_CLUSTER_NAME}" \
+    --node-count 1 \
+    --node-vm-size "${LME_SYSTEM_VM_SIZE}" \
+    --nodepool-name system \
+    --generate-ssh-keys \
+    --network-plugin azure \
+    -o none
+
+echo "=== Step 3/5: Adding workload node pool (${LME_WORK_VM_SIZE}) ==="
+az aks nodepool add \
+    --cluster-name "${LME_CLUSTER_NAME}" \
+    --resource-group "${LME_RESOURCE_GROUP}" \
+    --name loomlme \
+    --node-count 1 \
+    --node-vm-size "${LME_WORK_VM_SIZE}" \
+    --labels loom-role=lme \
+    --node-taints loom-role=lme:NoSchedule \
+    -o none
+
+echo "=== Step 4/5: Getting cluster credentials ==="
+az aks get-credentials \
+    --resource-group "${LME_RESOURCE_GROUP}" \
+    --name "${LME_CLUSTER_NAME}" \
+    --overwrite-existing
+
+echo "=== Step 5/5: Attaching ACR ${LME_ACR_NAME} ==="
+az aks update \
+    --resource-group "${LME_RESOURCE_GROUP}" \
+    --name "${LME_CLUSTER_NAME}" \
+    --attach-acr "${LME_ACR_NAME}" \
+    -o none
+
+echo ""
+echo "=== Cluster ready ==="
+kubectl get nodes -o wide

--- a/deploy/longmemeval/slice-loop-test.sh
+++ b/deploy/longmemeval/slice-loop-test.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# slice-loop-test.sh — Drives the real runner slice loop offline.
+#
+# The loop is where a multi-day, paid run can silently go wrong, so it is
+# tested rather than reasoned about: the script under test is extracted from
+# the rendered ConfigMap (not a copy), and only the harness is stubbed — the
+# real `loom-longmemeval info --json` still supplies the per-type counts, so
+# the derived-counts contract is exercised end to end.
+#
+# Covers:
+#   1. counts come from the dataset (a dataset whose per-type counts differ
+#      from any hardcoded table is walked exactly, with no overrun or omission)
+#   2. resume skips only chunks with a .done marker
+#   3. a deterministically-failing entry quarantines its chunk after
+#      MAX_CHUNK_ATTEMPTS instead of re-billing its healthy neighbours forever,
+#      and the remaining chunks still complete
+#   4. a rejected attempt's output is preserved outside the scorer's glob
+#   5. a dataset swapped underneath a resume is refused
+#
+# No cluster or Bedrock access needed. Usage:
+#   bash deploy/longmemeval/slice-loop-test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=render-common.sh
+source "${SCRIPT_DIR}/render-common.sh"
+
+for tool in jq python3 go; do
+    command -v "${tool}" >/dev/null 2>&1 || { echo "SKIP: ${tool} not available"; exit 0; }
+done
+python3 -c 'import yaml' 2>/dev/null || { echo "SKIP: python3 pyyaml not available"; exit 0; }
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+failures=0
+fail() { echo "FAIL: $*"; failures=$((failures + 1)); }
+ok() { echo "  ok: $*"; }
+
+# ── Extract the script under test from the rendered ConfigMap ────────────────
+export LME_NAMESPACE="lme-slice-test" LME_IMAGE="t/i" LME_IMAGE_TAG="t" \
+    LME_GRPC_PORT="50051" LME_MODEL="m" LME_DATASET="small" \
+    LME_DATASET_FILE="d.json" LME_MODE="ingest" LME_CONCURRENCY="1" \
+    LME_CHUNK="2" LME_OCCURRED_AT="false" LME_RUN_ID="sliceTest01" \
+    LME_RUN_MANIFEST="test-manifest" LME_ALLOW_MANIFEST_DRIFT="0" \
+    LME_MAX_CHUNK_ATTEMPTS="2"
+
+lme_render "${SCRIPT_DIR}/runner-script.yaml" > "${TMP_DIR}/cm.yaml" \
+    || { echo "FAIL: runner-script.yaml did not render"; exit 1; }
+python3 -c 'import sys, yaml; sys.stdout.write(yaml.safe_load(open(sys.argv[1]))["data"]["run-slices.sh"])' \
+    "${TMP_DIR}/cm.yaml" > "${TMP_DIR}/run-slices.sh" \
+    || { echo "FAIL: could not extract run-slices.sh"; exit 1; }
+
+# ── Real harness for `info`, stub for `run` ─────────────────────────────────
+echo "Building loom-longmemeval (used for the real info --json contract)..."
+go build -tags fts5 -o "${TMP_DIR}/loom-longmemeval" "${REPO_ROOT}/cmd/loom-longmemeval" \
+    || { echo "FAIL: could not build loom-longmemeval"; exit 1; }
+
+# Dataset with per-type counts that match no hardcoded table: 5 + 3 entries.
+# With CHUNK=2 that is chunks of 2,2,1 (alpha) and 2,1 (beta) — the ragged
+# final chunk a wrong hardcoded count would overrun or truncate.
+python3 - "${TMP_DIR}/dataset.json" <<'PY'
+import json, sys
+entries = []
+for t, n in (("alpha-type", 5), ("beta-type", 3)):
+    for i in range(n):
+        entries.append({
+            "question_id": f"{t}-{i}",
+            "question_type": t,
+            "question": "q",
+            "answer": "a",
+            "haystack_sessions": [[{"role": "user", "content": "hi"}]],
+        })
+json.dump(entries, open(sys.argv[1], "w"))
+PY
+
+# The stub answers `info` from the real binary and synthesizes `run` output.
+# POISON_IDS (space separated) are recorded as per-entry errors, exactly as
+# the harness does: omitted from the .jsonl, present with an "error" in the
+# detailed JSON. Every invocation is logged so re-billing is observable.
+cat > "${TMP_DIR}/harness-stub.sh" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+REAL="${TMP_DIR}/loom-longmemeval"
+if [[ "${1:-}" == "info" ]]; then
+    shift
+    exec "${REAL}" info "$@"
+fi
+shift  # drop "run"
+dataset="" types="" offset=0 limit=0 out="" det=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dataset) dataset="$2"; shift 2 ;;
+        --types) types="$2"; shift 2 ;;
+        --offset) offset="$2"; shift 2 ;;
+        --limit) limit="$2"; shift 2 ;;
+        --output) out="$2"; shift 2 ;;
+        --detailed) det="$2"; shift 2 ;;
+        --occurred-at=*) shift ;;
+        *) shift 2 ;;
+    esac
+done
+echo "${types} ${offset} ${limit}" >> "${TMP_DIR}/invocations.log"
+
+ids="$(jq -r --arg t "${types}" --argjson o "${offset}" --argjson l "${limit}" \
+    '[.[] | select(.question_type == $t) | .question_id][$o:($o+$l)][]' "${dataset}")"
+: > "${out}"
+printf '[' > "${det}"
+first=1
+for id in ${ids}; do
+    poisoned=0
+    for p in ${POISON_IDS:-}; do [[ "${id}" == "${p}" ]] && poisoned=1; done
+    [[ ${first} -eq 1 ]] || printf ',' >> "${det}"
+    first=0
+    if [[ ${poisoned} -eq 1 ]]; then
+        printf '{"question_id":"%s","error":"deterministic content-filter rejection"}' "${id}" >> "${det}"
+    else
+        printf '{"question_id":"%s","hypothesis":"h","error":""}' "${id}" >> "${det}"
+        printf '{"question_id":"%s","hypothesis":"h"}\n' "${id}" >> "${out}"
+    fi
+done
+printf ']' >> "${det}"
+exit 0
+STUB
+chmod +x "${TMP_DIR}/harness-stub.sh"
+
+# run_loop <results-dir> — one pass of the slice loop (one pod lifetime).
+run_loop() {
+    TMP_DIR="${TMP_DIR}" POISON_IDS="${POISON_IDS:-}" \
+    HARNESS_BIN="${TMP_DIR}/harness-stub.sh" \
+    SERVER="stub:1" DATASET_FILE="${TMP_DIR}/dataset.json" MODE="ingest" \
+    CONCURRENCY="1" CHUNK="2" OCCURRED_AT="false" RESULTS_DIR="$1" \
+    RUN_ID="${LME_RUN_ID}" RUN_MANIFEST="${LME_RUN_MANIFEST}" \
+    MAX_CHUNK_ATTEMPTS="${LME_MAX_CHUNK_ATTEMPTS}" \
+        bash "${TMP_DIR}/run-slices.sh" > "${TMP_DIR}/loop.log" 2>&1
+}
+
+# ── 1. Happy path: counts derived from the dataset, every entry covered ─────
+echo "=== 1. derived counts cover every entry exactly ==="
+R1="${TMP_DIR}/r1"; mkdir -p "${R1}"
+: > "${TMP_DIR}/invocations.log"
+POISON_IDS="" run_loop "${R1}"
+rc=$?
+run_dir="${R1}/runs/${LME_RUN_ID}"
+[[ ${rc} -eq 0 ]] || fail "happy-path loop exited ${rc} (log: $(tail -3 "${TMP_DIR}/loop.log"))"
+[[ ${rc} -eq 0 ]] && ok "loop exited 0"
+
+want_chunks=5   # alpha: 0,2,4  beta: 0,2
+got_done="$(find "${run_dir}" -name '*.done' | wc -l | tr -d ' ')"
+[[ "${got_done}" == "${want_chunks}" ]] \
+    && ok "${want_chunks} chunks completed" \
+    || fail "expected ${want_chunks} .done markers, got ${got_done}"
+
+got_entries="$(cat "${run_dir}"/s500-*.jsonl | wc -l | tr -d ' ')"
+[[ "${got_entries}" == "8" ]] \
+    && ok "all 8 dataset entries present in the results glob" \
+    || fail "expected 8 result rows, got ${got_entries}"
+
+# The ragged final chunk must be sized to what remains, never overrun the type.
+grep -q '^alpha-type 4 1$' "${TMP_DIR}/invocations.log" \
+    && ok "final alpha chunk requested limit 1 (not the full CHUNK)" \
+    || fail "final ragged chunk was not sized from the derived count"
+grep -q "^alpha-type 6" "${TMP_DIR}/invocations.log" \
+    && fail "loop ran past the last alpha entry" \
+    || ok "loop never ran past the last entry"
+
+# ── 2. Resume skips completed chunks (no re-billing) ────────────────────────
+echo "=== 2. resume skips completed chunks ==="
+: > "${TMP_DIR}/invocations.log"
+POISON_IDS="" run_loop "${R1}"
+rc=$?
+[[ ${rc} -eq 0 ]] || fail "resume pass exited ${rc}"
+[[ ! -s "${TMP_DIR}/invocations.log" ]] \
+    && ok "second pass made zero harness calls" \
+    || fail "second pass re-ran chunks: $(cat "${TMP_DIR}/invocations.log")"
+
+# ── 3-4. A poison entry quarantines its chunk, not the whole run ────────────
+echo "=== 3. deterministic failure quarantines its chunk ==="
+R2="${TMP_DIR}/r2"; mkdir -p "${R2}"
+run_dir2="${R2}/runs/${LME_RUN_ID}"
+: > "${TMP_DIR}/invocations.log"
+export POISON_IDS="alpha-type-2"   # lands in chunk alpha offset 2
+for pass in 1 2 3 4; do
+    run_loop "${R2}"
+    rc=$?
+done
+[[ ${rc} -ne 0 ]] \
+    && ok "run still exits nonzero while a chunk is missing" \
+    || fail "run exited 0 despite a quarantined chunk"
+
+[[ -f "${run_dir2}/s500-alpha-type-o002.failed" ]] \
+    && ok "poison chunk quarantined" \
+    || fail "poison chunk has no .failed marker"
+grep -q 'alpha-type-2' "${run_dir2}/s500-alpha-type-o002.failed" \
+    && ok "quarantine marker names the failing entry" \
+    || fail "quarantine marker does not name the failing entry"
+
+# Bounded re-billing: 2 attempts, not one per pass.
+attempts="$(grep -c '^alpha-type 2 ' "${TMP_DIR}/invocations.log")"
+[[ "${attempts}" == "${LME_MAX_CHUNK_ATTEMPTS}" ]] \
+    && ok "poison chunk attempted exactly ${LME_MAX_CHUNK_ATTEMPTS} times across 4 passes" \
+    || fail "poison chunk attempted ${attempts} times, expected ${LME_MAX_CHUNK_ATTEMPTS}"
+
+healthy_done="$(find "${run_dir2}" -name '*.done' | wc -l | tr -d ' ')"
+[[ "${healthy_done}" == "4" ]] \
+    && ok "the other 4 chunks completed despite the poison chunk" \
+    || fail "expected 4 healthy chunks to complete, got ${healthy_done}"
+
+[[ -f "${run_dir2}/RUN-INCOMPLETE.txt" ]] \
+    && ok "RUN-INCOMPLETE.txt records that the run is missing entries" \
+    || fail "no RUN-INCOMPLETE.txt written"
+
+echo "=== 4. rejected output is preserved, outside the scorer's glob ==="
+[[ -s "${run_dir2}/rejected/s500-alpha-type-o002-detailed.json" ]] \
+    && ok "rejected attempt preserved under rejected/" \
+    || fail "rejected attempt output was discarded"
+if compgen -G "${run_dir2}/s500-*.jsonl" >/dev/null; then
+    if cat "${run_dir2}"/s500-*.jsonl | grep -q 'alpha-type-3'; then
+        fail "an unpromoted entry leaked into the scorer's glob"
+    else
+        ok "no unpromoted entry in the s500-*.jsonl glob"
+    fi
+fi
+
+# ── 5. Dataset swapped underneath a resume is refused ───────────────────────
+echo "=== 5. dataset drift is refused on resume ==="
+python3 - "${TMP_DIR}/dataset.json" <<'PY'
+import json, sys
+entries = json.load(open(sys.argv[1]))
+entries.append({"question_id": "alpha-type-9", "question_type": "alpha-type",
+                "question": "q", "answer": "a", "haystack_sessions": []})
+json.dump(entries, open(sys.argv[1], "w"))
+PY
+POISON_IDS="" run_loop "${R1}"
+rc=$?
+[[ ${rc} -ne 0 ]] && grep -q 'no longer holds the' "${TMP_DIR}/loop.log" \
+    && ok "resume refused after the dataset changed under it" \
+    || fail "a revised dataset was accepted on resume (rc=${rc})"
+
+echo ""
+if [[ "${failures}" -gt 0 ]]; then
+    echo "slice-loop-test: ${failures} failure(s)"
+    exit 1
+fi
+echo "slice-loop-test: OK"

--- a/deploy/longmemeval/slice-loop-test.sh
+++ b/deploy/longmemeval/slice-loop-test.sh
@@ -27,10 +27,20 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 # shellcheck source=render-common.sh
 source "${SCRIPT_DIR}/render-common.sh"
 
+# LME_RIG_STRICT=1 (CI) turns a missing prerequisite into a failure. A green
+# no-op is worse than a red one here: these are the only regression tests for
+# a runner that spends real money.
+STRICT="${LME_RIG_STRICT:-0}"
+missing() {
+    if [[ "${STRICT}" == "1" ]]; then
+        echo "FAIL: ${1} is required (LME_RIG_STRICT=1)"; exit 1
+    fi
+    echo "SKIP: ${1} not available"; exit 0
+}
 for tool in jq python3 go; do
-    command -v "${tool}" >/dev/null 2>&1 || { echo "SKIP: ${tool} not available"; exit 0; }
+    command -v "${tool}" >/dev/null 2>&1 || missing "${tool}"
 done
-python3 -c 'import yaml' 2>/dev/null || { echo "SKIP: python3 pyyaml not available"; exit 0; }
+python3 -c 'import yaml' 2>/dev/null || missing "python3 pyyaml"
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT
@@ -45,7 +55,7 @@ export LME_NAMESPACE="lme-slice-test" LME_IMAGE="t/i" LME_IMAGE_TAG="t" \
     LME_DATASET_FILE="d.json" LME_MODE="ingest" LME_CONCURRENCY="1" \
     LME_CHUNK="2" LME_OCCURRED_AT="false" LME_RUN_ID="sliceTest01" \
     LME_RUN_MANIFEST="test-manifest" LME_ALLOW_MANIFEST_DRIFT="0" \
-    LME_MAX_CHUNK_ATTEMPTS="2"
+    LME_MAX_CHUNK_ATTEMPTS="2" LME_CONFIG_HASH="slicetestcfg"
 
 lme_render "${SCRIPT_DIR}/runner-script.yaml" > "${TMP_DIR}/cm.yaml" \
     || { echo "FAIL: runner-script.yaml did not render"; exit 1; }
@@ -224,8 +234,42 @@ if compgen -G "${run_dir2}/s500-*.jsonl" >/dev/null; then
     fi
 fi
 
-# ── 5. Dataset swapped underneath a resume is refused ───────────────────────
-echo "=== 5. dataset drift is refused on resume ==="
+# ── 5. A failed PVC write stops the run instead of reporting success ────────
+echo "=== 5. a persistence failure fails closed ==="
+if [[ "$(id -u)" == "0" ]]; then
+    echo "  note: running as root; chmod cannot make a directory unwritable — skipping"
+else
+    R3="${TMP_DIR}/r3"; mkdir -p "${R3}/runs/${LME_RUN_ID}"
+    chmod a-w "${R3}/runs/${LME_RUN_ID}"
+    POISON_IDS="" run_loop "${R3}"
+    rc=$?
+    chmod u+w "${R3}/runs/${LME_RUN_ID}"
+
+    [[ ${rc} -ne 0 ]] \
+        && ok "a run whose results volume rejects writes exits nonzero" \
+        || fail "the loop reported success while persistence was failing (rc=${rc})"
+    grep -q "FATAL: results PVC write failed" "${TMP_DIR}/loop.log" \
+        && ok "the failure names the volume, not the chunk" \
+        || fail "no PVC failure diagnostic in the log"
+fi
+
+# ── 6. A recovered run clears the incomplete sentinel ───────────────────────
+echo "=== 6. RUN-INCOMPLETE.txt is cleared once every chunk completes ==="
+run_dir1="${R1}/runs/${LME_RUN_ID}"
+# R1 completed in step 1; plant a stale sentinel as a recovered quarantine
+# would have left behind, then run a no-op pass.
+echo "stale" > "${run_dir1}/RUN-INCOMPLETE.txt"
+POISON_IDS="" run_loop "${R1}"
+rc=$?
+[[ ${rc} -eq 0 ]] \
+    && ok "a fully-completed run exits zero" \
+    || fail "completed run exited ${rc}"
+[[ ! -f "${run_dir1}/RUN-INCOMPLETE.txt" ]] \
+    && ok "stale sentinel removed — a complete run is not reported as missing entries" \
+    || fail "RUN-INCOMPLETE.txt survived a fully-completed run"
+
+# ── 7. Dataset swapped underneath a resume is refused ───────────────────────
+echo "=== 7. dataset drift is refused on resume ==="
 python3 - "${TMP_DIR}/dataset.json" <<'PY'
 import json, sys
 entries = json.load(open(sys.argv[1]))

--- a/deploy/longmemeval/teardown-cluster.sh
+++ b/deploy/longmemeval/teardown-cluster.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# teardown-cluster.sh — Delete the LongMemEval cluster and resource group.
+#
+# SAFETY: results on the lme-results PVC represent days of paid LLM compute
+# and are destroyed with the cluster. This script refuses to run unless you
+# confirm the results have been pulled (pull-results.sh) by setting
+# LME_CONFIRM_RESULTS_PULLED=1.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lme.env
+source "${SCRIPT_DIR}/lme.env"
+[[ -f "${SCRIPT_DIR}/lme.env.local" ]] && source "${SCRIPT_DIR}/lme.env.local"
+
+if [[ "${LME_CONFIRM_RESULTS_PULLED:-0}" != "1" ]]; then
+    echo "REFUSING to tear down: the lme-results PVC (and every benchmark result on it)"
+    echo "will be destroyed with the cluster."
+    echo ""
+    echo "  1. bash ${SCRIPT_DIR}/pull-results.sh"
+    echo "  2. verify the local copy"
+    echo "  3. LME_CONFIRM_RESULTS_PULLED=1 bash ${SCRIPT_DIR}/teardown-cluster.sh"
+    exit 1
+fi
+
+echo "Deleting resource group ${LME_RESOURCE_GROUP} (cluster, PVCs, everything)..."
+az group delete --name "${LME_RESOURCE_GROUP}" --yes --no-wait
+echo "Deletion started (runs in background in Azure)."

--- a/docs/guides/longmemeval-benchmark.md
+++ b/docs/guides/longmemeval-benchmark.md
@@ -189,6 +189,15 @@ Total sessions: 948 (avg 1.9/entry)
 Total turns:    10960 (avg 11.6/session)
 ```
 
+`--json` emits the same statistics machine-readably (`entries`,
+`question_types` as an ordered `{type, count}` array, `total_sessions`,
+`total_turns`). The AKS slice loop uses it to derive its per-type chunk counts
+from the dataset instead of hardcoding them:
+
+```bash
+./bin/loom-longmemeval info --json | jq -r '.question_types[] | [.type, .count] | @tsv'
+```
+
 ## Run Modes
 
 Selected with `--mode`:


### PR DESCRIPTION
Stacked on #320 (the runner image needs `--occurred-at`/`--dataset` from that branch); retarget to `main` after it merges.

## Summary
`deploy/longmemeval/` — an AKS rig modeled on `deploy/benchmark/`, adapted for a real-LLM, multi-day benchmark run:

- **CGO+fts5 image** (real `looms` + `loom-longmemeval`; the bench Dockerfile's CGO-off/distroless combo can't run the real server)
- **Small, cheap cluster** (D8s workload pool, ~$0.55/hr) — the run is Bedrock-quota-bound, not CPU-bound
- **Resumable chunked runner Job**: one output per `(type, offset)` chunk on an RWX PVC; pod restarts resume by skipping completed chunks (motivated by the pilot losing 4 entries to laptop sleep)
- **Bedrock bearer-key auth** via Secret → `LOOM_LLM_BEDROCK_BEARER_TOKEN`
- **Result safety**: mid-run `pull-results.sh`; teardown refuses until results are confirmed pulled
- README covers time/cost projections from the 2026-08 pilot (~60 min/entry serial in multi-session mode), concurrency guidance, off-cluster official scoring, and what a public claim must disclose

## Validation
- All shell scripts `bash -n` clean; all manifests YAML-parse after `envsubst` rendering; the embedded runner slice-loop parses standalone.
- Not yet exercised against a live cluster — first `az acr build` + `run-500.sh` invocation is the integration test, intentionally left for the operator (spends real money).

🤖 Generated with [Claude Code](https://claude.com/claude-code)