### PR TITLE
fix(tools): reconcile, filter, and evict stale MCP tool index entries (#334)

### DIFF
--- a/cmd/looms/cmd_serve.go
+++ b/cmd/looms/cmd_serve.go
@@ -16,7 +16,6 @@ package main
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -1462,12 +1461,7 @@ func runServe(cmd *cobra.Command, args []string) {
 			mcpIndexer := toolregistry.NewMCPIndexer(mgr, tracer)
 			indexers = append(indexers, mcpIndexer)
 			liveMCPServers = func() []string {
-				servers := mgr.ListServers()
-				names := make([]string, 0, len(servers))
-				for _, s := range servers {
-					names = append(names, s.Name)
-				}
-				return names
+				return enabledMCPServerNames(mgr, logger)
 			}
 		}
 
@@ -1476,6 +1470,7 @@ func runServe(cmd *cobra.Command, args []string) {
 			DBPath:         toolDBPath,
 			LLM:            llmProvider,
 			Tracer:         tracer,
+			Logger:         logger,
 			Indexers:       indexers,
 			LiveMCPServers: liveMCPServers,
 		})
@@ -2039,7 +2034,7 @@ func runServe(cmd *cobra.Command, args []string) {
 					// Enable dynamic tool registration for discovered MCP tools
 					var mcpMgrAdapter shuttle.MCPManager
 					if mcpManager != nil {
-						mcpMgrAdapter = &mcpManagerAdapter{mgr: mcpManager.GetManager()}
+						mcpMgrAdapter = toolregistry.NewShuttleMCPManager(mcpManager.GetManager())
 					}
 					ag.SetToolRegistryForDynamicDiscovery(toolRegistry, mcpMgrAdapter)
 					logger.Info("    Enabled dynamic tool registration")
@@ -3281,7 +3276,7 @@ func runServe(cmd *cobra.Command, args []string) {
 				// Enable dynamic tool registration for discovered MCP tools
 				var mcpMgrAdapter shuttle.MCPManager
 				if mcpManager != nil {
-					mcpMgrAdapter = &mcpManagerAdapter{mgr: mcpManager.GetManager()}
+					mcpMgrAdapter = toolregistry.NewShuttleMCPManager(mcpManager.GetManager())
 				}
 				newAgent.SetToolRegistryForDynamicDiscovery(toolRegistry, mcpMgrAdapter)
 				logger.Info("  Enabled dynamic tool registration")
@@ -3792,27 +3787,27 @@ func initializeMCPManager(config *Config, logger *zap.Logger) (*mcpManager, erro
 	}, nil
 }
 
-// mcpManagerAdapter adapts *manager.Manager to shuttle.MCPManager interface.
-// This is needed because manager.Manager.GetClient returns (*client.Client, error)
-// but the interface requires (interface{}, error) for generic handling.
-type mcpManagerAdapter struct {
-	mgr *manager.Manager
-}
-
-func (a *mcpManagerAdapter) GetClient(serverName string) (interface{}, error) {
-	c, err := a.mgr.GetClient(serverName)
-	if err != nil {
-		// Distinguish "server was removed from configuration" (a stale tool
-		// index entry the executor should evict, issue #334) from "server is
-		// configured but not currently connected" (transient — keep it).
-		if errors.Is(err, manager.ErrServerNotFound) {
-			if _, cfgErr := a.mgr.GetServerConfig(serverName); cfgErr != nil {
-				return nil, fmt.Errorf("%w: %s", shuttle.ErrMCPServerNotFound, serverName)
-			}
+// enabledMCPServerNames returns the names of the manager's servers that are
+// enabled in configuration, connected or not. Disabled servers are excluded:
+// their stale index rows would pass the search liveness filter, yet their
+// tools can never execute, so surfacing them only misleads agents (#334).
+// Skipped servers are logged so filtered-out tools stay traceable.
+func enabledMCPServerNames(mgr *manager.Manager, logger *zap.Logger) []string {
+	servers := mgr.ListServers()
+	names := make([]string, 0, len(servers))
+	var skipped []string
+	for _, s := range servers {
+		if !s.Enabled {
+			skipped = append(skipped, s.Name)
+			continue
 		}
-		return nil, err
+		names = append(names, s.Name)
 	}
-	return c, nil
+	if len(skipped) > 0 && logger != nil {
+		logger.Debug("Excluding disabled MCP servers from tool search",
+			zap.Strings("disabled_servers", skipped))
+	}
+	return names
 }
 
 // copyDir recursively copies a directory tree from src to dst.

--- a/cmd/looms/cmd_serve.go
+++ b/cmd/looms/cmd_serve.go
@@ -16,6 +16,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -1453,17 +1454,30 @@ func runServe(cmd *cobra.Command, args []string) {
 		// Create MCP indexer if MCP manager is available
 		var indexers []toolregistry.Indexer
 		indexers = append(indexers, builtinIndexer)
+		// Search results only surface MCP tools whose server currently
+		// exists; with no manager, no MCP tool is servable at all (#334).
+		liveMCPServers := func() []string { return nil }
 		if mcpManager != nil {
-			mcpIndexer := toolregistry.NewMCPIndexer(mcpManager.GetManager(), tracer)
+			mgr := mcpManager.GetManager()
+			mcpIndexer := toolregistry.NewMCPIndexer(mgr, tracer)
 			indexers = append(indexers, mcpIndexer)
+			liveMCPServers = func() []string {
+				servers := mgr.ListServers()
+				names := make([]string, 0, len(servers))
+				for _, s := range servers {
+					names = append(names, s.Name)
+				}
+				return names
+			}
 		}
 
 		var err error
 		toolRegistry, err = toolregistry.New(toolregistry.Config{
-			DBPath:   toolDBPath,
-			LLM:      llmProvider,
-			Tracer:   tracer,
-			Indexers: indexers,
+			DBPath:         toolDBPath,
+			LLM:            llmProvider,
+			Tracer:         tracer,
+			Indexers:       indexers,
+			LiveMCPServers: liveMCPServers,
 		})
 		if err != nil {
 			logger.Warn("Failed to create tool registry", zap.Error(err))
@@ -3785,7 +3799,19 @@ type mcpManagerAdapter struct {
 }
 
 func (a *mcpManagerAdapter) GetClient(serverName string) (interface{}, error) {
-	return a.mgr.GetClient(serverName)
+	c, err := a.mgr.GetClient(serverName)
+	if err != nil {
+		// Distinguish "server was removed from configuration" (a stale tool
+		// index entry the executor should evict, issue #334) from "server is
+		// configured but not currently connected" (transient — keep it).
+		if errors.Is(err, manager.ErrServerNotFound) {
+			if _, cfgErr := a.mgr.GetServerConfig(serverName); cfgErr != nil {
+				return nil, fmt.Errorf("%w: %s", shuttle.ErrMCPServerNotFound, serverName)
+			}
+		}
+		return nil, err
+	}
+	return c, nil
 }
 
 // copyDir recursively copies a directory tree from src to dst.

--- a/cmd/looms/cmd_serve.go
+++ b/cmd/looms/cmd_serve.go
@@ -1492,6 +1492,7 @@ func runServe(cmd *cobra.Command, args []string) {
 					zap.Int32("builtin_tools", resp.BuiltinCount),
 					zap.Int32("mcp_tools", resp.McpCount),
 					zap.Int32("total_tools", resp.TotalCount),
+					zap.Int32("pruned_stale_tools", resp.PrunedCount),
 					zap.Int64("duration_ms", resp.DurationMs))
 			}
 		}

--- a/cmd/looms/cmd_serve_mcp_liveness_test.go
+++ b/cmd/looms/cmd_serve_mcp_liveness_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"github.com/teradata-labs/loom/pkg/mcp/manager"
+	toolregistry "github.com/teradata-labs/loom/pkg/tools/registry"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// newLivenessTestManager builds an unstarted manager with one enabled and one
+// disabled server, mirroring a config where a server was turned off but its
+// tool index rows still exist.
+func newLivenessTestManager(t *testing.T) *manager.Manager {
+	t.Helper()
+	mgr, err := manager.NewManager(manager.Config{
+		Servers: map[string]manager.ServerConfig{
+			"alpha":    {Enabled: true, Transport: "stdio", Command: "echo"},
+			"disabled": {Enabled: false, Transport: "stdio", Command: "echo"},
+		},
+		ClientInfo: manager.ClientInfo{Name: "test", Version: "0.1.0"},
+	}, zap.NewNop())
+	require.NoError(t, err)
+	return mgr
+}
+
+// TestEnabledMCPServerNamesSkipsDisabled verifies the liveness callback's
+// helper reports only enabled servers: a disabled server's stale index rows
+// would pass the search filter, yet its tools can never execute.
+func TestEnabledMCPServerNamesSkipsDisabled(t *testing.T) {
+	mgr := newLivenessTestManager(t)
+
+	core, observed := observer.New(zapcore.DebugLevel)
+	names := enabledMCPServerNames(mgr, zap.New(core))
+	assert.ElementsMatch(t, []string{"alpha"}, names,
+		"only enabled servers may be reported live")
+
+	// The exclusion is logged so filtered-out tools stay traceable.
+	entries := observed.FilterMessage("Excluding disabled MCP servers from tool search").All()
+	require.Len(t, entries, 1)
+	assert.Equal(t, []interface{}{"disabled"}, entries[0].ContextMap()["disabled_servers"])
+
+	// A nil logger must not panic.
+	assert.ElementsMatch(t, []string{"alpha"}, enabledMCPServerNames(mgr, nil))
+}
+
+// TestDisabledServerToolsFilteredFromSearch wires the helper into a tool
+// registry the way serve does and verifies a disabled server's indexed tools
+// never surface in search results, while an enabled server's tools do.
+func TestDisabledServerToolsFilteredFromSearch(t *testing.T) {
+	mgr := newLivenessTestManager(t)
+	ctx := context.Background()
+
+	reg, err := toolregistry.New(toolregistry.Config{
+		DBPath: ":memory:",
+		LiveMCPServers: func() []string {
+			return enabledMCPServerNames(mgr, nil)
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reg.Close() })
+
+	indexTool := func(server, name string) {
+		require.NoError(t, reg.RegisterTool(ctx, &loomv1.IndexedTool{
+			Id:          "mcp:" + server + ":" + name,
+			Name:        name,
+			Description: name + " tool from " + server,
+			Source:      loomv1.ToolSource_TOOL_SOURCE_MCP,
+			McpServer:   server,
+			IndexedAt:   time.Now().Format(time.RFC3339),
+			Keywords:    []string{"query"},
+		}))
+	}
+	indexTool("alpha", "query_live")
+	indexTool("disabled", "query_disabled")
+
+	resp, err := reg.Search(ctx, &loomv1.SearchToolsRequest{
+		Query:      "query",
+		Mode:       loomv1.SearchMode_SEARCH_MODE_FAST,
+		MaxResults: 10,
+	})
+	require.NoError(t, err)
+
+	names := make(map[string]bool)
+	for _, res := range resp.Results {
+		names[res.Tool.Name] = true
+	}
+	assert.True(t, names["query_live"], "enabled server's tool must be searchable")
+	assert.False(t, names["query_disabled"],
+		"disabled server's tool must be filtered from search: it can never execute")
+}

--- a/docs/reference/tool-registry.md
+++ b/docs/reference/tool-registry.md
@@ -98,6 +98,12 @@ type Config struct {
     LLM      types.LLMProvider // LLM provider for search assistance
     Tracer   observability.Tracer
     Indexers []Indexer         // Tool source indexers
+
+    // LiveMCPServers, when set, restricts MCP tools in search results
+    // (Search, GetToolsByCapability) to servers that currently exist,
+    // so stale index rows are never surfaced to agents (issue #334).
+    // nil disables the filter; an empty result hides all MCP tools.
+    LiveMCPServers func() []string
 }
 ```
 
@@ -140,7 +146,16 @@ defer registry.Close()
 
 **Function**: `IndexAll(ctx context.Context) (*loomv1.IndexToolsResponse, error)`
 
-Indexes tools from all registered indexers.
+Indexes tools from all registered indexers, then reconciles the index: rows
+that a `ReconcilingIndexer` run proves stale are deleted (issue #334).
+
+**Reconciliation semantics** (per indexer implementing `ReconcilingIndexer`):
+- Rows whose MCP server was **removed from configuration** are pruned.
+- Rows for tools a server **no longer reports** are pruned.
+- A server that is configured but **unreachable this run keeps its rows** —
+  a transient failure never wipes a server's tools.
+- Plain `Indexer` implementations keep upsert-only behavior, so tools
+  registered out-of-band via `RegisterTool` (gRPC custom tools) survive.
 
 **Response**:
 ```go
@@ -151,6 +166,7 @@ type IndexToolsResponse struct {
     CustomCount  int32          // Custom tools count
     DurationMs   int64          // Indexing duration
     Errors       []*IndexError  // Any indexing errors
+    PrunedCount  int32          // Stale rows removed by reconciliation
 }
 ```
 
@@ -160,6 +176,7 @@ resp, err := registry.IndexAll(ctx)
 // resp.TotalCount = 45
 // resp.BuiltinCount = 10
 // resp.McpCount = 35
+// resp.PrunedCount = 3   // e.g. tools of a deleted MCP server
 // resp.DurationMs = 234
 ```
 

--- a/gen/go/loom/v1/tools.pb.go
+++ b/gen/go/loom/v1/tools.pb.go
@@ -910,7 +910,11 @@ type IndexToolsResponse struct {
 	// Any errors during indexing.
 	Errors []*IndexError `protobuf:"bytes,5,rep,name=errors,proto3" json:"errors,omitempty"`
 	// Time taken (milliseconds).
-	DurationMs    int64 `protobuf:"varint,6,opt,name=duration_ms,json=durationMs,proto3" json:"duration_ms,omitempty"`
+	DurationMs int64 `protobuf:"varint,6,opt,name=duration_ms,json=durationMs,proto3" json:"duration_ms,omitempty"`
+	// Number of stale rows removed during reconciliation: tools whose source
+	// no longer reports them (removed from a server) or whose MCP server is
+	// no longer configured.
+	PrunedCount   int32 `protobuf:"varint,7,opt,name=pruned_count,json=prunedCount,proto3" json:"pruned_count,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -983,6 +987,13 @@ func (x *IndexToolsResponse) GetErrors() []*IndexError {
 func (x *IndexToolsResponse) GetDurationMs() int64 {
 	if x != nil {
 		return x.DurationMs
+	}
+	return 0
+}
+
+func (x *IndexToolsResponse) GetPrunedCount() int32 {
+	if x != nil {
+		return x.PrunedCount
 	}
 	return 0
 }
@@ -1464,7 +1475,7 @@ const file_loom_v1_tools_proto_rawDesc = "" +
 	"\ffull_reindex\x18\x01 \x01(\bR\vfullReindex\x12-\n" +
 	"\asources\x18\x02 \x03(\x0e2\x13.loom.v1.ToolSourceR\asources\x12\x1f\n" +
 	"\vmcp_servers\x18\x03 \x03(\tR\n" +
-	"mcpServers\"\xe8\x01\n" +
+	"mcpServers\"\x8b\x02\n" +
 	"\x12IndexToolsResponse\x12#\n" +
 	"\rbuiltin_count\x18\x01 \x01(\x05R\fbuiltinCount\x12\x1b\n" +
 	"\tmcp_count\x18\x02 \x01(\x05R\bmcpCount\x12!\n" +
@@ -1473,7 +1484,8 @@ const file_loom_v1_tools_proto_rawDesc = "" +
 	"totalCount\x12+\n" +
 	"\x06errors\x18\x05 \x03(\v2\x13.loom.v1.IndexErrorR\x06errors\x12\x1f\n" +
 	"\vduration_ms\x18\x06 \x01(\x03R\n" +
-	"durationMs\"\x7f\n" +
+	"durationMs\x12!\n" +
+	"\fpruned_count\x18\a \x01(\x05R\vprunedCount\"\x7f\n" +
 	"\n" +
 	"IndexError\x12+\n" +
 	"\x06source\x18\x01 \x01(\x0e2\x13.loom.v1.ToolSourceR\x06source\x12\x1f\n" +

--- a/gen/openapiv2/loom/v1/tools.swagger.json
+++ b/gen/openapiv2/loom/v1/tools.swagger.json
@@ -106,6 +106,11 @@
           "type": "string",
           "format": "int64",
           "description": "Time taken (milliseconds)."
+        },
+        "prunedCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of stale rows removed during reconciliation: tools whose source\nno longer reports them (removed from a server) or whose MCP server is\nno longer configured."
         }
       },
       "description": "IndexToolsResponse returns indexing results."

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -150,6 +150,10 @@ func NewAgent(backend fabric.ExecutionBackend, llmProvider LLMProvider, opts ...
 	// Create executor with tool registry
 	// Note: Pass instrumented executor via SetExecutor() if you want tool tracing
 	a.executor = shuttle.NewExecutor(a.tools)
+	// Route executor housekeeping logs (e.g. failed stale-index evictions)
+	// through the process logger; zap.L() is a no-op unless the host installed
+	// one via zap.ReplaceGlobals (cmd_serve does).
+	a.executor.SetLogger(zap.L())
 
 	// Set permission checker on executor if provided
 	if a.permissionChecker != nil {

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -2706,5 +2706,17 @@ type mcpManagerAdapter struct {
 }
 
 func (a *mcpManagerAdapter) GetClient(serverName string) (interface{}, error) {
-	return a.mgr.GetClient(serverName)
+	c, err := a.mgr.GetClient(serverName)
+	if err != nil {
+		// Distinguish "server was removed from configuration" (a stale tool
+		// index entry the executor should evict, issue #334) from "server is
+		// configured but not currently connected" (transient — keep it).
+		if errors.Is(err, manager.ErrServerNotFound) {
+			if _, cfgErr := a.mgr.GetServerConfig(serverName); cfgErr != nil {
+				return nil, fmt.Errorf("%w: %s", shuttle.ErrMCPServerNotFound, serverName)
+			}
+		}
+		return nil, err
+	}
+	return c, nil
 }

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -996,7 +996,7 @@ func (r *Registry) buildAgent(ctx context.Context, config *loomv1.AgentConfig) (
 		// Wrap the MCP manager to satisfy the shuttle.MCPManager interface
 		var mcpMgrAdapter shuttle.MCPManager
 		if r.mcpMgr != nil {
-			mcpMgrAdapter = &mcpManagerAdapter{mgr: r.mcpMgr}
+			mcpMgrAdapter = toolregistry.NewShuttleMCPManager(r.mcpMgr)
 		}
 		agent.SetToolRegistryForDynamicDiscovery(r.toolRegistry, mcpMgrAdapter)
 		r.logger.Debug("Enabled dynamic tool registration for agent",
@@ -2696,27 +2696,4 @@ func removeFile(path string) error {
 		return nil
 	}
 	return err
-}
-
-// mcpManagerAdapter adapts *manager.Manager to shuttle.MCPManager interface.
-// This is needed because manager.Manager.GetClient returns (*client.Client, error)
-// but the interface requires (interface{}, error) for generic handling.
-type mcpManagerAdapter struct {
-	mgr *manager.Manager
-}
-
-func (a *mcpManagerAdapter) GetClient(serverName string) (interface{}, error) {
-	c, err := a.mgr.GetClient(serverName)
-	if err != nil {
-		// Distinguish "server was removed from configuration" (a stale tool
-		// index entry the executor should evict, issue #334) from "server is
-		// configured but not currently connected" (transient — keep it).
-		if errors.Is(err, manager.ErrServerNotFound) {
-			if _, cfgErr := a.mgr.GetServerConfig(serverName); cfgErr != nil {
-				return nil, fmt.Errorf("%w: %s", shuttle.ErrMCPServerNotFound, serverName)
-			}
-		}
-		return nil, err
-	}
-	return c, nil
 }

--- a/pkg/mcp/manager/manager.go
+++ b/pkg/mcp/manager/manager.go
@@ -429,8 +429,13 @@ func (m *Manager) HealthCheck(ctx context.Context) map[string]bool {
 	return results
 }
 
-// GetServerConfig returns the configuration for a server.
+// GetServerConfig returns the configuration for a server. The read must hold
+// m.mu: AddServer/RemoveServer mutate m.config.Servers under the write lock,
+// so an unlocked read here is a data race.
 func (m *Manager) GetServerConfig(serverName string) (ServerConfig, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	config, exists := m.config.Servers[serverName]
 	if !exists {
 		return ServerConfig{}, fmt.Errorf("%w: %s", ErrServerNotFound, serverName)

--- a/pkg/mcp/manager/manager.go
+++ b/pkg/mcp/manager/manager.go
@@ -16,6 +16,7 @@ package manager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -25,6 +26,12 @@ import (
 	"github.com/teradata-labs/loom/pkg/mcp/transport"
 	"go.uber.org/zap"
 )
+
+// ErrServerNotFound reports that a server name is unknown to the manager —
+// either never configured or not currently connected, depending on the call.
+// Callers use errors.Is to distinguish a missing server from transport or
+// protocol failures (e.g. to evict stale tool-index entries, issue #334).
+var ErrServerNotFound = errors.New("server not found")
 
 // Manager orchestrates multiple MCP server connections.
 type Manager struct {
@@ -303,7 +310,7 @@ func (m *Manager) StopServer(name string) error {
 
 	client, exists := m.clients[name]
 	if !exists {
-		return fmt.Errorf("server not found: %s", name)
+		return fmt.Errorf("%w: %s", ErrServerNotFound, name)
 	}
 
 	// The watcher must be gone before its client closes; otherwise it keeps
@@ -355,7 +362,7 @@ func (m *Manager) GetClient(serverName string) (*client.Client, error) {
 
 	client, exists := m.clients[serverName]
 	if !exists {
-		return nil, fmt.Errorf("server not found: %s", serverName)
+		return nil, fmt.Errorf("%w: %s", ErrServerNotFound, serverName)
 	}
 
 	return client, nil
@@ -426,7 +433,7 @@ func (m *Manager) HealthCheck(ctx context.Context) map[string]bool {
 func (m *Manager) GetServerConfig(serverName string) (ServerConfig, error) {
 	config, exists := m.config.Servers[serverName]
 	if !exists {
-		return ServerConfig{}, fmt.Errorf("server not found: %s", serverName)
+		return ServerConfig{}, fmt.Errorf("%w: %s", ErrServerNotFound, serverName)
 	}
 	return config, nil
 }

--- a/pkg/mcp/manager/manager_test.go
+++ b/pkg/mcp/manager/manager_test.go
@@ -166,6 +166,8 @@ func TestManager_GetClient_NonExistent(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, client)
 	assert.Contains(t, err.Error(), "server not found")
+	assert.ErrorIs(t, err, ErrServerNotFound,
+		"GetClient must wrap the sentinel so callers can errors.Is it (issue #334)")
 }
 
 func TestManager_GetServerConfig(t *testing.T) {

--- a/pkg/mcp/manager/manager_test.go
+++ b/pkg/mcp/manager/manager_test.go
@@ -16,6 +16,7 @@ package manager
 import (
 	"context"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -199,6 +200,51 @@ func TestManager_GetServerConfig(t *testing.T) {
 	_, err = mgr.GetServerConfig("nonexistent")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "server not found")
+}
+
+// TestManager_GetServerConfig_ConcurrentWithAddRemove is a -race regression:
+// GetServerConfig used to read m.config.Servers without holding m.mu while
+// AddServer/RemoveServer mutate the map under the write lock.
+func TestManager_GetServerConfig_ConcurrentWithAddRemove(t *testing.T) {
+	mgr, err := NewManager(Config{
+		Servers:    map[string]ServerConfig{},
+		ClientInfo: ClientInfo{Name: "test", Version: "0.1.0"},
+	}, zap.NewNop())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	// A disabled server is never started, so AddServer only mutates the
+	// config map — exactly the write the unlocked read raced with.
+	cfg := ServerConfig{Enabled: false, Transport: "stdio", Command: "echo"}
+
+	const iterations = 500
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = mgr.AddServer(ctx, "racer", cfg)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = mgr.RemoveServer("racer")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			// Both outcomes are valid mid-race; the assertion is the race
+			// detector staying quiet.
+			if config, err := mgr.GetServerConfig("racer"); err == nil {
+				assert.False(t, config.Enabled)
+			}
+		}
+	}()
+
+	wg.Wait()
 }
 
 func TestManager_Stop_NotStarted(t *testing.T) {

--- a/pkg/shuttle/executor.go
+++ b/pkg/shuttle/executor.go
@@ -26,6 +26,7 @@ import (
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
 	"github.com/teradata-labs/loom/pkg/session"
 	"github.com/teradata-labs/loom/pkg/storage"
+	"go.uber.org/zap"
 )
 
 // ToolRegistry is an interface for dynamic tool discovery.
@@ -72,6 +73,7 @@ type Executor struct {
 	toolRegistry        ToolRegistry                 // Tool registry for dynamic tool discovery
 	mcpManager          MCPManager                   // MCP manager for dynamic MCP tool registration
 	builtinToolProvider BuiltinToolProvider          // Builtin tool provider for dynamic builtin tool registration
+	logger              *zap.Logger                  // Structured logger; never nil (defaults to no-op)
 
 	// Metrics for large parameter optimization
 	largeParamStores      atomic.Int64 // Count of parameters stored
@@ -86,6 +88,15 @@ func NewExecutor(registry *Registry) *Executor {
 	return &Executor{
 		registry:  registry,
 		threshold: storage.DefaultSharedMemoryThreshold,
+		logger:    zap.NewNop(),
+	}
+}
+
+// SetLogger configures structured logging for executor housekeeping (e.g.
+// stale-index evictions that fail). A nil logger keeps the no-op default.
+func (e *Executor) SetLogger(logger *zap.Logger) {
+	if logger != nil {
+		e.logger = logger
 	}
 }
 
@@ -609,18 +620,28 @@ func (e *Executor) tryDynamicRegistration(ctx context.Context, toolName string) 
 	resp, err := e.toolRegistry.Search(ctx, &loomv1.SearchToolsRequest{
 		Query:         toolName,
 		Mode:          loomv1.SearchMode_SEARCH_MODE_FAST, // Use fast mode for keyword match
-		MaxResults:    1,
+		MaxResults:    5,
 		IncludeSchema: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to search tool registry: %w", err)
 	}
 
-	if len(resp.Results) == 0 {
-		return nil, fmt.Errorf("tool not found in registry")
+	// The search is fuzzy (tokenized full-text match), but the caller asked
+	// for one specific tool by name: only an exact name match may be
+	// registered and executed. Without this guard, a request for a tool whose
+	// index entry is gone would silently execute whichever different tool
+	// happens to share tokens with the dead tool's name.
+	var toolInfo *loomv1.IndexedTool
+	for _, result := range resp.Results {
+		if result.Tool != nil && result.Tool.Name == toolName {
+			toolInfo = result.Tool
+			break
+		}
 	}
-
-	toolInfo := resp.Results[0].Tool
+	if toolInfo == nil {
+		return nil, fmt.Errorf("tool not found in registry: no indexed tool is named %q", toolName)
+	}
 
 	// Handle based on tool source
 	switch toolInfo.Source {
@@ -653,9 +674,17 @@ func (e *Executor) registerMCPTool(ctx context.Context, toolInfo *loomv1.Indexed
 		// (issue #334). Transient failures keep the entry.
 		if errors.Is(err, ErrMCPServerNotFound) {
 			if evictor, ok := e.toolRegistry.(ToolEvictor); ok {
-				if evictErr := evictor.EvictTool(ctx, toolInfo.Id); evictErr == nil {
+				evictErr := evictor.EvictTool(ctx, toolInfo.Id)
+				if evictErr == nil {
 					return nil, fmt.Errorf("failed to get MCP client for server %s: %w (stale tool index entry %s evicted)", toolInfo.McpServer, err, toolInfo.Id)
 				}
+				// A failed eviction means the dead entry will be served
+				// again; that must be visible, not swallowed.
+				e.logger.Warn("Failed to evict stale tool index entry",
+					zap.String("tool_id", toolInfo.Id),
+					zap.String("tool_name", toolInfo.Name),
+					zap.String("mcp_server", toolInfo.McpServer),
+					zap.Error(evictErr))
 			}
 		}
 		return nil, fmt.Errorf("failed to get MCP client for server %s: %w", toolInfo.McpServer, err)

--- a/pkg/shuttle/executor.go
+++ b/pkg/shuttle/executor.go
@@ -16,6 +16,7 @@ package shuttle
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -32,6 +33,20 @@ import (
 type ToolRegistry interface {
 	Search(ctx context.Context, req *loomv1.SearchToolsRequest) (*loomv1.SearchToolsResponse, error)
 }
+
+// ToolEvictor is an optional extension of ToolRegistry: registries that
+// implement it get stale entries removed when dynamic registration proves
+// them dead (their MCP server no longer exists), so the same stale tool is
+// never served twice (issue #334).
+type ToolEvictor interface {
+	EvictTool(ctx context.Context, toolID string) error
+}
+
+// ErrMCPServerNotFound reports that an MCP tool's server does not exist —
+// not configured at all, as opposed to configured but temporarily
+// unreachable. MCPManager implementations wrap this sentinel so the executor
+// can evict the tool's index entry instead of retrying it forever.
+var ErrMCPServerNotFound = errors.New("MCP server not found")
 
 // MCPManager is an interface for getting MCP clients.
 // This avoids import cycles with pkg/mcp/manager.
@@ -633,6 +648,16 @@ func (e *Executor) registerMCPTool(ctx context.Context, toolInfo *loomv1.Indexed
 	// Get MCP client for the server
 	client, err := e.mcpManager.GetClient(toolInfo.McpServer)
 	if err != nil {
+		// A server that does not exist (vs. temporarily unreachable) means
+		// the index entry is stale: evict it so it is never served again
+		// (issue #334). Transient failures keep the entry.
+		if errors.Is(err, ErrMCPServerNotFound) {
+			if evictor, ok := e.toolRegistry.(ToolEvictor); ok {
+				if evictErr := evictor.EvictTool(ctx, toolInfo.Id); evictErr == nil {
+					return nil, fmt.Errorf("failed to get MCP client for server %s: %w (stale tool index entry %s evicted)", toolInfo.McpServer, err, toolInfo.Id)
+				}
+			}
+		}
 		return nil, fmt.Errorf("failed to get MCP client for server %s: %w", toolInfo.McpServer, err)
 	}
 

--- a/pkg/shuttle/executor_evict_test.go
+++ b/pkg/shuttle/executor_evict_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package shuttle_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+	"github.com/teradata-labs/loom/pkg/tools/registry"
+)
+
+// notFoundMCPManager reports every server as not existing, wrapping the
+// shuttle.ErrMCPServerNotFound sentinel like the production adapters do for
+// servers that were removed from configuration.
+type notFoundMCPManager struct{}
+
+func (m *notFoundMCPManager) GetClient(serverName string) (interface{}, error) {
+	return nil, fmt.Errorf("%w: %s", shuttle.ErrMCPServerNotFound, serverName)
+}
+
+// transientErrMCPManager fails without the sentinel — a temporarily
+// unreachable server, not a removed one.
+type transientErrMCPManager struct{}
+
+func (m *transientErrMCPManager) GetClient(serverName string) (interface{}, error) {
+	return nil, fmt.Errorf("connection refused: %s", serverName)
+}
+
+func newStaleToolRegistry(t *testing.T) *registry.Registry {
+	t.Helper()
+
+	staleTool := &loomv1.IndexedTool{
+		Id:          "mcp:ghost:stale_tool",
+		Name:        "stale_tool",
+		Description: "tool from a server that no longer exists",
+		Source:      loomv1.ToolSource_TOOL_SOURCE_MCP,
+		McpServer:   "ghost",
+		InputSchema: `{"type":"object"}`,
+	}
+
+	toolReg, err := registry.New(registry.Config{
+		DBPath:   ":memory:",
+		Indexers: []registry.Indexer{newMockMCPIndexer([]*loomv1.IndexedTool{staleTool})},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = toolReg.Close() })
+
+	_, err = toolReg.IndexAll(context.Background())
+	require.NoError(t, err)
+	return toolReg
+}
+
+// TestDynamicRegistration_EvictsStaleTool verifies that a tool whose MCP
+// server no longer exists is removed from the index on first failed use, so
+// the same stale entry is never served twice (issue #334).
+func TestDynamicRegistration_EvictsStaleTool(t *testing.T) {
+	ctx := context.Background()
+	exec := shuttle.NewExecutor(shuttle.NewRegistry())
+	toolReg := newStaleToolRegistry(t)
+
+	exec.SetToolRegistry(toolReg)
+	exec.SetMCPManager(&notFoundMCPManager{})
+
+	_, err := exec.Execute(ctx, "stale_tool", map[string]interface{}{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "MCP server not found")
+	require.Contains(t, err.Error(), "evicted")
+
+	// The stale entry is gone from the index.
+	_, err = toolReg.GetTool(ctx, "mcp:ghost:stale_tool")
+	require.Error(t, err, "stale tool must be evicted from the index")
+}
+
+// TestDynamicRegistration_TransientErrorKeepsTool verifies that a failure
+// without the not-found sentinel (e.g. a server that is configured but
+// temporarily unreachable) does NOT evict the index entry.
+func TestDynamicRegistration_TransientErrorKeepsTool(t *testing.T) {
+	ctx := context.Background()
+	exec := shuttle.NewExecutor(shuttle.NewRegistry())
+	toolReg := newStaleToolRegistry(t)
+
+	exec.SetToolRegistry(toolReg)
+	exec.SetMCPManager(&transientErrMCPManager{})
+
+	_, err := exec.Execute(ctx, "stale_tool", map[string]interface{}{})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "evicted")
+
+	// The entry survives: the server may come back.
+	_, err = toolReg.GetTool(ctx, "mcp:ghost:stale_tool")
+	require.NoError(t, err, "tool must survive a transient failure")
+}

--- a/pkg/shuttle/executor_name_guard_test.go
+++ b/pkg/shuttle/executor_name_guard_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package shuttle_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+	"github.com/teradata-labs/loom/pkg/tools/registry"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// recordingMCPClient counts CallTool invocations so a test can assert a tool
+// was NOT executed.
+type recordingMCPClient struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (c *recordingMCPClient) CallTool(ctx context.Context, name string, args map[string]interface{}) (interface{}, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls = append(c.calls, name)
+	return map[string]interface{}{"ok": true}, nil
+}
+
+func (c *recordingMCPClient) callNames() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.calls...)
+}
+
+// TestDynamicRegistration_FuzzyMatchNameMismatchIsRejected verifies the
+// executor never executes a search hit whose name differs from the requested
+// tool: the registry lookup is a fuzzy full-text search, so a request for a
+// dead tool whose tokens overlap a different tool's name used to silently
+// register and execute that different tool.
+func TestDynamicRegistration_FuzzyMatchNameMismatchIsRejected(t *testing.T) {
+	ctx := context.Background()
+	exec := shuttle.NewExecutor(shuttle.NewRegistry())
+
+	client := &recordingMCPClient{}
+	mcpManager := newMockMCPManager()
+	mcpManager.addClient("test-server", client)
+
+	// Only alpha_beta_gamma is indexed. A request for "alpha_beta" (e.g. an
+	// evicted tool the agent still remembers) fuzzy-matches it.
+	indexed := &loomv1.IndexedTool{
+		Id:          "mcp:test-server:alpha_beta_gamma",
+		Name:        "alpha_beta_gamma",
+		Description: "alpha beta gamma tool",
+		Source:      loomv1.ToolSource_TOOL_SOURCE_MCP,
+		McpServer:   "test-server",
+		InputSchema: `{"type":"object"}`,
+	}
+	toolReg, err := registry.New(registry.Config{
+		DBPath:   ":memory:",
+		Indexers: []registry.Indexer{newMockMCPIndexer([]*loomv1.IndexedTool{indexed})},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = toolReg.Close() })
+	_, err = toolReg.IndexAll(ctx)
+	require.NoError(t, err)
+
+	exec.SetToolRegistry(toolReg)
+	exec.SetMCPManager(mcpManager)
+
+	// The mismatching fuzzy hit must be rejected, not executed.
+	_, err = exec.Execute(ctx, "alpha_beta", map[string]interface{}{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tool not found")
+	assert.Empty(t, client.callNames(),
+		"a fuzzy match with a different name must never reach execution")
+
+	// Control: the exact name still registers and executes.
+	result, err := exec.Execute(ctx, "alpha_beta_gamma", map[string]interface{}{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, []string{"alpha_beta_gamma"}, client.callNames())
+}
+
+// failingEvictRegistry delegates search to a real registry but fails every
+// eviction, to exercise the evict-failure path.
+type failingEvictRegistry struct {
+	inner    *registry.Registry
+	evictErr error
+}
+
+func (f *failingEvictRegistry) Search(ctx context.Context, req *loomv1.SearchToolsRequest) (*loomv1.SearchToolsResponse, error) {
+	return f.inner.Search(ctx, req)
+}
+
+func (f *failingEvictRegistry) EvictTool(ctx context.Context, toolID string) error {
+	return f.evictErr
+}
+
+// TestDynamicRegistration_EvictFailureIsLogged verifies a failed eviction of
+// a stale index entry is logged (with the tool's identity) instead of being
+// silently swallowed: a failed eviction means the dead entry will be served
+// again.
+func TestDynamicRegistration_EvictFailureIsLogged(t *testing.T) {
+	ctx := context.Background()
+	core, observed := observer.New(zapcore.WarnLevel)
+
+	exec := shuttle.NewExecutor(shuttle.NewRegistry())
+	exec.SetLogger(zap.New(core))
+	exec.SetToolRegistry(&failingEvictRegistry{
+		inner:    newStaleToolRegistry(t),
+		evictErr: assert.AnError,
+	})
+	exec.SetMCPManager(&notFoundMCPManager{})
+
+	_, err := exec.Execute(ctx, "stale_tool", map[string]interface{}{})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "evicted",
+		"a failed eviction must not be reported as evicted")
+
+	entries := observed.FilterMessage("Failed to evict stale tool index entry").All()
+	require.Len(t, entries, 1, "the failed eviction must be logged")
+	fields := entries[0].ContextMap()
+	assert.Equal(t, "mcp:ghost:stale_tool", fields["tool_id"])
+	assert.Equal(t, "stale_tool", fields["tool_name"])
+	assert.Equal(t, "ghost", fields["mcp_server"])
+	assert.Equal(t, assert.AnError.Error(), fields["error"])
+}

--- a/pkg/tools/registry/fts_integrity_test.go
+++ b/pkg/tools/registry/fts_integrity_test.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package registry
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+)
+
+// ftsIntegrityCheck runs FTS5's integrity-check command against the tools_fts
+// index. A non-nil error means the index disagrees with the tools content
+// table (e.g. ghost postings left by INSERT OR REPLACE).
+func ftsIntegrityCheck(reg *Registry) error {
+	_, err := reg.db.Exec(`INSERT INTO tools_fts(tools_fts) VALUES('integrity-check')`)
+	return err
+}
+
+// searchToolNames runs a FAST-mode search and returns the names of all tools
+// it surfaced.
+func searchToolNames(t *testing.T, reg *Registry, query string) []string {
+	t.Helper()
+	resp, err := reg.Search(context.Background(), &loomv1.SearchToolsRequest{
+		Query:      query,
+		Mode:       loomv1.SearchMode_SEARCH_MODE_FAST,
+		MaxResults: 10,
+	})
+	require.NoError(t, err)
+	names := make([]string, 0, len(resp.Results))
+	for _, res := range resp.Results {
+		names = append(names, res.Tool.Name)
+	}
+	return names
+}
+
+// TestUpsertReindexEvictReuseKeepsFTSConsistent reproduces the production
+// sequence that corrupted the FTS index when upsertTool used INSERT OR
+// REPLACE: index tool A, re-index A (the REPLACE path deleted A's row without
+// firing tools_ad, leaving ghost postings on the freed rowid), evict A, then
+// index a new tool B. SQLite reuses the freed max rowid for B, so B landed on
+// A's ghost postings: searching A's name returned B and integrity-check
+// reported corruption. With the ON CONFLICT upsert the rowid stays stable and
+// the index stays consistent.
+func TestUpsertReindexEvictReuseKeepsFTSConsistent(t *testing.T) {
+	reg := newReconcileTestRegistry(t, Config{})
+	ctx := context.Background()
+
+	toolA := mcpTool("alpha", "alpha_lookup")
+
+	// Index A, then re-index it (the step that used to plant the ghost).
+	require.NoError(t, reg.RegisterTool(ctx, toolA))
+	require.NoError(t, reg.RegisterTool(ctx, toolA))
+
+	// Evict A, freeing its rowid, then index a brand-new tool B, which
+	// reuses it.
+	require.NoError(t, reg.EvictTool(ctx, toolA.Id))
+	toolB := mcpTool("beta", "beta_report")
+	require.NoError(t, reg.RegisterTool(ctx, toolB))
+
+	// Searching A's name must not return B (pre-fix it did, via the ghost
+	// postings attached to B's reused rowid) — nothing may match at all.
+	namesForA := searchToolNames(t, reg, "alpha_lookup")
+	assert.NotContains(t, namesForA, "beta_report",
+		"ghost FTS postings must never surface a different tool")
+	assert.Empty(t, namesForA, "evicted tool's name must match nothing")
+
+	// B itself is searchable.
+	assert.Contains(t, searchToolNames(t, reg, "beta_report"), "beta_report")
+
+	// And the FTS index agrees with the content table.
+	require.NoError(t, ftsIntegrityCheck(reg),
+		"FTS5 integrity-check must pass after reindex/evict/reuse")
+}
+
+// TestNewRepairsLegacyGhostPostings verifies the once-per-open FTS rebuild in
+// New: a database written by earlier builds (whose upsert was INSERT OR
+// REPLACE) contains ghost postings, and reopening it must repair the index in
+// place so the ghosts cannot be inherited by reused rowids.
+func TestNewRepairsLegacyGhostPostings(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "tools.db")
+	ctx := context.Background()
+
+	reg, err := New(Config{DBPath: dbPath})
+	require.NoError(t, err)
+
+	// Plant the ghost exactly the way the legacy upsert did: INSERT OR
+	// REPLACE over an existing row. The implicit DELETE does not fire
+	// tools_ad (recursive_triggers is off), so the old rowid's postings
+	// survive as ghosts.
+	legacyUpsert := `
+		INSERT OR REPLACE INTO tools (
+			id, name, description, source, mcp_server, input_schema, output_schema,
+			capabilities, keywords, examples, indexed_at, version, requires_approval, rate_limit
+		) VALUES (?, ?, ?, ?, ?, '', '', '["search"]', '["alpha_lookup"]', '[]', ?, '', 0, '{}')`
+	for i := 0; i < 2; i++ {
+		_, err = reg.db.Exec(legacyUpsert,
+			"mcp:alpha:alpha_lookup", "alpha_lookup", "alpha_lookup tool from alpha",
+			int(loomv1.ToolSource_TOOL_SOURCE_MCP), "alpha", time.Now().Format(time.RFC3339))
+		require.NoError(t, err)
+	}
+	require.Error(t, ftsIntegrityCheck(reg),
+		"test premise: the legacy REPLACE upsert must have planted ghost postings")
+	require.NoError(t, reg.Close())
+
+	// Reopen: New's startup rebuild must repair the index.
+	reg, err = New(Config{DBPath: dbPath})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reg.Close() })
+
+	require.NoError(t, ftsIntegrityCheck(reg),
+		"reopening must rebuild the FTS index and clear legacy ghosts")
+
+	// The real row is still searchable after the rebuild.
+	assert.Contains(t, searchToolNames(t, reg, "alpha_lookup"), "alpha_lookup")
+
+	// And the repaired database no longer exhibits the wrong-tool bug:
+	// evicting A and indexing B (which reuses A's rowid) must not attach
+	// A's tokens to B.
+	require.NoError(t, reg.EvictTool(ctx, "mcp:alpha:alpha_lookup"))
+	require.NoError(t, reg.RegisterTool(ctx, mcpTool("beta", "beta_report")))
+	assert.NotContains(t, searchToolNames(t, reg, "alpha_lookup"), "beta_report")
+	require.NoError(t, ftsIntegrityCheck(reg))
+}

--- a/pkg/tools/registry/indexers.go
+++ b/pkg/tools/registry/indexers.go
@@ -57,6 +57,16 @@ func (i *BuiltinIndexer) Source() loomv1.ToolSource {
 
 // Index indexes all builtin tools.
 func (i *BuiltinIndexer) Index(ctx context.Context) ([]*loomv1.IndexedTool, error) {
+	outcome, err := i.IndexWithOutcome(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return outcome.Tools, nil
+}
+
+// IndexWithOutcome indexes all builtin tools. The result is always the
+// complete builtin set, so builtin rows not re-reported are pruned.
+func (i *BuiltinIndexer) IndexWithOutcome(ctx context.Context) (*IndexOutcome, error) {
 	_, span := i.tracer.StartSpan(ctx, "tools.indexer.builtin.index")
 	defer i.tracer.EndSpan(span)
 
@@ -103,7 +113,14 @@ func (i *BuiltinIndexer) Index(ctx context.Context) ([]*loomv1.IndexedTool, erro
 		Message: fmt.Sprintf("Indexed %d builtin tools", len(tools)),
 	}
 
-	return tools, nil
+	// Builtin tools live in a single unscoped ("") namespace and this run
+	// enumerated all of them, so it is authoritative for that scope.
+	return &IndexOutcome{
+		Tools:             tools,
+		CompleteScopes:    []string{""},
+		KnownScopes:       []string{""},
+		PruneOrphanScopes: true,
+	}, nil
 }
 
 // MCPIndexer indexes tools from MCP servers.
@@ -135,34 +152,53 @@ func (i *MCPIndexer) Source() loomv1.ToolSource {
 
 // Index indexes tools from all connected MCP servers.
 func (i *MCPIndexer) Index(ctx context.Context) ([]*loomv1.IndexedTool, error) {
+	outcome, err := i.IndexWithOutcome(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return outcome.Tools, nil
+}
+
+// IndexWithOutcome indexes tools from all connected MCP servers and reports
+// which servers still exist (KnownScopes: every configured server, so rows
+// of removed servers are pruned) and which were fully enumerated this run
+// (CompleteScopes: only those, so a transiently unreachable server never
+// loses its rows).
+func (i *MCPIndexer) IndexWithOutcome(ctx context.Context) (*IndexOutcome, error) {
 	ctx, span := i.tracer.StartSpan(ctx, "tools.indexer.mcp.index")
 	defer i.tracer.EndSpan(span)
 
 	if i.manager == nil {
-		return nil, nil
+		// No manager means no MCP servers exist: every indexed MCP row is
+		// unusable, so reconciliation removes them all.
+		return &IndexOutcome{PruneOrphanScopes: true}, nil
 	}
 
 	var allTools []*loomv1.IndexedTool
+	knownScopes := []string{}
+	completeScopes := []string{}
 
-	// Get all connected servers
+	// Get all configured servers (connected or not)
 	servers := i.manager.ListServers()
 
 	for _, serverInfo := range servers {
 		serverName := serverInfo.Name
+		knownScopes = append(knownScopes, serverName)
 
 		// Get client for this server
 		mcpClient, err := i.manager.GetClient(serverName)
 		if err != nil {
-			// Server not connected, skip
+			// Server not connected: keep its rows, just don't refresh them.
 			continue
 		}
 
 		// Get tools from this server
 		mcpTools, err := mcpClient.ListTools(ctx)
 		if err != nil {
-			// Log but continue with other servers
+			// Enumeration failed: keep its rows, continue with other servers.
 			continue
 		}
+		completeScopes = append(completeScopes, serverName)
 
 		for _, mcpTool := range mcpTools {
 			// Convert input schema to JSON string
@@ -193,7 +229,12 @@ func (i *MCPIndexer) Index(ctx context.Context) ([]*loomv1.IndexedTool, error) {
 		Message: fmt.Sprintf("Indexed %d MCP tools from %d servers", len(allTools), len(servers)),
 	}
 
-	return allTools, nil
+	return &IndexOutcome{
+		Tools:             allTools,
+		CompleteScopes:    completeScopes,
+		KnownScopes:       knownScopes,
+		PruneOrphanScopes: true,
+	}, nil
 }
 
 // CustomIndexer indexes custom tool definitions from YAML files.

--- a/pkg/tools/registry/mcp_adapter.go
+++ b/pkg/tools/registry/mcp_adapter.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package registry
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/teradata-labs/loom/pkg/mcp/manager"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+)
+
+// NewShuttleMCPManager adapts a *manager.Manager to the shuttle.MCPManager
+// interface (needed because manager.Manager.GetClient returns a concrete
+// *client.Client while the interface requires (interface{}, error)) and
+// applies the sentinel-translation policy shared by every composition layer:
+// "server was removed from configuration" (a stale tool index entry the
+// executor should evict, issue #334) is reported as
+// shuttle.ErrMCPServerNotFound, while "server is configured but not currently
+// connected" (transient — keep the entry) passes through untranslated.
+//
+// This package is the one importable home that already depends on both
+// pkg/mcp/manager and pkg/shuttle, so hosting the adapter here adds no import
+// edges. mgr must be non-nil.
+func NewShuttleMCPManager(mgr *manager.Manager) shuttle.MCPManager {
+	return &shuttleMCPManagerAdapter{mgr: mgr}
+}
+
+// shuttleMCPManagerAdapter is the concrete adapter behind NewShuttleMCPManager.
+type shuttleMCPManagerAdapter struct {
+	mgr *manager.Manager
+}
+
+func (a *shuttleMCPManagerAdapter) GetClient(serverName string) (interface{}, error) {
+	c, err := a.mgr.GetClient(serverName)
+	if err != nil {
+		// Distinguish "server was removed from configuration" (a stale tool
+		// index entry the executor should evict, issue #334) from "server is
+		// configured but not currently connected" (transient — keep it).
+		if errors.Is(err, manager.ErrServerNotFound) {
+			if _, cfgErr := a.mgr.GetServerConfig(serverName); cfgErr != nil {
+				return nil, fmt.Errorf("%w: %s", shuttle.ErrMCPServerNotFound, serverName)
+			}
+		}
+		return nil, err
+	}
+	return c, nil
+}

--- a/pkg/tools/registry/mcp_adapter_test.go
+++ b/pkg/tools/registry/mcp_adapter_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package registry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/teradata-labs/loom/pkg/mcp/manager"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+	"go.uber.org/zap"
+)
+
+// TestNewShuttleMCPManagerSentinelTranslation verifies the shared adapter's
+// policy (previously duplicated in cmd/looms and pkg/agent): a server missing
+// from configuration surfaces shuttle.ErrMCPServerNotFound so the executor
+// evicts the stale index entry, while a server that is configured but not
+// connected reports a plain error, keeping the entry for when it comes back.
+func TestNewShuttleMCPManagerSentinelTranslation(t *testing.T) {
+	mgr, err := manager.NewManager(manager.Config{
+		Servers: map[string]manager.ServerConfig{
+			// Configured but never started: GetClient fails without the
+			// removed-from-configuration sentinel.
+			"configured": {Enabled: true, Transport: "stdio", Command: "echo"},
+		},
+		ClientInfo: manager.ClientInfo{Name: "test", Version: "0.1.0"},
+	}, zap.NewNop())
+	require.NoError(t, err)
+
+	adapter := NewShuttleMCPManager(mgr)
+
+	// Not configured at all: the stale-index sentinel must surface.
+	_, err = adapter.GetClient("removed-from-config")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, shuttle.ErrMCPServerNotFound,
+		"unconfigured server must translate to the eviction sentinel (issue #334)")
+
+	// Configured but not connected: transient — no sentinel, entry kept.
+	_, err = adapter.GetClient("configured")
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, shuttle.ErrMCPServerNotFound,
+		"configured-but-disconnected server must not trigger eviction")
+}

--- a/pkg/tools/registry/prune_logging_test.go
+++ b/pkg/tools/registry/prune_logging_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// stringsField extracts a zap.Strings field value from an observed log entry.
+func stringsField(t *testing.T, entry observer.LoggedEntry, key string) []string {
+	t.Helper()
+	raw, ok := entry.ContextMap()[key]
+	require.True(t, ok, "field %s not found on entry %q", key, entry.Message)
+	items, ok := raw.([]interface{})
+	require.True(t, ok, "field %s must be an array, got %T", key, raw)
+	values := make([]string, 0, len(items))
+	for _, item := range items {
+		s, ok := item.(string)
+		require.True(t, ok, "field %s must contain strings, got %T", key, item)
+		values = append(values, s)
+	}
+	return values
+}
+
+// TestPruneStaleRowsLogsPrunedIDs verifies the prune path records exactly
+// which tool IDs and servers it removed, so a tool disappearing from search
+// is traceable to the reconciliation decision that deleted it.
+func TestPruneStaleRowsLogsPrunedIDs(t *testing.T) {
+	core, observed := observer.New(zapcore.InfoLevel)
+
+	serverA := []*loomv1.IndexedTool{mcpTool("alpha", "query"), mcpTool("alpha", "list")}
+	serverB := []*loomv1.IndexedTool{mcpTool("beta", "read")}
+	indexer := &fakeReconcilingIndexer{
+		name:   "mcp",
+		source: loomv1.ToolSource_TOOL_SOURCE_MCP,
+		outcome: &IndexOutcome{
+			Tools:             append(append([]*loomv1.IndexedTool{}, serverA...), serverB...),
+			CompleteScopes:    []string{"alpha", "beta"},
+			KnownScopes:       []string{"alpha", "beta"},
+			PruneOrphanScopes: true,
+		},
+	}
+	reg := newReconcileTestRegistry(t, Config{
+		Logger:   zap.New(core),
+		Indexers: []Indexer{indexer},
+	})
+	ctx := context.Background()
+
+	_, err := reg.IndexAll(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, observed.FilterMessage("Pruned stale tool index entries").All(),
+		"a run that prunes nothing must not log a prune entry")
+
+	// Second run: server beta was removed and tool alpha:list disappeared.
+	indexer.outcome = &IndexOutcome{
+		Tools:             []*loomv1.IndexedTool{mcpTool("alpha", "query")},
+		CompleteScopes:    []string{"alpha"},
+		KnownScopes:       []string{"alpha"},
+		PruneOrphanScopes: true,
+	}
+	resp, err := reg.IndexAll(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int32(2), resp.PrunedCount)
+
+	entries := observed.FilterMessage("Pruned stale tool index entries").All()
+	require.Len(t, entries, 2, "one entry per prune reason")
+
+	var allIDs, allServers []string
+	for _, entry := range entries {
+		allIDs = append(allIDs, stringsField(t, entry, "tool_ids")...)
+		allServers = append(allServers, stringsField(t, entry, "mcp_servers")...)
+	}
+	assert.ElementsMatch(t, []string{"mcp:beta:read", "mcp:alpha:list"}, allIDs,
+		"every pruned tool ID must be logged")
+	assert.ElementsMatch(t, []string{"beta", "alpha"}, allServers,
+		"every affected server must be logged")
+}
+
+// TestEvictToolLogsEviction verifies EvictTool records which entry it removed
+// and stays silent for no-op evictions of unknown IDs.
+func TestEvictToolLogsEviction(t *testing.T) {
+	core, observed := observer.New(zapcore.InfoLevel)
+	reg := newReconcileTestRegistry(t, Config{Logger: zap.New(core)})
+	ctx := context.Background()
+
+	tool := mcpTool("ghost", "stale_tool")
+	require.NoError(t, reg.RegisterTool(ctx, tool))
+	require.NoError(t, reg.EvictTool(ctx, tool.Id))
+
+	entries := observed.FilterMessage("Evicted stale tool index entry").All()
+	require.Len(t, entries, 1)
+	assert.Equal(t, tool.Id, entries[0].ContextMap()["tool_id"])
+
+	// Evicting a missing ID deletes nothing and must not log.
+	require.NoError(t, reg.EvictTool(ctx, "mcp:ghost:never_existed"))
+	assert.Len(t, observed.FilterMessage("Evicted stale tool index entry").All(), 1)
+}

--- a/pkg/tools/registry/reconcile_test.go
+++ b/pkg/tools/registry/reconcile_test.go
@@ -1,0 +1,368 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package registry
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+)
+
+// fakeReconcilingIndexer implements ReconcilingIndexer with a scripted outcome.
+type fakeReconcilingIndexer struct {
+	name    string
+	source  loomv1.ToolSource
+	outcome *IndexOutcome
+	err     error
+}
+
+func (f *fakeReconcilingIndexer) Name() string              { return f.name }
+func (f *fakeReconcilingIndexer) Source() loomv1.ToolSource { return f.source }
+func (f *fakeReconcilingIndexer) Index(ctx context.Context) ([]*loomv1.IndexedTool, error) {
+	outcome, err := f.IndexWithOutcome(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return outcome.Tools, nil
+}
+func (f *fakeReconcilingIndexer) IndexWithOutcome(ctx context.Context) (*IndexOutcome, error) {
+	return f.outcome, f.err
+}
+
+// fakePlainIndexer implements only the base Indexer (no reconciliation).
+type fakePlainIndexer struct {
+	source loomv1.ToolSource
+	tools  []*loomv1.IndexedTool
+}
+
+func (f *fakePlainIndexer) Name() string              { return "plain" }
+func (f *fakePlainIndexer) Source() loomv1.ToolSource { return f.source }
+func (f *fakePlainIndexer) Index(ctx context.Context) ([]*loomv1.IndexedTool, error) {
+	return f.tools, nil
+}
+
+func mcpTool(server, name string) *loomv1.IndexedTool {
+	return &loomv1.IndexedTool{
+		Id:          fmt.Sprintf("mcp:%s:%s", server, name),
+		Name:        name,
+		Description: fmt.Sprintf("%s tool from %s", name, server),
+		Source:      loomv1.ToolSource_TOOL_SOURCE_MCP,
+		McpServer:   server,
+		IndexedAt:   time.Now().Format(time.RFC3339),
+		Keywords:    []string{name},
+	}
+}
+
+func newReconcileTestRegistry(t *testing.T, cfg Config) *Registry {
+	t.Helper()
+	tmpFile, err := os.CreateTemp("", "test_reconcile_*.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(tmpFile.Name()) })
+	_ = tmpFile.Close()
+
+	cfg.DBPath = tmpFile.Name()
+	reg, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reg.Close() })
+	return reg
+}
+
+func toolIDs(t *testing.T, reg *Registry) map[string]bool {
+	t.Helper()
+	rows, err := reg.db.Query(`SELECT id FROM tools`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	ids := make(map[string]bool)
+	for rows.Next() {
+		var id string
+		require.NoError(t, rows.Scan(&id))
+		ids[id] = true
+	}
+	require.NoError(t, rows.Err())
+	return ids
+}
+
+func TestIndexAllReconciliation(t *testing.T) {
+	serverA := []*loomv1.IndexedTool{mcpTool("alpha", "query"), mcpTool("alpha", "list")}
+	serverB := []*loomv1.IndexedTool{mcpTool("beta", "read")}
+
+	tests := []struct {
+		name        string
+		firstRun    *IndexOutcome
+		secondRun   *IndexOutcome
+		wantIDs     []string
+		wantGoneIDs []string
+		wantPruned  int32
+	}{
+		{
+			name: "removed server rows are pruned",
+			firstRun: &IndexOutcome{
+				Tools:             append(append([]*loomv1.IndexedTool{}, serverA...), serverB...),
+				CompleteScopes:    []string{"alpha", "beta"},
+				KnownScopes:       []string{"alpha", "beta"},
+				PruneOrphanScopes: true,
+			},
+			secondRun: &IndexOutcome{
+				Tools:             serverA,
+				CompleteScopes:    []string{"alpha"},
+				KnownScopes:       []string{"alpha"},
+				PruneOrphanScopes: true,
+			},
+			wantIDs:     []string{"mcp:alpha:query", "mcp:alpha:list"},
+			wantGoneIDs: []string{"mcp:beta:read"},
+			wantPruned:  1,
+		},
+		{
+			name: "removed tool on a live server is pruned",
+			firstRun: &IndexOutcome{
+				Tools:             serverA,
+				CompleteScopes:    []string{"alpha"},
+				KnownScopes:       []string{"alpha"},
+				PruneOrphanScopes: true,
+			},
+			secondRun: &IndexOutcome{
+				Tools:             []*loomv1.IndexedTool{mcpTool("alpha", "query")},
+				CompleteScopes:    []string{"alpha"},
+				KnownScopes:       []string{"alpha"},
+				PruneOrphanScopes: true,
+			},
+			wantIDs:     []string{"mcp:alpha:query"},
+			wantGoneIDs: []string{"mcp:alpha:list"},
+			wantPruned:  1,
+		},
+		{
+			name: "unreachable but configured server keeps its rows",
+			firstRun: &IndexOutcome{
+				Tools:             append(append([]*loomv1.IndexedTool{}, serverA...), serverB...),
+				CompleteScopes:    []string{"alpha", "beta"},
+				KnownScopes:       []string{"alpha", "beta"},
+				PruneOrphanScopes: true,
+			},
+			secondRun: &IndexOutcome{
+				Tools:             serverA,
+				CompleteScopes:    []string{"alpha"},         // beta failed to enumerate
+				KnownScopes:       []string{"alpha", "beta"}, // but is still configured
+				PruneOrphanScopes: true,
+			},
+			wantIDs:    []string{"mcp:alpha:query", "mcp:alpha:list", "mcp:beta:read"},
+			wantPruned: 0,
+		},
+		{
+			name: "no servers configured prunes every MCP row",
+			firstRun: &IndexOutcome{
+				Tools:             append(append([]*loomv1.IndexedTool{}, serverA...), serverB...),
+				CompleteScopes:    []string{"alpha", "beta"},
+				KnownScopes:       []string{"alpha", "beta"},
+				PruneOrphanScopes: true,
+			},
+			secondRun: &IndexOutcome{
+				PruneOrphanScopes: true,
+			},
+			wantGoneIDs: []string{"mcp:alpha:query", "mcp:alpha:list", "mcp:beta:read"},
+			wantPruned:  3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			indexer := &fakeReconcilingIndexer{
+				name:    "mcp",
+				source:  loomv1.ToolSource_TOOL_SOURCE_MCP,
+				outcome: tt.firstRun,
+			}
+			reg := newReconcileTestRegistry(t, Config{Indexers: []Indexer{indexer}})
+			ctx := context.Background()
+
+			resp, err := reg.IndexAll(ctx)
+			require.NoError(t, err)
+			require.Empty(t, resp.Errors)
+
+			indexer.outcome = tt.secondRun
+			resp, err = reg.IndexAll(ctx)
+			require.NoError(t, err)
+			require.Empty(t, resp.Errors)
+			assert.Equal(t, tt.wantPruned, resp.PrunedCount)
+
+			ids := toolIDs(t, reg)
+			for _, id := range tt.wantIDs {
+				assert.True(t, ids[id], "expected %s to survive", id)
+			}
+			for _, id := range tt.wantGoneIDs {
+				assert.False(t, ids[id], "expected %s to be pruned", id)
+			}
+		})
+	}
+}
+
+// A plain (non-reconciling) indexer must keep the historical upsert-only
+// behavior: rows registered out-of-band (RegisterTool) survive IndexAll.
+func TestIndexAllPlainIndexerDoesNotPrune(t *testing.T) {
+	plain := &fakePlainIndexer{source: loomv1.ToolSource_TOOL_SOURCE_CUSTOM}
+	reg := newReconcileTestRegistry(t, Config{Indexers: []Indexer{plain}})
+	ctx := context.Background()
+
+	custom := &loomv1.IndexedTool{
+		Id:          "custom:my_tool",
+		Name:        "my_tool",
+		Description: "registered via gRPC, not reported by any indexer",
+		Source:      loomv1.ToolSource_TOOL_SOURCE_CUSTOM,
+		IndexedAt:   time.Now().Format(time.RFC3339),
+	}
+	require.NoError(t, reg.RegisterTool(ctx, custom))
+
+	resp, err := reg.IndexAll(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), resp.PrunedCount)
+
+	ids := toolIDs(t, reg)
+	assert.True(t, ids["custom:my_tool"], "out-of-band custom tool must survive IndexAll")
+}
+
+// Reconciliation is scoped per source: pruning MCP rows never touches
+// builtin rows, and vice versa.
+func TestIndexAllReconciliationScopedToSource(t *testing.T) {
+	builtin := &fakeReconcilingIndexer{
+		name:   "builtin",
+		source: loomv1.ToolSource_TOOL_SOURCE_BUILTIN,
+		outcome: &IndexOutcome{
+			Tools: []*loomv1.IndexedTool{{
+				Id:          "builtin:echo",
+				Name:        "echo",
+				Description: "echo tool",
+				Source:      loomv1.ToolSource_TOOL_SOURCE_BUILTIN,
+				IndexedAt:   time.Now().Format(time.RFC3339),
+			}},
+			CompleteScopes:    []string{""},
+			KnownScopes:       []string{""},
+			PruneOrphanScopes: true,
+		},
+	}
+	mcp := &fakeReconcilingIndexer{
+		name:   "mcp",
+		source: loomv1.ToolSource_TOOL_SOURCE_MCP,
+		outcome: &IndexOutcome{
+			// No MCP servers exist: prunes all MCP rows, must not touch builtin.
+			PruneOrphanScopes: true,
+		},
+	}
+	reg := newReconcileTestRegistry(t, Config{Indexers: []Indexer{builtin, mcp}})
+	ctx := context.Background()
+
+	// Seed a stale MCP row from a long-gone server.
+	require.NoError(t, reg.RegisterTool(ctx, mcpTool("ghost", "old_query")))
+
+	resp, err := reg.IndexAll(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), resp.PrunedCount)
+
+	ids := toolIDs(t, reg)
+	assert.True(t, ids["builtin:echo"], "builtin row must survive MCP pruning")
+	assert.False(t, ids["mcp:ghost:old_query"], "stale MCP row must be pruned")
+}
+
+func TestSearchFiltersDeadMCPServers(t *testing.T) {
+	live := []string{"alpha"}
+	reg := newReconcileTestRegistry(t, Config{
+		LiveMCPServers: func() []string { return live },
+	})
+	ctx := context.Background()
+
+	require.NoError(t, reg.RegisterTool(ctx, mcpTool("alpha", "query_database")))
+	require.NoError(t, reg.RegisterTool(ctx, mcpTool("ghost", "query_tables")))
+	require.NoError(t, reg.RegisterTool(ctx, &loomv1.IndexedTool{
+		Id:          "builtin:query_helper",
+		Name:        "query_helper",
+		Description: "builtin query helper",
+		Source:      loomv1.ToolSource_TOOL_SOURCE_BUILTIN,
+		IndexedAt:   time.Now().Format(time.RFC3339),
+		Keywords:    []string{"query"},
+	}))
+
+	search := func() map[string]bool {
+		resp, err := reg.Search(ctx, &loomv1.SearchToolsRequest{
+			Query:      "query",
+			Mode:       loomv1.SearchMode_SEARCH_MODE_FAST,
+			MaxResults: 10,
+		})
+		require.NoError(t, err)
+		names := make(map[string]bool)
+		for _, res := range resp.Results {
+			names[res.Tool.Name] = true
+		}
+		return names
+	}
+
+	names := search()
+	assert.True(t, names["query_database"], "tool on live server must be returned")
+	assert.True(t, names["query_helper"], "builtin tool must be unaffected by MCP liveness")
+	assert.False(t, names["query_tables"], "tool on dead server must be filtered out")
+
+	// With no live servers at all, every MCP tool disappears from search
+	// while builtin tools remain.
+	live = nil
+	names = search()
+	assert.False(t, names["query_database"])
+	assert.False(t, names["query_tables"])
+	assert.True(t, names["query_helper"])
+
+	// GetToolsByCapability honors the same filter.
+	tools, err := reg.GetToolsByCapability(ctx, "database", nil, 10)
+	require.NoError(t, err)
+	for _, tool := range tools {
+		assert.NotEqual(t, loomv1.ToolSource_TOOL_SOURCE_MCP, tool.Source,
+			"no MCP tool may be returned when no server is live")
+	}
+}
+
+func TestSearchWithoutLivenessCallbackIsUnfiltered(t *testing.T) {
+	reg := newReconcileTestRegistry(t, Config{}) // LiveMCPServers nil
+	ctx := context.Background()
+
+	require.NoError(t, reg.RegisterTool(ctx, mcpTool("ghost", "query_tables")))
+
+	resp, err := reg.Search(ctx, &loomv1.SearchToolsRequest{
+		Query:      "query",
+		Mode:       loomv1.SearchMode_SEARCH_MODE_FAST,
+		MaxResults: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, "query_tables", resp.Results[0].Tool.Name)
+}
+
+func TestEvictTool(t *testing.T) {
+	reg := newReconcileTestRegistry(t, Config{})
+	ctx := context.Background()
+
+	tool := mcpTool("ghost", "stale_tool")
+	require.NoError(t, reg.RegisterTool(ctx, tool))
+
+	_, err := reg.GetTool(ctx, tool.Id)
+	require.NoError(t, err)
+
+	require.NoError(t, reg.EvictTool(ctx, tool.Id))
+
+	_, err = reg.GetTool(ctx, tool.Id)
+	assert.Error(t, err, "evicted tool must no longer resolve")
+
+	// Evicting a missing ID is a no-op, not an error.
+	assert.NoError(t, reg.EvictTool(ctx, "mcp:ghost:never_existed"))
+}

--- a/pkg/tools/registry/registry.go
+++ b/pkg/tools/registry/registry.go
@@ -33,11 +33,12 @@ import (
 
 // Registry manages the tool index and provides search capabilities.
 type Registry struct {
-	db       *sql.DB
-	llm      types.LLMProvider
-	tracer   observability.Tracer
-	mu       sync.RWMutex
-	indexers []Indexer
+	db             *sql.DB
+	llm            types.LLMProvider
+	tracer         observability.Tracer
+	mu             sync.RWMutex
+	indexers       []Indexer
+	liveMCPServers func() []string
 }
 
 // Indexer is an interface for tool source indexers.
@@ -52,12 +53,59 @@ type Indexer interface {
 	Index(ctx context.Context) ([]*loomv1.IndexedTool, error)
 }
 
+// IndexOutcome is the result of an index run that can vouch for the
+// completeness of what it reports, so IndexAll can prune rows the run did
+// not re-report instead of accumulating them forever (issue #334).
+//
+// A scope is the value of the tools table's mcp_server column: the server
+// name for MCP tools, "" for sources that don't partition by server.
+type IndexOutcome struct {
+	// Tools is the set of tools reported by this run.
+	Tools []*loomv1.IndexedTool
+
+	// CompleteScopes lists the scopes for which Tools is the complete
+	// current set. Indexed rows in these scopes that are absent from Tools
+	// are stale and are deleted. A scope that failed to enumerate this run
+	// (e.g. an unreachable MCP server) must NOT be listed here, so a
+	// transient failure never wipes a server's tools.
+	CompleteScopes []string
+
+	// KnownScopes lists every scope that still exists for this source
+	// (e.g. every configured MCP server, reachable or not). Only consulted
+	// when PruneOrphanScopes is true.
+	KnownScopes []string
+
+	// PruneOrphanScopes, when true, deletes rows of this source whose scope
+	// is not in KnownScopes — the "server was removed from configuration"
+	// case. With an empty KnownScopes it deletes every row of the source.
+	PruneOrphanScopes bool
+}
+
+// ReconcilingIndexer is an optional extension of Indexer. Indexers that
+// implement it get stale rows pruned after each run; plain Indexers keep
+// the historical upsert-only behavior (required for sources like custom
+// tools, where rows are registered out-of-band via RegisterTool).
+type ReconcilingIndexer interface {
+	Indexer
+
+	// IndexWithOutcome indexes all tools and reports the reconciliation
+	// boundaries of the run.
+	IndexWithOutcome(ctx context.Context) (*IndexOutcome, error)
+}
+
 // Config holds registry configuration.
 type Config struct {
 	DBPath   string            // Path to SQLite database
 	LLM      types.LLMProvider // LLM provider for search assistance
 	Tracer   observability.Tracer
 	Indexers []Indexer // Tool source indexers
+
+	// LiveMCPServers, when set, returns the names of the MCP servers that
+	// currently exist; search results are then restricted to MCP tools from
+	// these servers, so stale index rows are never surfaced to agents even
+	// between reconciliation runs. nil disables the filter. An empty result
+	// filters out all MCP tools.
+	LiveMCPServers func() []string
 }
 
 // New creates a new tool registry.
@@ -73,10 +121,11 @@ func New(cfg Config) (*Registry, error) {
 	}
 
 	r := &Registry{
-		db:       db,
-		llm:      cfg.LLM,
-		tracer:   cfg.Tracer,
-		indexers: cfg.Indexers,
+		db:             db,
+		llm:            cfg.LLM,
+		tracer:         cfg.Tracer,
+		indexers:       cfg.Indexers,
+		liveMCPServers: cfg.LiveMCPServers,
 	}
 
 	// Initialize schema
@@ -177,7 +226,18 @@ func (r *Registry) IndexAll(ctx context.Context) (*loomv1.IndexToolsResponse, er
 	defer r.mu.Unlock()
 
 	for _, indexer := range r.indexers {
-		tools, err := indexer.Index(ctx)
+		var tools []*loomv1.IndexedTool
+		var outcome *IndexOutcome
+		var err error
+
+		if reconciler, ok := indexer.(ReconcilingIndexer); ok {
+			outcome, err = reconciler.IndexWithOutcome(ctx)
+			if outcome != nil {
+				tools = outcome.Tools
+			}
+		} else {
+			tools, err = indexer.Index(ctx)
+		}
 		if err != nil {
 			errors = append(errors, &loomv1.IndexError{
 				Source:       indexer.Source(),
@@ -196,6 +256,13 @@ func (r *Registry) IndexAll(ctx context.Context) (*loomv1.IndexToolsResponse, er
 				})
 				continue
 			}
+		}
+
+		// Prune rows this run vouches are stale (removed servers, removed tools).
+		if outcome != nil {
+			pruned, pruneErrs := r.pruneStaleRows(ctx, indexer.Source(), outcome)
+			resp.PrunedCount += types.SafeInt32(pruned)
+			errors = append(errors, pruneErrs...)
 		}
 
 		// Update counts
@@ -218,10 +285,117 @@ func (r *Registry) IndexAll(ctx context.Context) (*loomv1.IndexToolsResponse, er
 
 	span.Status = observability.Status{
 		Code:    observability.StatusOK,
-		Message: fmt.Sprintf("Indexed %d tools", resp.TotalCount),
+		Message: fmt.Sprintf("Indexed %d tools, pruned %d stale", resp.TotalCount, resp.PrunedCount),
 	}
 
 	return resp, nil
+}
+
+// pruneStaleRows deletes rows the outcome vouches are stale: rows in scopes
+// that no longer exist (PruneOrphanScopes/KnownScopes) and rows in
+// CompleteScopes that this run did not re-report. Returns the number of rows
+// deleted; failures are reported as IndexErrors, never as a hard failure —
+// a prune problem must not abort indexing. Caller holds r.mu.
+func (r *Registry) pruneStaleRows(ctx context.Context, source loomv1.ToolSource, outcome *IndexOutcome) (int, []*loomv1.IndexError) {
+	var errs []*loomv1.IndexError
+	pruned := 0
+
+	// Group the reported tool IDs by scope for the complete-scope diffs.
+	keepByScope := make(map[string]map[string]bool)
+	for _, tool := range outcome.Tools {
+		scope := tool.McpServer
+		if keepByScope[scope] == nil {
+			keepByScope[scope] = make(map[string]bool)
+		}
+		keepByScope[scope][tool.Id] = true
+	}
+
+	// 1. Orphaned scopes: the scope (MCP server) is gone from configuration.
+	if outcome.PruneOrphanScopes {
+		known := make(map[string]bool, len(outcome.KnownScopes))
+		for _, s := range outcome.KnownScopes {
+			known[s] = true
+		}
+		n, err := r.deleteRowsWhere(ctx, source, func(scope, id string) bool {
+			return !known[scope]
+		})
+		pruned += n
+		if err != nil {
+			errs = append(errs, &loomv1.IndexError{
+				Source:       source,
+				ErrorMessage: fmt.Sprintf("failed to prune orphaned scopes: %v", err),
+			})
+		}
+	}
+
+	// 2. Complete scopes: the scope still exists and this run enumerated it
+	// fully, so any row not re-reported is a removed tool.
+	if len(outcome.CompleteScopes) > 0 {
+		complete := make(map[string]bool, len(outcome.CompleteScopes))
+		for _, s := range outcome.CompleteScopes {
+			complete[s] = true
+		}
+		n, err := r.deleteRowsWhere(ctx, source, func(scope, id string) bool {
+			return complete[scope] && !keepByScope[scope][id]
+		})
+		pruned += n
+		if err != nil {
+			errs = append(errs, &loomv1.IndexError{
+				Source:       source,
+				ErrorMessage: fmt.Sprintf("failed to prune removed tools: %v", err),
+			})
+		}
+	}
+
+	return pruned, errs
+}
+
+// deleteRowsWhere deletes every row of the given source for which stale
+// returns true, evaluated over (scope, id). The candidate set is read first
+// and deleted by ID, so the work stays clear of SQLite bind-variable limits
+// regardless of tool count. Caller holds r.mu.
+func (r *Registry) deleteRowsWhere(ctx context.Context, source loomv1.ToolSource, stale func(scope, id string) bool) (int, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, COALESCE(mcp_server, '') FROM tools WHERE source = ?`, int(source))
+	if err != nil {
+		return 0, err
+	}
+
+	var staleIDs []string
+	for rows.Next() {
+		var id, scope string
+		if err := rows.Scan(&id, &scope); err != nil {
+			continue
+		}
+		if stale(scope, id) {
+			staleIDs = append(staleIDs, id)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return 0, err
+	}
+	_ = rows.Close()
+
+	deleted := 0
+	for _, id := range staleIDs {
+		if _, err := r.db.ExecContext(ctx, `DELETE FROM tools WHERE id = ?`, id); err != nil {
+			return deleted, err
+		}
+		deleted++
+	}
+	return deleted, nil
+}
+
+// EvictTool removes a single tool from the index by ID. Used when dynamic
+// registration proves an entry stale (its MCP server no longer exists), so
+// the same dead tool is never served twice.
+func (r *Registry) EvictTool(ctx context.Context, toolID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	_, err := r.db.ExecContext(ctx, `DELETE FROM tools WHERE id = ?`, toolID)
+	return err
 }
 
 // RegisterTool registers or updates a single tool in the database.
@@ -412,6 +586,12 @@ func (r *Registry) ftsSearch(ctx context.Context, query string, expandedTerms []
 		}
 	}
 
+	// Restrict MCP tools to live servers so stale index rows are never
+	// surfaced to agents (issue #334).
+	livenessSQL, livenessArgs := r.mcpLivenessClause("t")
+	sql += livenessSQL
+	args = append(args, livenessArgs...)
+
 	sql += " ORDER BY score LIMIT ?"
 	args = append(args, limit)
 
@@ -463,6 +643,41 @@ func (r *Registry) ftsSearch(ctx context.Context, query string, expandedTerms []
 	}
 
 	return results, nil
+}
+
+// mcpLivenessClause returns a SQL fragment (leading " AND ...") restricting
+// MCP-sourced rows to currently-live servers, with its bind arguments. It is
+// a no-op ("" and nil) when no liveness callback is configured. With a
+// callback returning no servers, every MCP row is excluded: a tool whose
+// server does not exist cannot be executed, so surfacing it only misleads
+// the agent (issue #334).
+func (r *Registry) mcpLivenessClause(alias string) (string, []interface{}) {
+	if r.liveMCPServers == nil {
+		return "", nil
+	}
+	col := "mcp_server"
+	srcCol := "source"
+	if alias != "" {
+		col = alias + "." + col
+		srcCol = alias + "." + srcCol
+	}
+
+	live := r.liveMCPServers()
+	if len(live) == 0 {
+		return fmt.Sprintf(" AND %s != ?", srcCol),
+			[]interface{}{int(loomv1.ToolSource_TOOL_SOURCE_MCP)}
+	}
+
+	placeholders := make([]string, len(live))
+	args := make([]interface{}, 0, len(live)+1)
+	args = append(args, int(loomv1.ToolSource_TOOL_SOURCE_MCP))
+	for i, server := range live {
+		placeholders[i] = "?"
+		args = append(args, server)
+	}
+	clause := fmt.Sprintf(" AND (%s != ? OR COALESCE(%s, '') IN (%s))",
+		srcCol, col, strings.Join(placeholders, ",")) // #nosec G201 -- placeholders are literal "?" strings, values are parameterized
+	return clause, args
 }
 
 // expandQuery uses LLM to expand the search query with synonyms and related terms.
@@ -671,6 +886,11 @@ func (r *Registry) GetToolsByCapability(ctx context.Context, capability string, 
 		}
 		sql += " AND source IN (" + strings.Join(placeholders, ",") + ")" // #nosec G202 -- placeholders are literal "?" strings, values are parameterized
 	}
+
+	// Restrict MCP tools to live servers (issue #334).
+	livenessSQL, livenessArgs := r.mcpLivenessClause("")
+	sql += livenessSQL
+	args = append(args, livenessArgs...)
 
 	sql += " LIMIT ?"
 	args = append(args, maxResults)

--- a/pkg/tools/registry/registry.go
+++ b/pkg/tools/registry/registry.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/teradata-labs/loom/internal/sqlitedriver"
 	"github.com/teradata-labs/loom/pkg/observability"
 	"github.com/teradata-labs/loom/pkg/types"
+	"go.uber.org/zap"
 )
 
 // Registry manages the tool index and provides search capabilities.
@@ -36,6 +37,7 @@ type Registry struct {
 	db             *sql.DB
 	llm            types.LLMProvider
 	tracer         observability.Tracer
+	logger         *zap.Logger
 	mu             sync.RWMutex
 	indexers       []Indexer
 	liveMCPServers func() []string
@@ -98,7 +100,8 @@ type Config struct {
 	DBPath   string            // Path to SQLite database
 	LLM      types.LLMProvider // LLM provider for search assistance
 	Tracer   observability.Tracer
-	Indexers []Indexer // Tool source indexers
+	Logger   *zap.Logger // Structured logger for prune/evict audit trails; nil uses a no-op logger
+	Indexers []Indexer   // Tool source indexers
 
 	// LiveMCPServers, when set, returns the names of the MCP servers that
 	// currently exist; search results are then restricted to MCP tools from
@@ -113,6 +116,9 @@ func New(cfg Config) (*Registry, error) {
 	if cfg.Tracer == nil {
 		cfg.Tracer = observability.NewNoOpTracer()
 	}
+	if cfg.Logger == nil {
+		cfg.Logger = zap.NewNop()
+	}
 
 	// Open SQLite database with FTS5 support
 	db, err := sql.Open("sqlite3", cfg.DBPath)
@@ -124,6 +130,7 @@ func New(cfg Config) (*Registry, error) {
 		db:             db,
 		llm:            cfg.LLM,
 		tracer:         cfg.Tracer,
+		logger:         cfg.Logger,
 		indexers:       cfg.Indexers,
 		liveMCPServers: cfg.LiveMCPServers,
 	}
@@ -132,6 +139,19 @@ func New(cfg Config) (*Registry, error) {
 	if err := r.initSchema(); err != nil {
 		_ = db.Close() // Best-effort cleanup; initSchema error takes priority
 		return nil, fmt.Errorf("failed to initialize schema: %w", err)
+	}
+
+	// Rebuild the FTS index from the content table, once per open. Databases
+	// written by earlier builds were populated via INSERT OR REPLACE, whose
+	// implicit DELETE does not fire the tools_ad trigger (recursive_triggers
+	// is off by default), leaving ghost FTS postings behind; a later DELETE
+	// could free the max rowid, which SQLite then reuses for a new tool,
+	// attaching the ghost postings to the wrong tool (wrong search results and
+	// a failing FTS5 integrity-check). The rebuild is idempotent and cheap at
+	// open time, and repairs any such database in place.
+	if _, err := db.Exec(`INSERT INTO tools_fts(tools_fts) VALUES('rebuild')`); err != nil {
+		_ = db.Close() // Best-effort cleanup; rebuild error takes priority
+		return nil, fmt.Errorf("failed to rebuild FTS index: %w", err)
 	}
 
 	return r, nil
@@ -316,10 +336,11 @@ func (r *Registry) pruneStaleRows(ctx context.Context, source loomv1.ToolSource,
 		for _, s := range outcome.KnownScopes {
 			known[s] = true
 		}
-		n, err := r.deleteRowsWhere(ctx, source, func(scope, id string) bool {
+		deleted, err := r.deleteRowsWhere(ctx, source, func(scope, id string) bool {
 			return !known[scope]
 		})
-		pruned += n
+		pruned += len(deleted)
+		r.logPruned("server removed from configuration", source, deleted)
 		if err != nil {
 			errs = append(errs, &loomv1.IndexError{
 				Source:       source,
@@ -335,10 +356,11 @@ func (r *Registry) pruneStaleRows(ctx context.Context, source loomv1.ToolSource,
 		for _, s := range outcome.CompleteScopes {
 			complete[s] = true
 		}
-		n, err := r.deleteRowsWhere(ctx, source, func(scope, id string) bool {
+		deleted, err := r.deleteRowsWhere(ctx, source, func(scope, id string) bool {
 			return complete[scope] && !keepByScope[scope][id]
 		})
-		pruned += n
+		pruned += len(deleted)
+		r.logPruned("tool no longer reported by its server", source, deleted)
 		if err != nil {
 			errs = append(errs, &loomv1.IndexError{
 				Source:       source,
@@ -350,39 +372,70 @@ func (r *Registry) pruneStaleRows(ctx context.Context, source loomv1.ToolSource,
 	return pruned, errs
 }
 
+// logPruned records exactly which index rows a prune removed, so a tool that
+// disappears from search is traceable to the reconciliation decision that
+// deleted it. No-op when nothing was deleted.
+func (r *Registry) logPruned(reason string, source loomv1.ToolSource, deleted []prunedRow) {
+	if len(deleted) == 0 {
+		return
+	}
+	ids := make([]string, len(deleted))
+	scopeSet := make(map[string]bool, len(deleted))
+	scopes := make([]string, 0, len(deleted))
+	for i, row := range deleted {
+		ids[i] = row.id
+		if !scopeSet[row.scope] {
+			scopeSet[row.scope] = true
+			scopes = append(scopes, row.scope)
+		}
+	}
+	r.logger.Info("Pruned stale tool index entries",
+		zap.String("reason", reason),
+		zap.String("source", source.String()),
+		zap.Strings("tool_ids", ids),
+		zap.Strings("mcp_servers", scopes))
+}
+
+// prunedRow identifies one deleted index row: its tool ID and its scope (the
+// tools.mcp_server value, "" for sources that don't partition by server).
+type prunedRow struct {
+	id    string
+	scope string
+}
+
 // deleteRowsWhere deletes every row of the given source for which stale
-// returns true, evaluated over (scope, id). The candidate set is read first
-// and deleted by ID, so the work stays clear of SQLite bind-variable limits
-// regardless of tool count. Caller holds r.mu.
-func (r *Registry) deleteRowsWhere(ctx context.Context, source loomv1.ToolSource, stale func(scope, id string) bool) (int, error) {
+// returns true, evaluated over (scope, id), and returns the rows it deleted.
+// The candidate set is read first and deleted by ID, so the work stays clear
+// of SQLite bind-variable limits regardless of tool count. Caller holds r.mu.
+func (r *Registry) deleteRowsWhere(ctx context.Context, source loomv1.ToolSource, stale func(scope, id string) bool) ([]prunedRow, error) {
 	rows, err := r.db.QueryContext(ctx,
 		`SELECT id, COALESCE(mcp_server, '') FROM tools WHERE source = ?`, int(source))
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
-	var staleIDs []string
+	var staleRows []prunedRow
 	for rows.Next() {
 		var id, scope string
 		if err := rows.Scan(&id, &scope); err != nil {
 			continue
 		}
 		if stale(scope, id) {
-			staleIDs = append(staleIDs, id)
+			staleRows = append(staleRows, prunedRow{id: id, scope: scope})
 		}
 	}
 	if err := rows.Err(); err != nil {
 		_ = rows.Close()
-		return 0, err
+		return nil, err
 	}
 	_ = rows.Close()
 
-	deleted := 0
-	for _, id := range staleIDs {
-		if _, err := r.db.ExecContext(ctx, `DELETE FROM tools WHERE id = ?`, id); err != nil {
+	var deleted []prunedRow
+	for _, row := range staleRows {
+		if _, err := r.db.ExecContext(ctx, `DELETE FROM tools WHERE id = ?`, row.id); err != nil {
 			return deleted, err
 		}
-		deleted++
+		deleted = append(deleted, row)
 	}
 	return deleted, nil
 }
@@ -394,8 +447,14 @@ func (r *Registry) EvictTool(ctx context.Context, toolID string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	_, err := r.db.ExecContext(ctx, `DELETE FROM tools WHERE id = ?`, toolID)
-	return err
+	res, err := r.db.ExecContext(ctx, `DELETE FROM tools WHERE id = ?`, toolID)
+	if err != nil {
+		return err
+	}
+	if n, raErr := res.RowsAffected(); raErr == nil && n > 0 {
+		r.logger.Info("Evicted stale tool index entry", zap.String("tool_id", toolID))
+	}
+	return nil
 }
 
 // RegisterTool registers or updates a single tool in the database.
@@ -408,6 +467,14 @@ func (r *Registry) RegisterTool(ctx context.Context, tool *loomv1.IndexedTool) e
 }
 
 // upsertTool inserts or updates a tool in the database.
+//
+// The upsert MUST be INSERT ... ON CONFLICT DO UPDATE, never INSERT OR
+// REPLACE: OR REPLACE resolves the conflict by deleting the existing row and
+// inserting a new one with a fresh rowid, and that implicit DELETE does not
+// fire the tools_ad trigger (recursive_triggers is off by default), leaving
+// ghost postings in the external-content tools_fts index. ON CONFLICT DO
+// UPDATE keeps the rowid stable, so the tools_au UPDATE trigger keeps the FTS
+// index in sync. The conflict target is the table's primary key, tools(id).
 func (r *Registry) upsertTool(ctx context.Context, tool *loomv1.IndexedTool) error {
 	capabilities, _ := json.Marshal(tool.Capabilities)
 	keywords, _ := json.Marshal(tool.Keywords)
@@ -415,10 +482,24 @@ func (r *Registry) upsertTool(ctx context.Context, tool *loomv1.IndexedTool) err
 	rateLimit, _ := json.Marshal(tool.RateLimit)
 
 	_, err := r.db.ExecContext(ctx, `
-		INSERT OR REPLACE INTO tools (
+		INSERT INTO tools (
 			id, name, description, source, mcp_server, input_schema, output_schema,
 			capabilities, keywords, examples, indexed_at, version, requires_approval, rate_limit
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			name = excluded.name,
+			description = excluded.description,
+			source = excluded.source,
+			mcp_server = excluded.mcp_server,
+			input_schema = excluded.input_schema,
+			output_schema = excluded.output_schema,
+			capabilities = excluded.capabilities,
+			keywords = excluded.keywords,
+			examples = excluded.examples,
+			indexed_at = excluded.indexed_at,
+			version = excluded.version,
+			requires_approval = excluded.requires_approval,
+			rate_limit = excluded.rate_limit
 	`,
 		tool.Id, tool.Name, tool.Description, tool.Source, tool.McpServer,
 		tool.InputSchema, tool.OutputSchema, string(capabilities), string(keywords),

--- a/pkg/tools/registry/registry.go
+++ b/pkg/tools/registry/registry.go
@@ -589,7 +589,7 @@ func (r *Registry) ftsSearch(ctx context.Context, query string, expandedTerms []
 	// Restrict MCP tools to live servers so stale index rows are never
 	// surfaced to agents (issue #334).
 	livenessSQL, livenessArgs := r.mcpLivenessClause("t")
-	sql += livenessSQL
+	sql += livenessSQL // #nosec G202 -- clause contains only literal "?" placeholders, values are parameterized
 	args = append(args, livenessArgs...)
 
 	sql += " ORDER BY score LIMIT ?"
@@ -889,7 +889,7 @@ func (r *Registry) GetToolsByCapability(ctx context.Context, capability string, 
 
 	// Restrict MCP tools to live servers (issue #334).
 	livenessSQL, livenessArgs := r.mcpLivenessClause("")
-	sql += livenessSQL
+	sql += livenessSQL // #nosec G202 -- clause contains only literal "?" placeholders, values are parameterized
 	args = append(args, livenessArgs...)
 
 	sql += " LIMIT ?"

--- a/proto/loom/v1/tools.proto
+++ b/proto/loom/v1/tools.proto
@@ -232,6 +232,11 @@ message IndexToolsResponse {
 
   // Time taken (milliseconds).
   int64 duration_ms = 6;
+
+  // Number of stale rows removed during reconciliation: tools whose source
+  // no longer reports them (removed from a server) or whose MCP server is
+  // no longer configured.
+  int32 pruned_count = 7;
 }
 
 // IndexError describes a failure during indexing.


### PR DESCRIPTION
Fixes #334.

The persistent tool index (`$LOOM_DATA_DIR/loom.db.tools`) kept MCP tool rows forever after their servers were removed from configuration. `tool_search` served them to agents with no liveness check, dynamic registration failed every call with `server not found`, and an agent could burn its entire client timeout cycling through dead tools. Observed live: 81 stale rows across 3 servers removed months earlier, while `tool_sources` correctly recorded 0 live MCP tools.

## The three seams, each closed

**1. Reconcile at index time** (`pkg/tools/registry`)
`IndexAll` was upsert-only. Indexers can now implement the optional `ReconcilingIndexer` interface, reporting per run:
- `KnownScopes` — every scope (MCP server) that still exists; rows outside these are orphans of removed servers and are deleted.
- `CompleteScopes` — scopes this run enumerated fully; rows in them not re-reported are removed tools and are deleted. A configured-but-unreachable server is *known* but not *complete*, so a transient failure never wipes its rows.

`BuiltinIndexer` and `MCPIndexer` implement it; plain `Indexer`s keep upsert-only behavior, so custom tools registered out-of-band via `RegisterTool` survive (covered by a test). The existing re-index calls after `AddMCPServer`/`DeleteMCPServer` in `pkg/server/mcp_management.go` now actually do what their comments always claimed. `IndexToolsResponse` gains `pruned_count` (field 7, additive), and `looms serve` logs `pruned_stale_tools` at startup.

**2. Filter at search time** (`Config.LiveMCPServers`)
An optional callback restricts MCP-sourced results in `Search` and `GetToolsByCapability` to servers that currently exist, covering the window between reconciliation runs. `cmd_serve` wires it to `manager.ListServers()`; with no MCP manager at all, every MCP row is hidden (nothing could execute them). `nil` callback = no filtering (library back-compat).

**3. Evict on failed dynamic registration** (`pkg/shuttle`)
`manager.GetClient` now wraps a `manager.ErrServerNotFound` sentinel (message text unchanged). The `mcpManagerAdapter`s translate it to `shuttle.ErrMCPServerNotFound` **only when the server is also absent from configuration** — a configured-but-disconnected server stays transient. On that sentinel, the executor evicts the index row via the new `ToolEvictor` optional interface, so a dead entry fails at most once instead of once per agent turn.

## Verification

- `just check` fully green (`✅ All checks passed! (matches GitHub CI)`), gosec 0 issues.
- New table-driven tests (all `-race`): reconciliation matrix (removed server / removed tool / unreachable-server-keeps-rows / zero-servers-prunes-all), source-scoped pruning, plain-indexer no-prune, search liveness filter incl. nil-callback back-compat, `EvictTool`, executor evict-on-sentinel vs keep-on-transient, `errors.Is` on the manager sentinel.
- **Live validation** against the real index that motivated the issue: startup with this build logged `pruned_stale_tools: 81` and left 0 stale MCP rows; builtin tools untouched; 170 agents load normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
