### PR TITLE
feat(mcp): park failed tool calls on a linked resource, wake on resources/updated (#343)

### DIFF
--- a/docs/guides/mcp-tool-call-lifecycle.md
+++ b/docs/guides/mcp-tool-call-lifecycle.md
@@ -1,0 +1,198 @@
+# MCP Tool-Call Lifecycle: Park-and-Wake and Session-Handle Auto-Release
+
+**Version**: v1.4.0
+**Status**: ✅ Implemented
+
+Two runtime behaviors of Loom's MCP tool adapter that manage the lifecycle of
+a tool call beyond the single request/response exchange:
+
+- **Park-and-wake** (issue #343): a failed tool call that links a resource
+  waits for that resource to update, then retries — one agent-visible call
+  instead of a retry loop.
+- **Session-handle auto-release** (issue #345): session handles minted by MCP
+  tools during a conversation are released by the runtime when the
+  conversation ends, instead of relying on the agent to clean up.
+
+Both behaviors are conventions the **server opts into**. A server that does
+not follow either convention sees exactly the pre-existing behavior.
+
+## Table of Contents
+
+- [Park-and-Wake](#park-and-wake)
+  - [The Convention](#the-convention)
+  - [Requirements and Budget](#requirements-and-budget)
+  - [How a Wait Ends](#how-a-wait-ends)
+  - [What Does NOT Trigger a Park](#what-does-not-trigger-a-park)
+- [Session-Handle Auto-Release](#session-handle-auto-release)
+  - [The Convention (Schema-Gated)](#the-convention-schema-gated)
+  - [Release Semantics](#release-semantics)
+  - [Scope: Per Chat, Not Per Session](#scope-per-chat-not-per-session)
+- [Observability](#observability)
+- [Limitations](#limitations)
+
+## Park-and-Wake
+
+A tool failure on a transient exhaustion condition (for example, a
+session-handle budget that is temporarily full) previously forced agents into
+client-side retry loops: one wasted round-trip and one wasted LLM turn per
+retry.
+
+### The Convention
+
+A server declares "this resource's next update may clear the failure" by
+including a **`resource_link`** content item in a failed `CallToolResult`
+(`isError: true`):
+
+```json
+{
+  "isError": true,
+  "content": [
+    { "type": "text", "text": "session-handle budget full" },
+    { "type": "resource_link", "uri": "example://session-handles", "name": "availability" }
+  ]
+}
+```
+
+When Loom's MCP tool adapter sees this, it parks the call: it opens a
+`subscriptions/listen` stream filtered to that URI and retries the original
+call when `notifications/resources/updated` arrives for it. The agent sees
+one tool call that succeeds late — no retry loop, no polling, no extra turns.
+
+The trigger is **`resource_link` content only**. An embedded plain `resource`
+content item in an error result is treated as payload (for example,
+diagnostic data), not as a retry condition, and never triggers a park.
+
+### Requirements and Budget
+
+- Requires a **2026-07-28 (stateless) connection** — the wait rides on
+  `subscriptions/listen`. Legacy connections surface the error unchanged.
+- The wait is bounded by a **60-second budget**, further capped by the
+  caller's context deadline (minus a 1-second margin). When the budget is
+  exhausted the original error surfaces.
+- Anything that prevents waiting — no linked resource, a legacy connection,
+  a failed subscription — degrades to the pre-existing error, unchanged.
+
+### How a Wait Ends
+
+1. **Subscription acknowledgment arrives.** The server's ack echoes the
+   subset of the requested filter it agreed to honor.
+   - If the resource subscription for the linked URI was **not honored**
+     (or the ack carries no parseable honored subset), no wake will ever
+     come: the adapter fails fast to the original error instead of stalling
+     out the budget.
+   - If it **was honored**, the adapter performs **one immediate optimistic
+     retry**. The ack proves the subscription is registered; a resource
+     update that raced the registration window would otherwise be lost, and
+     this retry covers it.
+2. **`notifications/resources/updated` arrives** for the URI: the adapter
+   retries the original call.
+3. A retry that fails with the **same** linked condition keeps the park
+   alive within the budget. A retry that fails **differently** surfaces that
+   new error immediately.
+4. **Budget exhausted / context cancelled / stream ended**: the most recent
+   error surfaces.
+
+### What Does NOT Trigger a Park
+
+- Successful results (regardless of content).
+- Error results without `resource_link` content.
+- Error results with an embedded plain `resource` content item only.
+- Any call on a legacy (pre-2026-07-28) connection.
+
+## Session-Handle Auto-Release
+
+A 3×64-agent live study showed that when releasing session-scoped resources
+is left to agent discretion, it does not happen: across 192 agent runs, zero
+agents released a handle, so server-side budget slots never churned until
+TTL expiry. The lifecycle therefore belongs to the runtime.
+
+### The Convention (Schema-Gated)
+
+Both ends of the convention are gated on the minting tool's **own
+`inputSchema`**:
+
+1. **Tracking**: when a successful tool result carries a top-level
+   `session_handle` string in its payload, the handle is tracked for
+   end-of-conversation release — but **only if** the tool's `inputSchema`
+   `properties` declare a release property, spelled either `releaseHandle`
+   or `release_handle`. A tool that never declared the property is never
+   tracked and never called back. This prevents auto-release calls against
+   permissive servers that would treat the unknown argument as a fresh mint
+   request.
+2. **Release**: at conversation end, each tracked handle is released by
+   calling the tool that minted it with a single argument — the release
+   property **as spelled in that tool's schema** (never a client-side case
+   convention):
+
+```json
+{ "releaseHandle": "tdsh_abc123" }
+```
+
+The release is only attempted when the schema's `required` fields are
+satisfiable by that single argument (`required ⊆ {release property}`).
+Otherwise the release is skipped with a warning and the handle is left to
+the server's TTL — the pre-existing behavior, which beats a call that
+client-side schema validation is guaranteed to reject.
+
+A handle the agent releases itself mid-conversation (a successful call
+carrying the release argument) is untracked and not double-released.
+
+Multi-item results are handled: the `session_handle` may appear in the
+payload of any `text` content item of a successful result.
+
+### Release Semantics
+
+- **Best-effort**: failures are logged and skipped; the conversation's
+  outcome is never affected.
+- **Bounded latency**: the whole release pass shares one **3-second total
+  budget** (not per handle) and runs releases concurrently (bounded to 4 in
+  flight). The pass is synchronous on the chat return path, so a hung server
+  adds at most ~3 seconds to the conversation's return — never 3 seconds per
+  handle.
+- Runs on a fresh background context, because the conversation's own context
+  is typically already cancelled at that point.
+
+### Scope: Per Chat, Not Per Session
+
+Handles are collected and released **per agent message exchange** (each
+`Chat`/`ChatWithProgress`/`ChatWithContentBlocks` call). A handle the agent
+reuses from conversation history in a **later** message will already have
+been released at the end of the message that minted it; the follow-up call
+fails and the agent must mint a fresh handle.
+
+This is deliberate: releasing per chat is the only boundary the runtime
+currently observes. Callers wanting session-long handle lifetimes need a
+session-end hook, which does not exist yet.
+
+Workflow paths and direct executor use do not plant a collector, so their
+behavior is unchanged: no tracking, no auto-release.
+
+## Observability
+
+The adapter logs every lifecycle event with `server`, `tool`, and (for
+releases) `handle` fields:
+
+- Park entry (`resource-wait: parked failed tool call on linked resource`,
+  with `uri` and `budget`), every retry outcome, and every park exit with
+  its reason (budget exhausted, subscription declined, stream ended,
+  context cancelled).
+- Every release attempt outcome: success (`session handle auto-released at
+  conversation end`), failure (best-effort warning), and every skip with
+  the reason (no release property; required fields beyond the release
+  property).
+
+Adapters created through the agent integration paths
+(`RegisterMCPTools`, `RegisterMCPServer`, `RegisterMCPTool`, dynamic tool
+discovery) have their loggers wired automatically.
+
+## Limitations
+
+- Park-and-wake requires a 2026-07-28 connection; there is no legacy
+  (`resources/subscribe`) fallback for parking.
+- Session handles are released per chat, not per session (see
+  [scope](#scope-per-chat-not-per-session)).
+- Handle detection is limited to a top-level `session_handle` string field
+  (max 256 characters) in the result payload; other field names are not
+  recognized.
+- The release pass is best-effort: if the server is unreachable within the
+  3-second budget, the handle leaks until server TTL.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -28,6 +28,7 @@ import (
 	"github.com/teradata-labs/loom/pkg/communication"
 	"github.com/teradata-labs/loom/pkg/fabric"
 	"github.com/teradata-labs/loom/pkg/llm"
+	mcpadapter "github.com/teradata-labs/loom/pkg/mcp/adapter"
 	"github.com/teradata-labs/loom/pkg/memory"
 	"github.com/teradata-labs/loom/pkg/metaagent/learning"
 	"github.com/teradata-labs/loom/pkg/observability"
@@ -1790,6 +1791,13 @@ func (a *Agent) chat(ctx context.Context, sessionID string, userMessage string, 
 
 	// Inject session ID into context for tool access
 	ctx = session.WithSessionID(ctx, sessionID)
+
+	// Session-handle lifecycle (issue #345): MCP tools that mint session
+	// handles get them auto-released when this conversation ends. Agent
+	// discretion doesn't work — in a 3×64-agent live study, zero agents
+	// released a handle — so the runtime owns the cleanup.
+	ctx, handleCollector := mcpadapter.WithHandleCollector(ctx)
+	defer handleCollector.ReleaseAll(nil)
 
 	// Start trace span — always created; NoOpTracer handles disabled case
 	startTime := time.Now()

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1797,7 +1797,7 @@ func (a *Agent) chat(ctx context.Context, sessionID string, userMessage string, 
 	// discretion doesn't work — in a 3×64-agent live study, zero agents
 	// released a handle — so the runtime owns the cleanup.
 	ctx, handleCollector := mcpadapter.WithHandleCollector(ctx)
-	defer handleCollector.ReleaseAll(nil)
+	defer handleCollector.ReleaseAll(zap.L())
 
 	// Start trace span — always created; NoOpTracer handles disabled case
 	startTime := time.Now()

--- a/pkg/agent/dynamic_tools.go
+++ b/pkg/agent/dynamic_tools.go
@@ -112,6 +112,7 @@ func (d *DynamicToolDiscovery) Search(ctx context.Context, intent string) (shutt
 			if d.matches(intent, tool) {
 				// Found a match! Convert to shuttle.Tool
 				mcpAdapter := adapter.NewMCPToolAdapter(client, tool, serverName)
+				mcpAdapter.SetLogger(d.logger)
 
 				// Cache for future use
 				d.mu.Lock()
@@ -157,6 +158,7 @@ func (d *DynamicToolDiscovery) SearchMultiple(ctx context.Context, intent string
 		for _, tool := range tools {
 			if d.matches(intent, tool) {
 				mcpAdapter := adapter.NewMCPToolAdapter(client, tool, serverName)
+				mcpAdapter.SetLogger(d.logger)
 
 				matchingTools = append(matchingTools, mcpAdapter)
 			}

--- a/pkg/agent/mcp_integration.go
+++ b/pkg/agent/mcp_integration.go
@@ -97,7 +97,11 @@ func (a *Agent) RegisterMCPTools(ctx context.Context, config MCPServerConfig) er
 	// threshold at compile/persist is the only size bound (HLD §4).
 	tools := make([]shuttle.Tool, len(mcpTools))
 	for i, mcpTool := range mcpTools {
-		tools[i] = adapter.NewMCPToolAdapter(config.Client, mcpTool, config.Name)
+		mcpAdapter := adapter.NewMCPToolAdapter(config.Client, mcpTool, config.Name)
+		// Adapter lifecycle events (park entry/exit, session-handle release
+		// attempts and skips) must be visible in production logs.
+		mcpAdapter.SetLogger(zap.L())
+		tools[i] = mcpAdapter
 	}
 
 	// Register each tool
@@ -198,6 +202,7 @@ func (a *Agent) RegisterMCPServer(ctx context.Context, mcpMgr *manager.Manager, 
 	// Register filtered tools. Results ride whole (HLD §4).
 	for _, tool := range toolsToRegister {
 		mcpAdapter := adapter.NewMCPToolAdapter(client, tool, serverName)
+		mcpAdapter.SetLogger(zap.L())
 		a.RegisterTool(mcpAdapter)
 		logger.Debug("registered MCP tool",
 			zap.String("server", serverName),
@@ -246,6 +251,7 @@ func (a *Agent) RegisterMCPTool(ctx context.Context, mcpMgr *manager.Manager, se
 	for _, tool := range tools {
 		if tool.Name == toolName {
 			mcpAdapter := adapter.NewMCPToolAdapter(client, tool, serverName)
+			mcpAdapter.SetLogger(zap.L())
 			shuttleTool := mcpAdapter
 			a.RegisterTool(shuttleTool)
 

--- a/pkg/agent/mcp_session_handles_e2e_test.go
+++ b/pkg/agent/mcp_session_handles_e2e_test.go
@@ -1,0 +1,178 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+	"github.com/teradata-labs/loom/pkg/mcp/client"
+	"github.com/teradata-labs/loom/pkg/mcp/protocol"
+)
+
+// sessionHandleE2ETransport is a scripted stateless (2026-07-28) MCP server
+// with one tool ("connect") that declares the session-handle release
+// convention and serves scripted tools/call results in order.
+type sessionHandleE2ETransport struct {
+	mu          sync.Mutex
+	callResults []json.RawMessage
+	callCount   int
+	callArgs    []map[string]interface{}
+	responses   chan []byte
+}
+
+func newSessionHandleE2ETransport(callResults ...json.RawMessage) *sessionHandleE2ETransport {
+	return &sessionHandleE2ETransport{callResults: callResults, responses: make(chan []byte, 16)}
+}
+
+func (f *sessionHandleE2ETransport) Send(_ context.Context, message []byte) error {
+	var req protocol.Request
+	if err := json.Unmarshal(message, &req); err != nil {
+		return err
+	}
+	if req.ID == nil || req.Method == "" {
+		return nil // notifications: unanswered
+	}
+
+	resp := protocol.Response{JSONRPC: protocol.JSONRPCVersion, ID: req.ID}
+	switch req.Method {
+	case "server/discover":
+		res := &protocol.DiscoverResult{
+			ResultType:        protocol.ResultTypeComplete,
+			SupportedVersions: []string{protocol.Version20260728},
+			CacheScope:        "public",
+		}
+		if err := res.SetServerInfo(protocol.Implementation{Name: "handlefake", Version: "1"}); err != nil {
+			return err
+		}
+		resp.Result, _ = json.Marshal(res)
+	case "tools/list":
+		resp.Result, _ = json.Marshal(protocol.ToolListResult{Tools: []protocol.Tool{{
+			Name:        "connect",
+			Description: "opens a session-scoped connection and mints a session handle",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"target":         map[string]interface{}{"type": "string"},
+					"release_handle": map[string]interface{}{"type": "string"},
+				},
+			},
+		}}})
+	case "tools/call":
+		var p struct {
+			Arguments map[string]interface{} `json:"arguments"`
+		}
+		_ = json.Unmarshal(req.Params, &p)
+		f.mu.Lock()
+		i := f.callCount
+		f.callCount++
+		f.callArgs = append(f.callArgs, p.Arguments)
+		f.mu.Unlock()
+		if i >= len(f.callResults) {
+			return fmt.Errorf("unscripted tools/call attempt %d", i)
+		}
+		resp.Result = f.callResults[i]
+	default:
+		resp.Error = protocol.NewError(protocol.MethodNotFound, "method not found", nil)
+	}
+	out, _ := json.Marshal(resp)
+	f.responses <- out
+	return nil
+}
+
+func (f *sessionHandleE2ETransport) Receive(ctx context.Context) ([]byte, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case data := <-f.responses:
+		return data, nil
+	}
+}
+
+func (f *sessionHandleE2ETransport) Close() error { return nil }
+
+func (f *sessionHandleE2ETransport) calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.callCount
+}
+
+func (f *sessionHandleE2ETransport) args(i int) map[string]interface{} {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if i < 0 || i >= len(f.callArgs) {
+		return nil
+	}
+	return f.callArgs[i]
+}
+
+// TestAgentChatAutoReleasesSessionHandle: end-to-end through the agent's own
+// wiring (issue #345) — Chat plants the handle collector, the registered MCP
+// tool mints a session handle mid-conversation, and by the time Chat returns
+// the runtime has released the handle through the minting tool with the
+// schema-declared release property. No adapter-level test plumbing: this is
+// the production path.
+func TestAgentChatAutoReleasesSessionHandle(t *testing.T) {
+	mint, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
+		{Type: "text", Text: `{"session_handle":"tdsh_e2e","target":"default"}`},
+	}})
+	released, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
+		{Type: "text", Text: `{"released":true}`},
+	}})
+	ft := newSessionHandleE2ETransport(mint, released)
+
+	mcpClient := client.NewClient(client.Config{Transport: ft})
+	t.Cleanup(func() { _ = mcpClient.Close() })
+	ctx := context.Background()
+	require.NoError(t, mcpClient.Connect(ctx, protocol.Implementation{Name: "loom-test", Version: "test"}))
+	require.True(t, mcpClient.IsStateless())
+
+	mockLLM := &mockToolCallingLLM{
+		responses: []mockLLMResponse{
+			{
+				content:   "",
+				toolCalls: []llmtypes.ToolCall{{ID: "call_1", Name: "handles:connect", Input: map[string]interface{}{"target": "default"}}},
+			},
+			{
+				content: "Connected.",
+			},
+		},
+	}
+
+	cfg := DefaultConfig()
+	cfg.PatternConfig = DefaultPatternConfig()
+	cfg.PatternConfig.UseLLMClassifier = false
+	ag := NewAgent(&mockBackend{}, mockLLM, WithConfig(cfg))
+
+	require.NoError(t, ag.RegisterMCPTools(ctx, MCPServerConfig{Name: "handles", Client: mcpClient}))
+
+	resp, err := ag.Chat(ctx, "session-handle-e2e", "Connect to the default target")
+	require.NoError(t, err)
+	require.Len(t, resp.ToolExecutions, 1)
+	require.True(t, resp.ToolExecutions[0].Result.Success)
+
+	// Chat's deferred ReleaseAll runs synchronously before Chat returns:
+	// the release must already be on the wire.
+	require.Equal(t, 2, ft.calls(), "mint + auto-release must have reached the server")
+	assert.Equal(t, "tdsh_e2e", ft.args(1)["release_handle"],
+		"the auto-release must carry the minted handle under the schema-declared property")
+}

--- a/pkg/mcp/adapter/resource_wait.go
+++ b/pkg/mcp/adapter/resource_wait.go
@@ -15,6 +15,7 @@ package adapter
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"time"
 
@@ -36,6 +37,19 @@ const defaultResourceWaitBudget = 60 * time.Second
 // subscriptions/listen stream for that URI and retries when
 // notifications/resources/updated arrives. The agent sees one tool call that
 // succeeds late instead of burning a turn per retry.
+//
+// Two acknowledgment-driven behaviors close the protocol's gaps:
+//
+//   - Missed-wake window: an update landing between the failed call and the
+//     subscription's registration is never delivered. The server's
+//     acknowledgment proves registration, so ONE optimistic retry fires as
+//     soon as the ack arrives — an update that raced the subscribe is covered
+//     by that attempt. Notification-driven retries continue afterwards.
+//
+//   - Honored subset: the acknowledgment echoes the filter subset the server
+//     agreed to honor. If our URI's resource subscription was not honored,
+//     no wake will ever come — fail fast to the original error instead of
+//     stalling out the full budget.
 //
 // Returns the retried call's outcome. Anything that prevents waiting — no
 // linked resource, a legacy (non-2026-07-28) connection, subscription
@@ -69,14 +83,46 @@ func (a *MCPToolAdapter) awaitLinkedResource(ctx context.Context, params map[str
 	})
 	if serr != nil {
 		a.logger.Debug("resource-wait: subscribe failed; surfacing original error",
+			zap.String("server", a.serverName),
+			zap.String("tool", a.tool.Name),
 			zap.String("uri", uri), zap.Error(serr))
 		return nil, callErr
 	}
 
 	a.logger.Info("resource-wait: parked failed tool call on linked resource",
+		zap.String("server", a.serverName),
 		zap.String("tool", a.tool.Name),
 		zap.String("uri", uri),
 		zap.Duration("budget", budget))
+
+	parkExit := func(reason string) {
+		a.logger.Info("resource-wait: park ended without success; surfacing error",
+			zap.String("server", a.serverName),
+			zap.String("tool", a.tool.Name),
+			zap.String("uri", uri),
+			zap.String("reason", reason))
+	}
+
+	// retryOnce re-issues the parked call. final=true means the outcome is
+	// terminal: success, or a failure that is not the same linked condition.
+	// A repeat of the same linked failure keeps the park alive within budget.
+	retryOnce := func(trigger string) (interface{}, error, bool) {
+		result, err := a.client.CallTool(ctx, a.tool.Name, params)
+		if err == nil {
+			a.logger.Info("resource-wait: retry succeeded",
+				zap.String("server", a.serverName),
+				zap.String("tool", a.tool.Name),
+				zap.String("uri", uri),
+				zap.String("trigger", trigger))
+			return result, nil, true
+		}
+		var again *client.ToolResultError
+		if !errors.As(err, &again) || again.RetryResourceURI() != uri {
+			parkExit("retry failed with a different error")
+			return nil, err, true
+		}
+		return nil, err, false
+	}
 
 	lastErr := callErr
 	timer := time.NewTimer(time.Until(waitDeadline))
@@ -84,33 +130,67 @@ func (a *MCPToolAdapter) awaitLinkedResource(ctx context.Context, params map[str
 	for {
 		select {
 		case <-ctx.Done():
+			parkExit("context cancelled")
 			return nil, lastErr
 		case <-timer.C:
+			parkExit("budget exhausted")
 			return nil, lastErr
 		case <-sub.Done():
 			// Stream ended (server closed it or no subscription support at
 			// runtime): nothing will wake us — surface the error.
+			parkExit("subscription stream ended")
 			return nil, lastErr
 		case notif, ok := <-sub.Notifications:
 			if !ok {
+				parkExit("subscription channel closed")
 				return nil, lastErr
 			}
-			if notif.Method != protocol.NotificationResourceUpdated {
-				continue // the acknowledgment, or an unrelated method
-			}
-			result, err := a.client.CallTool(ctx, a.tool.Name, params)
-			if err == nil {
-				a.logger.Info("resource-wait: retry succeeded after resource update",
-					zap.String("tool", a.tool.Name), zap.String("uri", uri))
-				return result, nil
-			}
-			lastErr = err
-			// Still failing with the same linked condition: keep waiting out
-			// the budget. A different failure surfaces immediately.
-			var again *client.ToolResultError
-			if !errors.As(err, &again) || again.RetryResourceURI() != uri {
-				return nil, err
+			switch notif.Method {
+			case protocol.NotificationSubscriptionAcknowledged:
+				if !ackHonorsResource(notif.Params, uri) {
+					// The server declined our resource subscription: no
+					// update will ever arrive, so waiting is a guaranteed
+					// full-budget stall. Fail fast to the original error.
+					parkExit("server declined the resource subscription")
+					return nil, lastErr
+				}
+				// The ack proves the subscription is registered; an update
+				// that landed before registration was lost. One optimistic
+				// retry covers that window.
+				result, err, final := retryOnce("post-ack")
+				if final {
+					return result, err
+				}
+				lastErr = err
+			case protocol.NotificationResourceUpdated:
+				result, err, final := retryOnce("resource-updated")
+				if final {
+					return result, err
+				}
+				lastErr = err
+			default:
+				continue // an unrelated method on this stream
 			}
 		}
 	}
+}
+
+// ackHonorsResource parses a subscriptions/listen acknowledgment's echoed
+// honored subset and reports whether the resource subscription for uri was
+// honored. A missing or unparseable subset counts as not honored: the
+// 2026-07-28 revision requires the acknowledgment to echo what the server
+// agreed to, so anything else gives no basis to expect a wake.
+func ackHonorsResource(params json.RawMessage, uri string) bool {
+	var ack struct {
+		Notifications protocol.NotificationFilter `json:"notifications"`
+	}
+	if err := json.Unmarshal(params, &ack); err != nil {
+		return false
+	}
+	for _, honored := range ack.Notifications.ResourceSubscriptions {
+		if honored == uri {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/mcp/adapter/resource_wait.go
+++ b/pkg/mcp/adapter/resource_wait.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package adapter
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/teradata-labs/loom/pkg/mcp/client"
+	"github.com/teradata-labs/loom/pkg/mcp/protocol"
+)
+
+// defaultResourceWaitBudget bounds how long a failed tool call may stay
+// parked waiting for its linked resource to update before the error is
+// surfaced. Also capped by the caller's context deadline.
+const defaultResourceWaitBudget = 60 * time.Second
+
+// awaitLinkedResource implements park-and-wake (issue #343): when a tool-level
+// failure links a resource in its error content — the spec-native way for a
+// server to say "this resource's next update may clear the failure" (e.g. a
+// session-handle budget that frees a slot) — the call parks on a
+// subscriptions/listen stream for that URI and retries when
+// notifications/resources/updated arrives. The agent sees one tool call that
+// succeeds late instead of burning a turn per retry.
+//
+// Returns the retried call's outcome. Anything that prevents waiting — no
+// linked resource, a legacy (non-2026-07-28) connection, subscription
+// failure — returns the original error unchanged, so behavior degrades to
+// exactly what it was before this mechanism existed.
+func (a *MCPToolAdapter) awaitLinkedResource(ctx context.Context, params map[string]interface{}, callErr error) (interface{}, error) {
+	var terr *client.ToolResultError
+	if !errors.As(callErr, &terr) {
+		return nil, callErr
+	}
+	uri := terr.RetryResourceURI()
+	if uri == "" || !a.client.IsStateless() {
+		return nil, callErr
+	}
+
+	budget := defaultResourceWaitBudget
+	if deadline, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(deadline) - time.Second; remaining < budget {
+			budget = remaining
+		}
+	}
+	if budget <= 0 {
+		return nil, callErr
+	}
+	waitDeadline := time.Now().Add(budget)
+
+	subCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	sub, serr := a.client.Subscribe(subCtx, protocol.NotificationFilter{
+		ResourceSubscriptions: []string{uri},
+	})
+	if serr != nil {
+		a.logger.Debug("resource-wait: subscribe failed; surfacing original error",
+			zap.String("uri", uri), zap.Error(serr))
+		return nil, callErr
+	}
+
+	a.logger.Info("resource-wait: parked failed tool call on linked resource",
+		zap.String("tool", a.tool.Name),
+		zap.String("uri", uri),
+		zap.Duration("budget", budget))
+
+	lastErr := callErr
+	timer := time.NewTimer(time.Until(waitDeadline))
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, lastErr
+		case <-timer.C:
+			return nil, lastErr
+		case <-sub.Done():
+			// Stream ended (server closed it or no subscription support at
+			// runtime): nothing will wake us — surface the error.
+			return nil, lastErr
+		case notif, ok := <-sub.Notifications:
+			if !ok {
+				return nil, lastErr
+			}
+			if notif.Method != protocol.NotificationResourceUpdated {
+				continue // the acknowledgment, or an unrelated method
+			}
+			result, err := a.client.CallTool(ctx, a.tool.Name, params)
+			if err == nil {
+				a.logger.Info("resource-wait: retry succeeded after resource update",
+					zap.String("tool", a.tool.Name), zap.String("uri", uri))
+				return result, nil
+			}
+			lastErr = err
+			// Still failing with the same linked condition: keep waiting out
+			// the budget. A different failure surfaces immediately.
+			var again *client.ToolResultError
+			if !errors.As(err, &again) || again.RetryResourceURI() != uri {
+				return nil, err
+			}
+		}
+	}
+}

--- a/pkg/mcp/adapter/resource_wait_test.go
+++ b/pkg/mcp/adapter/resource_wait_test.go
@@ -35,15 +35,33 @@ import (
 // inject the acknowledgment and resources/updated notifications.
 type waitTransport struct {
 	mu          sync.Mutex
-	callResults []json.RawMessage // per tools/call attempt, in order
+	toolSchema  map[string]interface{} // InputSchema served by tools/list
+	callResults []json.RawMessage      // per tools/call attempt, in order
 	callCount   int
 	callParams  []json.RawMessage
 	listenIDs   []json.RawMessage
 	responses   chan []byte
+	// callHook, when set, overrides the scripted results: it receives the
+	// call's arguments and returns the result plus whether to respond at
+	// all — false leaves the request hanging (a hung server).
+	callHook func(args map[string]interface{}) (json.RawMessage, bool)
 }
 
 func newWaitTransport(callResults ...json.RawMessage) *waitTransport {
-	return &waitTransport{callResults: callResults, responses: make(chan []byte, 16)}
+	return &waitTransport{
+		toolSchema:  map[string]interface{}{"type": "object"},
+		callResults: callResults,
+		responses:   make(chan []byte, 16),
+	}
+}
+
+// newWaitTransportWithSchema scripts a server whose single tool declares the
+// given InputSchema — the schema drives both client-side call validation and
+// the adapter's session-handle convention gating.
+func newWaitTransportWithSchema(schema map[string]interface{}, callResults ...json.RawMessage) *waitTransport {
+	ft := newWaitTransport(callResults...)
+	ft.toolSchema = schema
+	return ft
 }
 
 func (f *waitTransport) inject(data []byte) { f.responses <- data }
@@ -70,17 +88,33 @@ func (f *waitTransport) Send(_ context.Context, message []byte) error {
 		}
 		resp.Result, _ = json.Marshal(res)
 	case "tools/list":
+		f.mu.Lock()
+		schema := f.toolSchema
+		f.mu.Unlock()
 		resp.Result, _ = json.Marshal(protocol.ToolListResult{Tools: []protocol.Tool{{
 			Name:        "connect",
 			Description: "test tool",
-			InputSchema: map[string]interface{}{"type": "object"},
+			InputSchema: schema,
 		}}})
 	case "tools/call":
+		var p struct {
+			Arguments map[string]interface{} `json:"arguments"`
+		}
+		_ = json.Unmarshal(req.Params, &p)
 		f.mu.Lock()
 		i := f.callCount
 		f.callCount++
 		f.callParams = append(f.callParams, append(json.RawMessage(nil), req.Params...))
+		hook := f.callHook
 		f.mu.Unlock()
+		if hook != nil {
+			result, respond := hook(p.Arguments)
+			if !respond {
+				return nil // hung server: never answers this call
+			}
+			resp.Result = result
+			break
+		}
 		if i >= len(f.callResults) {
 			return fmt.Errorf("unscripted tools/call attempt %d", i)
 		}
@@ -131,17 +165,24 @@ func (f *waitTransport) listenID(t *testing.T) string {
 	return ""
 }
 
-func (f *waitTransport) lastCallParams() map[string]interface{} {
+func (f *waitTransport) argsOfCall(i int) map[string]interface{} {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if len(f.callParams) == 0 {
+	if i < 0 || i >= len(f.callParams) {
 		return nil
 	}
 	var p struct {
 		Arguments map[string]interface{} `json:"arguments"`
 	}
-	_ = json.Unmarshal(f.callParams[len(f.callParams)-1], &p)
+	_ = json.Unmarshal(f.callParams[i], &p)
 	return p.Arguments
+}
+
+func (f *waitTransport) lastCallParams() map[string]interface{} {
+	f.mu.Lock()
+	n := len(f.callParams)
+	f.mu.Unlock()
+	return f.argsOfCall(n - 1)
 }
 
 func (f *waitTransport) calls() int {
@@ -175,22 +216,37 @@ func notifJSON(method, subID string) []byte {
 		method, protocol.MetaSubscriptionID, subID))
 }
 
+// ackJSON builds a subscriptions/listen acknowledgment echoing the honored
+// subset, as the 2026-07-28 revision requires. No honored URIs means the
+// server declined every resource subscription.
+func ackJSON(subID string, honoredURIs ...string) []byte {
+	params := map[string]interface{}{
+		"_meta":         map[string]json.RawMessage{protocol.MetaSubscriptionID: json.RawMessage(subID)},
+		"notifications": protocol.NotificationFilter{ResourceSubscriptions: honoredURIs},
+	}
+	paramsJSON, _ := json.Marshal(params)
+	return []byte(fmt.Sprintf(`{"jsonrpc":"2.0","method":"%s","params":%s}`,
+		protocol.NotificationSubscriptionAcknowledged, paramsJSON))
+}
+
 func waitAdapter(t *testing.T, ft *waitTransport) *MCPToolAdapter {
 	t.Helper()
 	c := client.NewClient(client.Config{Transport: ft})
 	t.Cleanup(func() { _ = c.Close() })
 	require.NoError(t, c.Connect(context.Background(), protocol.Implementation{Name: "loom", Version: "test"}))
 	require.True(t, c.IsStateless())
-	return NewMCPToolAdapter(c, protocol.Tool{Name: "connect", InputSchema: map[string]interface{}{"type": "object"}}, "waitfake")
+	return NewMCPToolAdapter(c, protocol.Tool{Name: "connect", InputSchema: ft.toolSchema}, "waitfake")
 }
 
-// TestParkAndWake: a failed call that links a resource parks, is woken by
+// TestParkAndWake: a failed call that links a resource parks, probes once
+// when the acknowledgment lands (still failing), is woken by
 // notifications/resources/updated, retries, and succeeds — one Execute call,
-// two wire attempts, zero agent-visible retries (issue #343).
+// three wire attempts, zero agent-visible retries (issue #343).
 func TestParkAndWake(t *testing.T) {
 	uri := "test://slots"
 	ft := newWaitTransport(
 		errorResultWithLink("budget full", uri),
+		errorResultWithLink("budget full", uri), // post-ack probe: still failing
 		successResult("connected"),
 	)
 	adapter := waitAdapter(t, ft)
@@ -206,7 +262,7 @@ func TestParkAndWake(t *testing.T) {
 	}()
 
 	subID := ft.listenID(t)
-	ft.inject(notifJSON(protocol.NotificationSubscriptionAcknowledged, subID))
+	ft.inject(ackJSON(subID, uri))
 	ft.inject(notifJSON(protocol.NotificationResourceUpdated, subID))
 
 	select {
@@ -216,7 +272,81 @@ func TestParkAndWake(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("Execute did not return after resource update")
 	}
-	assert.Equal(t, 2, ft.calls(), "exactly one retry")
+	assert.Equal(t, 3, ft.calls(), "post-ack probe plus one notification-driven retry")
+}
+
+// TestPostAckRetryCoversMissedUpdate: the resource update fires server-side
+// BEFORE the subscription registers, so no resources/updated notification is
+// ever delivered. The acknowledgment proves registration, and the one
+// optimistic post-ack retry covers the raced update — the probe succeeds
+// without waiting out the budget.
+func TestPostAckRetryCoversMissedUpdate(t *testing.T) {
+	uri := "test://slots"
+	ft := newWaitTransport(
+		errorResultWithLink("budget full", uri),
+		successResult("connected"), // the update already happened: retry succeeds
+	)
+	adapter := waitAdapter(t, ft)
+
+	type outcome struct {
+		res *shuttle.Result
+		err error
+	}
+	done := make(chan outcome, 1)
+	start := time.Now()
+	go func() {
+		res, err := adapter.Execute(context.Background(), map[string]interface{}{})
+		done <- outcome{res, err}
+	}()
+
+	subID := ft.listenID(t)
+	ft.inject(ackJSON(subID, uri)) // ack only — no update notification, ever
+
+	select {
+	case o := <-done:
+		require.NoError(t, o.err)
+		require.True(t, o.res.Success, "post-ack retry must cover the missed update: %+v", o.res)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not return after the acknowledgment")
+	}
+	assert.Less(t, time.Since(start), 5*time.Second, "must not wait out the 60s budget")
+	assert.Equal(t, 2, ft.calls(), "exactly the post-ack retry")
+}
+
+// TestAckDeclineFailsFast: a spec-following server that declines the
+// resource subscription (acknowledgment echoes an honored subset without our
+// URI) guarantees no wake will come — the original error surfaces
+// immediately instead of stalling out the full budget.
+func TestAckDeclineFailsFast(t *testing.T) {
+	uri := "test://slots"
+	ft := newWaitTransport(errorResultWithLink("budget full", uri))
+	adapter := waitAdapter(t, ft)
+
+	type outcome struct {
+		res *shuttle.Result
+		err error
+	}
+	done := make(chan outcome, 1)
+	start := time.Now()
+	go func() {
+		res, err := adapter.Execute(context.Background(), map[string]interface{}{})
+		done <- outcome{res, err}
+	}()
+
+	subID := ft.listenID(t)
+	ft.inject(ackJSON(subID)) // honored subset is empty: subscription declined
+
+	select {
+	case o := <-done:
+		require.NoError(t, o.err)
+		assert.False(t, o.res.Success)
+		require.NotNil(t, o.res.Error)
+		assert.Contains(t, o.res.Error.Message, "budget full")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not fail fast on a declined subscription")
+	}
+	assert.Less(t, time.Since(start), 5*time.Second, "declined subscription must not stall the budget")
+	assert.Equal(t, 1, ft.calls(), "no retry without a honored subscription")
 }
 
 // TestNoLinkNoPark: a plain error (no linked resource) surfaces immediately
@@ -237,6 +367,31 @@ func TestNoLinkNoPark(t *testing.T) {
 	assert.Empty(t, ft.listenIDs, "no subscription for unlinked errors")
 }
 
+// TestEmbeddedResourceNoPark: an error whose content embeds a plain resource
+// (payload, e.g. diagnostic data) is NOT the park convention — only
+// resource_link declares a watchable retry condition. The error surfaces
+// immediately with no subscription.
+func TestEmbeddedResourceNoPark(t *testing.T) {
+	errWithEmbedded, _ := json.Marshal(protocol.CallToolResult{IsError: true, Content: []protocol.Content{
+		{Type: "text", Text: "hard failure with diagnostics"},
+		{Type: "resource", Resource: &protocol.ResourceRef{URI: "test://diagnostics", MimeType: "application/json"}},
+	}})
+	ft := newWaitTransport(errWithEmbedded)
+	adapter := waitAdapter(t, ft)
+
+	start := time.Now()
+	res, err := adapter.Execute(context.Background(), map[string]interface{}{})
+	require.NoError(t, err)
+	assert.False(t, res.Success)
+	require.NotNil(t, res.Error)
+	assert.Contains(t, res.Error.Message, "hard failure with diagnostics")
+	assert.Less(t, time.Since(start), 2*time.Second, "embedded plain resource must not trigger a park")
+	assert.Equal(t, 1, ft.calls())
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+	assert.Empty(t, ft.listenIDs, "no subscription for embedded plain resources")
+}
+
 // TestParkTimeoutSurfacesError: a linked failure with no update within the
 // context budget surfaces the original error.
 func TestParkTimeoutSurfacesError(t *testing.T) {
@@ -250,70 +405,5 @@ func TestParkTimeoutSurfacesError(t *testing.T) {
 	assert.False(t, res.Success)
 	require.NotNil(t, res.Error)
 	assert.Contains(t, res.Error.Message, "budget full")
-	assert.Equal(t, 1, ft.calls(), "no blind retries without an update")
-}
-
-// TestAutoReleaseOnConversationEnd: a successful call whose result carries a
-// session_handle is tracked by the ctx collector and released best-effort
-// when the conversation ends — the runtime-owned lifecycle of issue #345.
-func TestAutoReleaseOnConversationEnd(t *testing.T) {
-	mint, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
-		{Type: "text", Text: `{"session_handle":"tdsh_test123","target":"default"}`},
-	}})
-	released, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
-		{Type: "text", Text: `{"target":"released"}`},
-	}})
-	ft := newWaitTransport(mint, released)
-	adapter := waitAdapter(t, ft)
-
-	ctx, collector := WithHandleCollector(context.Background())
-	res, err := adapter.Execute(ctx, map[string]interface{}{})
-	require.NoError(t, err)
-	require.True(t, res.Success)
-	require.Equal(t, 1, collector.Count(), "minted handle must be tracked")
-
-	collector.ReleaseAll(nil)
-	assert.Equal(t, 0, collector.Count())
-	assert.Equal(t, 2, ft.calls(), "release call must reach the wire")
-	// The second call carried the tracked handle.
-	last := ft.lastCallParams()
-	assert.Equal(t, "tdsh_test123", last["release_handle"])
-}
-
-// TestAutoReleaseSkipsExplicitlyReleased: an agent that releases its own
-// handle is not double-released at conversation end.
-func TestAutoReleaseSkipsExplicitlyReleased(t *testing.T) {
-	mint, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
-		{Type: "text", Text: `{"session_handle":"tdsh_selfclean"}`},
-	}})
-	released, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
-		{Type: "text", Text: `{"target":"released"}`},
-	}})
-	ft := newWaitTransport(mint, released)
-	adapter := waitAdapter(t, ft)
-
-	ctx, collector := WithHandleCollector(context.Background())
-	_, err := adapter.Execute(ctx, map[string]interface{}{})
-	require.NoError(t, err)
-	_, err = adapter.Execute(ctx, map[string]interface{}{"release_handle": "tdsh_selfclean"})
-	require.NoError(t, err)
-
-	require.Equal(t, 0, collector.Count(), "explicit release must untrack the handle")
-	collector.ReleaseAll(nil)
-	assert.Equal(t, 2, ft.calls(), "no extra release call")
-}
-
-// TestNoCollectorNoTracking: without a collector in ctx (workflow paths),
-// behavior is unchanged.
-func TestNoCollectorNoTracking(t *testing.T) {
-	mint, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
-		{Type: "text", Text: `{"session_handle":"tdsh_untracked"}`},
-	}})
-	ft := newWaitTransport(mint)
-	adapter := waitAdapter(t, ft)
-
-	res, err := adapter.Execute(context.Background(), map[string]interface{}{})
-	require.NoError(t, err)
-	require.True(t, res.Success)
-	assert.Equal(t, 1, ft.calls())
+	assert.Equal(t, 1, ft.calls(), "no blind retries without an ack or update")
 }

--- a/pkg/mcp/adapter/resource_wait_test.go
+++ b/pkg/mcp/adapter/resource_wait_test.go
@@ -1,0 +1,239 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package adapter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/teradata-labs/loom/pkg/mcp/client"
+	"github.com/teradata-labs/loom/pkg/mcp/protocol"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+)
+
+// waitTransport is a minimal scripted stateless (2026-07-28) server: it
+// answers server/discover and tools/list, serves scripted per-attempt
+// tools/call results, and holds subscriptions/listen open so the test can
+// inject the acknowledgment and resources/updated notifications.
+type waitTransport struct {
+	mu          sync.Mutex
+	callResults []json.RawMessage // per tools/call attempt, in order
+	callCount   int
+	listenIDs   []json.RawMessage
+	responses   chan []byte
+}
+
+func newWaitTransport(callResults ...json.RawMessage) *waitTransport {
+	return &waitTransport{callResults: callResults, responses: make(chan []byte, 16)}
+}
+
+func (f *waitTransport) inject(data []byte) { f.responses <- data }
+
+func (f *waitTransport) Send(_ context.Context, message []byte) error {
+	var req protocol.Request
+	if err := json.Unmarshal(message, &req); err != nil {
+		return err
+	}
+	if req.ID == nil || req.Method == "" {
+		return nil // notifications / client responses: unanswered
+	}
+
+	resp := protocol.Response{JSONRPC: protocol.JSONRPCVersion, ID: req.ID}
+	switch req.Method {
+	case "server/discover":
+		res := &protocol.DiscoverResult{
+			ResultType:        protocol.ResultTypeComplete,
+			SupportedVersions: []string{protocol.Version20260728},
+			CacheScope:        "public",
+		}
+		if err := res.SetServerInfo(protocol.Implementation{Name: "waitfake", Version: "1"}); err != nil {
+			return err
+		}
+		resp.Result, _ = json.Marshal(res)
+	case "tools/list":
+		resp.Result, _ = json.Marshal(protocol.ToolListResult{Tools: []protocol.Tool{{
+			Name:        "connect",
+			Description: "test tool",
+			InputSchema: map[string]interface{}{"type": "object"},
+		}}})
+	case "tools/call":
+		f.mu.Lock()
+		i := f.callCount
+		f.callCount++
+		f.mu.Unlock()
+		if i >= len(f.callResults) {
+			return fmt.Errorf("unscripted tools/call attempt %d", i)
+		}
+		resp.Result = f.callResults[i]
+	case "subscriptions/listen":
+		// Record the listen id and hold the stream open (no response).
+		idRaw, _ := json.Marshal(req.ID)
+		f.mu.Lock()
+		f.listenIDs = append(f.listenIDs, idRaw)
+		f.mu.Unlock()
+		return nil
+	default:
+		resp.Error = protocol.NewError(protocol.MethodNotFound, "method not found", nil)
+	}
+	out, _ := json.Marshal(resp)
+	f.responses <- out
+	return nil
+}
+
+func (f *waitTransport) Receive(ctx context.Context) ([]byte, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case data := <-f.responses:
+		return data, nil
+	}
+}
+
+func (f *waitTransport) Close() error { return nil }
+
+func (f *waitTransport) listenID(t *testing.T) string {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		f.mu.Lock()
+		n := len(f.listenIDs)
+		var id string
+		if n > 0 {
+			id = string(f.listenIDs[0])
+		}
+		f.mu.Unlock()
+		if n > 0 {
+			return id
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("no subscriptions/listen arrived")
+	return ""
+}
+
+func (f *waitTransport) calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.callCount
+}
+
+func errorResultWithLink(msg, uri string) json.RawMessage {
+	r, _ := json.Marshal(protocol.CallToolResult{IsError: true, Content: []protocol.Content{
+		{Type: "text", Text: msg},
+		{Type: "resource_link", URI: uri, Name: "availability"},
+	}})
+	return r
+}
+
+func errorResultPlain(msg string) json.RawMessage {
+	r, _ := json.Marshal(protocol.CallToolResult{IsError: true, Content: []protocol.Content{
+		{Type: "text", Text: msg},
+	}})
+	return r
+}
+
+func successResult(text string) json.RawMessage {
+	r, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{{Type: "text", Text: text}}})
+	return r
+}
+
+func notifJSON(method, subID string) []byte {
+	return []byte(fmt.Sprintf(`{"jsonrpc":"2.0","method":"%s","params":{"_meta":{"%s":%s}}}`,
+		method, protocol.MetaSubscriptionID, subID))
+}
+
+func waitAdapter(t *testing.T, ft *waitTransport) *MCPToolAdapter {
+	t.Helper()
+	c := client.NewClient(client.Config{Transport: ft})
+	t.Cleanup(func() { _ = c.Close() })
+	require.NoError(t, c.Connect(context.Background(), protocol.Implementation{Name: "loom", Version: "test"}))
+	require.True(t, c.IsStateless())
+	return NewMCPToolAdapter(c, protocol.Tool{Name: "connect", InputSchema: map[string]interface{}{"type": "object"}}, "waitfake")
+}
+
+// TestParkAndWake: a failed call that links a resource parks, is woken by
+// notifications/resources/updated, retries, and succeeds — one Execute call,
+// two wire attempts, zero agent-visible retries (issue #343).
+func TestParkAndWake(t *testing.T) {
+	uri := "test://slots"
+	ft := newWaitTransport(
+		errorResultWithLink("budget full", uri),
+		successResult("connected"),
+	)
+	adapter := waitAdapter(t, ft)
+
+	type outcome struct {
+		res *shuttle.Result
+		err error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		res, err := adapter.Execute(context.Background(), map[string]interface{}{})
+		done <- outcome{res, err}
+	}()
+
+	subID := ft.listenID(t)
+	ft.inject(notifJSON(protocol.NotificationSubscriptionAcknowledged, subID))
+	ft.inject(notifJSON(protocol.NotificationResourceUpdated, subID))
+
+	select {
+	case o := <-done:
+		require.NoError(t, o.err)
+		require.True(t, o.res.Success, "parked call must succeed after wake: %+v", o.res)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not return after resource update")
+	}
+	assert.Equal(t, 2, ft.calls(), "exactly one retry")
+}
+
+// TestNoLinkNoPark: a plain error (no linked resource) surfaces immediately
+// with no subscription opened — pre-#343 behavior exactly.
+func TestNoLinkNoPark(t *testing.T) {
+	ft := newWaitTransport(errorResultPlain("hard failure"))
+	adapter := waitAdapter(t, ft)
+
+	start := time.Now()
+	res, err := adapter.Execute(context.Background(), map[string]interface{}{})
+	require.NoError(t, err)
+	assert.False(t, res.Success)
+	require.NotNil(t, res.Error)
+	assert.Contains(t, res.Error.Message, "hard failure")
+	assert.Less(t, time.Since(start), 2*time.Second, "must not park")
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+	assert.Empty(t, ft.listenIDs, "no subscription for unlinked errors")
+}
+
+// TestParkTimeoutSurfacesError: a linked failure with no update within the
+// context budget surfaces the original error.
+func TestParkTimeoutSurfacesError(t *testing.T) {
+	ft := newWaitTransport(errorResultWithLink("budget full", "test://slots"))
+	adapter := waitAdapter(t, ft)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+	res, err := adapter.Execute(ctx, map[string]interface{}{})
+	require.NoError(t, err)
+	assert.False(t, res.Success)
+	require.NotNil(t, res.Error)
+	assert.Contains(t, res.Error.Message, "budget full")
+	assert.Equal(t, 1, ft.calls(), "no blind retries without an update")
+}

--- a/pkg/mcp/adapter/resource_wait_test.go
+++ b/pkg/mcp/adapter/resource_wait_test.go
@@ -37,6 +37,7 @@ type waitTransport struct {
 	mu          sync.Mutex
 	callResults []json.RawMessage // per tools/call attempt, in order
 	callCount   int
+	callParams  []json.RawMessage
 	listenIDs   []json.RawMessage
 	responses   chan []byte
 }
@@ -78,6 +79,7 @@ func (f *waitTransport) Send(_ context.Context, message []byte) error {
 		f.mu.Lock()
 		i := f.callCount
 		f.callCount++
+		f.callParams = append(f.callParams, append(json.RawMessage(nil), req.Params...))
 		f.mu.Unlock()
 		if i >= len(f.callResults) {
 			return fmt.Errorf("unscripted tools/call attempt %d", i)
@@ -127,6 +129,19 @@ func (f *waitTransport) listenID(t *testing.T) string {
 	}
 	t.Fatal("no subscriptions/listen arrived")
 	return ""
+}
+
+func (f *waitTransport) lastCallParams() map[string]interface{} {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.callParams) == 0 {
+		return nil
+	}
+	var p struct {
+		Arguments map[string]interface{} `json:"arguments"`
+	}
+	_ = json.Unmarshal(f.callParams[len(f.callParams)-1], &p)
+	return p.Arguments
 }
 
 func (f *waitTransport) calls() int {
@@ -236,4 +251,69 @@ func TestParkTimeoutSurfacesError(t *testing.T) {
 	require.NotNil(t, res.Error)
 	assert.Contains(t, res.Error.Message, "budget full")
 	assert.Equal(t, 1, ft.calls(), "no blind retries without an update")
+}
+
+// TestAutoReleaseOnConversationEnd: a successful call whose result carries a
+// session_handle is tracked by the ctx collector and released best-effort
+// when the conversation ends — the runtime-owned lifecycle of issue #345.
+func TestAutoReleaseOnConversationEnd(t *testing.T) {
+	mint, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
+		{Type: "text", Text: `{"session_handle":"tdsh_test123","target":"default"}`},
+	}})
+	released, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
+		{Type: "text", Text: `{"target":"released"}`},
+	}})
+	ft := newWaitTransport(mint, released)
+	adapter := waitAdapter(t, ft)
+
+	ctx, collector := WithHandleCollector(context.Background())
+	res, err := adapter.Execute(ctx, map[string]interface{}{})
+	require.NoError(t, err)
+	require.True(t, res.Success)
+	require.Equal(t, 1, collector.Count(), "minted handle must be tracked")
+
+	collector.ReleaseAll(nil)
+	assert.Equal(t, 0, collector.Count())
+	assert.Equal(t, 2, ft.calls(), "release call must reach the wire")
+	// The second call carried the tracked handle.
+	last := ft.lastCallParams()
+	assert.Equal(t, "tdsh_test123", last["release_handle"])
+}
+
+// TestAutoReleaseSkipsExplicitlyReleased: an agent that releases its own
+// handle is not double-released at conversation end.
+func TestAutoReleaseSkipsExplicitlyReleased(t *testing.T) {
+	mint, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
+		{Type: "text", Text: `{"session_handle":"tdsh_selfclean"}`},
+	}})
+	released, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
+		{Type: "text", Text: `{"target":"released"}`},
+	}})
+	ft := newWaitTransport(mint, released)
+	adapter := waitAdapter(t, ft)
+
+	ctx, collector := WithHandleCollector(context.Background())
+	_, err := adapter.Execute(ctx, map[string]interface{}{})
+	require.NoError(t, err)
+	_, err = adapter.Execute(ctx, map[string]interface{}{"release_handle": "tdsh_selfclean"})
+	require.NoError(t, err)
+
+	require.Equal(t, 0, collector.Count(), "explicit release must untrack the handle")
+	collector.ReleaseAll(nil)
+	assert.Equal(t, 2, ft.calls(), "no extra release call")
+}
+
+// TestNoCollectorNoTracking: without a collector in ctx (workflow paths),
+// behavior is unchanged.
+func TestNoCollectorNoTracking(t *testing.T) {
+	mint, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
+		{Type: "text", Text: `{"session_handle":"tdsh_untracked"}`},
+	}})
+	ft := newWaitTransport(mint)
+	adapter := waitAdapter(t, ft)
+
+	res, err := adapter.Execute(context.Background(), map[string]interface{}{})
+	require.NoError(t, err)
+	require.True(t, res.Success)
+	assert.Equal(t, 1, ft.calls())
 }

