### PR TITLE
fix(mcp): restore server's original parameter names instead of blind camelCasing (#339)

### DIFF
--- a/pkg/mcp/adapter/shuttle.go
+++ b/pkg/mcp/adapter/shuttle.go
@@ -128,10 +128,25 @@ func buildParamNameMap(inputSchema map[string]interface{}) map[string]string {
 		return nil
 	}
 	m := make(map[string]string)
+	ambiguous := map[string]bool{}
 	for original := range props {
-		if visible := toSnakeCase(original); visible != original {
-			m[visible] = original
+		visible := toSnakeCase(original)
+		if visible == original {
+			// An identity property claims its own name: a differently-cased
+			// sibling that collapses to it must not shadow it.
+			ambiguous[visible] = true
+			delete(m, visible)
+			continue
 		}
+		if _, taken := m[visible]; taken || ambiguous[visible] {
+			// Two original properties collapse to one visible name
+			// (e.g. tableName + table_name). Renaming would be a
+			// nondeterministic guess; ambiguous names pass through as-is.
+			ambiguous[visible] = true
+			delete(m, visible)
+			continue
+		}
+		m[visible] = original
 	}
 	if len(m) == 0 {
 		return nil

--- a/pkg/mcp/adapter/shuttle.go
+++ b/pkg/mcp/adapter/shuttle.go
@@ -91,15 +91,23 @@ type MCPToolAdapter struct {
 	serverName    string      // Used as backend identifier
 	uiResourceURI string      // From tool._meta.ui.resourceUri (MCP Apps)
 	logger        *zap.Logger // Structured logger (defaults to no-op)
+
+	// paramNameMap maps the LLM-visible property name (snake_case, as
+	// presented by InputSchema) back to the server's ORIGINAL property name
+	// from the tool's own schema. Execute renames via this map only — a key
+	// with no entry passes through unchanged, so the adapter never invents a
+	// casing the server's schema doesn't contain (issue #339).
+	paramNameMap map[string]string
 }
 
 // NewMCPToolAdapter creates a new adapter that wraps an MCP tool
 func NewMCPToolAdapter(client *client.Client, tool protocol.Tool, serverName string) *MCPToolAdapter {
 	adapter := &MCPToolAdapter{
-		client:     client,
-		tool:       tool,
-		serverName: serverName,
-		logger:     zap.NewNop(), // No-op by default; use SetLogger to enable
+		client:       client,
+		tool:         tool,
+		serverName:   serverName,
+		logger:       zap.NewNop(), // No-op by default; use SetLogger to enable
+		paramNameMap: buildParamNameMap(tool.InputSchema),
 	}
 
 	// Extract UI metadata from tool._meta.ui if present (MCP Apps)
@@ -108,6 +116,45 @@ func NewMCPToolAdapter(client *client.Client, tool protocol.Tool, serverName str
 	}
 
 	return adapter
+}
+
+// buildParamNameMap derives the snake_case → original-name mapping from the
+// tool's input schema, recording only entries where the LLM-visible name
+// differs from the server's. For a snake_case schema the map is empty
+// (identity); for a camelCase schema it restores the original names exactly.
+func buildParamNameMap(inputSchema map[string]interface{}) map[string]string {
+	props, ok := inputSchema["properties"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	m := make(map[string]string)
+	for original := range props {
+		if visible := toSnakeCase(original); visible != original {
+			m[visible] = original
+		}
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return m
+}
+
+// restoreParameterNames renames each parameter from its LLM-visible name back
+// to the server's original schema property name via paramNameMap. Keys without
+// a mapping pass through unchanged.
+func (a *MCPToolAdapter) restoreParameterNames(params map[string]interface{}) map[string]interface{} {
+	if params == nil || len(a.paramNameMap) == 0 {
+		return params
+	}
+	restored := make(map[string]interface{}, len(params))
+	for key, value := range params {
+		if original, ok := a.paramNameMap[key]; ok {
+			restored[original] = value
+		} else {
+			restored[key] = value
+		}
+	}
+	return restored
 }
 
 // SetLogger configures the structured logger for this adapter.
@@ -194,13 +241,17 @@ func (a *MCPToolAdapter) InputSchema() *shuttle.JSONSchema {
 func (a *MCPToolAdapter) Execute(ctx context.Context, params map[string]interface{}) (*shuttle.Result, error) {
 	startTime := time.Now()
 
-	// Convert parameter names from snake_case back to camelCase for MCP tools
-	// LLMs naturally use snake_case but MCP tools expect camelCase
-	camelCaseParams := normalizeParametersToCamelCase(params)
+	// Restore the server's original parameter names. InputSchema presents
+	// properties to the LLM in snake_case; this maps each name back to the
+	// exact property name in the tool's schema. A blind snake→camel
+	// conversion here corrupted calls to snake_case servers (issue #339):
+	// "table_name" became "tableName", which strict servers reject and
+	// lenient servers silently drop.
+	restoredParams := a.restoreParameterNames(params)
 
 	// Check schema cache for schema-related tools (#4: Schema Caching)
 	if a.isSchemaLookupTool() {
-		cacheKey := a.buildSchemaCacheKey(camelCaseParams)
+		cacheKey := a.buildSchemaCacheKey(restoredParams)
 		if cached, ok := globalSchemaCache.get(cacheKey); ok {
 			return &shuttle.Result{
 				Success:         true,
@@ -217,7 +268,7 @@ func (a *MCPToolAdapter) Execute(ctx context.Context, params map[string]interfac
 	}
 
 	// Call MCP tool with camelCase parameters
-	mcpResultInterface, err := a.client.CallTool(ctx, a.tool.Name, camelCaseParams)
+	mcpResultInterface, err := a.client.CallTool(ctx, a.tool.Name, restoredParams)
 	executionTime := time.Since(startTime).Milliseconds()
 
 	if err != nil {
@@ -255,7 +306,7 @@ func (a *MCPToolAdapter) Execute(ctx context.Context, params map[string]interfac
 
 	// Cache schema results (#4: Schema Caching)
 	if a.isSchemaLookupTool() {
-		cacheKey := a.buildSchemaCacheKey(camelCaseParams)
+		cacheKey := a.buildSchemaCacheKey(restoredParams)
 		if str, ok := data.(string); ok {
 			globalSchemaCache.set(cacheKey, str)
 		}
@@ -418,37 +469,4 @@ func toSnakeCase(s string) string {
 		}
 	}
 	return result.String()
-}
-
-// toCamelCase converts a snake_case string to camelCase.
-// Example: "database_name" -> "databaseName"
-func toCamelCase(s string) string {
-	parts := strings.Split(s, "_")
-	if len(parts) == 1 {
-		return s // Already camelCase or single word
-	}
-
-	var result strings.Builder
-	result.WriteString(parts[0]) // First part stays lowercase
-	for i := 1; i < len(parts); i++ {
-		if len(parts[i]) > 0 {
-			result.WriteRune(unicode.ToUpper(rune(parts[i][0])))
-			result.WriteString(parts[i][1:])
-		}
-	}
-	return result.String()
-}
-
-// normalizeParametersToCamelCase converts all parameter keys in a map from snake_case to camelCase.
-// This restores the original parameter names expected by MCP tools.
-func normalizeParametersToCamelCase(params map[string]interface{}) map[string]interface{} {
-	if params == nil {
-		return nil
-	}
-
-	normalized := make(map[string]interface{}, len(params))
-	for key, value := range params {
-		normalized[toCamelCase(key)] = value
-	}
-	return normalized
 }

--- a/pkg/mcp/adapter/shuttle_test.go
+++ b/pkg/mcp/adapter/shuttle_test.go
@@ -621,7 +621,7 @@ func TestAdaptMCPTools_PreservesUIMetadata(t *testing.T) {
 }
 
 // =============================================================================
-// Tests for toSnakeCase, toCamelCase, normalizeParametersToCamelCase,
+// Tests for toSnakeCase, buildParamNameMap, restoreParameterNames,
 // detectAndExtractSQLResult, and Execute integration scenarios
 // =============================================================================
 
@@ -654,109 +654,99 @@ func TestToSnakeCase(t *testing.T) {
 	}
 }
 
-func TestToCamelCase(t *testing.T) {
+func TestBuildParamNameMap(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    string
-		expected string
+		schema   map[string]interface{}
+		expected map[string]string
 	}{
-		{"snake_case basic", "database_name", "databaseName"},
-		{"single word", "single", "single"},
-		{"three parts", "a_b_c", "aBC"},
-		{"empty string", "", ""},
-		{"two word snake", "already_camel", "alreadyCamel"},
-		{"double underscore", "with__double", "withDouble"},
-		{"trailing underscore", "trailing_", "trailing"},
-		{"leading underscore", "_leading", "Leading"},
-		{"three word snake", "my_table_name", "myTableName"},
-		{"all single chars", "x_y_z", "xYZ"},
-		{"no underscore passthrough", "nounderscores", "nounderscores"},
+		{
+			name:     "nil schema",
+			schema:   nil,
+			expected: nil,
+		},
+		{
+			name:     "no properties key",
+			schema:   map[string]interface{}{"type": "object"},
+			expected: nil,
+		},
+		{
+			name: "snake_case schema is identity (nil map)",
+			schema: map[string]interface{}{
+				"properties": map[string]interface{}{
+					"table_name": map[string]interface{}{"type": "string"},
+					"database":   map[string]interface{}{"type": "string"},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "camelCase schema maps back to original names",
+			schema: map[string]interface{}{
+				"properties": map[string]interface{}{
+					"databaseName": map[string]interface{}{"type": "string"},
+					"maxRows":      map[string]interface{}{"type": "integer"},
+					"sql":          map[string]interface{}{"type": "string"},
+				},
+			},
+			expected: map[string]string{
+				"database_name": "databaseName",
+				"max_rows":      "maxRows",
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := toCamelCase(tt.input)
+			result := buildParamNameMap(tt.schema)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
 
-func TestNormalizeParametersToCamelCase(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    map[string]interface{}
-		expected map[string]interface{}
-	}{
-		{
-			name:     "nil input",
-			input:    nil,
-			expected: nil,
+func TestRestoreParameterNames(t *testing.T) {
+	camelTool := protocol.Tool{Name: "t", InputSchema: map[string]interface{}{
+		"properties": map[string]interface{}{
+			"databaseName": map[string]interface{}{"type": "string"},
+			"sql":          map[string]interface{}{"type": "string"},
 		},
-		{
-			name:     "empty map",
-			input:    map[string]interface{}{},
-			expected: map[string]interface{}{},
+	}}
+	snakeTool := protocol.Tool{Name: "t", InputSchema: map[string]interface{}{
+		"properties": map[string]interface{}{
+			"table_name":     map[string]interface{}{"type": "string"},
+			"session_handle": map[string]interface{}{"type": "string"},
 		},
-		{
-			name: "snake_case keys converted",
-			input: map[string]interface{}{
-				"database_name": "test_db",
-				"table_name":    "users",
-			},
-			expected: map[string]interface{}{
-				"databaseName": "test_db",
-				"tableName":    "users",
-			},
-		},
-		{
-			name: "already camelCase passes through",
-			input: map[string]interface{}{
-				"databaseName": "test_db",
-				"tableName":    "users",
-			},
-			expected: map[string]interface{}{
-				"databaseName": "test_db",
-				"tableName":    "users",
-			},
-		},
-		{
-			name: "mixed keys",
-			input: map[string]interface{}{
-				"database_name": "mydb",
-				"limit":         10,
-				"include_meta":  true,
-			},
-			expected: map[string]interface{}{
-				"databaseName": "mydb",
-				"limit":        10,
-				"includeMeta":  true,
-			},
-		},
-		{
-			name: "values preserved including nested structures",
-			input: map[string]interface{}{
-				"filter_config": map[string]interface{}{
-					"inner_key": "value",
-				},
-			},
-			expected: map[string]interface{}{
-				"filterConfig": map[string]interface{}{
-					"inner_key": "value", // only top-level keys are converted
-				},
-			},
-		},
-	}
+	}}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := normalizeParametersToCamelCase(tt.input)
-			if tt.expected == nil {
-				assert.Nil(t, result)
-			} else {
-				assert.Equal(t, tt.expected, result)
-			}
+	t.Run("camelCase server gets original names restored", func(t *testing.T) {
+		a := NewMCPToolAdapter(nil, camelTool, "s")
+		out := a.restoreParameterNames(map[string]interface{}{
+			"database_name": "demo",
+			"sql":           "SELECT 1",
 		})
-	}
+		assert.Equal(t, map[string]interface{}{"databaseName": "demo", "sql": "SELECT 1"}, out)
+	})
+
+	t.Run("snake_case server params pass through untouched (issue #339)", func(t *testing.T) {
+		a := NewMCPToolAdapter(nil, snakeTool, "s")
+		params := map[string]interface{}{
+			"table_name":     "titanic",
+			"session_handle": "tdsh_abc",
+		}
+		out := a.restoreParameterNames(params)
+		assert.Equal(t, params, out)
+	})
+
+	t.Run("unknown keys pass through unchanged", func(t *testing.T) {
+		a := NewMCPToolAdapter(nil, camelTool, "s")
+		out := a.restoreParameterNames(map[string]interface{}{"not_in_schema": 1})
+		assert.Equal(t, map[string]interface{}{"not_in_schema": 1}, out)
+	})
+
+	t.Run("nil params stay nil", func(t *testing.T) {
+		a := NewMCPToolAdapter(nil, camelTool, "s")
+		assert.Nil(t, a.restoreParameterNames(nil))
+	})
 }
 
 // =============================================================================
@@ -912,31 +902,29 @@ func TestInputSchema_CamelCaseToSnakeCase_Conversion(t *testing.T) {
 	assert.Contains(t, schema.Required, "table_name")
 }
 
-func TestNormalizeParametersToCamelCase_RoundTrip(t *testing.T) {
-	// Test the round-trip: camelCase -> snake_case (InputSchema) -> camelCase (normalizeParametersToCamelCase)
-	// This validates that the LLM sees snake_case but the MCP server receives camelCase
-	originalKeys := []string{"databaseName", "tableName", "maxRows"}
+func TestParamNameRoundTrip(t *testing.T) {
+	// Round-trip for a camelCase server: schema names -> snake_case
+	// (InputSchema) -> LLM params -> original names (restoreParameterNames).
+	tool := protocol.Tool{Name: "t", InputSchema: map[string]interface{}{
+		"properties": map[string]interface{}{
+			"databaseName": map[string]interface{}{"type": "string"},
+			"tableName":    map[string]interface{}{"type": "string"},
+			"maxRows":      map[string]interface{}{"type": "integer"},
+		},
+	}}
+	a := NewMCPToolAdapter(nil, tool, "s")
 
-	// Step 1: Convert to snake_case (what InputSchema does)
-	snakeKeys := make([]string, len(originalKeys))
-	for i, k := range originalKeys {
-		snakeKeys[i] = toSnakeCase(k)
-	}
-	assert.Equal(t, []string{"database_name", "table_name", "max_rows"}, snakeKeys)
-
-	// Step 2: Build params map as the LLM would (snake_case)
+	// The LLM sees snake_case and sends snake_case.
 	params := map[string]interface{}{
 		"database_name": "mydb",
 		"table_name":    "users",
 		"max_rows":      100,
 	}
 
-	// Step 3: Normalize back to camelCase (what Execute does)
-	normalized := normalizeParametersToCamelCase(params)
-
-	assert.Equal(t, "mydb", normalized["databaseName"])
-	assert.Equal(t, "users", normalized["tableName"])
-	assert.Equal(t, 100, normalized["maxRows"])
+	restored := a.restoreParameterNames(params)
+	assert.Equal(t, "mydb", restored["databaseName"])
+	assert.Equal(t, "users", restored["tableName"])
+	assert.Equal(t, 100, restored["maxRows"])
 }
 
 // =============================================================================
@@ -967,10 +955,9 @@ func TestExecute_SchemaToolCacheHit_ReturnsEarly(t *testing.T) {
 		"table_name":    "users",
 	}
 
-	// Pre-populate the cache with what Execute would store
-	// normalizeParametersToCamelCase converts the keys
-	camelParams := normalizeParametersToCamelCase(params)
-	cacheKey := adapter.buildSchemaCacheKey(camelParams)
+	// Pre-populate the cache with what Execute would store: the key is
+	// built from the restored (server-name) parameters.
+	cacheKey := adapter.buildSchemaCacheKey(adapter.restoreParameterNames(params))
 	globalSchemaCache.set(cacheKey, "CREATE TABLE users (id INT)")
 
 	// Execute should return cached result without calling the client
@@ -1021,9 +1008,9 @@ func TestExecute_ParameterNormalization(t *testing.T) {
 		"table_name":    "users",
 	}
 
-	// Build the cache key using camelCase (what Execute internally does)
-	camelParams := normalizeParametersToCamelCase(snakeParams)
-	cacheKey := adapter.buildSchemaCacheKey(camelParams)
+	// Build the cache key from the restored parameter names (what Execute
+	// internally does; identity here — the tool declares no schema)
+	cacheKey := adapter.buildSchemaCacheKey(adapter.restoreParameterNames(snakeParams))
 
 	// Pre-populate cache
 	globalSchemaCache.set(cacheKey, "schema result")

--- a/pkg/mcp/adapter/shuttle_test.go
+++ b/pkg/mcp/adapter/shuttle_test.go
@@ -727,6 +727,28 @@ func TestRestoreParameterNames(t *testing.T) {
 		assert.Equal(t, map[string]interface{}{"databaseName": "demo", "sql": "SELECT 1"}, out)
 	})
 
+	t.Run("colliding property names are never guessed", func(t *testing.T) {
+		// tableName and table_name both present as table_name; renaming would
+		// be a nondeterministic guess between two real schema properties, so
+		// the ambiguous name must pass through unchanged — deterministically.
+		collidingTool := protocol.Tool{Name: "t", InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"tableName":  map[string]interface{}{"type": "string"},
+				"table_name": map[string]interface{}{"type": "string"},
+				"rowCount":   map[string]interface{}{"type": "integer"},
+			},
+		}}
+		a := NewMCPToolAdapter(nil, collidingTool, "s")
+		out := a.restoreParameterNames(map[string]interface{}{
+			"table_name": "t1",
+			"row_count":  3,
+		})
+		assert.Equal(t, "t1", out["table_name"], "ambiguous name must not be renamed")
+		assert.NotContains(t, out, "tableName")
+		assert.Equal(t, 3, out["rowCount"], "unambiguous sibling still restores")
+	})
+
 	t.Run("snake_case server params pass through untouched (issue #339)", func(t *testing.T) {
 		a := NewMCPToolAdapter(nil, snakeTool, "s")
 		params := map[string]interface{}{


### PR DESCRIPTION
Fixes #339.

`MCPToolAdapter` presented schema properties to the LLM in snake_case, then **unconditionally camelCased every argument** before calling the server — corrupting calls to any MCP server whose input schemas are already snake_case (most Go/Python servers). `table_name` became `tableName`: strict servers (`additionalProperties: false`) reject the call outright; lenient servers silently drop the unknown key and behavior changes with no error. Only multi-word parameter names break, which hid the bug behind single-word tools (`sql`, `database`, `topic`).

Live trigger: a four-agent run against teradata-mcp-v2 where **29/29 `describe_table` calls failed** with `Additional property tableName is not allowed` while every single-word-param tool worked.

## Change

Replace the blind conversion with an exact reverse map derived from the tool's own schema:

- `buildParamNameMap` (at adapter construction): maps each LLM-visible snake_case name → the server's **original** property name, recording only names that actually differ. camelCase schema → exact restore map; snake_case schema → nil map (identity).
- `Execute` renames incoming keys via the map only; unmapped keys pass through unchanged. The adapter can no longer invent a casing the server's schema doesn't contain.
- The LLM-facing snake_case presentation in `InputSchema()` is unchanged — it just stops being lossy.
- Dead helpers `toCamelCase` / `normalizeParametersToCamelCase` removed; schema-cache keys now derive from the restored params.

camelCase servers keep today's behavior exactly; snake_case servers stop being corrupted.

## Verification

- New table-driven tests (all `-race`): `buildParamNameMap` matrix (nil schema, no properties, snake identity, camel mapping), `restoreParameterNames` (camel restore, snake pass-through, unknown-key pass-through, nil), and a camelCase round-trip test replacing the old one that asserted the buggy behavior.
- Existing schema-cache tests updated to the restored-params key derivation.
- **Live validation**: with this fix in the running server, `describe_table` against teradata-mcp-v2 returns clean column metadata through an agent — the exact call shape that failed 29/29 before.
- `just check` green (`✅ All checks passed! (matches GitHub CI)`).

Third in the series from wiring teradata-mcp-v2 into loom agents end-to-end: #334 (stale tool index → #335), #336 (dropped server instructions → #337), and this — the first bug on the argument path itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
