### PR TITLE
fix(server): wire registry subsystems on single-provider servers

### DIFF
--- a/cmd/looms/cmd_serve.go
+++ b/cmd/looms/cmd_serve.go
@@ -373,6 +373,53 @@ type judgeServerSetter interface {
 	SetJudgeServer(js *server.JudgeServer)
 }
 
+// registrySubsystemSink is the subset of *agent.Registry that receives the
+// server-level subsystems. Extracted so wireRegistrySubsystems is unit-testable
+// with a spy.
+type registrySubsystemSink interface {
+	SetTaskManager(manager *task.Manager, decomposer *task.Decomposer)
+	SetGraphMemoryStore(store memory.GraphMemoryStore, embedder memory.Embedder)
+	SetSuppressedBuiltinTools(names []string)
+}
+
+// wireRegistrySubsystems injects the server-level subsystems (task manager,
+// graph-memory store, tool-surface policy) into the agent registry so that
+// registry-built agents — gRPC-created, config-hot-reloaded, or benchmark
+// --isolate temp agents — receive them.
+//
+// This MUST run independently of whether a provider pool is configured. These
+// injections previously lived inside the `providerPool != nil` branch of the
+// serve wiring, so a single-provider server silently gave every registry-built
+// agent a nil graph-memory store (no extraction, no cross-session recall), a
+// nil task manager, and no tool-surface policy. The per-agent YAML flags
+// (memory.graph_memory.enabled, memory.task_board.enabled) still gate behavior;
+// these calls only make the subsystems reachable.
+func wireRegistrySubsystems(
+	reg registrySubsystemSink,
+	taskManager *task.Manager,
+	taskDecomposer *task.Decomposer,
+	graphMemoryStore memory.GraphMemoryStore,
+	memoryEmbedder memory.Embedder,
+	suppressed []string,
+	logger *zap.Logger,
+) {
+	if taskManager != nil {
+		reg.SetTaskManager(taskManager, taskDecomposer)
+		logger.Info("Task manager injected into agent registry",
+			zap.Bool("decomposer_present", taskDecomposer != nil))
+	}
+	if graphMemoryStore != nil {
+		reg.SetGraphMemoryStore(graphMemoryStore, memoryEmbedder)
+		logger.Info("Graph memory store injected into agent registry",
+			zap.Bool("embedder_present", memoryEmbedder != nil))
+	}
+	if len(suppressed) > 0 {
+		reg.SetSuppressedBuiltinTools(suppressed)
+		logger.Info("Suppressed builtin tools propagated to agent registry",
+			zap.Strings("tools", suppressed))
+	}
+}
+
 // buildProviderPool constructs a named provider pool from the server configuration.
 // Each entry in cfg.Providers is created by instantiating a per-entry ProviderFactory
 // buildRateLimiterConfig converts the YAML-sourced LLMRateLimitConfig into the
@@ -2373,36 +2420,10 @@ func runServe(cmd *cobra.Command, args []string) {
 			logger.Info("Provider pool injected into agent registry",
 				zap.Int("providers", len(providerPool)))
 		}
-		// Inject the task subsystem so registry-built agents reach Phase D
-		// (skills-overhaul task emission) and the sticky-while-open-tasks
-		// eviction checker. The per-agent memory.task_board.enabled flag
-		// still controls task_board tool surfacing; emission is always-on.
-		if registry != nil && taskManager != nil {
-			registry.SetTaskManager(taskManager, taskDecomposer)
-			logger.Info("Task manager injected into agent registry",
-				zap.Bool("decomposer_present", taskDecomposer != nil))
-		}
-		// Inject the graph memory subsystem so registry-built agents
-		// (gRPC-created or config-hot-reloaded) get the extractor. The
-		// per-agent memory.graph_memory.enabled flag in YAML can still
-		// opt out for a specific agent; the suppressed-tools list below
-		// controls tool surfacing independently.
-		if registry != nil && graphMemoryStore != nil {
-			registry.SetGraphMemoryStore(graphMemoryStore, memoryEmbedder)
-			logger.Info("Graph memory store injected into agent registry",
-				zap.Bool("embedder_present", memoryEmbedder != nil))
-		}
-		// Push the server-level tool-surface policy into the registry so
-		// gRPC-created agents see the same hidden-tools list as the
-		// statically-loaded ones. See builtinToolsToSuppress().
-		if registry != nil {
-			suppressed := builtinToolsToSuppress()
-			if len(suppressed) > 0 {
-				registry.SetSuppressedBuiltinTools(suppressed)
-				logger.Info("Suppressed builtin tools propagated to agent registry",
-					zap.Strings("tools", suppressed))
-			}
-		}
+		// NOTE: the task-manager, graph-memory, and tool-surface registry
+		// injections were moved OUT of this pool-gated branch to an
+		// unconditional block after the if/else — they must run whenever a
+		// registry exists, not only when a provider pool is configured.
 		// Wire the eval store for ABTest result persistence.
 		if ess, ok := interface{}(loomService).(evalStoreSetter); ok {
 			evalDBPath := config.Database.Path
@@ -2425,6 +2446,15 @@ func runServe(cmd *cobra.Command, args []string) {
 			jss.SetJudgeServer(judgeServer)
 			logger.Info("Judge server wired into loom service for ABTest judge_id resolution")
 		}
+	}
+
+	// Inject server subsystems into the agent registry UNCONDITIONALLY (not gated
+	// on a provider pool) so registry-built agents on a single-provider server
+	// still receive the graph-memory store, task manager, and tool-surface
+	// policy. See wireRegistrySubsystems for the regression this guards.
+	if registry != nil {
+		wireRegistrySubsystems(registry, taskManager, taskDecomposer,
+			graphMemoryStore, memoryEmbedder, builtinToolsToSuppress(), logger)
 	}
 
 	// Set agent registry for workflow execution