--- a/pkg/mcp/adapter/session_handles.go
+++ b/pkg/mcp/adapter/session_handles.go
@@ -84,29 +84,40 @@ func collectorFrom(ctx context.Context) *HandleCollector {
 	return c
 }
 
-// add records a minted handle once. Duplicates (the same handle re-reported)
-// are ignored; releases are deduplicated at collection time.
+// collectorKey scopes dedup to the minting server: two servers can mint
+// identical handle strings, and a release on one must never forget the
+// other's handle.
+func collectorKey(a *MCPToolAdapter, handle string) string {
+	return a.serverName + "\x00" + handle
+}
+
+// add records a minted handle once per server. Duplicates (the same handle
+// re-reported by the same server) are ignored; releases are deduplicated at
+// collection time.
 func (c *HandleCollector) add(a *MCPToolAdapter, handle string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.present[handle] {
+	key := collectorKey(a, handle)
+	if c.present[key] {
 		return
 	}
-	c.present[handle] = true
+	c.present[key] = true
 	c.minted = append(c.minted, mintedHandle{adapter: a, handle: handle})
 }
 
-// forget drops a handle the agent released explicitly (seen as a release
-// argument on a successful call), so ReleaseAll doesn't double-release it.
-func (c *HandleCollector) forget(handle string) {
+// forget drops a handle the agent released explicitly through the same
+// server (seen as a release argument on a successful call), so ReleaseAll
+// doesn't double-release it.
+func (c *HandleCollector) forget(a *MCPToolAdapter, handle string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if !c.present[handle] {
+	key := collectorKey(a, handle)
+	if !c.present[key] {
 		return
 	}
-	delete(c.present, handle)
+	delete(c.present, key)
 	for i, m := range c.minted {
-		if m.handle == handle {
+		if m.handle == handle && m.adapter.serverName == a.serverName {
 			c.minted = append(c.minted[:i:i], c.minted[i+1:]...)
 			break
 		}
@@ -272,7 +283,7 @@ func trackSessionHandles(ctx context.Context, a *MCPToolAdapter, params map[stri
 	}
 	for _, key := range []string{"release_handle", "releaseHandle"} {
 		if released, ok := params[key].(string); ok && released != "" {
-			c.forget(released)
+			c.forget(a, released)
 		}
 	}
 	if _, declared := releaseHandleProperty(a.tool.InputSchema); !declared {

--- a/pkg/mcp/adapter/session_handles.go
+++ b/pkg/mcp/adapter/session_handles.go
@@ -28,16 +28,25 @@ import (
 // handle, budget slots never churned, and waiting mechanisms starved. The
 // lifecycle therefore belongs to the runtime: the agent's conversation loop
 // plants a collector in context, the adapter deposits any session_handle it
-// sees in a successful tool result (the convention: a top-level
-// "session_handle" string field in the result payload), and when the loop
-// ends every collected handle is released best-effort by calling the tool
-// that minted it with {"release_handle": <handle>}.
+// sees in a successful tool result, and when the loop ends every collected
+// handle is released best-effort by calling the tool that minted it with the
+// release property that tool's own InputSchema declares.
+//
+// The convention is schema-gated on both ends: a handle is only tracked when
+// the minting tool's InputSchema declares a release property ("releaseHandle"
+// or "release_handle"), and a release is only attempted through a tool that
+// declares one. A server that never declared the convention is never called
+// back — an auto-release against a permissive server that treats unknown
+// arguments as a fresh mint request would otherwise leak harder than doing
+// nothing.
 
 // handleCollectorKey is the context key for the per-conversation collector.
 type handleCollectorKey struct{}
 
-// mintedHandle is one tracked session handle and the adapter that minted it
-// (the release call goes back through the same tool on the same server).
+// mintedHandle is one tracked session handle and the adapter that minted it.
+// The release call goes back through the same tool on the same server, with
+// the property name and required-fields check derived from that adapter's
+// own tool schema at release time.
 type mintedHandle struct {
 	adapter *MCPToolAdapter
 	handle  string
@@ -45,6 +54,15 @@ type mintedHandle struct {
 
 // HandleCollector accumulates session handles minted during one agent
 // conversation. Safe for concurrent use (parallel tool execution).
+//
+// Scope tradeoff: the collector is planted per chat() call, so handles live
+// for exactly one agent message exchange. A handle the agent reuses from
+// conversation history in a LATER message will already have been released at
+// the end of the message that minted it; the follow-up call fails and the
+// agent must mint a fresh handle. This is deliberate — releasing per chat is
+// the only boundary the runtime currently observes. Callers wanting
+// session-long handle lifetimes need a session-end hook, which does not
+// exist yet.
 type HandleCollector struct {
 	mu      sync.Mutex
 	minted  []mintedHandle
@@ -78,9 +96,8 @@ func (c *HandleCollector) add(a *MCPToolAdapter, handle string) {
 	c.minted = append(c.minted, mintedHandle{adapter: a, handle: handle})
 }
 
-// forget drops a handle the agent released explicitly (seen as a
-// release_handle argument on a successful call), so ReleaseAll doesn't
-// double-release it.
+// forget drops a handle the agent released explicitly (seen as a release
+// argument on a successful call), so ReleaseAll doesn't double-release it.
 func (c *HandleCollector) forget(handle string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -103,13 +120,32 @@ func (c *HandleCollector) Count() int {
 	return len(c.minted)
 }
 
-// releaseAllTimeout bounds the whole end-of-conversation release pass; the
-// conversation is already over, so this must never hold the caller long.
-const releaseAllTimeout = 10 * time.Second
+// releaseAllTimeout bounds the WHOLE end-of-conversation release pass — it is
+// a total budget shared by every release, not a per-handle allowance.
+// ReleaseAll runs synchronously on the chat return path, so a hung server
+// adds at most ~this much latency to the conversation's return.
+const releaseAllTimeout = 3 * time.Second
+
+// releaseAllConcurrency bounds how many releases run in flight at once.
+// Releases run concurrently so one slow server cannot serialize the rest
+// into the shared budget, but bounded so a conversation that minted many
+// handles doesn't burst-open work against every server simultaneously.
+const releaseAllConcurrency = 4
 
 // ReleaseAll releases every tracked handle, best-effort: it runs on a fresh
 // background context (the conversation's ctx is typically already cancelled),
-// each failure is logged and skipped, and the collector empties regardless.
+// each failure or skip is logged, and the collector empties regardless.
+//
+// The pass is synchronous — the caller's defer must not race agent teardown —
+// but internally concurrent (bounded by releaseAllConcurrency) under one
+// shared releaseAllTimeout budget, so the worst case adds ~3s, not 3s per
+// handle.
+//
+// A release is only attempted when the minting tool's own InputSchema
+// declares a release property AND that property alone satisfies the schema's
+// required fields; otherwise the handle is skipped with a warning and left
+// to the server's TTL (the pre-#345 behavior), which beats a call the
+// client-side schema validation is guaranteed to reject.
 func (c *HandleCollector) ReleaseAll(logger *zap.Logger) {
 	c.mu.Lock()
 	minted := c.minted
@@ -125,35 +161,122 @@ func (c *HandleCollector) ReleaseAll(logger *zap.Logger) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), releaseAllTimeout)
 	defer cancel()
+
+	sem := make(chan struct{}, releaseAllConcurrency)
+	var wg sync.WaitGroup
 	for _, m := range minted {
-		_, err := m.adapter.client.CallTool(ctx, m.adapter.tool.Name, map[string]interface{}{
-			"release_handle": m.handle,
-		})
-		if err != nil {
-			logger.Debug("session-handle auto-release failed (best-effort)",
-				zap.String("tool", m.adapter.tool.Name),
-				zap.String("server", m.adapter.serverName),
-				zap.Error(err))
-			continue
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(m mintedHandle) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			releaseOne(ctx, m, logger)
+		}(m)
+	}
+	wg.Wait()
+}
+
+// releaseOne attempts a single best-effort release, deriving the wire
+// spelling of the release property from the minting tool's own InputSchema.
+func releaseOne(ctx context.Context, m mintedHandle, logger *zap.Logger) {
+	fields := []zap.Field{
+		zap.String("server", m.adapter.serverName),
+		zap.String("tool", m.adapter.tool.Name),
+		zap.String("handle", m.handle),
+	}
+
+	prop, ok := releaseHandleProperty(m.adapter.tool.InputSchema)
+	if !ok {
+		// Tracking is schema-gated, so this only happens when the tool
+		// definition changed between mint and release. Leak to server TTL.
+		logger.Warn("session-handle auto-release skipped: tool schema declares no release property", fields...)
+		return
+	}
+	if !releaseSatisfiesRequired(m.adapter.tool.InputSchema, prop) {
+		// The schema requires more than the release property; a one-argument
+		// release call would fail client-side validation before reaching the
+		// server. Leaking to server TTL beats a guaranteed-failing call.
+		logger.Warn("session-handle auto-release skipped: schema requires fields beyond the release property",
+			append(fields, zap.String("release_property", prop))...)
+		return
+	}
+
+	_, err := m.adapter.client.CallTool(ctx, m.adapter.tool.Name, map[string]interface{}{
+		prop: m.handle,
+	})
+	if err != nil {
+		logger.Warn("session-handle auto-release failed (best-effort)",
+			append(fields, zap.Error(err))...)
+		return
+	}
+	logger.Info("session handle auto-released at conversation end", fields...)
+}
+
+// releaseHandleProperty resolves the release property name the tool's own
+// InputSchema declares — the server's actual wire spelling. It is derived
+// directly from the raw MCP schema (never from the adapter's LLM-facing
+// case conversion), so the release call always matches what the server
+// published regardless of how agent-issued parameters are normalized.
+func releaseHandleProperty(schema map[string]interface{}) (string, bool) {
+	props, _ := schema["properties"].(map[string]interface{})
+	if props == nil {
+		return "", false
+	}
+	for _, name := range []string{"releaseHandle", "release_handle"} {
+		if _, declared := props[name]; declared {
+			return name, true
 		}
-		logger.Info("session handle auto-released at conversation end",
-			zap.String("server", m.adapter.serverName),
-			zap.String("tool", m.adapter.tool.Name))
+	}
+	return "", false
+}
+
+// releaseSatisfiesRequired reports whether a call carrying only the release
+// property can satisfy the schema's required fields: required ⊆ {prop}.
+// The required list appears as []interface{} after a JSON round-trip and as
+// []string when constructed in Go; both are handled.
+func releaseSatisfiesRequired(schema map[string]interface{}, prop string) bool {
+	switch req := schema["required"].(type) {
+	case nil:
+		return true
+	case []string:
+		for _, r := range req {
+			if r != prop {
+				return false
+			}
+		}
+		return true
+	case []interface{}:
+		for _, r := range req {
+			name, isString := r.(string)
+			if !isString || name != prop {
+				return false
+			}
+		}
+		return true
+	default:
+		// Malformed required clause: don't guess — skip the release.
+		return false
 	}
 }
 
-// trackSessionHandles inspects a successful tool outcome: a top-level
+// trackSessionHandles inspects a successful tool outcome. A top-level
 // "session_handle" string in the result payload is collected for
-// end-of-conversation release, and a successful call that carried a
-// release_handle argument removes that handle from tracking (the agent
-// cleaned up itself).
+// end-of-conversation release — but only when the tool's own InputSchema
+// declares a release property, i.e. the server opted into the convention.
+// A successful call that carried a release argument (either spelling)
+// removes that handle from tracking (the agent cleaned up itself).
 func trackSessionHandles(ctx context.Context, a *MCPToolAdapter, params map[string]interface{}, data interface{}) {
 	c := collectorFrom(ctx)
 	if c == nil {
 		return
 	}
-	if released, ok := params["release_handle"].(string); ok && released != "" {
-		c.forget(released)
+	for _, key := range []string{"release_handle", "releaseHandle"} {
+		if released, ok := params[key].(string); ok && released != "" {
+			c.forget(released)
+		}
+	}
+	if _, declared := releaseHandleProperty(a.tool.InputSchema); !declared {
+		return // server never declared the convention: do not track
 	}
 	if h := sessionHandleFromData(data); h != "" {
 		c.add(a, h)
@@ -161,20 +284,56 @@ func trackSessionHandles(ctx context.Context, a *MCPToolAdapter, params map[stri
 }
 
 // sessionHandleFromData extracts a top-level session_handle string from a
-// tool result payload: either a JSON object already, or a string containing
-// one. Anything else yields "".
+// tool result payload in any of the shapes convertMCPContent produces: a
+// string containing a JSON object (single text content), a JSON object
+// already, or a multi-item content slice whose text items may carry the
+// JSON payload. Anything else yields "".
 func sessionHandleFromData(data interface{}) string {
 	switch v := data.(type) {
 	case string:
-		var m map[string]interface{}
-		if err := json.Unmarshal([]byte(v), &m); err != nil {
-			return ""
-		}
-		return stringField(m, "session_handle")
+		return sessionHandleFromJSON(v)
 	case map[string]interface{}:
-		return stringField(v, "session_handle")
+		return sessionHandleFromMap(v)
+	case []map[string]interface{}:
+		for _, item := range v {
+			if h := sessionHandleFromMap(item); h != "" {
+				return h
+			}
+		}
+	case []interface{}:
+		// The same slice shape after a JSON round-trip (workflow persistence).
+		for _, item := range v {
+			if m, ok := item.(map[string]interface{}); ok {
+				if h := sessionHandleFromMap(m); h != "" {
+					return h
+				}
+			}
+		}
 	}
 	return ""
+}
+
+// sessionHandleFromMap reads a session_handle from a result object: directly
+// as a top-level field, or inside a content item's "text" payload (the shape
+// convertMCPContent produces for multi-item results).
+func sessionHandleFromMap(m map[string]interface{}) string {
+	if h := stringField(m, "session_handle"); h != "" {
+		return h
+	}
+	if text, ok := m["text"].(string); ok {
+		return sessionHandleFromJSON(text)
+	}
+	return ""
+}
+
+// sessionHandleFromJSON parses a string as a JSON object and extracts its
+// top-level session_handle, or "".
+func sessionHandleFromJSON(s string) string {
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		return ""
+	}
+	return stringField(m, "session_handle")
 }
 
 func stringField(m map[string]interface{}, key string) string {

--- a/pkg/mcp/adapter/session_handles.go
+++ b/pkg/mcp/adapter/session_handles.go
@@ -1,0 +1,186 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package adapter
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// Session-handle auto-release (issue #345). A 3×64-agent live study showed
+// that MCP session-scoped resources leak until server TTL when their release
+// is left to agent discretion: across 192 agent runs, zero agents released a
+// handle, budget slots never churned, and waiting mechanisms starved. The
+// lifecycle therefore belongs to the runtime: the agent's conversation loop
+// plants a collector in context, the adapter deposits any session_handle it
+// sees in a successful tool result (the convention: a top-level
+// "session_handle" string field in the result payload), and when the loop
+// ends every collected handle is released best-effort by calling the tool
+// that minted it with {"release_handle": <handle>}.
+
+// handleCollectorKey is the context key for the per-conversation collector.
+type handleCollectorKey struct{}
+
+// mintedHandle is one tracked session handle and the adapter that minted it
+// (the release call goes back through the same tool on the same server).
+type mintedHandle struct {
+	adapter *MCPToolAdapter
+	handle  string
+}
+
+// HandleCollector accumulates session handles minted during one agent
+// conversation. Safe for concurrent use (parallel tool execution).
+type HandleCollector struct {
+	mu      sync.Mutex
+	minted  []mintedHandle
+	present map[string]bool
+}
+
+// WithHandleCollector returns a ctx carrying a fresh collector and the
+// collector itself. The caller (the agent conversation loop) must invoke
+// ReleaseAll when the conversation ends.
+func WithHandleCollector(ctx context.Context) (context.Context, *HandleCollector) {
+	c := &HandleCollector{present: map[string]bool{}}
+	return context.WithValue(ctx, handleCollectorKey{}, c), c
+}
+
+// collectorFrom returns the conversation's collector, or nil when the caller
+// did not opt in (workflows, direct executor use).
+func collectorFrom(ctx context.Context) *HandleCollector {
+	c, _ := ctx.Value(handleCollectorKey{}).(*HandleCollector)
+	return c
+}
+
+// add records a minted handle once. Duplicates (the same handle re-reported)
+// are ignored; releases are deduplicated at collection time.
+func (c *HandleCollector) add(a *MCPToolAdapter, handle string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.present[handle] {
+		return
+	}
+	c.present[handle] = true
+	c.minted = append(c.minted, mintedHandle{adapter: a, handle: handle})
+}
+
+// forget drops a handle the agent released explicitly (seen as a
+// release_handle argument on a successful call), so ReleaseAll doesn't
+// double-release it.
+func (c *HandleCollector) forget(handle string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.present[handle] {
+		return
+	}
+	delete(c.present, handle)
+	for i, m := range c.minted {
+		if m.handle == handle {
+			c.minted = append(c.minted[:i:i], c.minted[i+1:]...)
+			break
+		}
+	}
+}
+
+// Count reports tracked handles (tests, diagnostics).
+func (c *HandleCollector) Count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.minted)
+}
+
+// releaseAllTimeout bounds the whole end-of-conversation release pass; the
+// conversation is already over, so this must never hold the caller long.
+const releaseAllTimeout = 10 * time.Second
+
+// ReleaseAll releases every tracked handle, best-effort: it runs on a fresh
+// background context (the conversation's ctx is typically already cancelled),
+// each failure is logged and skipped, and the collector empties regardless.
+func (c *HandleCollector) ReleaseAll(logger *zap.Logger) {
+	c.mu.Lock()
+	minted := c.minted
+	c.minted = nil
+	c.present = map[string]bool{}
+	c.mu.Unlock()
+	if len(minted) == 0 {
+		return
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), releaseAllTimeout)
+	defer cancel()
+	for _, m := range minted {
+		_, err := m.adapter.client.CallTool(ctx, m.adapter.tool.Name, map[string]interface{}{
+			"release_handle": m.handle,
+		})
+		if err != nil {
+			logger.Debug("session-handle auto-release failed (best-effort)",
+				zap.String("tool", m.adapter.tool.Name),
+				zap.String("server", m.adapter.serverName),
+				zap.Error(err))
+			continue
+		}
+		logger.Info("session handle auto-released at conversation end",
+			zap.String("server", m.adapter.serverName),
+			zap.String("tool", m.adapter.tool.Name))
+	}
+}
+
+// trackSessionHandles inspects a successful tool outcome: a top-level
+// "session_handle" string in the result payload is collected for
+// end-of-conversation release, and a successful call that carried a
+// release_handle argument removes that handle from tracking (the agent
+// cleaned up itself).
+func trackSessionHandles(ctx context.Context, a *MCPToolAdapter, params map[string]interface{}, data interface{}) {
+	c := collectorFrom(ctx)
+	if c == nil {
+		return
+	}
+	if released, ok := params["release_handle"].(string); ok && released != "" {
+		c.forget(released)
+	}
+	if h := sessionHandleFromData(data); h != "" {
+		c.add(a, h)
+	}
+}
+
+// sessionHandleFromData extracts a top-level session_handle string from a
+// tool result payload: either a JSON object already, or a string containing
+// one. Anything else yields "".
+func sessionHandleFromData(data interface{}) string {
+	switch v := data.(type) {
+	case string:
+		var m map[string]interface{}
+		if err := json.Unmarshal([]byte(v), &m); err != nil {
+			return ""
+		}
+		return stringField(m, "session_handle")
+	case map[string]interface{}:
+		return stringField(v, "session_handle")
+	}
+	return ""
+}
+
+func stringField(m map[string]interface{}, key string) string {
+	s, _ := m[key].(string)
+	if len(s) == 0 || len(s) > 256 {
+		return ""
+	}
+	return s
+}

--- a/pkg/mcp/adapter/session_handles_test.go
+++ b/pkg/mcp/adapter/session_handles_test.go
@@ -403,3 +403,29 @@ func TestSessionHandleFromData(t *testing.T) {
 		})
 	}
 }
+
+// TestHandleCollectorScopedPerServer pins the dedup scope: two servers
+// minting the identical handle string are tracked independently, and a
+// release through one server never forgets the other's handle.
+func TestHandleCollectorScopedPerServer(t *testing.T) {
+	_, c := WithHandleCollector(context.Background())
+	aA := &MCPToolAdapter{serverName: "server-a"}
+	aB := &MCPToolAdapter{serverName: "server-b"}
+
+	c.add(aA, "tdsh_same")
+	c.add(aB, "tdsh_same")
+	if got := c.Count(); got != 2 {
+		t.Fatalf("expected both servers' identical handle strings tracked, got %d", got)
+	}
+
+	c.forget(aB, "tdsh_same")
+	if got := c.Count(); got != 1 {
+		t.Fatalf("expected server-a's handle to survive server-b's release, got %d", got)
+	}
+	c.mu.Lock()
+	survivor := c.minted[0]
+	c.mu.Unlock()
+	if survivor.adapter.serverName != "server-a" {
+		t.Fatalf("wrong survivor: %s", survivor.adapter.serverName)
+	}
+}

--- a/pkg/mcp/adapter/session_handles_test.go
+++ b/pkg/mcp/adapter/session_handles_test.go
@@ -1,0 +1,405 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package adapter
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/teradata-labs/loom/pkg/mcp/protocol"
+)
+
+// mintSchemaSnake declares the release convention with the snake_case
+// spelling; mintSchemaCamel with the camelCase spelling. The release wire
+// spelling must follow the tool's own schema, never a client-side case
+// convention.
+func mintSchemaSnake() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"target":         map[string]interface{}{"type": "string"},
+			"release_handle": map[string]interface{}{"type": "string"},
+		},
+	}
+}
+
+func mintSchemaCamel() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"target":        map[string]interface{}{"type": "string"},
+			"releaseHandle": map[string]interface{}{"type": "string"},
+		},
+	}
+}
+
+func mintResult(handle string) json.RawMessage {
+	r, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
+		{Type: "text", Text: `{"session_handle":"` + handle + `","target":"default"}`},
+	}})
+	return r
+}
+
+// TestAutoReleaseOnConversationEnd: a successful call whose result carries a
+// session_handle — minted by a tool whose schema declares the release
+// convention — is tracked by the ctx collector and released best-effort when
+// the conversation ends, using the schema's own property spelling
+// (issue #345).
+func TestAutoReleaseOnConversationEnd(t *testing.T) {
+	released, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
+		{Type: "text", Text: `{"target":"released"}`},
+	}})
+	ft := newWaitTransportWithSchema(mintSchemaSnake(), mintResult("tdsh_test123"), released)
+	adapter := waitAdapter(t, ft)
+
+	ctx, collector := WithHandleCollector(context.Background())
+	res, err := adapter.Execute(ctx, map[string]interface{}{})
+	require.NoError(t, err)
+	require.True(t, res.Success)
+	require.Equal(t, 1, collector.Count(), "minted handle must be tracked")
+
+	collector.ReleaseAll(nil)
+	assert.Equal(t, 0, collector.Count())
+	assert.Equal(t, 2, ft.calls(), "release call must reach the wire")
+	// The release carried the tracked handle under the schema's spelling.
+	last := ft.lastCallParams()
+	assert.Equal(t, "tdsh_test123", last["release_handle"])
+}
+
+// TestAutoReleaseUsesSchemaSpelling: a tool whose schema declares
+// releaseHandle (camelCase) gets its release with that exact wire spelling —
+// derived from the schema, not from any client-side case convention.
+func TestAutoReleaseUsesSchemaSpelling(t *testing.T) {
+	released, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
+		{Type: "text", Text: `{"released":true}`},
+	}})
+	ft := newWaitTransportWithSchema(mintSchemaCamel(), mintResult("tdsh_camel"), released)
+	adapter := waitAdapter(t, ft)
+
+	ctx, collector := WithHandleCollector(context.Background())
+	_, err := adapter.Execute(ctx, map[string]interface{}{})
+	require.NoError(t, err)
+	require.Equal(t, 1, collector.Count())
+
+	collector.ReleaseAll(nil)
+	require.Equal(t, 2, ft.calls(), "release call must reach the wire")
+	last := ft.lastCallParams()
+	assert.Equal(t, "tdsh_camel", last["releaseHandle"], "wire spelling must follow the tool schema")
+	_, hasSnake := last["release_handle"]
+	assert.False(t, hasSnake, "no convention-spelled duplicate")
+}
+
+// TestAutoReleaseSkipsUnsatisfiableRequired: a mint tool whose schema
+// requires fields beyond the release property would reject a one-argument
+// release in client-side validation before it ever reached the server — the
+// release is skipped with a warning and the handle leaks to server TTL (the
+// pre-#345 behavior) instead of producing a guaranteed-failing call.
+func TestAutoReleaseSkipsUnsatisfiableRequired(t *testing.T) {
+	schema := mintSchemaSnake()
+	schema["required"] = []interface{}{"target"}
+	ft := newWaitTransportWithSchema(schema, mintResult("tdsh_reqgate"))
+	adapter := waitAdapter(t, ft)
+
+	ctx, collector := WithHandleCollector(context.Background())
+	res, err := adapter.Execute(ctx, map[string]interface{}{"target": "db1"})
+	require.NoError(t, err)
+	require.True(t, res.Success)
+	require.Equal(t, 1, collector.Count(), "handle is tracked (property declared)")
+
+	core, logs := observer.New(zap.WarnLevel)
+	collector.ReleaseAll(zap.New(core))
+
+	assert.Equal(t, 1, ft.calls(), "no release attempt may reach the wire")
+	skips := logs.FilterMessageSnippet("auto-release skipped").All()
+	require.Len(t, skips, 1, "the skip must be logged")
+	ctxMap := skips[0].ContextMap()
+	assert.Equal(t, "waitfake", ctxMap["server"])
+	assert.Equal(t, "connect", ctxMap["tool"])
+	assert.Equal(t, "tdsh_reqgate", ctxMap["handle"])
+}
+
+// TestNoTrackingWithoutReleaseProperty: a tool that never declared the
+// release convention (no release_handle/releaseHandle property) mints
+// nothing trackable — a top-level session_handle in its result is ignored,
+// and no auto-release is ever attempted against it. This is what keeps a
+// permissive server (one that treats unknown arguments as a fresh request)
+// from receiving auto-release calls that mint fresh handles.
+func TestNoTrackingWithoutReleaseProperty(t *testing.T) {
+	ft := newWaitTransport(mintResult("tdsh_never"))
+	adapter := waitAdapter(t, ft)
+
+	ctx, collector := WithHandleCollector(context.Background())
+	res, err := adapter.Execute(ctx, map[string]interface{}{})
+	require.NoError(t, err)
+	require.True(t, res.Success)
+	assert.Equal(t, 0, collector.Count(), "no tracking without the schema-declared convention")
+
+	collector.ReleaseAll(nil)
+	assert.Equal(t, 1, ft.calls(), "no release call against a tool that never opted in")
+}
+
+// TestAutoReleaseSkipsExplicitlyReleased: an agent that releases its own
+// handle is not double-released at conversation end.
+func TestAutoReleaseSkipsExplicitlyReleased(t *testing.T) {
+	released, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
+		{Type: "text", Text: `{"target":"released"}`},
+	}})
+	ft := newWaitTransportWithSchema(mintSchemaSnake(), mintResult("tdsh_selfclean"), released)
+	adapter := waitAdapter(t, ft)
+
+	ctx, collector := WithHandleCollector(context.Background())
+	_, err := adapter.Execute(ctx, map[string]interface{}{})
+	require.NoError(t, err)
+	_, err = adapter.Execute(ctx, map[string]interface{}{"release_handle": "tdsh_selfclean"})
+	require.NoError(t, err)
+
+	require.Equal(t, 0, collector.Count(), "explicit release must untrack the handle")
+	collector.ReleaseAll(nil)
+	assert.Equal(t, 2, ft.calls(), "no extra release call")
+}
+
+// TestAutoReleaseMultiContentMint: a mint result with multiple content items
+// (text payload plus a resource_link) still has its session_handle tracked —
+// the collector reads the multi-item shape convertMCPContent produces.
+func TestAutoReleaseMultiContentMint(t *testing.T) {
+	mint, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
+		{Type: "text", Text: `{"session_handle":"tdsh_multi","target":"default"}`},
+		{Type: "resource_link", URI: "test://slots", Name: "availability"},
+	}})
+	released, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
+		{Type: "text", Text: `{"released":true}`},
+	}})
+	ft := newWaitTransportWithSchema(mintSchemaSnake(), mint, released)
+	adapter := waitAdapter(t, ft)
+
+	ctx, collector := WithHandleCollector(context.Background())
+	res, err := adapter.Execute(ctx, map[string]interface{}{})
+	require.NoError(t, err)
+	require.True(t, res.Success)
+	require.Equal(t, 1, collector.Count(), "multi-content mint must be tracked")
+
+	collector.ReleaseAll(nil)
+	require.Equal(t, 2, ft.calls())
+	assert.Equal(t, "tdsh_multi", ft.lastCallParams()["release_handle"])
+}
+
+// TestNoCollectorNoTracking: without a collector in ctx (workflow paths),
+// behavior is unchanged.
+func TestNoCollectorNoTracking(t *testing.T) {
+	ft := newWaitTransportWithSchema(mintSchemaSnake(), mintResult("tdsh_untracked"))
+	adapter := waitAdapter(t, ft)
+
+	res, err := adapter.Execute(context.Background(), map[string]interface{}{})
+	require.NoError(t, err)
+	require.True(t, res.Success)
+	assert.Equal(t, 1, ft.calls())
+}
+
+// TestReleaseAllTotalBudgetAndConcurrency: releases run concurrently under
+// ONE shared budget — a hung server neither serializes the other releases
+// behind its timeout nor extends the pass beyond ~releaseAllTimeout total.
+func TestReleaseAllTotalBudgetAndConcurrency(t *testing.T) {
+	released, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
+		{Type: "text", Text: `{"released":true}`},
+	}})
+	ft := newWaitTransportWithSchema(mintSchemaSnake())
+	ft.mu.Lock()
+	ft.callHook = func(args map[string]interface{}) (json.RawMessage, bool) {
+		if args["release_handle"] == "tdsh_hang" {
+			return nil, false // hung server: never answers this release
+		}
+		return released, true
+	}
+	ft.mu.Unlock()
+	adapter := waitAdapter(t, ft)
+
+	_, collector := WithHandleCollector(context.Background())
+	collector.add(adapter, "tdsh_hang")
+	collector.add(adapter, "tdsh_fast")
+
+	fastReleased := func() bool {
+		for i := 0; i < ft.calls(); i++ {
+			if ft.argsOfCall(i)["release_handle"] == "tdsh_fast" {
+				return true
+			}
+		}
+		return false
+	}
+
+	start := time.Now()
+	done := make(chan struct{})
+	go func() {
+		collector.ReleaseAll(nil)
+		close(done)
+	}()
+
+	// The fast release must reach the wire while the hung one is still
+	// pending — a sequential pass would queue it behind the full timeout.
+	require.Eventually(t, fastReleased, 2*time.Second, 10*time.Millisecond,
+		"fast release must not be serialized behind the hung one")
+
+	select {
+	case <-done:
+	case <-time.After(releaseAllTimeout + 3*time.Second):
+		t.Fatal("ReleaseAll exceeded its total budget")
+	}
+	assert.Less(t, time.Since(start), releaseAllTimeout+2*time.Second,
+		"the budget is total, not per handle")
+	assert.Equal(t, 0, collector.Count())
+}
+
+// TestReleaseHandleProperty: the release property resolves from the tool's
+// own schema, both spellings, never invented.
+func TestReleaseHandleProperty(t *testing.T) {
+	tests := []struct {
+		name     string
+		schema   map[string]interface{}
+		wantProp string
+		wantOK   bool
+	}{
+		{
+			name:     "snake_case declared",
+			schema:   mintSchemaSnake(),
+			wantProp: "release_handle",
+			wantOK:   true,
+		},
+		{
+			name:     "camelCase declared",
+			schema:   mintSchemaCamel(),
+			wantProp: "releaseHandle",
+			wantOK:   true,
+		},
+		{
+			name: "both declared prefers camelCase",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"releaseHandle":  map[string]interface{}{"type": "string"},
+					"release_handle": map[string]interface{}{"type": "string"},
+				},
+			},
+			wantProp: "releaseHandle",
+			wantOK:   true,
+		},
+		{
+			name:   "not declared",
+			schema: map[string]interface{}{"type": "object", "properties": map[string]interface{}{"target": map[string]interface{}{"type": "string"}}},
+			wantOK: false,
+		},
+		{
+			name:   "no properties",
+			schema: map[string]interface{}{"type": "object"},
+			wantOK: false,
+		},
+		{
+			name:   "nil schema",
+			schema: nil,
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prop, ok := releaseHandleProperty(tt.schema)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantProp, prop)
+		})
+	}
+}
+
+// TestReleaseSatisfiesRequired: a one-argument release is only attempted when
+// required ⊆ {release property}, across the shapes required lists appear in.
+func TestReleaseSatisfiesRequired(t *testing.T) {
+	tests := []struct {
+		name     string
+		required interface{} // nil means absent
+		prop     string
+		want     bool
+	}{
+		{name: "no required clause", required: nil, prop: "release_handle", want: true},
+		{name: "empty interface list", required: []interface{}{}, prop: "release_handle", want: true},
+		{name: "only the release property (interface list)", required: []interface{}{"release_handle"}, prop: "release_handle", want: true},
+		{name: "only the release property (string list)", required: []string{"releaseHandle"}, prop: "releaseHandle", want: true},
+		{name: "requires another field", required: []interface{}{"target"}, prop: "release_handle", want: false},
+		{name: "requires release plus another", required: []interface{}{"release_handle", "target"}, prop: "release_handle", want: false},
+		{name: "requires another field (string list)", required: []string{"target"}, prop: "release_handle", want: false},
+		{name: "malformed clause", required: "target", prop: "release_handle", want: false},
+		{name: "non-string entry", required: []interface{}{42}, prop: "release_handle", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := map[string]interface{}{"type": "object"}
+			if tt.required != nil {
+				schema["required"] = tt.required
+			}
+			assert.Equal(t, tt.want, releaseSatisfiesRequired(schema, tt.prop))
+		})
+	}
+}
+
+// TestSessionHandleFromData: the extractor reads every shape
+// convertMCPContent produces, including multi-item content slices.
+func TestSessionHandleFromData(t *testing.T) {
+	tests := []struct {
+		name string
+		data interface{}
+		want string
+	}{
+		{
+			name: "single text content (JSON string)",
+			data: `{"session_handle":"tdsh_str","target":"x"}`,
+			want: "tdsh_str",
+		},
+		{
+			name: "object payload",
+			data: map[string]interface{}{"session_handle": "tdsh_map"},
+			want: "tdsh_map",
+		},
+		{
+			name: "multi-item content slice with JSON text item",
+			data: []map[string]interface{}{
+				{"type": "resource_link", "uri": "test://slots"},
+				{"type": "text", "text": `{"session_handle":"tdsh_slice"}`},
+			},
+			want: "tdsh_slice",
+		},
+		{
+			name: "multi-item slice after JSON round-trip",
+			data: []interface{}{
+				map[string]interface{}{"type": "text", "text": `{"session_handle":"tdsh_roundtrip"}`},
+			},
+			want: "tdsh_roundtrip",
+		},
+		{
+			name: "content item carrying the field directly",
+			data: []map[string]interface{}{{"session_handle": "tdsh_direct"}},
+			want: "tdsh_direct",
+		},
+		{name: "non-JSON string", data: "plain text result", want: ""},
+		{name: "no handle anywhere", data: []map[string]interface{}{{"type": "text", "text": `{"other":"x"}`}}, want: ""},
+		{name: "nil", data: nil, want: ""},
+		{name: "oversized handle rejected", data: map[string]interface{}{"session_handle": string(make([]byte, 300))}, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sessionHandleFromData(tt.data))
+		})
+	}
+}

