### PR TITLE
feat(mcp): loom-mcp-probe — real-server wire testing for the 2026-07-28 client

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -246,8 +246,9 @@ build-mcp: proto
     @echo "✅ MCP binary: bin/loom-mcp"
 
 # Probe a real MCP server with Loom's client (negotiation, tools, MRTR, subscriptions)
+[positional-arguments]
 mcp-probe *ARGS:
-    GOWORK=off go run -tags fts5 ./cmd/loom-mcp-probe {{ARGS}}
+    GOWORK=off go run -tags fts5 ./cmd/loom-mcp-probe "$@"
 
 # Build all variants (server, tui, standalone, mcp)
 build-all: build-server build-tui build-standalone build-mcp

--- a/Justfile
+++ b/Justfile
@@ -245,6 +245,10 @@ build-mcp: proto
     GOWORK=off go build -tags fts5 -o bin/loom-mcp ./cmd/loom-mcp
     @echo "✅ MCP binary: bin/loom-mcp"
 
+# Probe a real MCP server with Loom's client (negotiation, tools, MRTR, subscriptions)
+mcp-probe *ARGS:
+    GOWORK=off go run -tags fts5 ./cmd/loom-mcp-probe {{ARGS}}
+
 # Build all variants (server, tui, standalone, mcp)
 build-all: build-server build-tui build-standalone build-mcp
     @echo "✅ All build variants complete!"

--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ looms config set mcp.servers.github.env.GITHUB_TOKEN "${GITHUB_TOKEN}"
 # MCP servers auto-start with: looms serve
 ```
 
+The client negotiates the MCP protocol revision per server (2026-07-28 stateless core with fallback to the legacy initialize handshake for 2024/2025-era servers). Verify any server before wiring it in with the probe:
+
+```bash
+just mcp-probe -url http://localhost:8971 -call some_tool -watch 5
+```
+
+See the [MCP Probe guide](docs/guides/mcp-probe.md) for negotiation, MRTR elicitation, and subscription testing against real servers.
+
 **4 built-in MCP UI Apps** served at `/apps/` and as MCP resources (`ui://` scheme):
 
 | App | Description |
