### PR TITLE
fix(llm): surface reasoning content on LLMResponse.Thinking (TER-770)

### DIFF
--- a/pkg/llm/bedrock/converse.go
+++ b/pkg/llm/bedrock/converse.go
@@ -138,6 +138,7 @@ func (c *Client) ChatConverse(ctx context.Context, messages []llmtypes.Message, 
 
 	// Extract response content
 	var contentText string
+	var thinkingText string
 	var toolCalls []llmtypes.ToolCall
 
 	if output.Output != nil {
@@ -148,6 +149,9 @@ func (c *Client) ChatConverse(ctx context.Context, messages []llmtypes.Message, 
 				switch b := block.(type) {
 				case *bedrocktypes.ContentBlockMemberText:
 					contentText += b.Value
+
+				case *bedrocktypes.ContentBlockMemberReasoningContent:
+					thinkingText += reasoningContentText(b.Value)
 
 				case *bedrocktypes.ContentBlockMemberToolUse:
 					// Extract tool call
@@ -180,6 +184,7 @@ func (c *Client) ChatConverse(ctx context.Context, messages []llmtypes.Message, 
 	// Build response
 	response := &llmtypes.LLMResponse{
 		Content:    contentText,
+		Thinking:   thinkingText,
 		ToolCalls:  toolCalls,
 		StopReason: string(output.StopReason),
 		Usage:      usage,
@@ -221,4 +226,19 @@ func toolUseInputToMap(doc document.Interface) map[string]interface{} {
 	}
 	_ = json.Unmarshal(raw, &input)
 	return input
+}
+
+// reasoningContentText extracts the model's reasoning text from a Converse
+// reasoningContent block. Reasoning models on Bedrock (DeepSeek, Qwen, ...)
+// interleave these with text/toolUse blocks; before this they were silently
+// dropped, so a reasoning-heavy turn could surface as an empty response.
+// The text maps to LLMResponse.Thinking — never Content — reasoning is not
+// part of the user-facing answer and must not enter the replayed
+// conversation. Redacted reasoning (encrypted bytes) has no readable text
+// and is skipped.
+func reasoningContentText(rc bedrocktypes.ReasoningContentBlock) string {
+	if r, ok := rc.(*bedrocktypes.ReasoningContentBlockMemberReasoningText); ok {
+		return aws.ToString(r.Value.Text)
+	}
+	return ""
 }

--- a/pkg/llm/bedrock/converse_reasoning_test.go
+++ b/pkg/llm/bedrock/converse_reasoning_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package bedrock
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	bedrocktypes "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// Reasoning models on Bedrock (DeepSeek, Qwen, ...) return reasoningContent
+// blocks through Converse. reasoningContentText extracts the readable text so
+// ChatConverse can surface it on LLMResponse.Thinking instead of silently
+// dropping it (which made reasoning-heavy turns look like empty responses).
+func TestReasoningContentText_TextBlock(t *testing.T) {
+	rc := &bedrocktypes.ReasoningContentBlockMemberReasoningText{
+		Value: bedrocktypes.ReasoningTextBlock{
+			Text:      aws.String("the user asked for X, so I should call tool Y"),
+			Signature: aws.String("sig"),
+		},
+	}
+	assert.Equal(t, "the user asked for X, so I should call tool Y", reasoningContentText(rc))
+}
+
+// Redacted reasoning is encrypted bytes with no readable text — skipped.
+func TestReasoningContentText_RedactedBlock(t *testing.T) {
+	rc := &bedrocktypes.ReasoningContentBlockMemberRedactedContent{
+		Value: []byte{0x01, 0x02},
+	}
+	assert.Empty(t, reasoningContentText(rc))
+}
+
+func TestReasoningContentText_Nil(t *testing.T) {
+	assert.Empty(t, reasoningContentText(nil))
+}

--- a/pkg/llm/openai/client.go
+++ b/pkg/llm/openai/client.go
@@ -505,6 +505,11 @@ func (c *Client) convertResponse(resp *ChatCompletionResponse) *llmtypes.LLMResp
 			}
 		}
 
+		// Reasoning models surface their trace in reasoning_content; map it to
+		// Thinking (never Content) so it is observable without polluting the
+		// user-facing answer or the replayed conversation.
+		llmResp.Thinking = choice.Message.ReasoningContent
+
 		// Extract tool calls
 		for _, tc := range choice.Message.ToolCalls {
 			// Parse arguments JSON string back to map

--- a/pkg/llm/openai/reasoning_content_test.go
+++ b/pkg/llm/openai/reasoning_content_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Reasoning models served through OpenAI-compatible gateways (LiteLLM) return
+// their trace in message.reasoning_content. It must land on Thinking — never
+// Content — so reasoning-heavy turns are observable without polluting the
+// user-facing answer or the replayed conversation.
+func TestClient_ConvertResponse_ReasoningContent(t *testing.T) {
+	client := NewClient(Config{APIKey: "test", Model: "deepseek-v3"})
+
+	resp := &ChatCompletionResponse{
+		Model: "deepseek-v3",
+		Choices: []ChatCompletionChoice{
+			{
+				Message: ChatMessage{
+					Role:             "assistant",
+					Content:          "The answer is 42.",
+					ReasoningContent: "the user wants the answer; compute it",
+				},
+				FinishReason: "stop",
+			},
+		},
+		Usage: ChatCompletionUsage{PromptTokens: 5, CompletionTokens: 7, TotalTokens: 12},
+	}
+
+	got := client.convertResponse(resp)
+	assert.Equal(t, "The answer is 42.", got.Content)
+	assert.Equal(t, "the user wants the answer; compute it", got.Thinking)
+}
+
+// A reasoning-only turn (no visible text) still surfaces the trace on
+// Thinking while Content stays empty — the empty-answer handling above this
+// layer remains in charge of what the user sees.
+func TestClient_ConvertResponse_ReasoningOnly(t *testing.T) {
+	client := NewClient(Config{APIKey: "test", Model: "deepseek-v3"})
+
+	resp := &ChatCompletionResponse{
+		Model: "deepseek-v3",
+		Choices: []ChatCompletionChoice{
+			{
+				Message: ChatMessage{
+					Role:             "assistant",
+					ReasoningContent: "…still thinking…",
+				},
+				FinishReason: "length",
+			},
+		},
+	}
+
+	got := client.convertResponse(resp)
+	assert.Empty(t, got.Content)
+	assert.Equal(t, "…still thinking…", got.Thinking)
+}
+
+// reasoning_content is response-only: a request-side ChatMessage without it
+// must serialize without the key at all (omitempty), so outgoing payloads to
+// strict OpenAI-compatible servers are unchanged.
+func TestChatMessage_ReasoningContentOmittedFromRequests(t *testing.T) {
+	raw, err := json.Marshal(ChatMessage{Role: "user", Content: "hi"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "reasoning_content")
+}

--- a/pkg/llm/openai/types.go
+++ b/pkg/llm/openai/types.go
@@ -47,6 +47,11 @@ type ChatMessage struct {
 	Name       string      `json:"name,omitempty"`
 	ToolCalls  []ToolCall  `json:"tool_calls,omitempty"`
 	ToolCallID string      `json:"tool_call_id,omitempty"` // For tool role messages
+
+	// ReasoningContent carries the reasoning trace that reasoning models
+	// (DeepSeek, Qwen, ...) return through OpenAI-compatible gateways such as
+	// LiteLLM. Response-only: omitempty keeps it off outgoing requests.
+	ReasoningContent string `json:"reasoning_content,omitempty"`
 }
 
 // ToolCall represents a function call from the assistant.


### PR DESCRIPTION
## What

Stacked on #324 (same file, same response-parsing seam — merge that first; GitHub will retarget this to `main` automatically).

Reasoning models (DeepSeek, Qwen, …) return their trace as `reasoningContent` blocks on Bedrock Converse and as `message.reasoning_content` through OpenAI-compatible gateways (LiteLLM). Both paths silently dropped it, so a reasoning-heavy turn could surface as an **empty response** with no trace of what the model did — the second of the TER-770 secondary findings.

- `ChatConverse`: new `ContentBlockMemberReasoningContent` case → `reasoningContentText` helper extracts `ReasoningText` (redacted reasoning is skipped — encrypted bytes, no readable text) → `LLMResponse.Thinking`.
- OpenAI client: `ChatMessage.ReasoningContent` (`json:"reasoning_content,omitempty"` — response-only; a serialization test pins that outgoing requests stay byte-identical) → `LLMResponse.Thinking` in `convertResponse`.

Deliberately **never** into `Content`: reasoning is not the user-facing answer and must not enter the replayed conversation. A reasoning-only turn still has empty `Content` and the existing empty-answer handling above this layer stays in charge of what the user sees — the trace just becomes observable (`llm.thinking.length` span attribute, persisted Thinking).

Out of scope: `ConverseStream` (known tool-serialization issues, unused by the cloud — `bedrockConverseProvider.ChatStream` falls back to non-streaming `ChatConverse`).

## Tests

- `TestReasoningContentText_{TextBlock,RedactedBlock,Nil}` (bedrock)
- `TestClient_ConvertResponse_{ReasoningContent,ReasoningOnly}` + `TestChatMessage_ReasoningContentOmittedFromRequests` (openai)

`go test -race` green on both packages, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