--- a/cmd/looms/registry_subsystems_test.go
+++ b/cmd/looms/registry_subsystems_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/teradata-labs/loom/pkg/memory"
+	"github.com/teradata-labs/loom/pkg/task"
+)
+
+// spyRegistrySink records which subsystem setters were invoked.
+type spyRegistrySink struct {
+	taskManagerSet bool
+	graphStoreSet  bool
+	suppressedSet  []string
+}
+
+func (s *spyRegistrySink) SetTaskManager(*task.Manager, *task.Decomposer) { s.taskManagerSet = true }
+func (s *spyRegistrySink) SetGraphMemoryStore(memory.GraphMemoryStore, memory.Embedder) {
+	s.graphStoreSet = true
+}
+func (s *spyRegistrySink) SetSuppressedBuiltinTools(names []string) { s.suppressedSet = names }
+
+// stubGraphStore is a non-nil memory.GraphMemoryStore whose methods are never
+// invoked here (the helper only checks for nil). Embedding the interface
+// satisfies all ~29 methods without hand-stubbing them.
+type stubGraphStore struct{ memory.GraphMemoryStore }
+
+// TestWireRegistrySubsystems is the regression guard for the single-provider
+// nil-graph-store bug: the registry subsystem injections must run whenever the
+// subsystems are present, with no dependence on a provider pool. This helper
+// has no pool parameter at all — that is the point. Previously these calls were
+// nested inside `providerPool != nil`, so a single-provider server left every
+// registry-built agent (including benchmark --isolate temp agents) with a nil
+// graph-memory store, disabling extraction and cross-session recall.
+func TestWireRegistrySubsystems(t *testing.T) {
+	t.Run("present subsystems are all wired (no pool involved)", func(t *testing.T) {
+		spy := &spyRegistrySink{}
+		// Non-nil task manager and graph store; a nil provider pool is not even
+		// expressible here because the helper takes none.
+		tm := &task.Manager{}
+		gm := memory.GraphMemoryStore(&stubGraphStore{})
+		wireRegistrySubsystems(spy, tm, nil, gm, nil, []string{"graph_memory", "task_board"}, zap.NewNop())
+
+		assert.True(t, spy.taskManagerSet, "task manager must be injected")
+		assert.True(t, spy.graphStoreSet, "graph memory store must be injected")
+		assert.Equal(t, []string{"graph_memory", "task_board"}, spy.suppressedSet,
+			"tool-surface policy must be propagated")
+	})
+
+	t.Run("nil subsystems are skipped, empty suppression is a no-op", func(t *testing.T) {
+		spy := &spyRegistrySink{}
+		wireRegistrySubsystems(spy, nil, nil, nil, nil, nil, zap.NewNop())
+
+		assert.False(t, spy.taskManagerSet, "nil task manager must not be injected")
+		assert.False(t, spy.graphStoreSet, "nil graph store must not be injected")
+		assert.Nil(t, spy.suppressedSet, "empty suppression list must not call the setter")
+	})
+}


### PR DESCRIPTION
## Problem

Graph-memory store, task manager, and tool-surface policy were injected into the agent registry **only inside the `providerPool != nil` branch** of the serve wiring (`cmd/looms/cmd_serve.go`). On a **single-provider server** (no provider pool configured), that branch never runs — so every registry-built agent got a **nil graph-memory store**:

- gRPC-created agents (`CreateAgentFromConfig`)
- config-hot-reloaded agents
- benchmark `--isolate` temp agents

With a nil store, graph-memory **extraction silently no-ops** and **cross-session recall returns nothing**. Statically-loaded agents were unaffected (they get `WithGraphMemoryStore` at load time), which is why this hid for so long.

## How it surfaced

In the LongMemEval **multi-session** benchmark, `--isolate` creates a fresh registry-built agent per question. Every one answered "I don't know" → **6.2%** (the no-memory blind floor). A clean two-session repro confirmed: extraction wrote nothing for isolate/registry agents, while a *statically-loaded* agent with the same config extracted and recalled correctly.

## Fix

Move the three registry-subsystem injections out of the pool-gated branch into `wireRegistrySubsystems`, called **unconditionally** whenever a registry exists. `SetProviderPool` and the ABTest judge/eval wiring stay pool-gated (they genuinely need the pool).

The helper takes an interface seam (`registrySubsystemSink`) so a spy test verifies all three setters fire with **no provider pool involved** — the regression guard. The helper signature has no pool parameter at all, which is the point.

## Verification

- **Unit:** `TestWireRegistrySubsystems` passes with `-tags fts5 -race`; full `cmd/looms` package green with `-race`.
- **Live, end-to-end:** on a single-provider (Azure gpt-4o) server, a hot-reloaded registry agent populated its graph (entities + memories persisted) and a **fresh session recalled the stored facts**. The LongMemEval gpt-4o multi-session subset went **6.2% → 66.7%** (back in the published full-history band) with only this change.

## Notes / follow-ups (not in this PR)

- `database.path` is silently ignored by the storage backend when `storage.sqlite.path` carries its default — data lands in `~/.loom/loom.db` regardless. Separate config bug, worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)