@@ -356,6 +364,7 @@ Releases are GPG-signed with SLSA provenance starting v1.1.0. See [docs/installa
 | Streaming | [docs/reference/streaming.md](docs/reference/streaming.md) |
 | MCP Apps Guide | [docs/guides/mcp-apps-guide.md](docs/guides/mcp-apps-guide.md) |
 | MCP Apps Reference | [docs/reference/mcp-apps.md](docs/reference/mcp-apps.md) |
+| MCP Probe (real-server testing) | [docs/guides/mcp-probe.md](docs/guides/mcp-probe.md) |
 | Supabase Integration | [docs/guides/supabase-integration.md](docs/guides/supabase-integration.md) |
 | Database Upgrade | `looms upgrade --help` |
 | API Reference | [pkg.go.dev](https://pkg.go.dev/github.com/teradata-labs/loom) |

--- a/cmd/loom-mcp-probe/main.go
+++ b/cmd/loom-mcp-probe/main.go
@@ -16,15 +16,16 @@
 // HTTP or stdio — and reports what actually negotiated: protocol revision,
 // era (stateless 2026-07-28 core vs legacy initialize handshake), server
 // identity, the tool list, an optional tool call, and an optional
-// subscriptions/listen watch. No fakes anywhere: it exercises the same
-// negotiation, fallback, and transport paths the manager uses in production,
-// against whatever server it is pointed at.
+// subscriptions/listen watch. The probe runs the shipped client and
+// transports unmodified — the same negotiation, fallback, and transport
+// paths the manager uses in production — against whatever real server it is
+// pointed at (its automated tests, by contrast, use scripted HTTP fixtures).
 //
 // Examples:
 //
 //	loom-mcp-probe -url http://localhost:8971 -call test_simple_text -watch 5
-//	loom-mcp-probe -cmd "npx -y @modelcontextprotocol/server-everything stdio" \
-//	    -call echo -args '{"message":"hello"}'
+//	loom-mcp-probe -cmd npx -arg -y -arg @modelcontextprotocol/server-everything \
+//	    -arg stdio -call echo -args '{"message":"hello"}'
 //	loom-mcp-probe -url http://localhost:9090/mcp -pin legacy
 //	loom-mcp-probe -url http://localhost:8971 -call test_elicitation \
 //	    -args '{"message":"pick a username"}' -answer '{"username":"loom"}'
@@ -56,15 +57,17 @@ import (
 
 // options selects the server to probe and what to exercise against it.
 type options struct {
-	URL      string        // streamable HTTP endpoint; mutually exclusive with Cmd
-	Cmd      string        // stdio server command line; mutually exclusive with URL
-	Pin      string        // protocol_version pin: "" or "auto", "legacy", or an exact revision
-	Call     string        // tool to invoke, if any
-	Args     string        // JSON arguments for Call
-	Answer   string        // JSON object accepted for every elicitation (enables the MRTR driver)
-	WatchSec int           // seconds to hold a subscriptions/listen stream (stateless only)
-	Timeout  time.Duration // negotiation-probe/request timeout
-	Verbose  bool
+	URL        string        // streamable HTTP endpoint; mutually exclusive with Cmd
+	Cmd        string        // stdio server executable (verbatim; args ride CmdArgs); mutually exclusive with URL
+	CmdArgs    []string      // arguments for Cmd, one per -arg flag
+	HeadersEnv string        // env var holding a JSON object of HTTP headers (auth without argv exposure)
+	Pin        string        // protocol_version pin: "" or "auto", "legacy", or an exact revision
+	Call       string        // tool to invoke, if any
+	Args       string        // JSON arguments for Call
+	Answer     string        // JSON object accepted for every elicitation (enables the MRTR driver)
+	WatchSec   int           // seconds to hold a subscriptions/listen stream (stateless only)
+	Timeout    time.Duration // per-operation timeout: connect, tools/list, tools/call (incl. MRTR rounds), subscription ack
+	Verbose    bool
 }
 
 // report is what the probe observed on the wire.
@@ -78,8 +81,7 @@ type report struct {
 	CallOutput      string   // first content text of the tool call, if Call was set
 	Elicited        []string // elicitation messages answered by the MRTR driver
 	Notifications   []string // methods received while watching, if WatchSec > 0
-	WatchEndErr     error    // nil = graceful or client-cancelled
-	WatchSkipped    bool     // legacy connection cannot subscribe
+	WatchEndErr     error    // nil = held for the full window (client-cancelled at the deadline)
 }
 
 const toolNamesShown = 6
@@ -96,13 +98,18 @@ func main() {
 	opts := options{}
 	var timeoutMs int
 	flag.StringVar(&opts.URL, "url", "", "streamable HTTP endpoint (e.g. http://localhost:8971)")
-	flag.StringVar(&opts.Cmd, "cmd", "", "stdio server command line (space-separated)")
+	flag.StringVar(&opts.Cmd, "cmd", "", "stdio server executable (path taken verbatim; pass arguments via repeated -arg)")
+	flag.Func("arg", "argument for the -cmd executable (repeatable, order-preserving)", func(v string) error {
+		opts.CmdArgs = append(opts.CmdArgs, v)
+		return nil
+	})
+	flag.StringVar(&opts.HeadersEnv, "headers-env", "", "name of an env var holding a JSON object of HTTP headers (e.g. auth tokens; never passed on the command line)")
 	flag.StringVar(&opts.Pin, "pin", "", `protocol_version pin: "auto" (default), "legacy", or an exact revision`)
 	flag.StringVar(&opts.Call, "call", "", "tool to invoke")
 	flag.StringVar(&opts.Args, "args", "{}", "JSON arguments for -call")
 	flag.StringVar(&opts.Answer, "answer", "", "JSON object accepted for every elicitation; enables the MRTR driver (default: fail fast on input_required)")
 	flag.IntVar(&opts.WatchSec, "watch", 0, "seconds to hold a subscriptions/listen stream (stateless connections only)")
-	flag.IntVar(&timeoutMs, "timeout", 15000, "negotiation-probe/request timeout in ms")
+	flag.IntVar(&timeoutMs, "timeout", 15000, "per-operation timeout in ms: connect (incl. negotiation probe), tools/list, tools/call with its MRTR rounds, and the subscription acknowledgment")
 	flag.BoolVar(&opts.Verbose, "v", false, "debug logging")
 	flag.Parse()
 	opts.Timeout = time.Duration(timeoutMs) * time.Millisecond
@@ -113,10 +120,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
-
-	rep, err := run(ctx, opts, os.Stdout)
+	rep, err := run(context.Background(), opts, os.Stdout)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "PROBE FAILED: %v\n", err)
 		os.Exit(1)
@@ -133,12 +137,28 @@ func run(ctx context.Context, opts options, out io.Writer) (*report, error) {
 		return nil, fmt.Errorf("logger: %w", err)
 	}
 
+	rep := &report{}
+
+	// Every flag that can fail validation is checked before the transport is
+	// built: a stdio transport starts a subprocess, and a validation error
+	// after that point would leak the child with no cleanup registered.
+	var callArgs map[string]interface{}
+	if opts.Call != "" {
+		if err := json.Unmarshal([]byte(opts.Args), &callArgs); err != nil {
+			return nil, fmt.Errorf("-args is not a JSON object: %w", err)
+		}
+	}
+	var mrtr client.InputHandler
+	if opts.Answer != "" {
+		if mrtr, err = buildMRTRHandler(opts.Answer, rep, pr); err != nil {
+			return nil, err
+		}
+	}
+
 	tr, err := buildTransport(opts, logger)
 	if err != nil {
 		return nil, fmt.Errorf("transport: %w", err)
 	}
-
-	rep := &report{}
 
 	cfg := client.Config{
 		Transport:       tr,
@@ -146,11 +166,7 @@ func run(ctx context.Context, opts options, out io.Writer) (*report, error) {
 		ProtocolVersion: opts.Pin,
 		RequestTimeout:  opts.Timeout,
 	}
-	if opts.Answer != "" {
-		mrtr, err := buildMRTRHandler(opts.Answer, rep, pr)
-		if err != nil {
-			return nil, err
-		}
+	if mrtr != nil {
 		cfg.MRTR = client.MRTRConfig{Handler: mrtr}
 	}
 
@@ -158,7 +174,10 @@ func run(ctx context.Context, opts options, out io.Writer) (*report, error) {
 	defer func() { _ = c.Close() }()
 
 	start := time.Now()
-	if err := c.Connect(ctx, protocol.Implementation{Name: "loom-mcp-probe", Version: version.Version}); err != nil {
+	connectCtx, cancelConnect := context.WithTimeout(ctx, opts.Timeout)
+	err = c.Connect(connectCtx, protocol.Implementation{Name: "loom-mcp-probe", Version: version.Version})
+	cancelConnect()
+	if err != nil {
 		return nil, fmt.Errorf("connect: %w", err)
 	}
 	rep.ConnectDuration = time.Since(start)
@@ -171,7 +190,9 @@ func run(ctx context.Context, opts options, out io.Writer) (*report, error) {
 	pr.f("  era        : %s\n", era(rep.Stateless))
 	pr.f("  serverInfo : %s %s\n", rep.ServerInfo.Name, rep.ServerInfo.Version)
 
-	tools, err := c.ListTools(ctx)
+	listCtx, cancelList := context.WithTimeout(ctx, opts.Timeout)
+	tools, err := c.ListTools(listCtx)
+	cancelList()
 	if err != nil {
 		return rep, fmt.Errorf("tools/list: %w", err)
 	}
@@ -186,7 +207,10 @@ func run(ctx context.Context, opts options, out io.Writer) (*report, error) {
 		rep.ToolCount, strings.Join(rep.ToolNames, ", "), more(rep.ToolCount, toolNamesShown))
 
 	if opts.Call != "" {
-		if err := runCall(ctx, c, opts, rep, pr); err != nil {
+		callCtx, cancelCall := context.WithTimeout(ctx, opts.Timeout)
+		err := runCall(callCtx, c, opts, callArgs, rep, pr)
+		cancelCall()
+		if err != nil {
 			return rep, err
 		}
 	}
@@ -200,11 +224,7 @@ func run(ctx context.Context, opts options, out io.Writer) (*report, error) {
 	return rep, nil
 }
 
-func runCall(ctx context.Context, c *client.Client, opts options, rep *report, pr printer) error {
-	var args map[string]interface{}
-	if err := json.Unmarshal([]byte(opts.Args), &args); err != nil {
-		return fmt.Errorf("-args is not a JSON object: %w", err)
-	}
+func runCall(ctx context.Context, c *client.Client, opts options, args map[string]interface{}, rep *report, pr printer) error {
 	res, err := c.CallTool(ctx, opts.Call, args)
 	if err != nil {
 		return fmt.Errorf("tools/call %s: %w", opts.Call, err)
@@ -221,10 +241,11 @@ func runCall(ctx context.Context, c *client.Client, opts options, rep *report, p
 }
 
 func runWatch(ctx context.Context, c *client.Client, opts options, rep *report, pr printer) error {
+	// A requested watch is a gate: every path that cannot deliver a healthy,
+	// acknowledged subscription held for the full window is a probe failure,
+	// never a silent exit 0.
 	if !c.IsStateless() {
-		rep.WatchSkipped = true
-		pr.f("  watch      : skipped (legacy connection; subscriptions/listen is 2026-07-28)\n")
-		return nil
+		return fmt.Errorf("-watch requested, but the connection is legacy (%s): subscriptions/listen is 2026-07-28 only", c.NegotiatedVersion())
 	}
 	subCtx, subCancel := context.WithCancel(ctx)
 	defer subCancel()
@@ -235,28 +256,43 @@ func runWatch(ctx context.Context, c *client.Client, opts options, rep *report, 
 	if err != nil {
 		return fmt.Errorf("subscriptions/listen: %w", err)
 	}
-	pr.f("  watch      : subscription %s open for %ds\n", sub.ID, opts.WatchSec)
+
+	// The acknowledgment is the first item on the channel; without it within
+	// the operation timeout the subscription was never established.
+	ackTimer := time.After(opts.Timeout)
+	select {
+	case n, ok := <-sub.Notifications:
+		if !ok {
+			return fmt.Errorf("subscription ended before acknowledgment: %v", endState(sub.Err()))
+		}
+		if n.Method != protocol.NotificationSubscriptionAcknowledged {
+			return fmt.Errorf("first subscription message was %s, not the acknowledgment", n.Method)
+		}
+	case <-ackTimer:
+		return fmt.Errorf("no subscription acknowledgment within %s", opts.Timeout)
+	}
+	pr.f("  watch      : subscription %s acknowledged, holding for %ds\n", sub.ID, opts.WatchSec)
 
 	deadline := time.After(time.Duration(opts.WatchSec) * time.Second)
 	for {
 		select {
 		case n, ok := <-sub.Notifications:
 			if !ok {
+				// Any end before the requested window — error or graceful
+				// server-side closure — means the watch did not hold.
 				rep.WatchEndErr = sub.Err()
-				pr.f("  watch done : %d notifications, end state: %v\n",
-					len(rep.Notifications), endState(rep.WatchEndErr))
-				return nil
+				return fmt.Errorf("subscription ended %s before the watch window elapsed: %v",
+					sub.ID, endState(rep.WatchEndErr))
 			}
 			rep.Notifications = append(rep.Notifications, n.Method)
 			pr.f("    notif #%d : %s\n", len(rep.Notifications), n.Method)
 		case <-deadline:
 			subCancel()
 			<-sub.Done()
-			// Client-initiated cancellation ends the watch; the context
-			// cancellation recorded on the subscription is expected, not an
-			// abnormal end.
-			pr.f("  watch done : %d notifications, end state: client cancelled\n",
-				len(rep.Notifications))
+			// Client-initiated cancellation at the deadline is the healthy
+			// outcome: the subscription held for the full window.
+			pr.f("  watch done : %d notifications, held %ds, end state: client cancelled\n",
+				len(rep.Notifications), opts.WatchSec)
 			return nil
 		}
 	}
@@ -300,18 +336,45 @@ func buildMRTRHandler(answer string, rep *report, pr printer) (client.InputHandl
 
 func buildTransport(opts options, logger *zap.Logger) (transport.Transport, error) {
 	if opts.URL != "" {
+		headers, err := headersFromEnv(opts.HeadersEnv)
+		if err != nil {
+			return nil, err
+		}
 		return transport.NewStreamableHTTPTransport(transport.StreamableHTTPConfig{
 			Endpoint:       opts.URL,
 			EnableSessions: true, // legacy servers may mint a session; 2026 servers never do
+			Headers:        headers,
 			Logger:         logger,
 		})
 	}
-	parts := strings.Fields(opts.Cmd)
+	// The executable is taken verbatim (Windows paths and spaces survive);
+	// arguments arrive one per -arg flag, so nothing is ever re-tokenized.
+	if strings.TrimSpace(opts.Cmd) == "" {
+		return nil, fmt.Errorf("-cmd must name an executable")
+	}
 	return transport.NewStdioTransport(transport.StdioConfig{
-		Command: parts[0],
-		Args:    parts[1:],
+		Command: opts.Cmd,
+		Args:    opts.CmdArgs,
 		Logger:  logger,
 	})
+}
+
+// headersFromEnv reads a JSON object of HTTP headers from the named env var.
+// Headers ride the environment rather than argv so tokens never appear in
+// process listings or shell history.
+func headersFromEnv(envName string) (map[string]string, error) {
+	if envName == "" {
+		return nil, nil
+	}
+	raw, ok := os.LookupEnv(envName)
+	if !ok {
+		return nil, fmt.Errorf("-headers-env: environment variable %s is not set", envName)
+	}
+	var headers map[string]string
+	if err := json.Unmarshal([]byte(raw), &headers); err != nil {
+		return nil, fmt.Errorf("-headers-env: %s does not hold a JSON object of strings: %w", envName, err)
+	}
+	return headers, nil
 }
 
 func buildLogger(verbose bool) (*zap.Logger, error) {

--- a/cmd/loom-mcp-probe/main.go
+++ b/cmd/loom-mcp-probe/main.go
@@ -249,27 +249,42 @@ func runWatch(ctx context.Context, c *client.Client, opts options, rep *report, 
 	}
 	subCtx, subCancel := context.WithCancel(ctx)
 	defer subCancel()
+
+	// -timeout bounds everything before the acknowledgment — including the
+	// transport's wait for HTTP response headers inside Subscribe, which no
+	// other deadline covers (the transport's http.Client has none) — without
+	// capping the hold itself, which runs on the -watch clock. The watchdog
+	// cancels the subscription context, so a server that stalls before
+	// sending headers fails here instead of hanging forever.
+	ackWatchdog := time.AfterFunc(opts.Timeout, subCancel)
+	defer ackWatchdog.Stop()
+	noAck := func(detail error) error {
+		if subCtx.Err() != nil && ctx.Err() == nil {
+			return fmt.Errorf("no subscription acknowledgment within %s: %v", opts.Timeout, detail)
+		}
+		return detail
+	}
 	sub, err := c.Subscribe(subCtx, protocol.NotificationFilter{
 		ToolsListChanged:     true,
 		ResourcesListChanged: true,
 	})
 	if err != nil {
-		return fmt.Errorf("subscriptions/listen: %w", err)
+		return noAck(fmt.Errorf("subscriptions/listen: %w", err))
 	}
 
 	// The acknowledgment is the first item on the channel; without it within
 	// the operation timeout the subscription was never established.
-	ackTimer := time.After(opts.Timeout)
 	select {
 	case n, ok := <-sub.Notifications:
 		if !ok {
-			return fmt.Errorf("subscription ended before acknowledgment: %v", endState(sub.Err()))
+			return noAck(fmt.Errorf("subscription ended before acknowledgment: %v", endState(sub.Err())))
 		}
 		if n.Method != protocol.NotificationSubscriptionAcknowledged {
 			return fmt.Errorf("first subscription message was %s, not the acknowledgment", n.Method)
 		}
-	case <-ackTimer:
-		return fmt.Errorf("no subscription acknowledgment within %s", opts.Timeout)
+		ackWatchdog.Stop()
+	case <-subCtx.Done():
+		return noAck(fmt.Errorf("subscription context ended: %v", subCtx.Err()))
 	}
 	pr.f("  watch      : subscription %s acknowledged, holding for %ds\n", sub.ID, opts.WatchSec)
 

--- a/cmd/loom-mcp-probe/main.go
+++ b/cmd/loom-mcp-probe/main.go
@@ -27,7 +27,7 @@
 //	loom-mcp-probe -cmd npx -arg -y -arg @modelcontextprotocol/server-everything \
 //	    -arg stdio -call echo -args '{"message":"hello"}'
 //	loom-mcp-probe -url http://localhost:9090/mcp -pin legacy
-//	loom-mcp-probe -url http://localhost:8971 -call test_elicitation \
+//	loom-mcp-probe -url http://localhost:8971 -call test_input_required_result_elicitation \
 //	    -args '{"message":"pick a username"}' -answer '{"username":"loom"}'
 //
 // With -answer set, the probe drives Multi Round-Trip Requests (MRTR,
@@ -119,6 +119,24 @@ func main() {
 		flag.Usage()
 		os.Exit(2)
 	}
+	// A silently ignored flag is a gate that verified nothing: every flag
+	// that cannot take effect under this flag combination is an error.
+	for _, bad := range []struct {
+		cond bool
+		msg  string
+	}{
+		{opts.WatchSec < 0, "-watch must be >= 0"},
+		{opts.Call == "" && opts.Args != "{}", "-args requires -call"},
+		{opts.Call == "" && opts.Answer != "", "-answer requires -call"},
+		{opts.URL != "" && len(opts.CmdArgs) > 0, "-arg applies only to -cmd (stdio)"},
+		{opts.Cmd != "" && opts.HeadersEnv != "", "-headers-env applies only to -url (HTTP)"},
+	} {
+		if bad.cond {
+			fmt.Fprintln(os.Stderr, bad.msg)
+			flag.Usage()
+			os.Exit(2)
+		}
+	}
 
 	rep, err := run(context.Background(), opts, os.Stdout)
 	if err != nil {
@@ -189,6 +207,13 @@ func run(ctx context.Context, opts options, out io.Writer) (*report, error) {
 	pr.f("  negotiated : %s\n", rep.Negotiated)
 	pr.f("  era        : %s\n", era(rep.Stateless))
 	pr.f("  serverInfo : %s %s\n", rep.ServerInfo.Name, rep.ServerInfo.Version)
+
+	// -answer promises an MRTR exercise, and MRTR exists only on stateless
+	// (2026-07-28) connections: after a legacy fallback the driver is
+	// unreachable, so exiting 0 would gate nothing. Mirror the -watch rule.
+	if opts.Answer != "" && !c.IsStateless() {
+		return rep, fmt.Errorf("-answer requested, but the connection is legacy (%s): MRTR is 2026-07-28 only", c.NegotiatedVersion())
+	}
 
 	listCtx, cancelList := context.WithTimeout(ctx, opts.Timeout)
 	tools, err := c.ListTools(listCtx)

--- a/cmd/loom-mcp-probe/main.go
+++ b/cmd/loom-mcp-probe/main.go
@@ -1,0 +1,345 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// loom-mcp-probe connects Loom's MCP client to a real MCP server — streamable
+// HTTP or stdio — and reports what actually negotiated: protocol revision,
+// era (stateless 2026-07-28 core vs legacy initialize handshake), server
+// identity, the tool list, an optional tool call, and an optional
+// subscriptions/listen watch. No fakes anywhere: it exercises the same
+// negotiation, fallback, and transport paths the manager uses in production,
+// against whatever server it is pointed at.
+//
+// Examples:
+//
+//	loom-mcp-probe -url http://localhost:8971 -call test_simple_text -watch 5
+//	loom-mcp-probe -cmd "npx -y @modelcontextprotocol/server-everything stdio" \
+//	    -call echo -args '{"message":"hello"}'
+//	loom-mcp-probe -url http://localhost:9090/mcp -pin legacy
+//	loom-mcp-probe -url http://localhost:8971 -call test_elicitation \
+//	    -args '{"message":"pick a username"}' -answer '{"username":"loom"}'
+//
+// With -answer set, the probe drives Multi Round-Trip Requests (MRTR,
+// 2026-07-28): a server's input_required interim result is answered by
+// accepting every elicitation with the -answer object, and the original
+// call is retried — the same loop the manager's HITL adapter drives in
+// production, with a canned human.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/teradata-labs/loom/internal/version"
+	"github.com/teradata-labs/loom/pkg/mcp/client"
+	"github.com/teradata-labs/loom/pkg/mcp/protocol"
+	"github.com/teradata-labs/loom/pkg/mcp/transport"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// options selects the server to probe and what to exercise against it.
+type options struct {
+	URL      string        // streamable HTTP endpoint; mutually exclusive with Cmd
+	Cmd      string        // stdio server command line; mutually exclusive with URL
+	Pin      string        // protocol_version pin: "" or "auto", "legacy", or an exact revision
+	Call     string        // tool to invoke, if any
+	Args     string        // JSON arguments for Call
+	Answer   string        // JSON object accepted for every elicitation (enables the MRTR driver)
+	WatchSec int           // seconds to hold a subscriptions/listen stream (stateless only)
+	Timeout  time.Duration // negotiation-probe/request timeout
+	Verbose  bool
+}
+
+// report is what the probe observed on the wire.
+type report struct {
+	ConnectDuration time.Duration
+	Negotiated      string
+	Stateless       bool
+	ServerInfo      protocol.Implementation
+	ToolCount       int
+	ToolNames       []string // first few, for display
+	CallOutput      string   // first content text of the tool call, if Call was set
+	Elicited        []string // elicitation messages answered by the MRTR driver
+	Notifications   []string // methods received while watching, if WatchSec > 0
+	WatchEndErr     error    // nil = graceful or client-cancelled
+	WatchSkipped    bool     // legacy connection cannot subscribe
+}
+
+const toolNamesShown = 6
+
+// printer writes best-effort human-readable progress: a failed write to the
+// progress sink must not fail the probe itself.
+type printer struct{ w io.Writer }
+
+func (p printer) f(format string, a ...interface{}) {
+	_, _ = fmt.Fprintf(p.w, format, a...)
+}
+
+func main() {
+	opts := options{}
+	var timeoutMs int
+	flag.StringVar(&opts.URL, "url", "", "streamable HTTP endpoint (e.g. http://localhost:8971)")
+	flag.StringVar(&opts.Cmd, "cmd", "", "stdio server command line (space-separated)")
+	flag.StringVar(&opts.Pin, "pin", "", `protocol_version pin: "auto" (default), "legacy", or an exact revision`)
+	flag.StringVar(&opts.Call, "call", "", "tool to invoke")
+	flag.StringVar(&opts.Args, "args", "{}", "JSON arguments for -call")
+	flag.StringVar(&opts.Answer, "answer", "", "JSON object accepted for every elicitation; enables the MRTR driver (default: fail fast on input_required)")
+	flag.IntVar(&opts.WatchSec, "watch", 0, "seconds to hold a subscriptions/listen stream (stateless connections only)")
+	flag.IntVar(&timeoutMs, "timeout", 15000, "negotiation-probe/request timeout in ms")
+	flag.BoolVar(&opts.Verbose, "v", false, "debug logging")
+	flag.Parse()
+	opts.Timeout = time.Duration(timeoutMs) * time.Millisecond
+
+	if (opts.URL == "") == (opts.Cmd == "") {
+		fmt.Fprintln(os.Stderr, "exactly one of -url or -cmd is required")
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	rep, err := run(ctx, opts, os.Stdout)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "PROBE FAILED: %v\n", err)
+		os.Exit(1)
+	}
+	_ = rep
+}
+
+// run performs the probe and streams human-readable progress to out. The
+// returned report carries the same observations for programmatic use.
+func run(ctx context.Context, opts options, out io.Writer) (*report, error) {
+	pr := printer{w: out}
+	logger, err := buildLogger(opts.Verbose)
+	if err != nil {
+		return nil, fmt.Errorf("logger: %w", err)
+	}
+
+	tr, err := buildTransport(opts, logger)
+	if err != nil {
+		return nil, fmt.Errorf("transport: %w", err)
+	}
+
+	rep := &report{}
+
+	cfg := client.Config{
+		Transport:       tr,
+		Logger:          logger,
+		ProtocolVersion: opts.Pin,
+		RequestTimeout:  opts.Timeout,
+	}
+	if opts.Answer != "" {
+		mrtr, err := buildMRTRHandler(opts.Answer, rep, pr)
+		if err != nil {
+			return nil, err
+		}
+		cfg.MRTR = client.MRTRConfig{Handler: mrtr}
+	}
+
+	c := client.NewClient(cfg)
+	defer func() { _ = c.Close() }()
+
+	start := time.Now()
+	if err := c.Connect(ctx, protocol.Implementation{Name: "loom-mcp-probe", Version: version.Version}); err != nil {
+		return nil, fmt.Errorf("connect: %w", err)
+	}
+	rep.ConnectDuration = time.Since(start)
+	rep.Negotiated = c.NegotiatedVersion()
+	rep.Stateless = c.IsStateless()
+	rep.ServerInfo = c.ServerInfo()
+
+	pr.f("CONNECTED in %s\n", rep.ConnectDuration.Round(time.Millisecond))
+	pr.f("  negotiated : %s\n", rep.Negotiated)
+	pr.f("  era        : %s\n", era(rep.Stateless))
+	pr.f("  serverInfo : %s %s\n", rep.ServerInfo.Name, rep.ServerInfo.Version)
+
+	tools, err := c.ListTools(ctx)
+	if err != nil {
+		return rep, fmt.Errorf("tools/list: %w", err)
+	}
+	rep.ToolCount = len(tools)
+	for i, t := range tools {
+		if i == toolNamesShown {
+			break
+		}
+		rep.ToolNames = append(rep.ToolNames, t.Name)
+	}
+	pr.f("  tools      : %d (%s%s)\n",
+		rep.ToolCount, strings.Join(rep.ToolNames, ", "), more(rep.ToolCount, toolNamesShown))
+
+	if opts.Call != "" {
+		if err := runCall(ctx, c, opts, rep, pr); err != nil {
+			return rep, err
+		}
+	}
+
+	if opts.WatchSec > 0 {
+		if err := runWatch(ctx, c, opts, rep, pr); err != nil {
+			return rep, err
+		}
+	}
+
+	return rep, nil
+}
+
+func runCall(ctx context.Context, c *client.Client, opts options, rep *report, pr printer) error {
+	var args map[string]interface{}
+	if err := json.Unmarshal([]byte(opts.Args), &args); err != nil {
+		return fmt.Errorf("-args is not a JSON object: %w", err)
+	}
+	res, err := c.CallTool(ctx, opts.Call, args)
+	if err != nil {
+		return fmt.Errorf("tools/call %s: %w", opts.Call, err)
+	}
+	if r, ok := res.(*protocol.CallToolResult); ok && len(r.Content) > 0 {
+		rep.CallOutput = r.Content[0].Text
+	}
+	display := rep.CallOutput
+	if len(display) > 120 {
+		display = display[:120] + "…"
+	}
+	pr.f("  call %s → %q\n", opts.Call, display)
+	return nil
+}
+
+func runWatch(ctx context.Context, c *client.Client, opts options, rep *report, pr printer) error {
+	if !c.IsStateless() {
+		rep.WatchSkipped = true
+		pr.f("  watch      : skipped (legacy connection; subscriptions/listen is 2026-07-28)\n")
+		return nil
+	}
+	subCtx, subCancel := context.WithCancel(ctx)
+	defer subCancel()
+	sub, err := c.Subscribe(subCtx, protocol.NotificationFilter{
+		ToolsListChanged:     true,
+		ResourcesListChanged: true,
+	})
+	if err != nil {
+		return fmt.Errorf("subscriptions/listen: %w", err)
+	}
+	pr.f("  watch      : subscription %s open for %ds\n", sub.ID, opts.WatchSec)
+
+	deadline := time.After(time.Duration(opts.WatchSec) * time.Second)
+	for {
+		select {
+		case n, ok := <-sub.Notifications:
+			if !ok {
+				rep.WatchEndErr = sub.Err()
+				pr.f("  watch done : %d notifications, end state: %v\n",
+					len(rep.Notifications), endState(rep.WatchEndErr))
+				return nil
+			}
+			rep.Notifications = append(rep.Notifications, n.Method)
+			pr.f("    notif #%d : %s\n", len(rep.Notifications), n.Method)
+		case <-deadline:
+			subCancel()
+			<-sub.Done()
+			// Client-initiated cancellation ends the watch; the context
+			// cancellation recorded on the subscription is expected, not an
+			// abnormal end.
+			pr.f("  watch done : %d notifications, end state: client cancelled\n",
+				len(rep.Notifications))
+			return nil
+		}
+	}
+}
+
+// buildMRTRHandler answers every elicitation in a server's input_required
+// result by accepting it with the -answer object — a canned human standing in
+// for the manager's HITL adapter. Non-elicitation input requests (sampling,
+// roots) are refused so the exchange fails loudly rather than fabricating a
+// model response.
+func buildMRTRHandler(answer string, rep *report, pr printer) (client.InputHandler, error) {
+	var content map[string]interface{}
+	if err := json.Unmarshal([]byte(answer), &content); err != nil {
+		return nil, fmt.Errorf("-answer is not a JSON object: %w", err)
+	}
+	accept, err := json.Marshal(map[string]interface{}{
+		"action":  "accept",
+		"content": content,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return func(_ context.Context, reqs protocol.InputRequests) (protocol.InputResponses, error) {
+		responses := protocol.InputResponses{}
+		for id, r := range reqs {
+			if r.Method != "elicitation/create" {
+				return nil, fmt.Errorf("input request %q is %s; the probe only answers elicitation/create", id, r.Method)
+			}
+			var params struct {
+				Message string `json:"message"`
+			}
+			_ = json.Unmarshal(r.Params, &params)
+			rep.Elicited = append(rep.Elicited, params.Message)
+			pr.f("  elicited   : %q → accepting with -answer\n", params.Message)
+			responses[id] = accept
+		}
+		return responses, nil
+	}, nil
+}
+
+func buildTransport(opts options, logger *zap.Logger) (transport.Transport, error) {
+	if opts.URL != "" {
+		return transport.NewStreamableHTTPTransport(transport.StreamableHTTPConfig{
+			Endpoint:       opts.URL,
+			EnableSessions: true, // legacy servers may mint a session; 2026 servers never do
+			Logger:         logger,
+		})
+	}
+	parts := strings.Fields(opts.Cmd)
+	return transport.NewStdioTransport(transport.StdioConfig{
+		Command: parts[0],
+		Args:    parts[1:],
+		Logger:  logger,
+	})
+}
+
+func buildLogger(verbose bool) (*zap.Logger, error) {
+	cfg := zap.NewDevelopmentConfig()
+	cfg.Level = zap.NewAtomicLevelAt(zapcore.WarnLevel)
+	if verbose {
+		cfg.Level = zap.NewAtomicLevelAt(zapcore.DebugLevel)
+	}
+	return cfg.Build()
+}
+
+func era(stateless bool) string {
+	if stateless {
+		return "stateless (2026-07-28 core)"
+	}
+	return "legacy (initialize handshake)"
+}
+
+func more(total, shown int) string {
+	if total > shown {
+		return ", …"
+	}
+	return ""
+}
+
+func endState(err error) string {
+	if err == nil {
+		return "graceful (server closed the subscription)"
+	}
+	return err.Error()
+}

--- a/cmd/loom-mcp-probe/main.go
+++ b/cmd/loom-mcp-probe/main.go
@@ -238,6 +238,12 @@ func run(ctx context.Context, opts options, out io.Writer) (*report, error) {
 		if err != nil {
 			return rep, err
 		}
+		// A call that completed without ever eliciting exercised the MRTR
+		// driver on nothing: -answer was a gate that verified nothing, so
+		// exiting 0 would prove nothing. Mirror the legacy-connection rule.
+		if opts.Answer != "" && len(rep.Elicited) == 0 {
+			return rep, fmt.Errorf("-answer requested, but tools/call %s completed without input_required: the answer was never exercised", opts.Call)
+		}
 	}
 
 	if opts.WatchSec > 0 {

--- a/cmd/loom-mcp-probe/main_test.go
+++ b/cmd/loom-mcp-probe/main_test.go
@@ -385,6 +385,17 @@ func TestProbeInputRequiredWithoutAnswerFailsFast(t *testing.T) {
 	require.Error(t, err, "input_required with no -answer must fail, not silently pass")
 }
 
+func TestProbeAnswerWithoutElicitationIsError(t *testing.T) {
+	// Stateless server whose tool completes immediately: the MRTR driver is
+	// armed but never runs, so -answer verified nothing and must fail loudly.
+	srv := startScripted(t, &scriptedHTTPServer{statelessOK: true})
+	_, err := run(context.Background(), options{
+		URL: srv.URL, Call: "greet", Args: "{}", Answer: `{"x":1}`, Timeout: 5 * time.Second,
+	}, io.Discard)
+	require.Error(t, err, "-answer with a call that never elicits must fail, not exit 0")
+	assert.Contains(t, err.Error(), "never exercised")
+}
+
 func TestProbeAnswerOnLegacyConnectionIsError(t *testing.T) {
 	srv := startScripted(t, &scriptedHTTPServer{statelessOK: false})
 	_, err := run(context.Background(), options{

--- a/cmd/loom-mcp-probe/main_test.go
+++ b/cmd/loom-mcp-probe/main_test.go
@@ -38,6 +38,7 @@ type scriptedHTTPServer struct {
 	statelessOK bool
 	elicitFirst bool
 	watchMode   string // "": listen → MethodNotFound; "no-ack": SSE opens, no ack; "ack-then-close": ack then immediate close
+	callIsError bool   // tools/call answers isError:true
 
 	mu         sync.Mutex
 	callParams []json.RawMessage // raw params of each tools/call attempt
@@ -139,6 +140,14 @@ func (s *scriptedHTTPServer) handler(w http.ResponseWriter, r *http.Request) {
 					},
 				},
 				"requestState": "sealed-round-1",
+			})
+			return
+		}
+		if s.callIsError {
+			writeResult(map[string]interface{}{
+				"resultType": protocol.ResultTypeComplete,
+				"isError":    true,
+				"content":    []map[string]interface{}{{"type": "text", "text": "tool exploded"}},
 			})
 			return
 		}
@@ -263,9 +272,6 @@ func TestProbeMRTRElicitation(t *testing.T) {
 }
 
 func TestProbeRejectsNonElicitationInputRequests(t *testing.T) {
-	_, err := buildMRTRHandler(`{"x":1}`, &report{}, printer{w: io.Discard})
-	require.NoError(t, err)
-
 	h, err := buildMRTRHandler(`{"x":1}`, &report{}, printer{w: io.Discard})
 	require.NoError(t, err)
 	_, err = h(context.Background(), protocol.InputRequests{
@@ -351,6 +357,42 @@ func TestHeadersFromEnv(t *testing.T) {
 	h, err = headersFromEnv("")
 	require.NoError(t, err)
 	assert.Nil(t, h)
+}
+
+// The gate-script pitch: every path that verifies nothing must exit non-zero.
+func TestProbeIsErrorResultFailsProbe(t *testing.T) {
+	srv := startScripted(t, &scriptedHTTPServer{statelessOK: true, callIsError: true})
+	_, err := run(context.Background(), options{
+		URL: srv.URL, Call: "greet", Args: "{}", Timeout: 5 * time.Second,
+	}, io.Discard)
+	require.Error(t, err, "an isError:true tool result must fail the probe")
+	assert.Contains(t, err.Error(), "greet")
+}
+
+func TestProbeBadArgsJSONFailsBeforeTransport(t *testing.T) {
+	_, err := run(context.Background(), options{
+		URL: "http://127.0.0.1:1", Call: "greet", Args: "not-json", Timeout: time.Second,
+	}, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "-args")
+}
+
+func TestProbeInputRequiredWithoutAnswerFailsFast(t *testing.T) {
+	srv := startScripted(t, &scriptedHTTPServer{statelessOK: true, elicitFirst: true})
+	_, err := run(context.Background(), options{
+		URL: srv.URL, Call: "greet", Args: "{}", Timeout: 5 * time.Second,
+	}, io.Discard)
+	require.Error(t, err, "input_required with no -answer must fail, not silently pass")
+}
+
+func TestProbeAnswerOnLegacyConnectionIsError(t *testing.T) {
+	srv := startScripted(t, &scriptedHTTPServer{statelessOK: false})
+	_, err := run(context.Background(), options{
+		URL: srv.URL, Call: "greet", Args: "{}", Answer: `{"x":1}`, Timeout: 5 * time.Second,
+	}, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "legacy")
+	assert.Contains(t, err.Error(), "MRTR")
 }
 
 func TestHelpers(t *testing.T) {

--- a/cmd/loom-mcp-probe/main_test.go
+++ b/cmd/loom-mcp-probe/main_test.go
@@ -148,6 +148,14 @@ func (s *scriptedHTTPServer) handler(w http.ResponseWriter, r *http.Request) {
 		})
 	case protocol.MethodSubscriptionsListen:
 		switch s.watchMode {
+		case "stall-headers":
+			// Stall before sending ANY response headers: the transport's
+			// http.Client has no deadline of its own, so only the probe's
+			// pre-ack watchdog can catch this.
+			select {
+			case <-r.Context().Done():
+			case <-time.After(3 * time.Second):
+			}
 		case "no-ack":
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.WriteHeader(http.StatusOK)
@@ -298,6 +306,18 @@ func TestProbeWatchNoAckIsError(t *testing.T) {
 	}, io.Discard)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "acknowledgment")
+}
+
+func TestProbeWatchHeaderStallIsError(t *testing.T) {
+	srv := startScripted(t, &scriptedHTTPServer{statelessOK: true, watchMode: "stall-headers"})
+	start := time.Now()
+	_, err := run(context.Background(), options{
+		URL: srv.URL, WatchSec: 5, Timeout: 500 * time.Millisecond,
+	}, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "acknowledgment")
+	assert.Less(t, time.Since(start), 3*time.Second,
+		"the pre-ack watchdog must fire on -timeout, not wait out the stalled server")
 }
 
 func TestProbeWatchEarlyCloseIsError(t *testing.T) {

--- a/cmd/loom-mcp-probe/main_test.go
+++ b/cmd/loom-mcp-probe/main_test.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/teradata-labs/loom/pkg/mcp/protocol"
+)
+
+// scriptedHTTPServer is a minimal wire-level MCP server for probing: statelessOK
+// selects the 2026-07-28 era (discover answered) vs a legacy 2025 era
+// (discover rejected, initialize handshake served). elicitFirst makes the
+// first tools/call answer input_required so the probe's MRTR driver runs.
+type scriptedHTTPServer struct {
+	t           *testing.T
+	statelessOK bool
+	elicitFirst bool
+
+	mu         sync.Mutex
+	callParams []json.RawMessage // raw params of each tools/call attempt
+}
+
+func (s *scriptedHTTPServer) handler(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	require.NoError(s.t, err)
+	var req protocol.Request
+	require.NoError(s.t, json.Unmarshal(body, &req))
+
+	if req.ID == nil { // notification (e.g. notifications/initialized)
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	writeResult := func(result interface{}) {
+		raw, err := json.Marshal(result)
+		require.NoError(s.t, err)
+		resp, err := json.Marshal(protocol.Response{JSONRPC: protocol.JSONRPCVersion, ID: req.ID, Result: raw})
+		require.NoError(s.t, err)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(resp)
+	}
+	writeError := func(code int, msg string) {
+		resp, err := json.Marshal(protocol.Response{
+			JSONRPC: protocol.JSONRPCVersion, ID: req.ID,
+			Error: protocol.NewError(code, msg, nil),
+		})
+		require.NoError(s.t, err)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(resp)
+	}
+
+	switch req.Method {
+	case "server/discover":
+		if !s.statelessOK {
+			writeError(protocol.MethodNotFound, "method not found")
+			return
+		}
+		res := protocol.DiscoverResult{
+			ResultType:        protocol.ResultTypeComplete,
+			SupportedVersions: []string{protocol.Version20260728},
+			Capabilities:      protocol.ServerCapabilities{Tools: &protocol.ToolsCapability{}},
+			TTLMs:             0,
+			CacheScope:        "private",
+		}
+		require.NoError(s.t, res.SetServerInfo(protocol.Implementation{Name: "scripted-http", Version: "1.0"}))
+		writeResult(res)
+	case "initialize":
+		writeResult(protocol.InitializeResult{
+			ProtocolVersion: protocol.Version20251125,
+			ServerInfo:      protocol.Implementation{Name: "scripted-legacy", Version: "1.0"},
+		})
+	case "tools/list":
+		writeResult(map[string]interface{}{
+			"resultType": protocol.ResultTypeComplete,
+			"tools": []protocol.Tool{{
+				Name:        "greet",
+				Description: "greets",
+				InputSchema: map[string]interface{}{"type": "object"},
+			}},
+		})
+	case "tools/call":
+		s.mu.Lock()
+		s.callParams = append(s.callParams, append(json.RawMessage(nil), req.Params...))
+		attempt := len(s.callParams)
+		s.mu.Unlock()
+		if s.elicitFirst && attempt == 1 {
+			writeResult(map[string]interface{}{
+				"resultType": protocol.ResultTypeInputRequired,
+				"inputRequests": map[string]interface{}{
+					"who": map[string]interface{}{
+						"method": "elicitation/create",
+						"params": map[string]interface{}{
+							"mode":    "form",
+							"message": "who should be greeted?",
+						},
+					},
+				},
+				"requestState": "sealed-round-1",
+			})
+			return
+		}
+		writeResult(map[string]interface{}{
+			"resultType": protocol.ResultTypeComplete,
+			"content":    []map[string]interface{}{{"type": "text", "text": "hello from scripted server"}},
+		})
+	default:
+		writeError(protocol.MethodNotFound, "method not found")
+	}
+}
+
+func startScripted(t *testing.T, s *scriptedHTTPServer) *httptest.Server {
+	t.Helper()
+	s.t = t
+	srv := httptest.NewServer(http.HandlerFunc(s.handler))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestProbeStatelessServer(t *testing.T) {
+	srv := startScripted(t, &scriptedHTTPServer{statelessOK: true})
+
+	var out strings.Builder
+	rep, err := run(context.Background(), options{
+		URL: srv.URL, Call: "greet", Args: "{}", Timeout: 5 * time.Second,
+	}, &out)
+	require.NoError(t, err)
+
+	assert.Equal(t, protocol.Version20260728, rep.Negotiated)
+	assert.True(t, rep.Stateless)
+	assert.Equal(t, "scripted-http", rep.ServerInfo.Name)
+	assert.Equal(t, 1, rep.ToolCount)
+	assert.Equal(t, "hello from scripted server", rep.CallOutput)
+	assert.Contains(t, out.String(), "stateless (2026-07-28 core)")
+}
+
+func TestProbeLegacyFallback(t *testing.T) {
+	srv := startScripted(t, &scriptedHTTPServer{statelessOK: false})
+
+	var out strings.Builder
+	rep, err := run(context.Background(), options{
+		URL: srv.URL, Timeout: 5 * time.Second,
+	}, &out)
+	require.NoError(t, err)
+
+	assert.Equal(t, protocol.Version20251125, rep.Negotiated)
+	assert.False(t, rep.Stateless)
+	assert.Equal(t, "scripted-legacy", rep.ServerInfo.Name)
+	assert.Contains(t, out.String(), "legacy (initialize handshake)")
+}
+
+// TestProbeMRTRElicitation drives the full loop over the wire: the first
+// tools/call answers input_required, the probe's handler accepts the
+// elicitation with -answer, and the retry must carry both the response and
+// the exact requestState.
+func TestProbeMRTRElicitation(t *testing.T) {
+	s := &scriptedHTTPServer{statelessOK: true, elicitFirst: true}
+	srv := startScripted(t, s)
+
+	var out strings.Builder
+	rep, err := run(context.Background(), options{
+		URL: srv.URL, Call: "greet", Args: "{}",
+		Answer: `{"name":"loom"}`, Timeout: 5 * time.Second,
+	}, &out)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"who should be greeted?"}, rep.Elicited)
+	assert.Equal(t, "hello from scripted server", rep.CallOutput)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	require.Len(t, s.callParams, 2, "input_required must drive exactly one retry")
+	var retry struct {
+		InputResponses map[string]struct {
+			Action  string                 `json:"action"`
+			Content map[string]interface{} `json:"content"`
+		} `json:"inputResponses"`
+		RequestState *string `json:"requestState"`
+	}
+	require.NoError(t, json.Unmarshal(s.callParams[1], &retry))
+	require.Contains(t, retry.InputResponses, "who")
+	assert.Equal(t, "accept", retry.InputResponses["who"].Action)
+	assert.Equal(t, "loom", retry.InputResponses["who"].Content["name"])
+	require.NotNil(t, retry.RequestState, "requestState must be echoed on the retry")
+	assert.Equal(t, "sealed-round-1", *retry.RequestState)
+}
+
+func TestProbeRejectsNonElicitationInputRequests(t *testing.T) {
+	_, err := buildMRTRHandler(`{"x":1}`, &report{}, printer{w: io.Discard})
+	require.NoError(t, err)
+
+	h, err := buildMRTRHandler(`{"x":1}`, &report{}, printer{w: io.Discard})
+	require.NoError(t, err)
+	_, err = h(context.Background(), protocol.InputRequests{
+		"llm": protocol.InputRequest{Method: "sampling/createMessage"},
+	})
+	require.Error(t, err, "sampling must not be fabricated by the probe")
+}
+
+func TestProbeBadAnswerJSON(t *testing.T) {
+	_, err := buildMRTRHandler(`not-json`, &report{}, printer{w: io.Discard})
+	require.Error(t, err)
+}
+
+func TestHelpers(t *testing.T) {
+	assert.Equal(t, "stateless (2026-07-28 core)", era(true))
+	assert.Equal(t, "legacy (initialize handshake)", era(false))
+	assert.Equal(t, ", …", more(10, 6))
+	assert.Equal(t, "", more(3, 6))
+	assert.Equal(t, "graceful (server closed the subscription)", endState(nil))
+}

--- a/cmd/loom-mcp-probe/main_test.go
+++ b/cmd/loom-mcp-probe/main_test.go
@@ -16,6 +16,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -34,19 +35,27 @@ import (
 // (discover rejected, initialize handshake served). elicitFirst makes the
 // first tools/call answer input_required so the probe's MRTR driver runs.
 type scriptedHTTPServer struct {
-	t           *testing.T
 	statelessOK bool
 	elicitFirst bool
+	watchMode   string // "": listen → MethodNotFound; "no-ack": SSE opens, no ack; "ack-then-close": ack then immediate close
 
 	mu         sync.Mutex
 	callParams []json.RawMessage // raw params of each tools/call attempt
 }
 
+// handler runs on the HTTP server goroutine, where FailNow is illegal — any
+// internal problem becomes an HTTP 500 the client-side assertions surface.
 func (s *scriptedHTTPServer) handler(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(r.Body)
-	require.NoError(s.t, err)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	var req protocol.Request
-	require.NoError(s.t, json.Unmarshal(body, &req))
+	if err := json.Unmarshal(body, &req); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	if req.ID == nil { // notification (e.g. notifications/initialized)
 		w.WriteHeader(http.StatusAccepted)
@@ -55,9 +64,15 @@ func (s *scriptedHTTPServer) handler(w http.ResponseWriter, r *http.Request) {
 
 	writeResult := func(result interface{}) {
 		raw, err := json.Marshal(result)
-		require.NoError(s.t, err)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 		resp, err := json.Marshal(protocol.Response{JSONRPC: protocol.JSONRPCVersion, ID: req.ID, Result: raw})
-		require.NoError(s.t, err)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(resp)
 	}
@@ -66,7 +81,10 @@ func (s *scriptedHTTPServer) handler(w http.ResponseWriter, r *http.Request) {
 			JSONRPC: protocol.JSONRPCVersion, ID: req.ID,
 			Error: protocol.NewError(code, msg, nil),
 		})
-		require.NoError(s.t, err)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(resp)
 	}
@@ -84,7 +102,10 @@ func (s *scriptedHTTPServer) handler(w http.ResponseWriter, r *http.Request) {
 			TTLMs:             0,
 			CacheScope:        "private",
 		}
-		require.NoError(s.t, res.SetServerInfo(protocol.Implementation{Name: "scripted-http", Version: "1.0"}))
+		if err := res.SetServerInfo(protocol.Implementation{Name: "scripted-http", Version: "1.0"}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 		writeResult(res)
 	case "initialize":
 		writeResult(protocol.InitializeResult{
@@ -125,6 +146,34 @@ func (s *scriptedHTTPServer) handler(w http.ResponseWriter, r *http.Request) {
 			"resultType": protocol.ResultTypeComplete,
 			"content":    []map[string]interface{}{{"type": "text", "text": "hello from scripted server"}},
 		})
+	case protocol.MethodSubscriptionsListen:
+		switch s.watchMode {
+		case "no-ack":
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			w.(http.Flusher).Flush()
+			// Hold the stream open without ever acknowledging.
+			select {
+			case <-r.Context().Done():
+			case <-time.After(3 * time.Second):
+			}
+		case "ack-then-close":
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			idJSON, _ := json.Marshal(req.ID)
+			ack, _ := json.Marshal(map[string]interface{}{
+				"jsonrpc": protocol.JSONRPCVersion,
+				"method":  protocol.NotificationSubscriptionAcknowledged,
+				"params": map[string]interface{}{
+					"_meta": map[string]json.RawMessage{protocol.MetaSubscriptionID: idJSON},
+				},
+			})
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", ack)
+			w.(http.Flusher).Flush()
+			// Returning here closes the stream immediately after the ack.
+		default:
+			writeError(protocol.MethodNotFound, "subscriptions unsupported")
+		}
 	default:
 		writeError(protocol.MethodNotFound, "method not found")
 	}
@@ -132,7 +181,6 @@ func (s *scriptedHTTPServer) handler(w http.ResponseWriter, r *http.Request) {
 
 func startScripted(t *testing.T, s *scriptedHTTPServer) *httptest.Server {
 	t.Helper()
-	s.t = t
 	srv := httptest.NewServer(http.HandlerFunc(s.handler))
 	t.Cleanup(srv.Close)
 	return srv
@@ -221,6 +269,68 @@ func TestProbeRejectsNonElicitationInputRequests(t *testing.T) {
 func TestProbeBadAnswerJSON(t *testing.T) {
 	_, err := buildMRTRHandler(`not-json`, &report{}, printer{w: io.Discard})
 	require.Error(t, err)
+}
+
+// Round-1 blocker: -watch must never exit 0 without a healthy, acknowledged
+// subscription held for the full window. Four escape paths, four regressions.
+func TestProbeWatchOnLegacyIsError(t *testing.T) {
+	srv := startScripted(t, &scriptedHTTPServer{statelessOK: false})
+	_, err := run(context.Background(), options{
+		URL: srv.URL, WatchSec: 1, Timeout: 5 * time.Second,
+	}, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "legacy")
+}
+
+func TestProbeWatchMethodNotFoundIsError(t *testing.T) {
+	srv := startScripted(t, &scriptedHTTPServer{statelessOK: true}) // watchMode "": listen → MethodNotFound
+	_, err := run(context.Background(), options{
+		URL: srv.URL, WatchSec: 1, Timeout: 5 * time.Second,
+	}, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "subscription")
+}
+
+func TestProbeWatchNoAckIsError(t *testing.T) {
+	srv := startScripted(t, &scriptedHTTPServer{statelessOK: true, watchMode: "no-ack"})
+	_, err := run(context.Background(), options{
+		URL: srv.URL, WatchSec: 5, Timeout: 500 * time.Millisecond,
+	}, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "acknowledgment")
+}
+
+func TestProbeWatchEarlyCloseIsError(t *testing.T) {
+	srv := startScripted(t, &scriptedHTTPServer{statelessOK: true, watchMode: "ack-then-close"})
+	_, err := run(context.Background(), options{
+		URL: srv.URL, WatchSec: 3, Timeout: 5 * time.Second,
+	}, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "before the watch window")
+}
+
+func TestProbeWhitespaceCmdIsError(t *testing.T) {
+	_, err := run(context.Background(), options{Cmd: "   ", Timeout: time.Second}, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "-cmd")
+}
+
+func TestHeadersFromEnv(t *testing.T) {
+	t.Setenv("PROBE_H_OK", `{"Authorization":"Bearer fake-test-token"}`)
+	h, err := headersFromEnv("PROBE_H_OK")
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer fake-test-token", h["Authorization"])
+
+	_, err = headersFromEnv("PROBE_H_MISSING")
+	require.Error(t, err)
+
+	t.Setenv("PROBE_H_BAD", `not-json`)
+	_, err = headersFromEnv("PROBE_H_BAD")
+	require.Error(t, err)
+
+	h, err = headersFromEnv("")
+	require.NoError(t, err)
+	assert.Nil(t, h)
 }
 
 func TestHelpers(t *testing.T) {

--- a/docs/guides/integration/mcp-implementation.md
+++ b/docs/guides/integration/mcp-implementation.md
@@ -102,7 +102,9 @@ mcp:
 > **Note:** The `http` and `sse` transport values are interchangeable and both
 > use the legacy HTTP/SSE transport. For new deployments, prefer `streamable-http`.
 
-### Streamable HTTP Transport (MCP 2025-03-26 spec) ✅
+### Streamable HTTP Transport (negotiated revision) ✅
+
+The client negotiates the MCP protocol revision per server: 2026-07-28 stateless core when the server supports it, with automatic fallback to the legacy initialize handshake (and legacy `Mcp-Session-Id` handling) for 2024/2025-era servers. Pin a revision per server with `protocol_version`.
 
 ```yaml
 mcp:
@@ -110,8 +112,8 @@ mcp:
     remote:
       url: http://localhost:8080/mcp
       transport: streamable-http
+      protocol_version: auto  # auto | legacy | exact revision (e.g. "2026-07-28")
       enable_sessions: true
-      enable_resumption: false
 ```
 
 
@@ -284,8 +286,9 @@ mcp:
       enabled: bool            # Enable/disable server
       timeout: string          # Operation timeout (e.g., "30s", "1m")
       url: string              # Server URL (required for http/sse/streamable-http)
-      enable_sessions: bool    # Enable session management (streamable-http only)
-      enable_resumption: bool  # Enable stream resumption (streamable-http only)
+      protocol_version: string # "auto" (default) | "legacy" | exact revision (e.g. "2026-07-28")
+      enable_sessions: bool    # Echo legacy session IDs (streamable-http only)
+      enable_resumption: bool  # DEPRECATED no-op: resumption was removed by MCP 2026-07-28; parses with a warning
 
       # Tool filtering
       tools:

--- a/docs/guides/integration/mcp-readme.md
+++ b/docs/guides/integration/mcp-readme.md
@@ -135,7 +135,7 @@ mcp:
 #### 2. streamable-http (Remote Servers - Modern)
 ✅ **Recommended for remote servers**
 
-Modern MCP transport (2025-03-26 spec) with session management and stream resumption.
+Streamable HTTP with per-server protocol revision negotiation. The client speaks the MCP **2026-07-28** stateless core (per-request `_meta`, multi round-trip requests, `subscriptions/listen`, required request headers) and automatically falls back to the legacy initialize handshake for 2024/2025-era servers — including strict session servers that reject pre-initialize requests. Legacy session IDs (`Mcp-Session-Id`) are adopted and echoed automatically when a legacy server mints one.
 
 ```yaml
 mcp:
@@ -144,21 +144,29 @@ mcp:
       transport: streamable-http
       url: https://api.example.com/mcp
       enabled: true
-      enable_sessions: true    # Session IDs for state management
-      enable_resumption: true  # Fault tolerance with event replay
+      protocol_version: auto   # auto (default) | legacy | exact revision, e.g. "2026-07-28"
+      enable_sessions: true    # echo legacy session IDs when a server mints one
 ```
+
+**`protocol_version` values:**
+- `auto` (or empty) — probe `server/discover` and negotiate the best mutual revision; fall back to the initialize handshake for legacy servers
+- `legacy` — skip the probe, always run the initialize handshake
+- an exact revision (e.g. `"2026-07-28"`, `"2025-03-26"`) — require the server to speak exactly that revision; fails loudly instead of silently downgrading
+
+Verify what a server actually negotiates with `just mcp-probe -url <endpoint>` (see the [MCP Probe guide](../mcp-probe.md)).
 
 **Use streamable-http when:**
 - Connecting to remote MCP servers
-- Need session management (Mcp-Session-Id headers)
-- Want fault tolerance with stream resumption
+- Talking to 2026-07-28 stateless servers, legacy session servers, or mixed fleets
 - Deploying in production environments
 
 **Features:**
 - Single unified endpoint
-- Session management via `Mcp-Session-Id` headers
-- Stream resumption with `Last-Event-ID`
-- Better error handling (HTTP 404 for expired sessions)
+- Per-server revision negotiation with typed, loud failures on pin mismatches
+- Legacy session management via `Mcp-Session-Id` headers (2024/2025-era servers)
+- Broken-stream recovery: a lost SSE response stream is re-issued once with an idempotency key
+
+> **Note:** `enable_resumption` is deprecated and has no effect — SSE stream resumption (`Last-Event-ID`) was removed by the MCP 2026-07-28 revision. The field still parses (with a warning) so existing configs keep loading; recovery is re-issue plus refetch instead of event replay.
 
 #### 3. http/sse (Remote Servers - Legacy)
 ⚠️ **Deprecated - Use streamable-http instead**

--- a/docs/guides/mcp-probe.md
+++ b/docs/guides/mcp-probe.md
@@ -47,7 +47,7 @@ All from official sources:
 |---|---|---|
 | Go SDK conformance everything-server | **2026-07-28** (stateless HTTP + stdio); sessionful legacy with `-stateless=false` | `go install github.com/modelcontextprotocol/go-sdk/conformance/everything-server@v1.7.0` then `everything-server -http localhost:8971` |
 | `@modelcontextprotocol/server-everything` (npm, TypeScript) | legacy 2025-11-25 | `npx -y @modelcontextprotocol/server-everything stdio` |
-| Loom's own `looms` + `loom-mcp --transport=http` | 🚧 **dual-era pending PR #328** (server-side 2026-07-28); on `main` today this endpoint is legacy-only. The transcript below was captured against the #328 branch | `looms serve` then `loom-mcp --transport=http --http-addr=127.0.0.1:8765 --grpc-addr=localhost:60051` |
+| Loom's own `looms` + `loom-mcp --transport=http` | **dual-era**: 2026-07-28 stateless AND legacy 2024-11-05 handshake on one endpoint (server side landed in PR #328; transcript below) | `looms serve` then `loom-mcp --transport=http --http-addr=127.0.0.1:8765 --grpc-addr=localhost:60051` |
 
 As of 2026-08-19 the Go SDK is the only official SDK with a 2026-07-28 runtime; the TypeScript SDK tops out at 2025-11-25, which makes its servers exactly the legacy peers the fallback ladder needs.
 
@@ -108,7 +108,7 @@ CONNECTED in 6ms
   call echo → "Echo: session test"
 ```
 
-**Dogfood: Loom's own dual-era endpoint** (`loom-mcp --transport=http` bridging a running `looms`). 🚧 This behavior is PR #328's server side, and the session below was captured against that branch — on `main` the endpoint is legacy-only until #328 merges. One endpoint serves both eras:
+**Dogfood: Loom's own dual-era endpoint** (`loom-mcp --transport=http` bridging a running `looms`; server side landed in PR #328). One endpoint serves both eras:
 
 ```text
 $ loom-mcp-probe -url http://127.0.0.1:8765/ -call loom_list_agents -watch 3
@@ -131,7 +131,7 @@ CONNECTED in 3ms
 
 - The MRTR driver answers **elicitations only**, with one canned object for all of them; sampling and roots input requests fail the exchange by design.
 - `-watch` requires a stateless (2026-07-28) connection; `subscriptions/listen` does not exist on legacy revisions.
-- This is a probe, not a conformance suite: it reports what happened on one connection. The dual-revision conformance matrix and official-SDK interop suite (migration spec §10) ride PR #328; on `main` today `pkg/mcp/conformance` holds the legacy tests only.
+- This is a probe, not a conformance suite: it reports what happened on one connection. The dual-revision conformance matrix and official-SDK interop suite live in `pkg/mcp/conformance` (migration spec §10, landed in PR #328).
 - Authenticated HTTP endpoints need `-headers-env`: the manager passes configured headers from agent config, and the probe reads the same shape from the named environment variable.
 
 ## Field notes from real servers

--- a/docs/guides/mcp-probe.md
+++ b/docs/guides/mcp-probe.md
@@ -1,0 +1,106 @@
+# MCP Probe: real-server testing for Loom's MCP client
+
+**Status**: ✅ Implemented (`cmd/loom-mcp-probe`, wire-level tests included)
+
+`loom-mcp-probe` connects Loom's MCP client to a **real** MCP server — streamable HTTP or stdio — and reports what actually negotiated: protocol revision, era, server identity, tools, an optional tool call, an optional MRTR elicitation exchange, and an optional `subscriptions/listen` watch. It exercises the exact negotiation, fallback, MRTR, and transport code paths the manager uses in production. No fakes anywhere.
+
+Use it to verify a server before wiring it into an agent config, to reproduce interop problems, or to watch what era/revision a fleet server actually speaks.
+
+## Running
+
+```bash
+just mcp-probe -url http://localhost:8971 -call test_simple_text -watch 5
+# or without just:
+go run -tags fts5 ./cmd/loom-mcp-probe -cmd "npx -y @modelcontextprotocol/server-everything stdio" \
+    -call echo -args '{"message":"hello"}'
+```
+
+## Flags
+
+| Flag | Meaning |
+|---|---|
+| `-url` | streamable HTTP endpoint (mutually exclusive with `-cmd`) |
+| `-cmd` | stdio server command line, space-separated |
+| `-pin` | `protocol_version` pin: `auto` (default), `legacy`, or an exact revision such as `2026-07-28` |
+| `-call` | tool to invoke |
+| `-args` | JSON arguments object for `-call` (default `{}`) |
+| `-answer` | JSON object accepted for **every** elicitation; enables the MRTR driver. Unset = the client's fail-fast default on `input_required` |
+| `-watch` | seconds to hold a `subscriptions/listen` stream (stateless connections only) |
+| `-timeout` | negotiation-probe/request timeout in ms (default 15000) |
+| `-v` | debug logging |
+
+The probe exits non-zero on any failure, so it can gate scripts.
+
+## What each mode exercises
+
+- **Auto negotiation**: the `server/discover` probe with the full fallback ladder — non-modern JSON-RPC errors, bare HTTP 404/405/501, 400 without a modern error body, and (stdio only) probe silence within the bounded timeout.
+- **`-answer`**: the Multi Round-Trip Requests loop (2026-07-28, SEP-2322). A server's `input_required` interim result is answered by accepting every elicitation with the `-answer` object — a canned human standing in for the manager's HITL adapter — and the original call is retried with `inputResponses` plus the exact echoed `requestState`. Non-elicitation input requests (sampling, roots) are refused so the exchange fails loudly rather than fabricating a model response.
+- **`-watch`**: a live `subscriptions/listen` stream (acknowledgment, demultiplexed change notifications, client-side cancellation — closing the SSE stream on HTTP, `notifications/cancelled` on stdio).
+
+## Known-good real servers
+
+All from official sources:
+
+| Server | Era | How to run |
+|---|---|---|
+| Go SDK conformance everything-server | **2026-07-28** (stateless HTTP + stdio); sessionful legacy with `-stateless=false` | `go install github.com/modelcontextprotocol/go-sdk/conformance/everything-server@v1.7.0` then `everything-server -http localhost:8971` |
+| `@modelcontextprotocol/server-everything` (npm, TypeScript) | legacy 2025-11-25 | `npx -y @modelcontextprotocol/server-everything stdio` |
+| Loom's own `looms` / `loom-mcp` | per branch | `looms serve` |
+
+As of 2026-08-19 the Go SDK is the only official SDK with a 2026-07-28 runtime; the TypeScript SDK tops out at 2025-11-25, which makes its servers exactly the legacy peers the fallback ladder needs.
+
+## Example sessions
+
+Real transcripts against the official Go SDK conformance server and the npm TypeScript server (2026-08-19).
+
+**Stateless 2026-07-28 over streamable HTTP, with a live subscription:**
+
+```text
+$ loom-mcp-probe -url http://localhost:8971 -call test_simple_text -watch 4
+CONNECTED in 6ms
+  negotiated : 2026-07-28
+  era        : stateless (2026-07-28 core)
+  serverInfo : mcp-conformance-test-server 1.0.0
+  tools      : 28 (json_schema_2020_12_tool, test_audio_content, test_elicitation, …)
+  call test_simple_text → "This is a simple text response for testing."
+  watch      : subscription 4 open for 4s
+    notif #1 : notifications/subscriptions/acknowledged
+    notif #2 : notifications/resources/updated
+```
+
+**MRTR elicitation round-trip, including the server-verified `requestState` echo:**
+
+```text
+$ loom-mcp-probe -url http://localhost:8971 -call test_input_required_result_elicitation -answer '{"name":"Loom"}'
+  elicited   : "What is your name?" → accepting with -answer
+  call test_input_required_result_elicitation → "Hello, Loom!"
+
+$ loom-mcp-probe -url http://localhost:8971 -call test_input_required_result_request_state -answer '{"name":"Loom"}'
+  elicited   : "Please confirm" → accepting with -answer
+  call test_input_required_result_request_state → "state-ok: requestState received and confirmation accepted"
+```
+
+**Legacy fallback against a real 2025-era server (TypeScript SDK):**
+
+```text
+$ loom-mcp-probe -cmd "npx -y @modelcontextprotocol/server-everything stdio" -call echo -args '{"message":"hello from loom client"}'
+CONNECTED in 1.31s
+  negotiated : 2025-11-25
+  era        : legacy (initialize handshake)
+  serverInfo : mcp-servers/everything 2.0.0
+  tools      : 13 (echo, get-annotated-message, get-env, …)
+  call echo → "Echo: hello from loom client"
+```
+
+The sessionful mode of the Go SDK server (`-stateless=false`) also negotiates down to `2025-11-25` via the handshake — a live check that the fallback requests the newest legacy revision instead of silently under-negotiating.
+
+## Limitations
+
+- The MRTR driver answers **elicitations only**, with one canned object for all of them; sampling and roots input requests fail the exchange by design.
+- `-watch` requires a stateless (2026-07-28) connection; `subscriptions/listen` does not exist on legacy revisions.
+- This is a probe, not a conformance suite: it reports what happened on one connection. The dual-revision conformance matrix and official-SDK interop CI live in `pkg/mcp/conformance` (migration spec §10).
+
+## Field notes from real servers
+
+- The Go SDK conformance server's `test_elicitation` tool still uses the legacy server-initiated `Session.Elicit` API, which the SDK itself rejects on 2026-07-28 sessions ("return an InputRequests map instead"); use the `test_input_required_result_*` tools for MRTR.
+- The same server exits with status 1 after a cancelled `subscriptions/listen` over stdio (a bare stdin EOF exits 0). Loom's teardown is unaffected; the probe logs the exit as a warning.

--- a/docs/guides/mcp-probe.md
+++ b/docs/guides/mcp-probe.md
@@ -45,7 +45,7 @@ All from official sources:
 |---|---|---|
 | Go SDK conformance everything-server | **2026-07-28** (stateless HTTP + stdio); sessionful legacy with `-stateless=false` | `go install github.com/modelcontextprotocol/go-sdk/conformance/everything-server@v1.7.0` then `everything-server -http localhost:8971` |
 | `@modelcontextprotocol/server-everything` (npm, TypeScript) | legacy 2025-11-25 | `npx -y @modelcontextprotocol/server-everything stdio` |
-| Loom's own `looms` / `loom-mcp` | per branch | `looms serve` |
+| Loom's own `looms` + `loom-mcp --transport=http` | **dual-era**: 2026-07-28 stateless AND legacy 2024-11-05 handshake on one endpoint (verified, see below) | `looms serve` then `loom-mcp --transport=http --http-addr=127.0.0.1:8765 --grpc-addr=localhost:60051` |
 
 As of 2026-08-19 the Go SDK is the only official SDK with a 2026-07-28 runtime; the TypeScript SDK tops out at 2025-11-25, which makes its servers exactly the legacy peers the fallback ladder needs.
 
@@ -94,6 +94,39 @@ CONNECTED in 1.31s
 
 The sessionful mode of the Go SDK server (`-stateless=false`) also negotiates down to `2025-11-25` via the handshake — a live check that the fallback requests the newest legacy revision instead of silently under-negotiating.
 
+**Sessionful streamable HTTP against the TypeScript server** — the real-wire test of the 400-fallback rule and legacy session capture. The server rejects the pre-initialize `server/discover` probe with HTTP 400 and a non-modern JSON-RPC body (`-32000 "Bad Request: Server not initialized"`, id null); the client classifies that as a legacy signal, runs the handshake, adopts the minted `Mcp-Session-Id`, and echoes it on every later request — this server enforces sessions strictly, so the tool call succeeding proves the echo:
+
+```text
+$ npx -y @modelcontextprotocol/server-everything streamableHttp   # listens on :3001
+$ loom-mcp-probe -url http://localhost:3001/mcp -call echo -args '{"message":"session test"}'
+CONNECTED in 6ms
+  negotiated : 2025-11-25
+  era        : legacy (initialize handshake)
+  serverInfo : mcp-servers/everything 2.0.0
+  tools      : 13 (echo, get-annotated-message, get-env, …)
+  call echo → "Echo: session test"
+```
+
+**Dogfood: Loom's own dual-era endpoint** (`loom-mcp --transport=http` bridging a running `looms`). One endpoint serves both eras:
+
+```text
+$ loom-mcp-probe -url http://127.0.0.1:8765/ -call loom_list_agents -watch 3
+CONNECTED in 3ms
+  negotiated : 2026-07-28
+  era        : stateless (2026-07-28 core)
+  serverInfo : loom-mcp 1.4.0
+  tools      : 55 (loom_activate_skill, loom_answer_clarification, loom_build, …)
+  call loom_list_agents → "{\"agents\":[{\"id\":\"…\",\"name\":\"guide\",\"status\":\"running\",…"
+  watch      : subscription 4 open for 3s
+    notif #1 : notifications/subscriptions/acknowledged
+
+$ loom-mcp-probe -url http://127.0.0.1:8765/ -pin legacy
+CONNECTED in 3ms
+  negotiated : 2024-11-05
+  era        : legacy (initialize handshake)
+  serverInfo : loom-mcp 1.4.0
+```
+
 ## Limitations
 
 - The MRTR driver answers **elicitations only**, with one canned object for all of them; sampling and roots input requests fail the exchange by design.
@@ -104,3 +137,5 @@ The sessionful mode of the Go SDK server (`-stateless=false`) also negotiates do
 
 - The Go SDK conformance server's `test_elicitation` tool still uses the legacy server-initiated `Session.Elicit` API, which the SDK itself rejects on 2026-07-28 sessions ("return an InputRequests map instead"); use the `test_input_required_result_*` tools for MRTR.
 - The same server exits with status 1 after a cancelled `subscriptions/listen` over stdio (a bare stdin EOF exits 0). Loom's teardown is unaffected; the probe logs the exit as a warning.
+- The Go SDK server is dual-era even with `-stateless=true`: it still answers the `initialize` handshake, so a `legacy` pin against it connects at `2025-11-25` rather than failing. In sessionful mode it answers `server/discover` with `-32022` listing its legacy versions — a recognized modern error body, which correctly never triggers fallback under a stateless pin.
+- The TypeScript SDK server on streamable HTTP rejects every pre-initialize request with HTTP 400 and JSON-RPC `-32000` (id null) — the reason the fallback rule inspects 400 bodies instead of treating 400 as fatal.

--- a/docs/guides/mcp-probe.md
+++ b/docs/guides/mcp-probe.md
@@ -2,7 +2,7 @@
 
 **Status**: ✅ Implemented (`cmd/loom-mcp-probe`, wire-level tests included)
 
-`loom-mcp-probe` connects Loom's MCP client to a **real** MCP server — streamable HTTP or stdio — and reports what actually negotiated: protocol revision, era, server identity, tools, an optional tool call, an optional MRTR elicitation exchange, and an optional `subscriptions/listen` watch. It exercises the exact negotiation, fallback, MRTR, and transport code paths the manager uses in production. No fakes anywhere.
+`loom-mcp-probe` connects Loom's MCP client to a **real** MCP server — streamable HTTP or stdio — and reports what actually negotiated: protocol revision, era, server identity, tools, an optional tool call, an optional MRTR elicitation exchange, and an optional `subscriptions/listen` watch. The probe binary runs the shipped client and transports unmodified — the exact negotiation, fallback, MRTR, and transport code paths the manager uses in production — against real servers. (Its automated tests are the exception: they drive the same `run()` against scripted wire-level HTTP fixtures.)
 
 Use it to verify a server before wiring it into an agent config, to reproduce interop problems, or to watch what era/revision a fleet server actually speaks.
 
@@ -20,22 +20,24 @@ go run -tags fts5 ./cmd/loom-mcp-probe -cmd "npx -y @modelcontextprotocol/server
 | Flag | Meaning |
 |---|---|
 | `-url` | streamable HTTP endpoint (mutually exclusive with `-cmd`) |
-| `-cmd` | stdio server command line, space-separated |
+| `-cmd` | stdio server executable — the path is taken verbatim (spaces survive); pass arguments via `-arg` |
+| `-arg` | one argument for the `-cmd` executable; repeatable, order-preserving |
+| `-headers-env` | name of an env var holding a JSON object of HTTP headers (auth tokens ride the environment, never argv) |
 | `-pin` | `protocol_version` pin: `auto` (default), `legacy`, or an exact revision such as `2026-07-28` |
 | `-call` | tool to invoke |
 | `-args` | JSON arguments object for `-call` (default `{}`) |
 | `-answer` | JSON object accepted for **every** elicitation; enables the MRTR driver. Unset = the client's fail-fast default on `input_required` |
 | `-watch` | seconds to hold a `subscriptions/listen` stream (stateless connections only) |
-| `-timeout` | negotiation-probe/request timeout in ms (default 15000) |
+| `-timeout` | per-operation timeout in ms (default 15000): bounds connect (incl. the negotiation probe), `tools/list`, `tools/call` with its MRTR rounds, and the subscription acknowledgment. The `-watch` hold runs on its own clock |
 | `-v` | debug logging |
 
-The probe exits non-zero on any failure, so it can gate scripts.
+The probe exits non-zero on any failure, so it can gate scripts. For `-watch` that guarantee is strict: a legacy connection, a missing acknowledgment, or a subscription that ends — even gracefully — before the requested window all fail the probe.
 
 ## What each mode exercises
 
 - **Auto negotiation**: the `server/discover` probe with the full fallback ladder — non-modern JSON-RPC errors, bare HTTP 404/405/501, 400 without a modern error body, and (stdio only) probe silence within the bounded timeout.
 - **`-answer`**: the Multi Round-Trip Requests loop (2026-07-28, SEP-2322). A server's `input_required` interim result is answered by accepting every elicitation with the `-answer` object — a canned human standing in for the manager's HITL adapter — and the original call is retried with `inputResponses` plus the exact echoed `requestState`. Non-elicitation input requests (sampling, roots) are refused so the exchange fails loudly rather than fabricating a model response.
-- **`-watch`**: a live `subscriptions/listen` stream (acknowledgment, demultiplexed change notifications, client-side cancellation — closing the SSE stream on HTTP, `notifications/cancelled` on stdio).
+- **`-watch`**: a live `subscriptions/listen` stream — the acknowledgment is required before the hold starts, change notifications are demultiplexed during it, and the clean end is client-side cancellation at the deadline (closing the SSE stream on HTTP, `notifications/cancelled` on stdio). Anything short of that sequence is a probe failure.
 
 ## Known-good real servers
 
@@ -45,13 +47,13 @@ All from official sources:
 |---|---|---|
 | Go SDK conformance everything-server | **2026-07-28** (stateless HTTP + stdio); sessionful legacy with `-stateless=false` | `go install github.com/modelcontextprotocol/go-sdk/conformance/everything-server@v1.7.0` then `everything-server -http localhost:8971` |
 | `@modelcontextprotocol/server-everything` (npm, TypeScript) | legacy 2025-11-25 | `npx -y @modelcontextprotocol/server-everything stdio` |
-| Loom's own `looms` + `loom-mcp --transport=http` | **dual-era**: 2026-07-28 stateless AND legacy 2024-11-05 handshake on one endpoint (verified, see below) | `looms serve` then `loom-mcp --transport=http --http-addr=127.0.0.1:8765 --grpc-addr=localhost:60051` |
+| Loom's own `looms` + `loom-mcp --transport=http` | 🚧 **dual-era pending PR #328** (server-side 2026-07-28); on `main` today this endpoint is legacy-only. The transcript below was captured against the #328 branch | `looms serve` then `loom-mcp --transport=http --http-addr=127.0.0.1:8765 --grpc-addr=localhost:60051` |
 
 As of 2026-08-19 the Go SDK is the only official SDK with a 2026-07-28 runtime; the TypeScript SDK tops out at 2025-11-25, which makes its servers exactly the legacy peers the fallback ladder needs.
 
 ## Example sessions
 
-Real transcripts against the official Go SDK conformance server and the npm TypeScript server (2026-08-19).
+Real transcripts against the official Go SDK conformance server and the npm TypeScript server (2026-08-19), shown in the probe's current output format (the acknowledgment is consumed by the watch gate rather than listed as a notification).
 
 **Stateless 2026-07-28 over streamable HTTP, with a live subscription:**
 
@@ -63,9 +65,8 @@ CONNECTED in 6ms
   serverInfo : mcp-conformance-test-server 1.0.0
   tools      : 28 (json_schema_2020_12_tool, test_audio_content, test_elicitation, …)
   call test_simple_text → "This is a simple text response for testing."
-  watch      : subscription 4 open for 4s
-    notif #1 : notifications/subscriptions/acknowledged
-    notif #2 : notifications/resources/updated
+  watch      : subscription 4 acknowledged, holding for 4s
+    notif #1 : notifications/resources/updated
 ```
 
 **MRTR elicitation round-trip, including the server-verified `requestState` echo:**
@@ -107,7 +108,7 @@ CONNECTED in 6ms
   call echo → "Echo: session test"
 ```
 
-**Dogfood: Loom's own dual-era endpoint** (`loom-mcp --transport=http` bridging a running `looms`). One endpoint serves both eras:
+**Dogfood: Loom's own dual-era endpoint** (`loom-mcp --transport=http` bridging a running `looms`). 🚧 This behavior is PR #328's server side, and the session below was captured against that branch — on `main` the endpoint is legacy-only until #328 merges. One endpoint serves both eras:
 
 ```text
 $ loom-mcp-probe -url http://127.0.0.1:8765/ -call loom_list_agents -watch 3
@@ -117,8 +118,7 @@ CONNECTED in 3ms
   serverInfo : loom-mcp 1.4.0
   tools      : 55 (loom_activate_skill, loom_answer_clarification, loom_build, …)
   call loom_list_agents → "{\"agents\":[{\"id\":\"…\",\"name\":\"guide\",\"status\":\"running\",…"
-  watch      : subscription 4 open for 3s
-    notif #1 : notifications/subscriptions/acknowledged
+  watch      : subscription 4 acknowledged, holding for 3s
 
 $ loom-mcp-probe -url http://127.0.0.1:8765/ -pin legacy
 CONNECTED in 3ms
@@ -131,7 +131,8 @@ CONNECTED in 3ms
 
 - The MRTR driver answers **elicitations only**, with one canned object for all of them; sampling and roots input requests fail the exchange by design.
 - `-watch` requires a stateless (2026-07-28) connection; `subscriptions/listen` does not exist on legacy revisions.
-- This is a probe, not a conformance suite: it reports what happened on one connection. The dual-revision conformance matrix and official-SDK interop CI live in `pkg/mcp/conformance` (migration spec §10).
+- This is a probe, not a conformance suite: it reports what happened on one connection. The dual-revision conformance matrix and official-SDK interop suite (migration spec §10) ride PR #328; on `main` today `pkg/mcp/conformance` holds the legacy tests only.
+- Authenticated HTTP endpoints need `-headers-env`: the manager passes configured headers from agent config, and the probe reads the same shape from the named environment variable.
 
 ## Field notes from real servers
 

--- a/docs/guides/mcp-probe.md
+++ b/docs/guides/mcp-probe.md
@@ -133,6 +133,8 @@ CONNECTED in 3ms
 - The MRTR driver answers **elicitations only**, with one canned object for all of them; sampling and roots input requests fail the exchange by design.
 - `-watch` requires a stateless (2026-07-28) connection; `subscriptions/listen` does not exist on legacy revisions.
 - This is a probe, not a conformance suite: it reports what happened on one connection. The dual-revision conformance matrix and official-SDK interop suite live in `pkg/mcp/conformance` (migration spec §10, landed in PR #328).
+- On stdio, a child process that stops draining stdin while a watch is being cancelled can wedge the final teardown write (a pre-existing transport limitation — `Send` checks the context only before writing). Unattended stdio gates should wrap the probe in an outer `timeout(1)` as a belt; the HTTP path has no such edge.
+- Flags that cannot take effect under the chosen mode are rejected up front (`-args`/`-answer` without `-call`, `-arg` with `-url`, `-headers-env` with `-cmd`, negative `-watch`): a silently ignored flag would be a gate that verified nothing.
 - Authenticated HTTP endpoints need `-headers-env`: the manager passes configured headers from agent config, and the probe reads the same shape from the named environment variable.
 
 ## Field notes from real servers

--- a/docs/guides/mcp-probe.md
+++ b/docs/guides/mcp-probe.md
@@ -11,7 +11,7 @@ Use it to verify a server before wiring it into an agent config, to reproduce in
 ```bash
 just mcp-probe -url http://localhost:8971 -call test_simple_text -watch 5
 # or without just:
-go run -tags fts5 ./cmd/loom-mcp-probe -cmd "npx -y @modelcontextprotocol/server-everything stdio" \
+go run -tags fts5 ./cmd/loom-mcp-probe -cmd npx -arg -y -arg @modelcontextprotocol/server-everything -arg stdio \
     -call echo -args '{"message":"hello"}'
 ```
 
@@ -84,7 +84,8 @@ $ loom-mcp-probe -url http://localhost:8971 -call test_input_required_result_req
 **Legacy fallback against a real 2025-era server (TypeScript SDK):**
 
 ```text
-$ loom-mcp-probe -cmd "npx -y @modelcontextprotocol/server-everything stdio" -call echo -args '{"message":"hello from loom client"}'
+$ loom-mcp-probe -cmd npx -arg -y -arg @modelcontextprotocol/server-everything -arg stdio \
+    -call echo -args '{"message":"hello from loom client"}'
 CONNECTED in 1.31s
   negotiated : 2025-11-25
   era        : legacy (initialize handshake)

--- a/pkg/mcp/client/client.go
+++ b/pkg/mcp/client/client.go
@@ -547,8 +547,12 @@ func (c *Client) dispatchAndWait(ctx context.Context, req *protocol.Request) (*p
 		zap.String("method", req.Method),
 		zap.String("id", reqIDStr))
 
+	// The error is returned to the caller, who knows its severity — a failed
+	// server/discover probe is a routine legacy-fallback signal, not an
+	// incident. Logging it at Error here double-reported every healthy legacy
+	// connect as a stack-traced failure.
 	if err := c.transport.Send(ctx, reqJSON); err != nil {
-		c.logger.Error("Failed to send request via transport",
+		c.logger.Debug("failed to send request via transport",
 			zap.String("method", req.Method),
 			zap.Error(err))
 		return nil, fmt.Errorf("failed to send request: %w", err)

--- a/web/index.html
+++ b/web/index.html
@@ -498,7 +498,7 @@
       </tr>
       <tr>
         <td>mcp</td>
-        <td>Any MCP server via config; built-in UI apps; agents can compile dashboards from a JSON spec at runtime.</td>
+        <td>Any MCP server via config &mdash; the client negotiates MCP 2026-07-28 (stateless core, MRTR, subscriptions) with fallback to legacy servers, and <code>loom-mcp-probe</code> verifies any server on the real wire; built-in UI apps; agents can compile dashboards from a JSON spec at runtime.</td>
         <td>4 apps &middot; 14 components</td>
       </tr>
       <tr>

--- a/web/index.html
+++ b/web/index.html
@@ -323,6 +323,7 @@
         <code id="brew-cmd">brew install teradata-labs/tap/loom</code>
         <button class="copy-btn" data-copy="brew install teradata-labs/tap/loom">copy</button>
       </div>
+      <p class="install-note"><strong>New:</strong> the MCP client speaks the <strong>2026-07-28</strong> revision — stateless core, multi round-trip requests, live subscriptions — and negotiates down to every legacy server era automatically. Verified on the wire against the official SDKs; point <a href="https://github.com/teradata-labs/loom/blob/main/docs/guides/mcp-probe.md">loom-mcp-probe</a> at any server to see what it really speaks.</p>
     </div>
 
     <div class="term" id="weaver">


### PR DESCRIPTION
## Summary

First deliverable of the real-wire testing plan for the merged MCP client (#327): a probe CLI that connects Loom's client to **real** servers and reports what actually negotiated — revision, era, server identity, tools, an optional tool call, an optional **MRTR elicitation exchange**, and an optional **subscriptions/listen watch**. It exercises the exact negotiation, fallback, MRTR, and transport paths the manager uses in production. `just mcp-probe` runs it.

Includes one client fix the probing itself surfaced (see below).

## Verified live (2026-08-19), all official servers

- **Go SDK conformance everything-server** (the only official 2026-07-28 runtime today):
  - stateless streamable HTTP → negotiated `2026-07-28`, 28 tools, tool call, live subscription delivered a real `notifications/resources/updated`, clean client-side cancel
  - stdio → `2026-07-28` including the stdio `notifications/cancelled` unsubscribe path
  - sessionful mode (`-stateless=false`) → fallback negotiated `2025-11-25` (the newest-legacy request from the #327 review round 1, live)
  - **MRTR**: `test_input_required_result_elicitation` → elicited, answered, `"Hello, Loom!"`; `test_input_required_result_request_state` → the server itself confirmed the opaque `requestState` echoed correctly across the retry
  - **pin matrix**: exact pins honored in both eras; `-pin 2026-07-28` vs a legacy-only endpoint fails loudly with `-32022` listing the server's versions (no silent downgrade)
- **npm `@modelcontextprotocol/server-everything`** (TypeScript SDK):
  - stdio → fallback → `2025-11-25`, `echo` round-trip; client-side schema validation rejected a missing required arg before the wire
  - **sessionful streamable HTTP** (`streamableHttp` mode, :3001/mcp) → the server rejects the pre-initialize discover probe with **HTTP 400 + non-modern `-32000` body (id null)** — the exact case the #327 round-2 fallback rule handles — then the handshake runs, the minted `Mcp-Session-Id` is adopted and echoed on every later request (this server enforces sessions strictly, so the succeeding `echo` call is the proof)
- **Dogfood: Loom's own dual-era endpoint** (`loom-mcp --transport=http` bridging `looms` from the #328 branch): one endpoint verified serving **both eras** — auto-negotiation → `2026-07-28` stateless with 55 bridge tools, a real gRPC-backed `loom_list_agents` round-trip, and `subscriptions/listen` acknowledged by our own server; `-pin legacy` → the `2024-11-05` initialize handshake, matching `handleDiscover`'s advertised `[2026-07-28, 2024-11-05]`

Field notes recorded in the guide: the TS SDK tops out at 2025-11-25 (legacy-ladder peer, not a 2026 target); the SDK server's legacy `test_elicitation` tool is rejected by the SDK itself on 2026 sessions (use `test_input_required_result_*`); the SDK server is dual-era even in stateless mode; it exits 1 after a cancelled stdio listen (bare EOF exits 0 — Loom unaffected); the TS server's pre-initialize 400 semantics are why the fallback rule inspects 400 bodies.

## Client fix surfaced by the probing (`0be8e9e6`)

`dispatchAndWait` logged transport send failures at **Error with a stack trace** — which means every healthy legacy connect against a strict session server (the fallback-400 path above) was reported as an incident. The error is returned to the caller, who knows its actual severity, so the log is demoted to Debug. Without real-wire probing this double-reporting was invisible: no fake ever exercised the fallback through a transport error.

## Tests

Wire-level tests (httptest, real HTTP through the shipped client): stateless negotiation, legacy fallback, and a full MRTR round asserting the retry carries `inputResponses` **plus the exact `requestState`**; handler guards (sampling refused, bad `-answer` JSON); helper tables. `go test -tags fts5 -race ./cmd/loom-mcp-probe` clean; `just check` green.

## Docs

`docs/guides/mcp-probe.md` (flags, what each mode exercises, known-good official servers, real transcripts — including the sessionful-HTTP session-capture and the Loom dual-era dogfood — limitations, field notes), README MCP Integration section + docs table, homepage mcp feature row updated to state negotiated-revision support and the probe — all within implemented-and-verified claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)