--- a/pkg/mcp/adapter/shuttle.go
+++ b/pkg/mcp/adapter/shuttle.go
@@ -324,6 +324,10 @@ func (a *MCPToolAdapter) Execute(ctx context.Context, params map[string]interfac
 	// only size logic, so no second bound may cut the payload upstream here.
 	data := convertMCPContent(mcpResult.Content)
 
+	// Session-handle lifecycle (issue #345): collect minted handles for
+	// end-of-conversation auto-release; drop ones the agent released itself.
+	trackSessionHandles(ctx, a, params, data)
+
 	// Cache schema results (#4: Schema Caching)
 	if a.isSchemaLookupTool() {
 		cacheKey := a.buildSchemaCacheKey(restoredParams)

--- a/pkg/mcp/adapter/shuttle.go
+++ b/pkg/mcp/adapter/shuttle.go
@@ -284,6 +284,11 @@ func (a *MCPToolAdapter) Execute(ctx context.Context, params map[string]interfac
 
 	// Call MCP tool with camelCase parameters
 	mcpResultInterface, err := a.client.CallTool(ctx, a.tool.Name, restoredParams)
+	if err != nil {
+		// Park-and-wake (issue #343): a failure that links a resource parks
+		// here and retries when the resource updates; otherwise unchanged.
+		mcpResultInterface, err = a.awaitLinkedResource(ctx, restoredParams, err)
+	}
 	executionTime := time.Since(startTime).Milliseconds()
 
 	if err != nil {

--- a/pkg/mcp/adapter/shuttle.go
+++ b/pkg/mcp/adapter/shuttle.go
@@ -395,6 +395,17 @@ func convertMCPContent(content []protocol.Content) interface{} {
 				item["uri"] = c.Resource.URI
 				item["mimeType"] = c.Resource.MimeType
 			}
+		case "resource_link":
+			// A reference to a server resource without its contents
+			// (2025-06-18+): preserve uri/name so the agent can see and act
+			// on the link instead of receiving an empty content item.
+			item["uri"] = c.URI
+			if c.Name != "" {
+				item["name"] = c.Name
+			}
+			if c.MimeType != "" {
+				item["mimeType"] = c.MimeType
+			}
 		}
 
 		results[i] = item

--- a/pkg/mcp/adapter/shuttle_test.go
+++ b/pkg/mcp/adapter/shuttle_test.go
@@ -339,6 +339,52 @@ func TestConvertMCPContent_Mixed(t *testing.T) {
 	assert.Equal(t, "text/plain", resultSlice[3]["mimeType"])
 }
 
+// TestConvertMCPContent_ResourceLink: resource_link content on a successful
+// result keeps its uri/name (issue #343 uses links on errors, but servers
+// also return them on success — dropping them left an empty content item).
+func TestConvertMCPContent_ResourceLink(t *testing.T) {
+	content := []protocol.Content{
+		{
+			Type: "text",
+			Text: "See the linked resource:",
+		},
+		{
+			Type:     "resource_link",
+			URI:      "test://slots",
+			Name:     "availability",
+			MimeType: "application/json",
+		},
+	}
+
+	result := convertMCPContent(content)
+	resultSlice, ok := result.([]map[string]interface{})
+	require.True(t, ok)
+	require.Len(t, resultSlice, 2)
+
+	assert.Equal(t, "resource_link", resultSlice[1]["type"])
+	assert.Equal(t, "test://slots", resultSlice[1]["uri"])
+	assert.Equal(t, "availability", resultSlice[1]["name"])
+	assert.Equal(t, "application/json", resultSlice[1]["mimeType"])
+}
+
+// TestConvertMCPContent_ResourceLinkMinimal: optional fields stay absent
+// instead of appearing as empty strings.
+func TestConvertMCPContent_ResourceLinkMinimal(t *testing.T) {
+	content := []protocol.Content{
+		{Type: "text", Text: "link:"},
+		{Type: "resource_link", URI: "test://slots"},
+	}
+
+	result := convertMCPContent(content)
+	resultSlice, ok := result.([]map[string]interface{})
+	require.True(t, ok)
+	require.Len(t, resultSlice, 2)
+
+	assert.Equal(t, "test://slots", resultSlice[1]["uri"])
+	assert.NotContains(t, resultSlice[1], "name")
+	assert.NotContains(t, resultSlice[1], "mimeType")
+}
+
 func TestConvertMCPContent_UnknownType(t *testing.T) {
 	content := []protocol.Content{
 		{

--- a/pkg/mcp/client/tool_result_error_test.go
+++ b/pkg/mcp/client/tool_result_error_test.go
@@ -43,13 +43,22 @@ func TestToolResultError(t *testing.T) {
 			wantURI: "teradata://session-handles",
 		},
 		{
-			name: "embedded resource reference also counts",
+			name: "embedded plain resource is payload, not a retry condition",
 			content: []protocol.Content{
 				{Type: "text", Text: "busy"},
 				{Type: "resource", Resource: &protocol.ResourceRef{URI: "x://slots"}},
 			},
 			wantMsg: "tool error: busy",
-			wantURI: "x://slots",
+			wantURI: "",
+		},
+		{
+			name: "resource_link without uri is ignored",
+			content: []protocol.Content{
+				{Type: "text", Text: "busy"},
+				{Type: "resource_link", Name: "nameless"},
+			},
+			wantMsg: "tool error: busy",
+			wantURI: "",
 		},
 		{
 			name:    "no content",

--- a/pkg/mcp/client/tool_result_error_test.go
+++ b/pkg/mcp/client/tool_result_error_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/teradata-labs/loom/pkg/mcp/protocol"
+)
+
+func TestToolResultError(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []protocol.Content
+		wantMsg string
+		wantURI string
+	}{
+		{
+			name:    "text only renders historical message, no retry URI",
+			content: []protocol.Content{{Type: "text", Text: "budget full"}},
+			wantMsg: "tool error: budget full",
+			wantURI: "",
+		},
+		{
+			name: "resource_link marks the retry resource",
+			content: []protocol.Content{
+				{Type: "text", Text: "budget full"},
+				{Type: "resource_link", URI: "teradata://session-handles", Name: "session-handles"},
+			},
+			wantMsg: "tool error: budget full",
+			wantURI: "teradata://session-handles",
+		},
+		{
+			name: "embedded resource reference also counts",
+			content: []protocol.Content{
+				{Type: "text", Text: "busy"},
+				{Type: "resource", Resource: &protocol.ResourceRef{URI: "x://slots"}},
+			},
+			wantMsg: "tool error: busy",
+			wantURI: "x://slots",
+		},
+		{
+			name:    "no content",
+			content: nil,
+			wantMsg: "tool returned error",
+			wantURI: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &ToolResultError{Result: &protocol.CallToolResult{IsError: true, Content: tt.content}}
+			assert.Equal(t, tt.wantMsg, e.Error())
+			assert.Equal(t, tt.wantURI, e.RetryResourceURI())
+		})
+	}
+
+	t.Run("nil result", func(t *testing.T) {
+		e := &ToolResultError{}
+		assert.Equal(t, "tool returned error", e.Error())
+		assert.Equal(t, "", e.RetryResourceURI())
+	})
+}

--- a/pkg/mcp/client/tools.go
+++ b/pkg/mcp/client/tools.go
@@ -152,11 +152,10 @@ func (c *Client) CallTool(ctx context.Context, name string, arguments map[string
 
 	// Check if tool returned error
 	if result.IsError {
-		// Extract error message from content
-		if len(result.Content) > 0 && result.Content[0].Type == "text" {
-			return nil, fmt.Errorf("tool error: %s", result.Content[0].Text)
-		}
-		return nil, fmt.Errorf("tool returned error")
+		// Preserve the full result: error content may carry more than the
+		// message — e.g. a resource_link marking a watchable retry condition
+		// (issue #343). The rendered message is unchanged.
+		return nil, &ToolResultError{Result: &result}
 	}
 
 	return &result, nil
@@ -188,4 +187,43 @@ func (c *Client) getTool(ctx context.Context, name string) (protocol.Tool, error
 	}
 
 	return tool, nil
+}
+
+// ToolResultError is a tool-level failure (CallToolResult.isError) that
+// preserves the full result, so callers can inspect error content beyond the
+// message — notably a resource_link marking a watchable retry condition
+// (issue #343). Error() renders exactly what the historical flattened error
+// did, so string-matching callers and analytics see no change.
+type ToolResultError struct {
+	Result *protocol.CallToolResult
+}
+
+func (e *ToolResultError) Error() string {
+	if e.Result != nil && len(e.Result.Content) > 0 && e.Result.Content[0].Type == "text" {
+		return fmt.Sprintf("tool error: %s", e.Result.Content[0].Text)
+	}
+	return "tool returned error"
+}
+
+// RetryResourceURI returns the URI of a resource the failed result links as
+// its retry condition: the first resource_link (or embedded resource
+// reference) in the error content. Empty when the result links nothing —
+// the convention is opt-in per server, per error.
+func (e *ToolResultError) RetryResourceURI() string {
+	if e.Result == nil {
+		return ""
+	}
+	for _, c := range e.Result.Content {
+		switch c.Type {
+		case "resource_link":
+			if c.URI != "" {
+				return c.URI
+			}
+		case "resource":
+			if c.Resource != nil && c.Resource.URI != "" {
+				return c.Resource.URI
+			}
+		}
+	}
+	return ""
 }

--- a/pkg/mcp/client/tools.go
+++ b/pkg/mcp/client/tools.go
@@ -206,23 +206,18 @@ func (e *ToolResultError) Error() string {
 }
 
 // RetryResourceURI returns the URI of a resource the failed result links as
-// its retry condition: the first resource_link (or embedded resource
-// reference) in the error content. Empty when the result links nothing —
-// the convention is opt-in per server, per error.
+// its retry condition: the first resource_link in the error content. Empty
+// when the result links nothing — the convention is opt-in per server, per
+// error, and only resource_link content declares it. An embedded plain
+// resource in error content is payload (e.g. diagnostic data), not a
+// watchable retry condition, and never triggers a park.
 func (e *ToolResultError) RetryResourceURI() string {
 	if e.Result == nil {
 		return ""
 	}
 	for _, c := range e.Result.Content {
-		switch c.Type {
-		case "resource_link":
-			if c.URI != "" {
-				return c.URI
-			}
-		case "resource":
-			if c.Resource != nil && c.Resource.URI != "" {
-				return c.Resource.URI
-			}
+		if c.Type == "resource_link" && c.URI != "" {
+			return c.URI
 		}
 	}
 	return ""

--- a/pkg/mcp/protocol/types.go
+++ b/pkg/mcp/protocol/types.go
@@ -127,11 +127,16 @@ type CallToolResult struct {
 
 // Content represents different types of content (text, image, resource)
 type Content struct {
-	Type     string       `json:"type"` // "text", "image", "resource"
+	Type     string       `json:"type"` // "text", "image", "resource", "resource_link"
 	Text     string       `json:"text,omitempty"`
 	Data     string       `json:"data,omitempty"`     // Base64 for images
 	MimeType string       `json:"mimeType,omitempty"` // For images/resources
 	Resource *ResourceRef `json:"resource,omitempty"` // For resource type
+	// URI and Name carry resource_link content (2025-06-18+): a reference to
+	// a server resource without its contents. On a failed tool result a
+	// linked resource marks a watchable retry condition (issue #343).
+	URI  string `json:"uri,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 // ResourceRef references a resource


### PR DESCRIPTION
Fixes #343.

A tool failure on a transient exhaustion condition previously forced agents into client-side retry loops — a 64-agent live run against teradata-mcp-v2 produced 951 connect calls with 935 `session_handle_budget_full` rejections: one wasted round-trip and one wasted LLM turn per retry.

## The convention (any spec-following server)

A failed `CallToolResult` whose content includes a **`resource_link`** declares *"this resource's next update may clear the failure."* The MCP tool adapter now parks such a call on a `subscriptions/listen` stream filtered to that URI (2026-07-28 stateless connections) and retries when `notifications/resources/updated` arrives — bounded by a 60s budget capped to the caller's deadline. The agent sees one tool call that succeeds late: no retry loop, no polling, no extra turns. Anything that prevents waiting (no link, legacy connection, subscribe failure) degrades to the pre-existing error unchanged.

Servers opt in with plain MCP — teradata-mcp-v2 already attaches the link on budget-full errors (`teradata://session-handles`).

## Seam fixes required en route

- `protocol.Content` now parses `resource_link` (its `uri`/`name` were silently dropped).
- `Client.CallTool` returns a typed `ToolResultError` preserving the full error result (content was flattened to a string, destroying any link). `Error()` renders the historical message byte-for-byte, so string-matching callers and analytics see no change.

## Verification

- `-race` tests: park→notify→retry→success end-to-end over a scripted stateless transport (asserts exactly one retry and one listen stream), no-link fast-fail with zero subscriptions opened, park-timeout surfacing the original error, and the `ToolResultError` matrix (message compat + link extraction).
- `just check` green (matches CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)