### PR TITLE
fix(bedrock): extract Converse toolUse input via MarshalSmithyDocument (TER-770)

### DIFF
--- a/pkg/llm/bedrock/converse.go
+++ b/pkg/llm/bedrock/converse.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
 	bedrocktypes "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
 	"github.com/teradata-labs/loom/pkg/shuttle"
@@ -153,20 +154,12 @@ func (c *Client) ChatConverse(ctx context.Context, messages []llmtypes.Message, 
 					toolCall := llmtypes.ToolCall{
 						ID:    aws.ToString(b.Value.ToolUseId),
 						Name:  aws.ToString(b.Value.Name),
-						Input: make(map[string]interface{}),
+						Input: toolUseInputToMap(b.Value.Input),
 					}
 
 					// Map sanitized name back to original name
 					if originalName, found := c.toolNameMap[toolCall.Name]; found {
 						toolCall.Name = originalName
-					}
-
-					// Convert document.Interface to map[string]interface{}
-					if b.Value.Input != nil {
-						inputBytes, err := json.Marshal(b.Value.Input)
-						if err == nil {
-							_ = json.Unmarshal(inputBytes, &toolCall.Input)
-						}
 					}
 
 					toolCalls = append(toolCalls, toolCall)
@@ -203,4 +196,29 @@ func (c *Client) ChatConverse(ctx context.Context, messages []llmtypes.Message, 
 	}
 
 	return response, nil
+}
+
+// toolUseInputToMap converts a Converse toolUse input document into the
+// map form the rest of the stack expects.
+//
+// The document's concrete response type keeps its value in an unexported
+// field and implements MarshalSmithyDocument, not json.Marshaler — so a
+// plain json.Marshal(doc) serializes an empty struct ("{}") and silently
+// drops every tool argument. Models then see each call rejected for
+// missing required parameters and re-issue it turn after turn (observed
+// live with DeepSeek/Qwen on Bedrock Converse: an endless manage_skills
+// retry loop). MarshalSmithyDocument is the correct accessor for the raw
+// JSON. A nil document or a non-object input degrades to an empty map,
+// and the tool's own validation reports the missing arguments.
+func toolUseInputToMap(doc document.Interface) map[string]interface{} {
+	input := make(map[string]interface{})
+	if doc == nil {
+		return input
+	}
+	raw, err := doc.MarshalSmithyDocument()
+	if err != nil {
+		return input
+	}
+	_ = json.Unmarshal(raw, &input)
+	return input
 }

--- a/pkg/llm/bedrock/converse_tool_input_test.go
+++ b/pkg/llm/bedrock/converse_tool_input_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package bedrock
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// toolUseInputToMap must extract the arguments a Converse toolUse block
+// carries. The document's concrete types keep their value in an unexported
+// field and do NOT implement json.Marshaler, so the pre-fix approach —
+// json.Marshal(doc) — produced "{}" and silently dropped every argument.
+// Live symptom: DeepSeek/Qwen tool calls arrived with empty input, each
+// call failed required-parameter validation, and the model looped
+// re-issuing it (TER-770).
+func TestToolUseInputToMap_ExtractsArguments(t *testing.T) {
+	doc := document.NewLazyDocument(map[string]interface{}{
+		"action": "load",
+		"name":   "get-started",
+		"count":  float64(3),
+		"nested": map[string]interface{}{"a": true},
+	})
+
+	got := toolUseInputToMap(doc)
+
+	require.NotNil(t, got)
+	assert.Equal(t, "load", got["action"])
+	assert.Equal(t, "get-started", got["name"])
+	assert.Equal(t, float64(3), got["count"])
+	assert.Equal(t, map[string]interface{}{"a": true}, got["nested"])
+}
+
+// Pin the failure mode the fix removes: plain json.Marshal on a smithy
+// document yields "{}" (unexported fields, no json.Marshaler). If a future
+// SDK bump makes json.Marshal work, this test documents why the helper
+// exists; if someone reverts the helper to json.Marshal, the test above
+// fails.
+func TestToolUseInputToMap_PlainJSONMarshalDropsArguments(t *testing.T) {
+	doc := document.NewLazyDocument(map[string]interface{}{"action": "load"})
+
+	raw, err := json.Marshal(doc)
+	require.NoError(t, err)
+	assert.JSONEq(t, "{}", string(raw),
+		"json.Marshal on a smithy document no longer drops the value — revisit whether toolUseInputToMap is still needed")
+}
+
+func TestToolUseInputToMap_NilDocument(t *testing.T) {
+	got := toolUseInputToMap(nil)
+	require.NotNil(t, got)
+	assert.Empty(t, got)
+}
+
+// A model may emit a non-object input (string, array). The helper degrades
+// to an empty map and leaves reporting to the tool's own validation.
+func TestToolUseInputToMap_NonObjectInputDegradesToEmpty(t *testing.T) {
+	doc := document.NewLazyDocument("not-an-object")
+	got := toolUseInputToMap(doc)
+	require.NotNil(t, got)
+	assert.Empty(t, got)
+}


### PR DESCRIPTION
## Root cause (TER-770)

`ChatConverse` extracted a toolUse block's input with `json.Marshal(b.Value.Input)`. The smithy `document.Interface` concrete types keep their value in an **unexported** field and implement `MarshalSmithyDocument`, not `json.Marshaler` — so `json.Marshal` serializes `{}` and **every tool argument from every Converse-routed model (DeepSeek, Qwen, Meta, …) was silently dropped**.

Downstream effect, reproduced live on preprod pp75 with `deepseek.v3.2` and `qwen.qwen3-235b`:

- any tool with required params rejects the call (`invalid_input`),
- the model re-issues the same call turn after turn until the per-turn cap (the "continuous loading loop" in TER-770),
- no-arg tools (`list_skills`) work, which made the skill system look at fault instead of the transport,
- Anthropic models are unaffected (they never route through `ChatConverse`), so this presented as "skills fail to load on models other than Claude".

Persisted evidence from the repro session: 11 consecutive `manage_skills` calls, each with a Bedrock-assigned `tooluse_…` id and a name but **no input**, each answered `Tool error: invalid_input - action must be 'load' or 'list', got ""`, ending with the model saying "I'm having trouble with the tool format."

## Fix

New `toolUseInputToMap` helper: `MarshalSmithyDocument()` → `json.Unmarshal` into the map (keeps standard `encoding/json` number semantics, matching every other provider path). Nil / non-object inputs degrade to an empty map so the tool's own validation reports the problem.

## Tests

- `TestToolUseInputToMap_ExtractsArguments` — real smithy document round-trips args.
- `TestToolUseInputToMap_PlainJSONMarshalDropsArguments` — pins the failure mode the fix removes (fails loudly if an SDK bump ever changes it).
- nil-document and non-object-input degradation cases.

`go test -race ./pkg/llm/bedrock/` green, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
