### PR TITLE
fix(llm,looms): attach rate limiter on the custom-LLM path; make dispatch concurrent

### DIFF
--- a/cmd/looms/cmd_serve.go
+++ b/cmd/looms/cmd_serve.go
@@ -823,6 +823,11 @@ func createLLMProviderFromProtoConfig(protoConfig *loomv1.LLMConfig, serverConfi
 
 	timeout := time.Duration(serverConfig.LLM.Timeout) * time.Second
 
+	// Rate limiting must be attached on THIS path too: a client built without
+	// it is unthrottled and retry-less (429 retry lives inside the limiter),
+	// which produced the 512-agent thundering-herd outage of issue #348.
+	rlCfg := agent.BuildRateLimiterConfig(protoConfig.RateLimit, logger)
+
 	switch protoConfig.Provider {
 	case "anthropic":
 		model := protoConfig.Model
@@ -835,11 +840,12 @@ func createLLMProviderFromProtoConfig(protoConfig *loomv1.LLMConfig, serverConfi
 			apiKey = os.Getenv("ANTHROPIC_API_KEY")
 		}
 		return anthropic.NewClient(anthropic.Config{
-			APIKey:      apiKey,
-			Model:       model,
-			MaxTokens:   maxTokens,
-			Temperature: temperature,
-			Timeout:     timeout,
+			APIKey:            apiKey,
+			Model:             model,
+			MaxTokens:         maxTokens,
+			Temperature:       temperature,
+			Timeout:           timeout,
+			RateLimiterConfig: rlCfg,
 		}), nil
 
 	case "bedrock":
@@ -851,15 +857,16 @@ func createLLMProviderFromProtoConfig(protoConfig *loomv1.LLMConfig, serverConfi
 		// caching SDK client and others to the Converse client (single source of
 		// truth for Bedrock client selection — see bedrock.NewClientForModel).
 		return bedrock.NewClientForModel(bedrock.Config{
-			Region:          serverConfig.LLM.BedrockRegion,
-			AccessKeyID:     serverConfig.LLM.BedrockAccessKeyID,
-			SecretAccessKey: serverConfig.LLM.BedrockSecretAccessKey,
-			SessionToken:    serverConfig.LLM.BedrockSessionToken,
-			BearerToken:     serverConfig.LLM.BedrockBearerToken,
-			Profile:         serverConfig.LLM.BedrockProfile,
-			ModelID:         modelID,
-			MaxTokens:       maxTokens,
-			Temperature:     temperature,
+			Region:            serverConfig.LLM.BedrockRegion,
+			AccessKeyID:       serverConfig.LLM.BedrockAccessKeyID,
+			SecretAccessKey:   serverConfig.LLM.BedrockSecretAccessKey,
+			SessionToken:      serverConfig.LLM.BedrockSessionToken,
+			BearerToken:       serverConfig.LLM.BedrockBearerToken,
+			Profile:           serverConfig.LLM.BedrockProfile,
+			ModelID:           modelID,
+			MaxTokens:         maxTokens,
+			Temperature:       temperature,
+			RateLimiterConfig: rlCfg,
 		})
 
 	case "ollama":
@@ -868,11 +875,12 @@ func createLLMProviderFromProtoConfig(protoConfig *loomv1.LLMConfig, serverConfi
 			model = serverConfig.LLM.OllamaModel
 		}
 		return ollama.NewClient(ollama.Config{
-			Endpoint:    serverConfig.LLM.OllamaEndpoint,
-			Model:       model,
-			MaxTokens:   maxTokens,
-			Temperature: temperature,
-			Timeout:     timeout,
+			Endpoint:          serverConfig.LLM.OllamaEndpoint,
+			Model:             model,
+			MaxTokens:         maxTokens,
+			Temperature:       temperature,
+			Timeout:           timeout,
+			RateLimiterConfig: rlCfg,
 		}), nil
 
 	case "openai":
@@ -886,11 +894,12 @@ func createLLMProviderFromProtoConfig(protoConfig *loomv1.LLMConfig, serverConfi
 			apiKey = os.Getenv("OPENAI_API_KEY")
 		}
 		return openai.NewClient(openai.Config{
-			APIKey:      apiKey,
-			Model:       model,
-			MaxTokens:   maxTokens,
-			Temperature: temperature,
-			Timeout:     timeout,
+			APIKey:            apiKey,
+			Model:             model,
+			MaxTokens:         maxTokens,
+			Temperature:       temperature,
+			Timeout:           timeout,
+			RateLimiterConfig: rlCfg,
 		}), nil
 
 	case "azure-openai", "azureopenai":
@@ -898,14 +907,31 @@ func createLLMProviderFromProtoConfig(protoConfig *loomv1.LLMConfig, serverConfi
 		if deploymentID == "" {
 			deploymentID = serverConfig.LLM.AzureOpenAIDeploymentID
 		}
+		// Env fallbacks for parity with the anthropic/openai branches and the
+		// registry path — without them an env-only key fails this path and
+		// silently changes which construction path (and rate-limit behavior)
+		// an agent gets (issue #348).
+		azEndpoint := serverConfig.LLM.AzureOpenAIEndpoint
+		if azEndpoint == "" {
+			azEndpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
+		}
+		azAPIKey := serverConfig.LLM.AzureOpenAIAPIKey
+		if azAPIKey == "" {
+			azAPIKey = os.Getenv("AZURE_OPENAI_API_KEY")
+		}
+		azEntraToken := serverConfig.LLM.AzureOpenAIEntraToken
+		if azEntraToken == "" {
+			azEntraToken = os.Getenv("AZURE_OPENAI_ENTRA_TOKEN")
+		}
 		return azureopenai.NewClient(azureopenai.Config{
-			Endpoint:     serverConfig.LLM.AzureOpenAIEndpoint,
-			DeploymentID: deploymentID,
-			APIKey:       serverConfig.LLM.AzureOpenAIAPIKey,
-			EntraToken:   serverConfig.LLM.AzureOpenAIEntraToken,
-			MaxTokens:    maxTokens,
-			Temperature:  temperature,
-			Timeout:      timeout,
+			Endpoint:          azEndpoint,
+			DeploymentID:      deploymentID,
+			APIKey:            azAPIKey,
+			EntraToken:        azEntraToken,
+			MaxTokens:         maxTokens,
+			Temperature:       temperature,
+			Timeout:           timeout,
+			RateLimiterConfig: rlCfg,
 		})
 
 	case "mistral":
@@ -914,11 +940,12 @@ func createLLMProviderFromProtoConfig(protoConfig *loomv1.LLMConfig, serverConfi
 			model = serverConfig.LLM.MistralModel
 		}
 		return mistral.NewClient(mistral.Config{
-			APIKey:      serverConfig.LLM.MistralAPIKey,
-			Model:       model,
-			MaxTokens:   maxTokens,
-			Temperature: temperature,
-			Timeout:     timeout,
+			APIKey:            serverConfig.LLM.MistralAPIKey,
+			Model:             model,
+			MaxTokens:         maxTokens,
+			Temperature:       temperature,
+			Timeout:           timeout,
+			RateLimiterConfig: rlCfg,
 		}), nil
 
 	case "gemini":
@@ -927,11 +954,12 @@ func createLLMProviderFromProtoConfig(protoConfig *loomv1.LLMConfig, serverConfi
 			model = serverConfig.LLM.GeminiModel
 		}
 		return gemini.NewClient(gemini.Config{
-			APIKey:      serverConfig.LLM.GeminiAPIKey,
-			Model:       model,
-			MaxTokens:   maxTokens,
-			Temperature: temperature,
-			Timeout:     timeout,
+			APIKey:            serverConfig.LLM.GeminiAPIKey,
+			Model:             model,
+			MaxTokens:         maxTokens,
+			Temperature:       temperature,
+			Timeout:           timeout,
+			RateLimiterConfig: rlCfg,
 		}), nil
 
 	case "huggingface":
@@ -940,11 +968,12 @@ func createLLMProviderFromProtoConfig(protoConfig *loomv1.LLMConfig, serverConfi
 			model = serverConfig.LLM.HuggingFaceModel
 		}
 		return huggingface.NewClient(huggingface.Config{
-			Token:       serverConfig.LLM.HuggingFaceToken,
-			Model:       model,
-			MaxTokens:   maxTokens,
-			Temperature: temperature,
-			Timeout:     timeout,
+			Token:             serverConfig.LLM.HuggingFaceToken,
+			Model:             model,
+			MaxTokens:         maxTokens,
+			Temperature:       temperature,
+			Timeout:           timeout,
+			RateLimiterConfig: rlCfg,
 		}), nil
 
 	case "litellm":
@@ -953,12 +982,13 @@ func createLLMProviderFromProtoConfig(protoConfig *loomv1.LLMConfig, serverConfi
 			model = serverConfig.LLM.LiteLLMModel
 		}
 		return litellm.NewClient(litellm.Config{
-			Endpoint:    serverConfig.LLM.LiteLLMEndpoint,
-			APIKey:      serverConfig.LLM.LiteLLMAPIKey,
-			Model:       model,
-			MaxTokens:   maxTokens,
-			Temperature: temperature,
-			Timeout:     timeout,
+			Endpoint:          serverConfig.LLM.LiteLLMEndpoint,
+			APIKey:            serverConfig.LLM.LiteLLMAPIKey,
+			Model:             model,
+			MaxTokens:         maxTokens,
+			Temperature:       temperature,
+			Timeout:           timeout,
+			RateLimiterConfig: rlCfg,
 		}), nil
 
 	default:

--- a/cmd/looms/config.go
+++ b/cmd/looms/config.go
@@ -376,8 +376,10 @@ type LLMRateLimitConfig struct {
 	// Max requests per second (0 = default: 2.0).
 	RequestsPerSecond float64 `mapstructure:"requests_per_second"`
 
-	// Max tokens per minute for token-based throttling (0 = default: 40000).
-	// Match your API tier: Anthropic free=30000, Tier1=100000, Bedrock varies.
+	// Max tokens per minute. OBSERVATIONAL ONLY today: token consumption is
+	// tracked and reported in rate-limiter metrics, but this value is never
+	// enforced — only requests_per_second, burst_capacity, and min_delay_ms
+	// gate requests (0 = default: 40000, metrics baseline).
 	TokensPerMinute int64 `mapstructure:"tokens_per_minute"`
 
 	// Max burst size before queuing (0 = default: 5).

--- a/cmd/looms/custom_llm_provider_test.go
+++ b/cmd/looms/custom_llm_provider_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"github.com/teradata-labs/loom/pkg/agent"
+)
+
+// Issue #348: the custom-LLM path built clients with no rate limiter and its
+// azure branch read only serverConfig (no env fallback), so WHERE the API key
+// lived silently decided whether an agent was throttled at all.
+
+func TestCreateLLMProviderFromProtoConfigAzureEnvFallback(t *testing.T) {
+	// Key present only in the environment must not fail client creation.
+	t.Setenv("AZURE_OPENAI_API_KEY", "test-key-not-real")
+	t.Setenv("AZURE_OPENAI_ENDPOINT", "https://unit-test.openai.azure.com/")
+
+	serverConfig := &Config{} // no azure fields set — env is the only source
+	protoConfig := &loomv1.LLMConfig{Provider: "azure-openai", Model: "gpt-4o"}
+
+	provider, err := createLLMProviderFromProtoConfig(protoConfig, serverConfig, zap.NewNop())
+	require.NoError(t, err, "env-only azure credentials must work on the custom-LLM path")
+	require.NotNil(t, provider)
+	assert.Equal(t, "azure-openai", provider.Name())
+}
+
+func TestCreateLLMProviderFromProtoConfigAzureYAMLKeyStillWorks(t *testing.T) {
+	t.Setenv("AZURE_OPENAI_API_KEY", "")
+	t.Setenv("AZURE_OPENAI_ENDPOINT", "")
+
+	serverConfig := &Config{}
+	serverConfig.LLM.AzureOpenAIEndpoint = "https://unit-test.openai.azure.com/"
+	serverConfig.LLM.AzureOpenAIAPIKey = "yaml-key-not-real"
+	protoConfig := &loomv1.LLMConfig{Provider: "azure-openai", Model: "gpt-4o"}
+
+	provider, err := createLLMProviderFromProtoConfig(protoConfig, serverConfig, zap.NewNop())
+	require.NoError(t, err)
+	assert.Equal(t, "azure-openai", provider.Name())
+}
+
+func TestBuildRateLimiterConfigDefaults(t *testing.T) {
+	// Nil proto → enabled with zero numerics (backfilled by NewRateLimiter).
+	cfg := agent.BuildRateLimiterConfig(nil, zap.NewNop())
+	assert.True(t, cfg.Enabled, "rate limiting must default to ON for every construction path")
+
+	// Explicit disable is honored.
+	off := agent.BuildRateLimiterConfig(&loomv1.LLMRateLimitConfig{Disabled: true}, zap.NewNop())
+	assert.False(t, off.Enabled)
+
+	// Agent-specified numbers pass through.
+	custom := agent.BuildRateLimiterConfig(&loomv1.LLMRateLimitConfig{
+		RequestsPerSecond: 100,
+		TokensPerMinute:   1_200_000,
+	}, zap.NewNop())
+	assert.Equal(t, 100.0, custom.RequestsPerSecond)
+	assert.Equal(t, int64(1_200_000), custom.TokensPerMinute)
+}

--- a/docs/reference/llm-azure-openai.md
+++ b/docs/reference/llm-azure-openai.md
@@ -1002,7 +1002,7 @@ Success: received response after 2 retries
 ```
 
 
-#### Option 2: Token Rate Limiting (Client-Side)
+#### Option 2: Client-Side Rate Limiting
 
 ```go
 import "github.com/teradata-labs/loom/pkg/llm"
@@ -1013,16 +1013,21 @@ client, err := azureopenai.NewClient(azureopenai.Config{
     DeploymentID: deploymentID,
     APIKey:       apiKey,
     RateLimiterConfig: llm.RateLimiterConfig{
-        Enabled:         true,
-        TokensPerMinute: 100000,  // 100K TPM (below your 120K quota)
+        Enabled:           true,
+        RequestsPerSecond: 2.0,     // enforced: paces request admission
+        TokensPerMinute:   100000,  // observational only: reported in metrics, NOT enforced
     },
 })
 ```
 
 **Behavior**:
-- Requests are automatically queued when rate limit approached
-- Prevents 429 errors before they occur
-- Smooths request rate across time
+- Requests are queued and admitted at the configured request rate
+  (`RequestsPerSecond`, `BurstCapacity`, `MinDelay`)
+- 429 responses are retried inside the limiter with jittered exponential
+  backoff, honoring the server's `Retry-After`
+- `TokensPerMinute` is **observational only today**: token consumption is
+  tracked and reported in rate-limiter metrics, but it is never enforced —
+  size `RequestsPerSecond` against your TPM quota instead
 
 
 #### Option 3: Load Balancing Across Deployments

--- a/docs/reference/llm-gemini.md
+++ b/docs/reference/llm-gemini.md
@@ -277,7 +277,7 @@ llm:
   rate_limit:
     disabled: false
     requests_per_second: 2.0
-    tokens_per_minute: 40000
+    tokens_per_minute: 40000   # observational only: reported in metrics, NOT enforced
     burst_capacity: 5
     min_delay_ms: 300
     max_retries: 5
@@ -439,8 +439,8 @@ func main() {
         Timeout:     120 * time.Second,
         RateLimiterConfig: llm.RateLimiterConfig{
             Enabled:           true,
-            RequestsPerSecond: 2.0,
-            TokensPerMinute:   40000,
+            RequestsPerSecond: 2.0,   // enforced: paces request admission
+            TokensPerMinute:   40000, // observational only: reported in metrics, NOT enforced
         },
     })
 
@@ -480,7 +480,7 @@ llm:
   rate_limit:
     disabled: false
     requests_per_second: 2.0
-    tokens_per_minute: 40000
+    tokens_per_minute: 40000   # observational only: reported in metrics, NOT enforced
     burst_capacity: 5
     min_delay_ms: 300
     max_retries: 5
@@ -489,6 +489,8 @@ llm:
 ```
 
 Both `Chat` and `ChatStream` methods respect the rate limiter. Token usage is recorded for the rate limiter's metrics after streaming completes.
+
+**Note**: `tokens_per_minute` is observational only today — token consumption is tracked and reported in rate-limiter metrics, but never enforced. Only `requests_per_second`, `burst_capacity`, and `min_delay_ms` gate requests; size `requests_per_second` against your TPM quota.
 
 
 ## Error Codes

--- a/docs/reference/llm-huggingface.md
+++ b/docs/reference/llm-huggingface.md
@@ -182,7 +182,7 @@ llm:
   # Optional: client-side rate limiting
   rate_limit:
     requests_per_second: 2.0
-    tokens_per_minute: 30000
+    tokens_per_minute: 30000   # observational only: reported in metrics, NOT enforced
     min_delay_ms: 400
 ```
 

--- a/docs/reference/llm-mistral.md
+++ b/docs/reference/llm-mistral.md
@@ -987,7 +987,7 @@ client := mistral.NewClient(mistral.Config{
     RateLimiterConfig: llm.RateLimiterConfig{
         Enabled:           true,
         RequestsPerSecond: 2.0,
-        TokensPerMinute:   450000,  // 450K TPM (below 500K limit)
+        TokensPerMinute:   450000,  // observational only: reported in metrics, NOT enforced
         BurstCapacity:     5,
         MinDelay:          200 * time.Millisecond,
         MaxRetries:        5,
@@ -998,9 +998,13 @@ client := mistral.NewClient(mistral.Config{
 ```
 
 **Behavior**:
-- Requests are automatically queued when approaching limit
-- Prevents 429 errors before they occur
-- Smooths request rate across time
+- Requests are queued and admitted at the configured request rate
+  (`RequestsPerSecond`, `BurstCapacity`, `MinDelay`)
+- 429 responses are retried inside the limiter with jittered exponential
+  backoff, honoring the server's `Retry-After`
+- `TokensPerMinute` is **observational only today**: token consumption is
+  tracked and reported in rate-limiter metrics, but it is never enforced —
+  size `RequestsPerSecond` against your TPM quota instead
 
 
 ## Testing

--- a/docs/reference/llm-openai.md
+++ b/docs/reference/llm-openai.md
@@ -1099,16 +1099,21 @@ client := openai.NewClient(openai.Config{
     APIKey:  apiKey,
     Model:   "gpt-4.1",
     RateLimiterConfig: llm.RateLimiterConfig{
-        Enabled:         true,
-        TokensPerMinute: 180000,  // 180K TPM (below 200K limit for Tier 1)
+        Enabled:           true,
+        RequestsPerSecond: 2.0,     // enforced: paces request admission
+        TokensPerMinute:   180000,  // observational only: reported in metrics, NOT enforced
     },
 })
 ```
 
 **Behavior**:
-- Requests are automatically queued when approaching limit
-- Prevents 429 errors before they occur
-- Smooths request rate across time
+- Requests are queued and admitted at the configured request rate
+  (`RequestsPerSecond`, `BurstCapacity`, `MinDelay`)
+- 429 responses are retried inside the limiter with jittered exponential
+  backoff, honoring the server's `Retry-After`
+- `TokensPerMinute` is **observational only today**: token consumption is
+  tracked and reported in rate-limiter metrics, but it is never enforced —
+  size `RequestsPerSecond` against your TPM quota instead
 
 
 ## Testing

--- a/gen/go/loom/v1/agent_config.pb.go
+++ b/gen/go/loom/v1/agent_config.pb.go
@@ -704,12 +704,10 @@ type LLMRateLimitConfig struct {
 	// exceed the quota, and a warning is logged when that happens.
 	// 0 = use default (2.0 RPS).
 	RequestsPerSecond float64 `protobuf:"fixed64,2,opt,name=requests_per_second,json=requestsPerSecond,proto3" json:"requests_per_second,omitempty"`
-	// Maximum input+output tokens per minute for token-based throttling.
-	// 0 = use default (40000 TPM).
-	// Set this to match your API tier:
-	//
-	//	Anthropic free: 30000, Tier 1: 100000
-	//	Bedrock: varies by model (40000-400000)
+	// Maximum input+output tokens per minute. OBSERVATIONAL ONLY today: token
+	// consumption is tracked and reported in rate-limiter metrics, but this
+	// value is never enforced — only requests_per_second, burst_capacity, and
+	// min_delay_ms gate requests. 0 = use default (40000 TPM metrics baseline).
 	TokensPerMinute int64 `protobuf:"varint,3,opt,name=tokens_per_minute,json=tokensPerMinute,proto3" json:"tokens_per_minute,omitempty"`
 	// Burst capacity: maximum concurrent requests allowed before queuing.
 	// 0 = use default (5).

--- a/gen/openapiv2/loom/v1/judge.swagger.json
+++ b/gen/openapiv2/loom/v1/judge.swagger.json
@@ -733,7 +733,7 @@
         "tokensPerMinute": {
           "type": "string",
           "format": "int64",
-          "title": "Maximum input+output tokens per minute for token-based throttling.\n0 = use default (40000 TPM).\nSet this to match your API tier:\n  Anthropic free: 30000, Tier 1: 100000\n  Bedrock: varies by model (40000-400000)"
+          "description": "Maximum input+output tokens per minute. OBSERVATIONAL ONLY today: token\nconsumption is tracked and reported in rate-limiter metrics, but this\nvalue is never enforced — only requests_per_second, burst_capacity, and\nmin_delay_ms gate requests. 0 = use default (40000 TPM metrics baseline)."
         },
         "burstCapacity": {
           "type": "integer",

--- a/gen/openapiv2/loom/v1/loom.swagger.json
+++ b/gen/openapiv2/loom/v1/loom.swagger.json
@@ -5776,7 +5776,7 @@
         "tokensPerMinute": {
           "type": "string",
           "format": "int64",
-          "title": "Maximum input+output tokens per minute for token-based throttling.\n0 = use default (40000 TPM).\nSet this to match your API tier:\n  Anthropic free: 30000, Tier 1: 100000\n  Bedrock: varies by model (40000-400000)"
+          "description": "Maximum input+output tokens per minute. OBSERVATIONAL ONLY today: token\nconsumption is tracked and reported in rate-limiter metrics, but this\nvalue is never enforced — only requests_per_second, burst_capacity, and\nmin_delay_ms gate requests. 0 = use default (40000 TPM metrics baseline)."
         },
         "burstCapacity": {
           "type": "integer",

--- a/pkg/agent/config_loader.go
+++ b/pkg/agent/config_loader.go
@@ -55,6 +55,19 @@ func convertLLMConfigYAMLToProto(y *LLMConfigYAML) (*loomv1.LLMConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	var rateLimit *loomv1.LLMRateLimitConfig
+	if y.RateLimit != nil {
+		rateLimit = &loomv1.LLMRateLimitConfig{
+			Disabled:            y.RateLimit.Disabled,
+			RequestsPerSecond:   y.RateLimit.RequestsPerSecond,
+			TokensPerMinute:     y.RateLimit.TokensPerMinute,
+			BurstCapacity:       y.RateLimit.BurstCapacity,
+			MinDelayMs:          y.RateLimit.MinDelayMs,
+			MaxRetries:          y.RateLimit.MaxRetries,
+			RetryBackoffMs:      y.RateLimit.RetryBackoffMs,
+			QueueTimeoutSeconds: y.RateLimit.QueueTimeoutSeconds,
+		}
+	}
 	return &loomv1.LLMConfig{
 		Provider:             y.Provider,
 		Model:                y.Model,
@@ -65,6 +78,7 @@ func convertLLMConfigYAMLToProto(y *LLMConfigYAML) (*loomv1.LLMConfig, error) {
 		TopK:                 topK,
 		MaxContextTokens:     maxContextTokens,
 		ReservedOutputTokens: reservedOutputTokens,
+		RateLimit:            rateLimit,
 	}, nil
 }
 
@@ -73,6 +87,19 @@ func convertLLMConfigYAMLToProto(y *LLMConfigYAML) (*loomv1.LLMConfig, error) {
 func convertProtoToLLMConfigYAML(pb *loomv1.LLMConfig) *LLMConfigYAML {
 	if pb == nil || pb.Provider == "" {
 		return nil
+	}
+	var rateLimit *LLMRateLimitYAML
+	if pb.RateLimit != nil {
+		rateLimit = &LLMRateLimitYAML{
+			Disabled:            pb.RateLimit.Disabled,
+			RequestsPerSecond:   pb.RateLimit.RequestsPerSecond,
+			TokensPerMinute:     pb.RateLimit.TokensPerMinute,
+			BurstCapacity:       pb.RateLimit.BurstCapacity,
+			MinDelayMs:          pb.RateLimit.MinDelayMs,
+			MaxRetries:          pb.RateLimit.MaxRetries,
+			RetryBackoffMs:      pb.RateLimit.RetryBackoffMs,
+			QueueTimeoutSeconds: pb.RateLimit.QueueTimeoutSeconds,
+		}
 	}
 	return &LLMConfigYAML{
 		Provider:             pb.Provider,
@@ -84,6 +111,7 @@ func convertProtoToLLMConfigYAML(pb *loomv1.LLMConfig) *LLMConfigYAML {
 		TopK:                 int(pb.TopK),
 		MaxContextTokens:     int(pb.MaxContextTokens),
 		ReservedOutputTokens: int(pb.ReservedOutputTokens),
+		RateLimit:            rateLimit,
 	}
 }
 
@@ -148,15 +176,30 @@ type K8sStyleAgentConfig struct {
 
 // LLMConfigYAML represents LLM configuration in YAML
 type LLMConfigYAML struct {
-	Provider             string   `yaml:"provider"`
-	Model                string   `yaml:"model"`
-	Temperature          float64  `yaml:"temperature"`
-	MaxTokens            int      `yaml:"max_tokens"`
-	StopSequences        []string `yaml:"stop_sequences"`
-	TopP                 float64  `yaml:"top_p"`
-	TopK                 int      `yaml:"top_k"`
-	MaxContextTokens     int      `yaml:"max_context_tokens"`
-	ReservedOutputTokens int      `yaml:"reserved_output_tokens"`
+	Provider             string            `yaml:"provider"`
+	Model                string            `yaml:"model"`
+	Temperature          float64           `yaml:"temperature"`
+	MaxTokens            int               `yaml:"max_tokens"`
+	StopSequences        []string          `yaml:"stop_sequences"`
+	TopP                 float64           `yaml:"top_p"`
+	TopK                 int               `yaml:"top_k"`
+	MaxContextTokens     int               `yaml:"max_context_tokens"`
+	ReservedOutputTokens int               `yaml:"reserved_output_tokens"`
+	RateLimit            *LLMRateLimitYAML `yaml:"rate_limit"`
+}
+
+// LLMRateLimitYAML mirrors proto LLMRateLimitConfig for agent YAML files.
+// Before this existed, a spec.llm.rate_limit block was silently dropped by
+// the loader — the proto field was never populated from YAML (issue #348).
+type LLMRateLimitYAML struct {
+	Disabled            bool    `yaml:"disabled"`
+	RequestsPerSecond   float64 `yaml:"requests_per_second"`
+	TokensPerMinute     int64   `yaml:"tokens_per_minute"`
+	BurstCapacity       int32   `yaml:"burst_capacity"`
+	MinDelayMs          int32   `yaml:"min_delay_ms"`
+	MaxRetries          int32   `yaml:"max_retries"`
+	RetryBackoffMs      int32   `yaml:"retry_backoff_ms"`
+	QueueTimeoutSeconds int32   `yaml:"queue_timeout_seconds"`
 }
 
 // ToolsConfigYAML represents tools configuration in YAML

--- a/pkg/agent/config_loader.go
+++ b/pkg/agent/config_loader.go
@@ -191,6 +191,10 @@ type LLMConfigYAML struct {
 // LLMRateLimitYAML mirrors proto LLMRateLimitConfig for agent YAML files.
 // Before this existed, a spec.llm.rate_limit block was silently dropped by
 // the loader — the proto field was never populated from YAML (issue #348).
+//
+// Note: tokens_per_minute is OBSERVATIONAL ONLY today — tracked and reported
+// in rate-limiter metrics, never enforced. Only requests_per_second,
+// burst_capacity, and min_delay_ms gate requests.
 type LLMRateLimitYAML struct {
 	Disabled            bool    `yaml:"disabled"`
 	RequestsPerSecond   float64 `yaml:"requests_per_second"`

--- a/pkg/agent/config_loader_rate_limit_test.go
+++ b/pkg/agent/config_loader_rate_limit_test.go
@@ -1,0 +1,43 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #348 follow-up: spec.llm.rate_limit in agent YAML was silently
+// dropped — LLMConfigYAML had no field for it, so the proto RateLimit was
+// never populated and every agent ran on provider defaults regardless of
+// what the YAML said.
+func TestLLMConfigYAMLRateLimitRoundTrip(t *testing.T) {
+	y := &LLMConfigYAML{
+		Provider: "azure-openai",
+		Model:    "gpt-4o",
+		RateLimit: &LLMRateLimitYAML{
+			RequestsPerSecond:   15,
+			TokensPerMinute:     1_200_000,
+			MinDelayMs:          10,
+			BurstCapacity:       32,
+			QueueTimeoutSeconds: 600,
+		},
+	}
+	pb, err := convertLLMConfigYAMLToProto(y)
+	require.NoError(t, err)
+	require.NotNil(t, pb.RateLimit, "rate_limit must survive YAML→proto conversion")
+	assert.Equal(t, 15.0, pb.RateLimit.RequestsPerSecond)
+	assert.Equal(t, int64(1_200_000), pb.RateLimit.TokensPerMinute)
+	assert.Equal(t, int32(10), pb.RateLimit.MinDelayMs)
+	assert.Equal(t, int32(32), pb.RateLimit.BurstCapacity)
+	assert.Equal(t, int32(600), pb.RateLimit.QueueTimeoutSeconds)
+
+	back := convertProtoToLLMConfigYAML(pb)
+	require.NotNil(t, back.RateLimit)
+	assert.Equal(t, y.RateLimit, back.RateLimit, "proto→YAML must round-trip")
+
+	// Absent block stays absent (nil, not zero-values).
+	pbNo, err := convertLLMConfigYAMLToProto(&LLMConfigYAML{Provider: "azure-openai"})
+	require.NoError(t, err)
+	assert.Nil(t, pbNo.RateLimit)
+}

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -1265,9 +1265,18 @@ func (r *Registry) createLLMProvider(config *loomv1.LLMConfig) (LLMProvider, err
 // When proto config has disabled=true, returns a disabled rate limiter config.
 // Non-zero numeric fields override the provider defaults set by NewRateLimiter().
 func (r *Registry) buildRateLimiterConfig(proto *loomv1.LLMRateLimitConfig) llm.RateLimiterConfig {
+	return BuildRateLimiterConfig(proto, r.logger)
+}
+
+// BuildRateLimiterConfig converts the proto LLMRateLimitConfig to the llm
+// package config. Exported so every client-construction path (the agent
+// registry and looms' custom-LLM path) applies identical rate-limit
+// semantics — a client built without this is unthrottled and, because 429
+// retry lives inside the limiter, also retry-less (issue #348).
+func BuildRateLimiterConfig(proto *loomv1.LLMRateLimitConfig, logger *zap.Logger) llm.RateLimiterConfig {
 	cfg := llm.RateLimiterConfig{
 		Enabled: true,
-		Logger:  r.logger,
+		Logger:  logger,
 		// All numeric fields left at zero → NewRateLimiter() fills them from DefaultRateLimiterConfig()
 	}
 

--- a/pkg/llm/anthropic/client.go
+++ b/pkg/llm/anthropic/client.go
@@ -593,11 +593,15 @@ func (c *Client) ChatStream(ctx context.Context, messages []llmtypes.Message,
 			if err != nil {
 				return nil, err
 			}
-			// Convert 429 to a retryable error so the rate limiter backs off and retries.
+			// Convert 429 to a retryable error so the rate limiter backs off and
+			// retries, carrying the server-specified Retry-After so the limiter
+			// waits at least that long.
 			if resp.StatusCode == http.StatusTooManyRequests {
 				respBody, _ := io.ReadAll(resp.Body)
 				_ = resp.Body.Close()
-				return nil, fmt.Errorf("API error (status 429): %s", string(respBody))
+				return nil, llm.NewThrottleError(
+					fmt.Errorf("API error (status 429): %s", string(respBody)),
+					llm.RetryAfterFromHeaders(resp.Header))
 			}
 			return resp, nil
 		})
@@ -821,11 +825,15 @@ func (c *Client) callAPI(ctx context.Context, req *MessagesRequest) (*MessagesRe
 			if err != nil {
 				return nil, err
 			}
-			// Convert 429 to a retryable error so the rate limiter backs off and retries.
+			// Convert 429 to a retryable error so the rate limiter backs off and
+			// retries, carrying the server-specified Retry-After so the limiter
+			// waits at least that long.
 			if resp.StatusCode == http.StatusTooManyRequests {
 				respBody, _ := io.ReadAll(resp.Body)
 				_ = resp.Body.Close()
-				return nil, fmt.Errorf("API error (status 429): %s", string(respBody))
+				return nil, llm.NewThrottleError(
+					fmt.Errorf("API error (status 429): %s", string(respBody)),
+					llm.RetryAfterFromHeaders(resp.Header))
 			}
 			return resp, nil
 		})

--- a/pkg/llm/anthropic/retry_429_test.go
+++ b/pkg/llm/anthropic/retry_429_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package anthropic
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/teradata-labs/loom/pkg/llm"
+	"github.com/teradata-labs/loom/pkg/llm/types"
+)
+
+// The server-specified wait on a 429 must floor the retry backoff: with a
+// tiny configured retry_backoff_ms all retries used to burn inside one
+// throttle window. Uses retry-after-ms to keep the test wait short while
+// still exercising the header-to-limiter path end to end.
+func TestRetryAfterHeaderHonored(t *testing.T) {
+	var mu sync.Mutex
+	var arrivals []time.Time
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		arrivals = append(arrivals, time.Now())
+		n := len(arrivals)
+		mu.Unlock()
+		if n == 1 {
+			w.Header().Set("retry-after-ms", "400")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"type":"error","error":{"type":"rate_limit_error","message":"rate limited"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-5-20250929","stop_reason":"end_turn","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{
+		APIKey:   "test-key-not-real-retry-after",
+		Endpoint: srv.URL,
+		RateLimiterConfig: llm.RateLimiterConfig{
+			Enabled:           true,
+			RequestsPerSecond: 1000,
+			BurstCapacity:     8,
+			MinDelay:          time.Millisecond,
+			RetryBackoff:      5 * time.Millisecond, // tiny: the wait must come from retry-after-ms
+			MaxRetries:        2,
+		},
+	})
+
+	resp, err := client.Chat(context.Background(), []types.Message{{Role: "user", Content: "hi"}}, nil)
+	require.NoError(t, err, "429 with retry-after-ms then success must be absorbed by retry")
+	assert.Contains(t, resp.Content, "ok")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, arrivals, 2)
+	gap := arrivals[1].Sub(arrivals[0])
+	assert.GreaterOrEqual(t, gap, 350*time.Millisecond,
+		"retry arrived %v after the 429: retry-after-ms 400 was not honored over the 5ms backoff", gap)
+}

--- a/pkg/llm/azureopenai/client.go
+++ b/pkg/llm/azureopenai/client.go
@@ -223,40 +223,49 @@ func (c *Client) callAPI(ctx context.Context, req *openai.ChatCompletionRequest)
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Create HTTP request
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	// Set headers
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	// Authentication: Use api-key OR Authorization header
-	if c.apiKey != "" {
-		// Option 1: API key authentication
-		httpReq.Header.Set("api-key", c.apiKey)
-	} else {
-		// Option 2: Microsoft Entra ID token
-		httpReq.Header.Set("Authorization", "Bearer "+c.entraToken)
+	// sendOnce builds and sends a fresh request. It must construct a new
+	// http.Request per attempt (a consumed body cannot be re-sent), and it
+	// surfaces HTTP 429 as an ERROR: httpClient.Do returns nil error for any
+	// HTTP status, so without this the rate limiter's executeWithRetry never
+	// saw throttling and 429s went straight to the caller un-retried.
+	sendOnce := func(ctx context.Context) (interface{}, error) {
+		httpReq, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		// Authentication: Use api-key OR Authorization header
+		if c.apiKey != "" {
+			httpReq.Header.Set("api-key", c.apiKey)
+		} else {
+			httpReq.Header.Set("Authorization", "Bearer "+c.entraToken)
+		}
+		resp, err := c.httpClient.Do(httpReq)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode == http.StatusTooManyRequests {
+			respBody, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("API error (status 429): %s", string(respBody))
+		}
+		return resp, nil
 	}
 
 	// Send request with rate limiting if enabled
 	var httpResp *http.Response
 	if c.rateLimiter != nil {
-		result, err := c.rateLimiter.Do(ctx, func(ctx context.Context) (interface{}, error) {
-			return c.httpClient.Do(httpReq)
-		})
+		result, err := c.rateLimiter.Do(ctx, sendOnce)
 		if err != nil {
 			return nil, fmt.Errorf("HTTP request failed: %w", err)
 		}
 		httpResp = result.(*http.Response)
 	} else {
-		var err error
-		httpResp, err = c.httpClient.Do(httpReq)
+		result, err := sendOnce(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("HTTP request failed: %w", err)
 		}
+		httpResp = result.(*http.Response)
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
@@ -678,36 +687,47 @@ func (c *Client) ChatStream(ctx context.Context, messages []llmtypes.Message,
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Create HTTP request
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	// Set headers
-	httpReq.Header.Set("Content-Type", "application/json")
-	if c.apiKey != "" {
-		httpReq.Header.Set("api-key", c.apiKey)
-	} else {
-		httpReq.Header.Set("Authorization", "Bearer "+c.entraToken)
+	// sendOnce builds and sends a fresh request per attempt (a consumed body
+	// cannot be re-sent) and surfaces HTTP 429 as an ERROR so the rate
+	// limiter's retry actually sees throttling — httpClient.Do returns nil
+	// error for any HTTP status.
+	sendOnce := func(ctx context.Context) (interface{}, error) {
+		httpReq, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		if c.apiKey != "" {
+			httpReq.Header.Set("api-key", c.apiKey)
+		} else {
+			httpReq.Header.Set("Authorization", "Bearer "+c.entraToken)
+		}
+		resp, err := c.httpClient.Do(httpReq)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode == http.StatusTooManyRequests {
+			respBody, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("API error (status 429): %s", string(respBody))
+		}
+		return resp, nil
 	}
 
 	// Send request with rate limiting if enabled
 	var httpResp *http.Response
 	if c.rateLimiter != nil {
-		result, err := c.rateLimiter.Do(ctx, func(ctx context.Context) (interface{}, error) {
-			return c.httpClient.Do(httpReq)
-		})
+		result, err := c.rateLimiter.Do(ctx, sendOnce)
 		if err != nil {
 			return nil, fmt.Errorf("HTTP request failed: %w", err)
 		}
 		httpResp = result.(*http.Response)
 	} else {
-		var err error
-		httpResp, err = c.httpClient.Do(httpReq)
+		result, err := sendOnce(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("HTTP request failed: %w", err)
 		}
+		httpResp = result.(*http.Response)
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 

--- a/pkg/llm/azureopenai/client.go
+++ b/pkg/llm/azureopenai/client.go
@@ -226,8 +226,10 @@ func (c *Client) callAPI(ctx context.Context, req *openai.ChatCompletionRequest)
 	// sendOnce builds and sends a fresh request. It must construct a new
 	// http.Request per attempt (a consumed body cannot be re-sent), and it
 	// surfaces HTTP 429 as an ERROR: httpClient.Do returns nil error for any
-	// HTTP status, so without this the rate limiter's executeWithRetry never
-	// saw throttling and 429s went straight to the caller un-retried.
+	// HTTP status, so without this the rate limiter's retry never saw
+	// throttling and 429s went straight to the caller un-retried. The error
+	// carries the server-specified wait (Retry-After / retry-after-ms /
+	// x-ratelimit reset headers) so the limiter waits at least that long.
 	sendOnce := func(ctx context.Context) (interface{}, error) {
 		httpReq, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(body))
 		if err != nil {
@@ -247,7 +249,9 @@ func (c *Client) callAPI(ctx context.Context, req *openai.ChatCompletionRequest)
 		if resp.StatusCode == http.StatusTooManyRequests {
 			respBody, _ := io.ReadAll(resp.Body)
 			_ = resp.Body.Close()
-			return nil, fmt.Errorf("API error (status 429): %s", string(respBody))
+			return nil, llm.NewThrottleError(
+				fmt.Errorf("API error (status 429): %s", string(respBody)),
+				llm.RetryAfterFromHeaders(resp.Header))
 		}
 		return resp, nil
 	}
@@ -690,7 +694,8 @@ func (c *Client) ChatStream(ctx context.Context, messages []llmtypes.Message,
 	// sendOnce builds and sends a fresh request per attempt (a consumed body
 	// cannot be re-sent) and surfaces HTTP 429 as an ERROR so the rate
 	// limiter's retry actually sees throttling — httpClient.Do returns nil
-	// error for any HTTP status.
+	// error for any HTTP status. The error carries the server-specified wait
+	// (Retry-After and friends) so the limiter waits at least that long.
 	sendOnce := func(ctx context.Context) (interface{}, error) {
 		httpReq, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(body))
 		if err != nil {
@@ -709,7 +714,9 @@ func (c *Client) ChatStream(ctx context.Context, messages []llmtypes.Message,
 		if resp.StatusCode == http.StatusTooManyRequests {
 			respBody, _ := io.ReadAll(resp.Body)
 			_ = resp.Body.Close()
-			return nil, fmt.Errorf("API error (status 429): %s", string(respBody))
+			return nil, llm.NewThrottleError(
+				fmt.Errorf("API error (status 429): %s", string(respBody)),
+				llm.RetryAfterFromHeaders(resp.Header))
 		}
 		return resp, nil
 	}

--- a/pkg/llm/azureopenai/retry_429_test.go
+++ b/pkg/llm/azureopenai/retry_429_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -15,8 +16,8 @@ import (
 	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
 )
 
-// HTTP 429 must surface as an error INSIDE the rate limiter so
-// executeWithRetry retries it — httpClient.Do returns nil error for any
+// HTTP 429 must surface as an error INSIDE the rate limiter so its retry
+// machinery fires — httpClient.Do returns nil error for any
 // status, so before this the retry machinery never saw throttling and 429s
 // went straight to the caller (issue #348 field evidence: 503/512 agents
 // dead on first-attempt 429s with zero retry log lines).
@@ -52,4 +53,54 @@ func TestCallAPI429IsRetriedThroughRateLimiter(t *testing.T) {
 	require.NoError(t, err, "two 429s then success must be absorbed by retry")
 	assert.Equal(t, int32(3), calls.Load(), "server must have been called three times (2x429 + success)")
 	assert.Contains(t, resp.Content, "ok")
+}
+
+// The server's Retry-After must floor the retry wait: with a tiny configured
+// retry_backoff_ms (5ms here) all retries used to burn inside one throttle
+// window, turning a recoverable throttle into a hard failure. The second
+// attempt must arrive no sooner than the header's delta-seconds.
+func TestRetryAfterHeaderHonored(t *testing.T) {
+	var mu sync.Mutex
+	var arrivals []time.Time
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		arrivals = append(arrivals, time.Now())
+		n := len(arrivals)
+		mu.Unlock()
+		if n == 1 {
+			w.Header().Set("Retry-After", "1") // delta-seconds
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":{"message":"exceeded rate limit","type":"too_many_requests"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"1","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(Config{
+		Endpoint:     srv.URL,
+		DeploymentID: "gpt-4o-test-retry-after",
+		APIKey:       "test-key-not-real",
+		RateLimiterConfig: llm.RateLimiterConfig{
+			Enabled:           true,
+			RequestsPerSecond: 1000,
+			BurstCapacity:     8,
+			MinDelay:          time.Millisecond,
+			RetryBackoff:      5 * time.Millisecond, // tiny: the wait must come from Retry-After
+			MaxRetries:        2,
+		},
+	})
+	require.NoError(t, err)
+
+	resp, err := client.Chat(context.Background(), []llmtypes.Message{{Role: "user", Content: "hi"}}, nil)
+	require.NoError(t, err, "429 with Retry-After then success must be absorbed by retry")
+	assert.Contains(t, resp.Content, "ok")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, arrivals, 2)
+	gap := arrivals[1].Sub(arrivals[0])
+	assert.GreaterOrEqual(t, gap, 900*time.Millisecond,
+		"retry arrived %v after the 429: Retry-After: 1 was not honored over the 5ms backoff", gap)
 }

--- a/pkg/llm/azureopenai/retry_429_test.go
+++ b/pkg/llm/azureopenai/retry_429_test.go
@@ -1,0 +1,55 @@
+package azureopenai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/teradata-labs/loom/pkg/llm"
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+)
+
+// HTTP 429 must surface as an error INSIDE the rate limiter so
+// executeWithRetry retries it — httpClient.Do returns nil error for any
+// status, so before this the retry machinery never saw throttling and 429s
+// went straight to the caller (issue #348 field evidence: 503/512 agents
+// dead on first-attempt 429s with zero retry log lines).
+func TestCallAPI429IsRetriedThroughRateLimiter(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) <= 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":{"message":"exceeded rate limit","type":"too_many_requests"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"1","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(Config{
+		Endpoint:     srv.URL,
+		DeploymentID: "gpt-4o-test-retry",
+		APIKey:       "test-key-not-real",
+		RateLimiterConfig: llm.RateLimiterConfig{
+			Enabled:           true,
+			RequestsPerSecond: 1000,
+			BurstCapacity:     8,
+			MinDelay:          time.Millisecond,
+			RetryBackoff:      5 * time.Millisecond,
+			MaxRetries:        4,
+		},
+	})
+	require.NoError(t, err)
+
+	resp, err := client.Chat(context.Background(), []llmtypes.Message{{Role: "user", Content: "hi"}}, nil)
+	require.NoError(t, err, "two 429s then success must be absorbed by retry")
+	assert.Equal(t, int32(3), calls.Load(), "server must have been called three times (2x429 + success)")
+	assert.Contains(t, resp.Content, "ok")
+}

--- a/pkg/llm/gemini/client.go
+++ b/pkg/llm/gemini/client.go
@@ -160,31 +160,23 @@ func (c *Client) callAPI(ctx context.Context, req *GenerateContentRequest) (*Gen
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Create HTTP request
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	// Set headers
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	// Send request with rate limiting if enabled
+	// Send request with rate limiting if enabled. sendOnce rebuilds the
+	// http.Request per attempt and surfaces 429 as a throttle error so the
+	// limiter's retry fires (and each retry re-sends the full body).
 	var httpResp *http.Response
+	sendOnce := c.sendOnce(apiURL, body)
 	if c.rateLimiter != nil {
-		result, err := c.rateLimiter.Do(ctx, func(ctx context.Context) (interface{}, error) {
-			return c.httpClient.Do(httpReq)
-		})
+		result, err := c.rateLimiter.Do(ctx, sendOnce)
 		if err != nil {
 			return nil, fmt.Errorf("HTTP request failed: %w", err)
 		}
 		httpResp = result.(*http.Response)
 	} else {
-		var err error
-		httpResp, err = c.httpClient.Do(httpReq)
+		result, err := sendOnce(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("HTTP request failed: %w", err)
 		}
+		httpResp = result.(*http.Response)
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
@@ -211,6 +203,35 @@ func (c *Client) callAPI(ctx context.Context, req *GenerateContentRequest) (*Gen
 	}
 
 	return &resp, nil
+}
+
+// sendOnce returns a closure that builds and sends ONE fresh HTTP request per
+// attempt. It must construct a new http.Request each time — a consumed body
+// cannot be re-sent, so a retry of a request built once outside the closure
+// would go out empty. It also surfaces HTTP 429 as an ERROR carrying any
+// server-specified wait (Retry-After and friends): httpClient.Do returns nil
+// error for any HTTP status, so without this the rate limiter's retry never
+// sees throttling and 429s go straight to the caller un-retried.
+func (c *Client) sendOnce(apiURL string, body []byte) func(context.Context) (interface{}, error) {
+	return func(ctx context.Context) (interface{}, error) {
+		httpReq, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		resp, err := c.httpClient.Do(httpReq)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode == http.StatusTooManyRequests {
+			respBody, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			return nil, llm.NewThrottleError(
+				fmt.Errorf("API error (status 429): %s", string(respBody)),
+				llm.RetryAfterFromHeaders(resp.Header))
+		}
+		return resp, nil
+	}
 }
 
 // convertResponse converts Gemini response to agent format.
@@ -565,31 +586,23 @@ func (c *Client) ChatStream(ctx context.Context, messages []llmtypes.Message,
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Create HTTP request
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	// Set headers
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	// Send request with rate limiting if enabled
+	// Send request with rate limiting if enabled. sendOnce rebuilds the
+	// http.Request per attempt and surfaces 429 as a throttle error so the
+	// limiter's retry fires (and each retry re-sends the full body).
 	var httpResp *http.Response
+	sendOnce := c.sendOnce(apiURL, body)
 	if c.rateLimiter != nil {
-		result, err := c.rateLimiter.Do(ctx, func(ctx context.Context) (interface{}, error) {
-			return c.httpClient.Do(httpReq)
-		})
+		result, err := c.rateLimiter.Do(ctx, sendOnce)
 		if err != nil {
 			return nil, fmt.Errorf("HTTP request failed: %w", err)
 		}
 		httpResp = result.(*http.Response)
 	} else {
-		var err error
-		httpResp, err = c.httpClient.Do(httpReq)
+		result, err := sendOnce(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("HTTP request failed: %w", err)
 		}
+		httpResp = result.(*http.Response)
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 

--- a/pkg/llm/gemini/retry_429_test.go
+++ b/pkg/llm/gemini/retry_429_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/teradata-labs/loom/pkg/llm"
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+)
+
+// HTTP 429 must surface as an error INSIDE the rate limiter so its retry
+// fires — httpClient.Do returns nil error for any status, so before this the
+// limiter never saw throttling for the gemini client and 429s went straight
+// to the caller. The request must also be rebuilt per attempt: the old code
+// built it once outside the closure, so a retry would have re-sent a consumed
+// (empty) body. Both attempts' bodies are asserted identical and complete.
+func TestChat429IsRetriedWithFullBody(t *testing.T) {
+	var mu sync.Mutex
+	var bodies [][]byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, body)
+		n := len(bodies)
+		mu.Unlock()
+		if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":{"code":429,"message":"Resource has been exhausted","status":"RESOURCE_EXHAUSTED"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{
+		APIKey: "test-key-not-real-gemini429",
+		Model:  "gemini-2.5-flash",
+		RateLimiterConfig: llm.RateLimiterConfig{
+			Enabled:           true,
+			RequestsPerSecond: 1000,
+			BurstCapacity:     8,
+			MinDelay:          time.Millisecond,
+			RetryBackoff:      5 * time.Millisecond,
+			MaxRetries:        4,
+		},
+	})
+	client.httpClient.Transport = &mockTransport{
+		baseURL:  srv.URL,
+		original: http.DefaultTransport,
+	}
+
+	resp, err := client.Chat(context.Background(), []llmtypes.Message{{Role: "user", Content: "hello gemini"}}, nil)
+	require.NoError(t, err, "one 429 then success must be absorbed by the limiter's retry")
+	assert.Contains(t, resp.Content, "ok")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, bodies, 2, "server must see the failed attempt and the retry")
+	assert.NotEmpty(t, bodies[1], "retry must carry the request body, not a consumed reader")
+	assert.Equal(t, bodies[0], bodies[1], "retry must re-send the identical full body")
+
+	var req GenerateContentRequest
+	require.NoError(t, json.Unmarshal(bodies[1], &req), "retried body must be complete valid JSON")
+	require.Len(t, req.Contents, 1)
+	require.Len(t, req.Contents[0].Parts, 1)
+	assert.Equal(t, "hello gemini", req.Contents[0].Parts[0].Text)
+}

--- a/pkg/llm/ollama/client.go
+++ b/pkg/llm/ollama/client.go
@@ -454,30 +454,47 @@ func (c *Client) ChatStream(ctx context.Context, messages []llmtypes.Message,
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Create HTTP request
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.endpoint+"/api/chat", bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+	// sendOnce builds and sends ONE fresh HTTP request per attempt. It must
+	// construct a new http.Request each time — a consumed body cannot be
+	// re-sent, so a retry of a request built once outside the closure would go
+	// out empty. It also surfaces HTTP 429 as an ERROR carrying any
+	// server-specified wait (Retry-After and friends): httpClient.Do returns
+	// nil error for any HTTP status, so without this the rate limiter's retry
+	// never sees throttling and 429s go straight to the caller un-retried.
+	sendOnce := func(ctx context.Context) (interface{}, error) {
+		httpReq, err := http.NewRequestWithContext(ctx, "POST", c.endpoint+"/api/chat", bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		resp, err := c.httpClient.Do(httpReq)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode == http.StatusTooManyRequests {
+			respBody, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			return nil, llm.NewThrottleError(
+				fmt.Errorf("API error (status 429): %s", string(respBody)),
+				llm.RetryAfterFromHeaders(resp.Header))
+		}
+		return resp, nil
 	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
 
 	// 2. Send request with rate limiting if enabled
 	var httpResp *http.Response
 	if c.rateLimiter != nil {
-		result, err := c.rateLimiter.Do(ctx, func(ctx context.Context) (interface{}, error) {
-			return c.httpClient.Do(httpReq)
-		})
+		result, err := c.rateLimiter.Do(ctx, sendOnce)
 		if err != nil {
 			return nil, fmt.Errorf("HTTP request failed: %w", err)
 		}
 		httpResp = result.(*http.Response)
 	} else {
-		var err error
-		httpResp, err = c.httpClient.Do(httpReq)
+		result, err := sendOnce(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("HTTP request failed: %w", err)
 		}
+		httpResp = result.(*http.Response)
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 

--- a/pkg/llm/ollama/retry_429_test.go
+++ b/pkg/llm/ollama/retry_429_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/teradata-labs/loom/pkg/llm"
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+)
+
+// HTTP 429 must surface as an error INSIDE the rate limiter so its retry
+// fires — httpClient.Do returns nil error for any status, so before this the
+// limiter never saw throttling for the ollama client (fronting proxies and
+// gateways do send 429). The request must also be rebuilt per attempt: the
+// old code built it once outside the closure, so a retry would have re-sent
+// a consumed (empty) body. Both attempts' bodies are asserted identical.
+func TestChat429IsRetriedWithFullBody(t *testing.T) {
+	var mu sync.Mutex
+	var bodies [][]byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if mockShowResponse(w, r) {
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, body)
+		n := len(bodies)
+		mu.Unlock()
+		if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":"too many requests"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"model":"llama3.1","message":{"role":"assistant","content":"ok"},"done":true,"prompt_eval_count":1,"eval_count":1}` + "\n"))
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{
+		Endpoint: srv.URL,
+		Model:    "llama3.1",
+		RateLimiterConfig: llm.RateLimiterConfig{
+			Enabled:           true,
+			RequestsPerSecond: 1000,
+			BurstCapacity:     8,
+			MinDelay:          time.Millisecond,
+			RetryBackoff:      5 * time.Millisecond,
+			MaxRetries:        4,
+		},
+	})
+
+	resp, err := client.Chat(context.Background(), []llmtypes.Message{{Role: "user", Content: "hello ollama"}}, nil)
+	require.NoError(t, err, "one 429 then success must be absorbed by the limiter's retry")
+	assert.Contains(t, resp.Content, "ok")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, bodies, 2, "server must see the failed attempt and the retry")
+	assert.NotEmpty(t, bodies[1], "retry must carry the request body, not a consumed reader")
+	assert.Equal(t, bodies[0], bodies[1], "retry must re-send the identical full body")
+
+	var req chatRequest
+	require.NoError(t, json.Unmarshal(bodies[1], &req), "retried body must be complete valid JSON")
+	assert.Equal(t, "llama3.1", req.Model)
+	require.NotEmpty(t, req.Messages)
+	assert.Equal(t, "hello ollama", req.Messages[len(req.Messages)-1].Content)
+}

--- a/pkg/llm/openai/client.go
+++ b/pkg/llm/openai/client.go
@@ -638,35 +638,23 @@ func (c *Client) ChatStream(ctx context.Context, messages []llmtypes.Message,
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Create HTTP request
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.endpoint, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	// Set headers
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
-	for k, v := range c.extraHeaders {
-		httpReq.Header.Set(k, v)
-	}
-
-	// 2. Send request with rate limiting if enabled
+	// 2. Send request with rate limiting if enabled. sendOnce rebuilds the
+	// http.Request per attempt and surfaces 429 as a throttle error so the
+	// limiter's retry fires (and each retry re-sends the full body).
 	var httpResp *http.Response
+	sendOnce := c.sendOnce(c.endpoint, body)
 	if c.rateLimiter != nil {
-		result, err := c.rateLimiter.Do(ctx, func(ctx context.Context) (interface{}, error) {
-			return c.httpClient.Do(httpReq)
-		})
+		result, err := c.rateLimiter.Do(ctx, sendOnce)
 		if err != nil {
 			return nil, fmt.Errorf("HTTP request failed: %w", err)
 		}
 		httpResp = result.(*http.Response)
 	} else {
-		var err error
-		httpResp, err = c.httpClient.Do(httpReq)
+		result, err := sendOnce(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("HTTP request failed: %w", err)
 		}
+		httpResp = result.(*http.Response)
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
@@ -843,6 +831,40 @@ func (c *Client) ChatStream(ctx context.Context, messages []llmtypes.Message,
 	}, nil
 }
 
+// sendOnce returns a closure that builds and sends ONE fresh HTTP request
+// per attempt. It must construct a new http.Request each time — a consumed
+// body cannot be re-sent, so a retry of a request built once outside the
+// closure would go out empty. It also surfaces HTTP 429 as an ERROR carrying
+// any server-specified wait (Retry-After / retry-after-ms / x-ratelimit reset
+// headers): httpClient.Do returns nil error for any HTTP status, so without
+// this the rate limiter's retry never sees throttling and 429s go straight to
+// the caller un-retried.
+func (c *Client) sendOnce(endpoint string, body []byte) func(context.Context) (interface{}, error) {
+	return func(ctx context.Context) (interface{}, error) {
+		httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+		for k, v := range c.extraHeaders {
+			httpReq.Header.Set(k, v)
+		}
+		resp, err := c.httpClient.Do(httpReq)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode == http.StatusTooManyRequests {
+			respBody, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			return nil, llm.NewThrottleError(
+				fmt.Errorf("API error (status 429): %s", string(respBody)),
+				llm.RetryAfterFromHeaders(resp.Header))
+		}
+		return resp, nil
+	}
+}
+
 // callAPI makes the HTTP request to OpenAI's API.
 func (c *Client) callAPI(ctx context.Context, req *ChatCompletionRequest) (*ChatCompletionResponse, error) {
 	// Marshal request
@@ -851,35 +873,21 @@ func (c *Client) callAPI(ctx context.Context, req *ChatCompletionRequest) (*Chat
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Create HTTP request
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.endpoint, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	// Set headers
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
-	for k, v := range c.extraHeaders {
-		httpReq.Header.Set(k, v)
-	}
-
 	// Send request with rate limiting if enabled
 	var httpResp *http.Response
+	sendOnce := c.sendOnce(c.endpoint, body)
 	if c.rateLimiter != nil {
-		result, err := c.rateLimiter.Do(ctx, func(ctx context.Context) (interface{}, error) {
-			return c.httpClient.Do(httpReq)
-		})
+		result, err := c.rateLimiter.Do(ctx, sendOnce)
 		if err != nil {
 			return nil, fmt.Errorf("HTTP request failed: %w", err)
 		}
 		httpResp = result.(*http.Response)
 	} else {
-		var err error
-		httpResp, err = c.httpClient.Do(httpReq)
+		result, err := sendOnce(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("HTTP request failed: %w", err)
 		}
+		httpResp = result.(*http.Response)
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 

--- a/pkg/llm/openai/retry_429_test.go
+++ b/pkg/llm/openai/retry_429_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/teradata-labs/loom/pkg/llm"
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+)
+
+func retryTestLimiterConfig() llm.RateLimiterConfig {
+	return llm.RateLimiterConfig{
+		Enabled:           true,
+		RequestsPerSecond: 1000,
+		BurstCapacity:     8,
+		MinDelay:          time.Millisecond,
+		RetryBackoff:      5 * time.Millisecond,
+		MaxRetries:        4,
+	}
+}
+
+// HTTP 429 must surface as an error INSIDE the rate limiter so its retry
+// fires — httpClient.Do returns nil error for any status, so before this the
+// limiter never saw throttling for the openai client and 429s went straight
+// to the caller. The request must also be rebuilt per attempt: the old code
+// built it once outside the closure, so a retry would have re-sent a consumed
+// (empty) body. Both attempts' bodies are asserted identical and complete.
+func TestChat429IsRetriedWithFullBody(t *testing.T) {
+	var mu sync.Mutex
+	var bodies [][]byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, body)
+		n := len(bodies)
+		mu.Unlock()
+		if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":{"message":"rate limit","type":"too_many_requests"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"1","model":"gpt-4o","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{
+		APIKey:            "test-key-not-real-chat429",
+		Model:             "gpt-4o",
+		Endpoint:          srv.URL,
+		RateLimiterConfig: retryTestLimiterConfig(),
+	})
+
+	resp, err := client.Chat(context.Background(), []llmtypes.Message{{Role: "user", Content: "hello there"}}, nil)
+	require.NoError(t, err, "one 429 then success must be absorbed by the limiter's retry")
+	assert.Contains(t, resp.Content, "ok")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, bodies, 2, "server must see the failed attempt and the retry")
+	assert.NotEmpty(t, bodies[1], "retry must carry the request body, not a consumed reader")
+	assert.Equal(t, bodies[0], bodies[1], "retry must re-send the identical full body")
+
+	var req ChatCompletionRequest
+	require.NoError(t, json.Unmarshal(bodies[1], &req), "retried body must be complete valid JSON")
+	assert.Equal(t, "gpt-4o", req.Model)
+	require.Len(t, req.Messages, 1)
+	assert.Equal(t, "hello there", req.Messages[0].Content)
+}
+
+// Same regression for the streaming path (which mistral/litellm inherit).
+func TestChatStream429IsRetriedWithFullBody(t *testing.T) {
+	var mu sync.Mutex
+	var bodies [][]byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, body)
+		n := len(bodies)
+		mu.Unlock()
+		if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":{"message":"rate limit","type":"too_many_requests"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"ok\"},\"finish_reason\":\"\"}]}\n\n" +
+			"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n" +
+			"data: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{
+		APIKey:            "test-key-not-real-stream429",
+		Model:             "gpt-4o",
+		Endpoint:          srv.URL,
+		RateLimiterConfig: retryTestLimiterConfig(),
+	})
+
+	resp, err := client.ChatStream(context.Background(), []llmtypes.Message{{Role: "user", Content: "hello stream"}}, nil, nil)
+	require.NoError(t, err, "one 429 then success must be absorbed by the limiter's retry")
+	assert.Contains(t, resp.Content, "ok")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, bodies, 2, "server must see the failed attempt and the retry")
+	assert.NotEmpty(t, bodies[1], "retry must carry the request body, not a consumed reader")
+	assert.Equal(t, bodies[0], bodies[1], "retry must re-send the identical full body")
+
+	var req ChatCompletionRequest
+	require.NoError(t, json.Unmarshal(bodies[1], &req), "retried body must be complete valid JSON")
+	assert.True(t, req.Stream)
+	require.Len(t, req.Messages, 1)
+	assert.Equal(t, "hello stream", req.Messages[0].Content)
+}

--- a/pkg/llm/rate_limiter.go
+++ b/pkg/llm/rate_limiter.go
@@ -276,38 +276,62 @@ func (rl *RateLimiter) processQueue() {
 	for {
 		select {
 		case req := <-rl.queue:
-			rl.processRequest(req)
+			// Pace ADMISSION here (request-token bucket + MinDelay spacing),
+			// then run the call concurrently. Executing calls synchronously in
+			// this loop serialized the whole fleet behind one LLM round-trip
+			// per request — ~1 call/s regardless of configuration (issue #349).
+			if !rl.waitForAdmission(req) {
+				continue // waitForAdmission already delivered the error result
+			}
+			// wg.Add here is safe: processQueue itself holds a wg count, so
+			// the counter cannot reach zero while new work is being added.
+			rl.wg.Add(1)
+			go func(r *rateLimitedRequest) {
+				defer rl.wg.Done()
+				rl.execute(r)
+			}(req)
 		case <-rl.stopCh:
 			return
 		}
 	}
 }
 
-// processRequest processes a single request with token bucket rate limiting.
-func (rl *RateLimiter) processRequest(req *rateLimitedRequest) {
-	// Wait for token availability
+// waitForAdmission blocks until the request may start: a request token from
+// the bucket (RequestsPerSecond), then MinDelay as inter-admission spacing.
+// Returns false — after delivering the error result — if the request's
+// context expires or the limiter stops while waiting.
+func (rl *RateLimiter) waitForAdmission(req *rateLimitedRequest) bool {
 	for !rl.acquireToken() {
 		select {
 		case <-time.After(50 * time.Millisecond):
 			// Continue waiting
 		case <-req.ctx.Done():
 			req.resultCh <- &rateLimitedResult{err: req.ctx.Err()}
-			return
+			return false
 		case <-rl.stopCh:
 			req.resultCh <- &rateLimitedResult{err: fmt.Errorf("rate limiter stopped")}
-			return
+			return false
 		}
 	}
 
-	// Enforce minimum delay
+	// Enforce minimum delay between request STARTS. Sleeping in the dispatch
+	// loop preserves the documented spacing semantics without serializing the
+	// calls themselves.
 	if rl.config.MinDelay > 0 {
-		time.Sleep(rl.config.MinDelay)
+		select {
+		case <-time.After(rl.config.MinDelay):
+		case <-rl.stopCh:
+			req.resultCh <- &rateLimitedResult{err: fmt.Errorf("rate limiter stopped")}
+			return false
+		}
 	}
+	return true
+}
 
-	// Execute call with retry on throttling
+// execute runs the call (with throttling retries) and delivers the result.
+func (rl *RateLimiter) execute(req *rateLimitedRequest) {
 	result, err := rl.executeWithRetry(req.ctx, req.call)
 
-	// Send result
 	select {
 	case req.resultCh <- &rateLimitedResult{result: result, err: err}:
 	case <-req.ctx.Done():

--- a/pkg/llm/rate_limiter.go
+++ b/pkg/llm/rate_limiter.go
@@ -15,7 +15,9 @@ package llm
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"math/rand/v2"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -32,8 +34,11 @@ type RateLimiterConfig struct {
 	// Default: 5 (conservative for AWS Bedrock)
 	RequestsPerSecond float64
 
-	// TokensPerMinute is the maximum tokens allowed per minute (for token-based rate limiting).
-	// Default: 100000 (AWS Bedrock typical limit)
+	// TokensPerMinute is OBSERVATIONAL ONLY today: consumption is tracked
+	// (RecordTokenUsage / GetTokenUsageLastMinute) and exported in metrics, but
+	// the limiter never enforces it — only the request bucket
+	// (RequestsPerSecond/BurstCapacity/MinDelay) gates admission.
+	// Default: 40000 (metrics baseline).
 	TokensPerMinute int64
 
 	// BurstCapacity is the maximum burst of requests allowed.
@@ -114,6 +119,11 @@ type rateLimitedRequest struct {
 	ctx      context.Context
 	call     func(context.Context) (interface{}, error)
 	resultCh chan *rateLimitedResult
+	// attempt is the 0-based attempt number. A value > 0 means this request
+	// re-entered the queue as a throttling retry: it is paced through
+	// admission exactly like fresh work (no queue jumping), so the configured
+	// request rate holds even when the upstream is throttling.
+	attempt int
 }
 
 type rateLimitedResult struct {
@@ -301,6 +311,14 @@ func (rl *RateLimiter) processQueue() {
 // Returns false — after delivering the error result — if the request's
 // context expires or the limiter stops while waiting.
 func (rl *RateLimiter) waitForAdmission(req *rateLimitedRequest) bool {
+	// An already-abandoned request must not consume a bucket token or stall
+	// the dispatcher for MinDelay — that would slow every request queued
+	// behind it for work nobody is waiting on.
+	if err := req.ctx.Err(); err != nil {
+		req.resultCh <- &rateLimitedResult{err: err}
+		return false
+	}
+
 	for !rl.acquireToken() {
 		select {
 		case <-time.After(50 * time.Millisecond):
@@ -328,58 +346,103 @@ func (rl *RateLimiter) waitForAdmission(req *rateLimitedRequest) bool {
 	return true
 }
 
-// execute runs the call (with throttling retries) and delivers the result.
+// execute runs ONE admitted attempt and delivers the result. A throttled
+// attempt with retries remaining sleeps its backoff and then re-enters the
+// admission path via the queue — it never re-sends directly. Every outbound
+// attempt therefore consumed an admission token, so the configured request
+// rate holds exactly even when the upstream is throttling; without this,
+// aggregate outbound rate was admitted RPS plus all concurrent retry waves.
 func (rl *RateLimiter) execute(req *rateLimitedRequest) {
-	result, err := rl.executeWithRetry(req.ctx, req.call)
+	result, err := req.call(req.ctx)
+	rl.recordMetric("request", 0)
+
+	// Success or non-retryable error: deliver as-is.
+	if err == nil || !isThrottlingError(err) {
+		rl.deliver(req, &rateLimitedResult{result: result, err: err})
+		return
+	}
+
+	rl.recordMetric("throttled", 0)
+
+	if req.attempt >= rl.config.MaxRetries {
+		// All attempts exhausted.
+		rl.deliver(req, &rateLimitedResult{err: fmt.Errorf(
+			"LLM request failed after %d retries due to throttling: %w",
+			rl.config.MaxRetries+1, err)})
+		return
+	}
+
+	delay := rl.retryDelay(req.attempt, err)
+	rl.config.Logger.Warn("LLM request throttled, retrying",
+		zap.Int("attempt", req.attempt+1),
+		zap.Int("max_retries", rl.config.MaxRetries),
+		zap.Duration("backoff", delay),
+		zap.Error(err),
+	)
 
 	select {
-	case req.resultCh <- &rateLimitedResult{result: result, err: err}:
+	case <-time.After(delay):
+	case <-req.ctx.Done():
+		rl.deliver(req, &rateLimitedResult{err: req.ctx.Err()})
+		return
+	case <-rl.stopCh:
+		rl.deliver(req, &rateLimitedResult{err: fmt.Errorf("rate limiter stopped during retry")})
+		return
+	}
+
+	// Re-enter the admission path: the retry queues behind fresh work and is
+	// paced exactly like a new request. The queue send cannot deadlock: the
+	// dispatcher keeps draining, and ctx/stop provide an escape while full.
+	req.attempt++
+	select {
+	case rl.queue <- req:
+	case <-req.ctx.Done():
+		rl.deliver(req, &rateLimitedResult{err: req.ctx.Err()})
+	case <-rl.stopCh:
+		rl.deliver(req, &rateLimitedResult{err: fmt.Errorf("rate limiter stopped during retry")})
+	}
+}
+
+// deliver hands the final result to the caller waiting in Do. Each request is
+// delivered exactly once onto its buffered (capacity 1) channel; the ctx/stop
+// cases cover a caller that has already left.
+func (rl *RateLimiter) deliver(req *rateLimitedRequest, res *rateLimitedResult) {
+	select {
+	case req.resultCh <- res:
 	case <-req.ctx.Done():
 	case <-rl.stopCh:
 	}
 }
 
-// executeWithRetry executes a call with exponential backoff retry on throttling.
-func (rl *RateLimiter) executeWithRetry(ctx context.Context, call func(context.Context) (interface{}, error)) (interface{}, error) {
-	backoff := rl.config.RetryBackoff
+// maxRetryDelay caps the exponential backoff so pathological attempt counts
+// cannot produce multi-hour waits.
+const maxRetryDelay = 5 * time.Minute
 
-	for attempt := 0; attempt <= rl.config.MaxRetries; attempt++ {
-		// Execute call
-		result, err := call(ctx)
-		rl.recordMetric("request", 0)
-
-		// Check for throttling error
-		if err != nil && isThrottlingError(err) {
-			rl.recordMetric("throttled", 0)
-			rl.config.Logger.Warn("LLM request throttled, retrying",
-				zap.Int("attempt", attempt+1),
-				zap.Int("max_retries", rl.config.MaxRetries),
-				zap.Duration("backoff", backoff),
-				zap.Error(err),
-			)
-
-			// Exponential backoff before retry (except on last attempt)
-			if attempt < rl.config.MaxRetries {
-				select {
-				case <-time.After(backoff):
-					backoff *= 2 // Double the backoff
-				case <-ctx.Done():
-					return nil, ctx.Err()
-				case <-rl.stopCh:
-					return nil, fmt.Errorf("rate limiter stopped during retry")
-				}
-				continue
-			}
-			// Last attempt failed with throttling - continue to return formatted error
-			continue
-		}
-
-		// Success or non-retryable error
-		return result, err
+// retryDelay computes the wait before retry attempt attempt+1: exponential
+// backoff (RetryBackoff doubled per attempt) with uniform ±50% jitter so
+// concurrent throttled requests do not retry in synchronized waves, floored
+// by any server-specified Retry-After carried on the error — retrying sooner
+// than the server's throttle window just burns attempts inside it.
+func (rl *RateLimiter) retryDelay(attempt int, err error) time.Duration {
+	shift := attempt
+	if shift > 30 {
+		shift = 30 // cap the shift; maxRetryDelay clamps below anyway
+	}
+	backoff := rl.config.RetryBackoff << uint(shift)
+	if backoff <= 0 || backoff > maxRetryDelay {
+		backoff = maxRetryDelay
 	}
 
-	// All retries exhausted
-	return nil, fmt.Errorf("LLM request failed after %d retries due to throttling", rl.config.MaxRetries+1)
+	// Uniform jitter in [0.5*backoff, 1.5*backoff].
+	delay := backoff/2 + time.Duration(rand.Int64N(int64(backoff)+1))
+
+	// Honor the server-specified wait when it is longer than the jittered
+	// backoff (delta-seconds, HTTP-date, and x-ratelimit reset forms all
+	// arrive here via ThrottleError.RetryAfter).
+	if ra := RetryAfter(err); ra > delay {
+		delay = ra
+	}
+	return delay
 }
 
 // acquireToken attempts to acquire a token from the bucket.
@@ -406,6 +469,12 @@ func (rl *RateLimiter) acquireToken() bool {
 func isThrottlingError(err error) bool {
 	if err == nil {
 		return false
+	}
+	// Typed throttle errors (carrying Retry-After) are always throttling,
+	// regardless of message wording.
+	var te *ThrottleError
+	if errors.As(err, &te) {
+		return true
 	}
 	errStr := err.Error()
 	return contains(errStr, "429") ||

--- a/pkg/llm/rate_limiter.go
+++ b/pkg/llm/rate_limiter.go
@@ -434,6 +434,7 @@ func (rl *RateLimiter) retryDelay(attempt int, err error) time.Duration {
 	}
 
 	// Uniform jitter in [0.5*backoff, 1.5*backoff].
+	// #nosec G404 -- retry-wave desynchronization jitter, not security-sensitive
 	delay := backoff/2 + time.Duration(rand.Int64N(int64(backoff)+1))
 
 	// Honor the server-specified wait when it is longer than the jittered

--- a/pkg/llm/rate_limiter_retry_test.go
+++ b/pkg/llm/rate_limiter_retry_test.go
@@ -1,0 +1,264 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package llm
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestRateLimiter_RetriesReenterAdmission is the regression for the retry
+// admission bypass: retries used to re-invoke the call without re-acquiring
+// an admission token, so under throttling the aggregate outbound rate was
+// admitted RPS plus all concurrent retry waves. With rps=10 and burst=1,
+// EVERY outbound attempt — first tries and retries alike — must be spaced by
+// the bucket, so no two attempts may start closer than ~100ms apart.
+func TestRateLimiter_RetriesReenterAdmission(t *testing.T) {
+	rl := NewRateLimiter(RateLimiterConfig{
+		Enabled:           true,
+		RequestsPerSecond: 10,
+		BurstCapacity:     1,
+		MinDelay:          time.Millisecond,
+		MaxRetries:        2,
+		RetryBackoff:      time.Millisecond, // tiny: pacing must come from admission, not backoff
+		Logger:            zap.NewNop(),
+	})
+	defer func() { _ = rl.Close() }()
+
+	const numRequests = 4
+	var mu sync.Mutex
+	var attemptTimes []time.Time
+
+	var wg sync.WaitGroup
+	for i := 0; i < numRequests; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			calls := 0
+			_, err := rl.Do(context.Background(), func(context.Context) (interface{}, error) {
+				mu.Lock()
+				attemptTimes = append(attemptTimes, time.Now())
+				mu.Unlock()
+				calls++
+				if calls == 1 {
+					return nil, errors.New("HTTP 429: throttle storm")
+				}
+				return "ok", nil
+			})
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, attemptTimes, numRequests*2, "each request must attempt twice (429 then success)")
+
+	sort.Slice(attemptTimes, func(i, j int) bool { return attemptTimes[i].Before(attemptTimes[j]) })
+	for i := 1; i < len(attemptTimes); i++ {
+		gap := attemptTimes[i].Sub(attemptTimes[i-1])
+		// Nominal spacing at 10 rps / burst 1 is 100ms; allow half for
+		// goroutine scheduling skew. Any retry that bypassed admission would
+		// start ~1ms (the backoff) after its failed attempt and fail this.
+		assert.GreaterOrEqual(t, gap, 50*time.Millisecond,
+			"attempts %d and %d started %v apart: a retry bypassed admission", i-1, i, gap)
+	}
+}
+
+// TestRateLimiter_RetryDelayJitter verifies the backoff jitter: for each
+// attempt the delay must stay within [0.5, 1.5]x of that attempt's
+// exponential base, and repeated computations must not all collapse to one
+// value (the old no-jitter backoff synchronized every admitted-burst request
+// into retry waves at the same ~1s/2s/4s marks).
+func TestRateLimiter_RetryDelayJitter(t *testing.T) {
+	rl := NewRateLimiter(RateLimiterConfig{
+		Enabled:      true,
+		RetryBackoff: 100 * time.Millisecond,
+		Logger:       zap.NewNop(),
+	})
+	defer func() { _ = rl.Close() }()
+
+	throttle := errors.New("HTTP 429: slow down")
+
+	tests := []struct {
+		name    string
+		attempt int
+		min     time.Duration
+		max     time.Duration
+	}{
+		{"attempt 0: base 100ms", 0, 50 * time.Millisecond, 150 * time.Millisecond},
+		{"attempt 1: base 200ms", 1, 100 * time.Millisecond, 300 * time.Millisecond},
+		{"attempt 2: base 400ms", 2, 200 * time.Millisecond, 600 * time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const samples = 32
+			seen := make(map[time.Duration]struct{}, samples)
+			for i := 0; i < samples; i++ {
+				d := rl.retryDelay(tt.attempt, throttle)
+				assert.GreaterOrEqual(t, d, tt.min)
+				assert.LessOrEqual(t, d, tt.max)
+				seen[d] = struct{}{}
+			}
+			assert.Greater(t, len(seen), 1, "32 jittered delays must not all be identical")
+		})
+	}
+}
+
+// TestRateLimiter_RetryDelayCapped verifies pathological attempt counts
+// cannot overflow or exceed the cap.
+func TestRateLimiter_RetryDelayCapped(t *testing.T) {
+	rl := NewRateLimiter(RateLimiterConfig{
+		Enabled:      true,
+		RetryBackoff: time.Second,
+		Logger:       zap.NewNop(),
+	})
+	defer func() { _ = rl.Close() }()
+
+	d := rl.retryDelay(63, errors.New("HTTP 429"))
+	assert.Greater(t, d, time.Duration(0))
+	assert.LessOrEqual(t, d, maxRetryDelay+maxRetryDelay/2)
+}
+
+// TestRateLimiter_RetryDelayHonorsRetryAfter verifies the server-specified
+// wait floors the computed backoff: with a tiny configured retry_backoff_ms,
+// all retries used to burn inside one throttle window and a recoverable
+// throttle became a hard failure.
+func TestRateLimiter_RetryDelayHonorsRetryAfter(t *testing.T) {
+	rl := NewRateLimiter(RateLimiterConfig{
+		Enabled:      true,
+		RetryBackoff: time.Millisecond, // tiny on purpose
+		Logger:       zap.NewNop(),
+	})
+	defer func() { _ = rl.Close() }()
+
+	err := NewThrottleError(errors.New("API error (status 429): busy"), 300*time.Millisecond)
+	for i := 0; i < 8; i++ {
+		d := rl.retryDelay(0, err)
+		assert.GreaterOrEqual(t, d, 300*time.Millisecond,
+			"retry delay must never undercut the server's Retry-After")
+	}
+
+	// Backoff larger than Retry-After wins (max of the two).
+	big := NewThrottleError(errors.New("API error (status 429): busy"), time.Microsecond)
+	d := rl.retryDelay(0, big)
+	assert.GreaterOrEqual(t, d, 500*time.Microsecond)
+}
+
+// TestRateLimiter_Do_WaitsRetryAfter is the end-to-end check: one throttled
+// attempt carrying Retry-After=300ms with retry_backoff_ms=1 must delay the
+// second attempt by at least the server's wait.
+func TestRateLimiter_Do_WaitsRetryAfter(t *testing.T) {
+	rl := NewRateLimiter(RateLimiterConfig{
+		Enabled:           true,
+		RequestsPerSecond: 1000,
+		BurstCapacity:     8,
+		MinDelay:          time.Millisecond,
+		MaxRetries:        2,
+		RetryBackoff:      time.Millisecond, // tiny: the wait must come from Retry-After
+		Logger:            zap.NewNop(),
+	})
+	defer func() { _ = rl.Close() }()
+
+	var times []time.Time
+	result, err := rl.Do(context.Background(), func(context.Context) (interface{}, error) {
+		times = append(times, time.Now())
+		if len(times) == 1 {
+			return nil, NewThrottleError(errors.New("API error (status 429): busy"), 300*time.Millisecond)
+		}
+		return "ok", nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", result)
+	require.Len(t, times, 2)
+	assert.GreaterOrEqual(t, times[1].Sub(times[0]), 300*time.Millisecond,
+		"second attempt must wait at least the server's Retry-After")
+}
+
+// TestRateLimiter_AbandonedRequestSkipsAdmission is the regression for the
+// fast-path context check: a request whose context expired while it sat in
+// the queue must not consume a bucket token or stall the dispatcher for
+// MinDelay — that stall lands on every live request queued behind it.
+func TestRateLimiter_AbandonedRequestSkipsAdmission(t *testing.T) {
+	rl := NewRateLimiter(RateLimiterConfig{
+		Enabled:           true,
+		RequestsPerSecond: 1000, // token refill is instant; MinDelay is the only stall
+		BurstCapacity:     2,
+		MinDelay:          200 * time.Millisecond,
+		Logger:            zap.NewNop(),
+	})
+	defer func() { _ = rl.Close() }()
+
+	// req1 occupies the dispatcher (its MinDelay sleep) while req2 and req3
+	// are queued behind it.
+	release := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = rl.Do(context.Background(), func(context.Context) (interface{}, error) {
+			<-release
+			return "ok", nil
+		})
+	}()
+	time.Sleep(20 * time.Millisecond)
+
+	// req2: queued live, then abandoned while waiting. Its Do returns the
+	// context error; the queued entry stays behind for the dispatcher.
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	executed := make(chan struct{}, 1)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := rl.Do(ctx2, func(context.Context) (interface{}, error) {
+			executed <- struct{}{}
+			return nil, nil
+		})
+		assert.ErrorIs(t, err, context.Canceled)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel2()
+
+	// req3: live, queued after the abandoned req2.
+	start := time.Now()
+	result, err := rl.Do(context.Background(), func(context.Context) (interface{}, error) {
+		return "live", nil
+	})
+	elapsed := time.Since(start)
+	close(release)
+	wg.Wait()
+
+	require.NoError(t, err)
+	assert.Equal(t, "live", result)
+	select {
+	case <-executed:
+		t.Fatal("abandoned request must never execute")
+	default:
+	}
+	// Expected stall: the tail of req1's MinDelay (~160ms) plus req3's own
+	// MinDelay (200ms) ≈ 360ms. The bug adds a full MinDelay burned on the
+	// abandoned req2 (~560ms total). Assert well under the buggy floor.
+	assert.Less(t, elapsed, 450*time.Millisecond,
+		"live request stalled %v: dispatcher spent admission on an abandoned request", elapsed)
+}

--- a/pkg/llm/rate_limiter_test.go
+++ b/pkg/llm/rate_limiter_test.go
@@ -686,3 +686,78 @@ func BenchmarkRateLimiter_Concurrent(b *testing.B) {
 		}
 	})
 }
+
+// TestRateLimiter_ConcurrentDispatch proves execution is no longer serialized
+// behind the dispatch loop (issue #349): 8 calls of 200ms each must complete
+// in far less than the 1.6s a serial dispatcher needs.
+func TestRateLimiter_ConcurrentDispatch(t *testing.T) {
+	rl := NewRateLimiter(RateLimiterConfig{
+		Enabled:           true,
+		RequestsPerSecond: 1000,
+		BurstCapacity:     16,
+		MinDelay:          time.Millisecond,
+		Logger:            zap.NewNop(),
+	})
+	defer func() { _ = rl.Close() }()
+
+	const n = 8
+	callDur := 200 * time.Millisecond
+	var wg sync.WaitGroup
+	start := time.Now()
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := rl.Do(context.Background(), func(context.Context) (interface{}, error) {
+				time.Sleep(callDur)
+				return "ok", nil
+			})
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+	// Serial execution would need n*callDur = 1.6s. Allow generous scheduling
+	// slack while still proving overlap.
+	assert.Less(t, elapsed, n*callDur/2,
+		"calls must overlap: %v elapsed for %d x %v calls", elapsed, n, callDur)
+}
+
+// TestRateLimiter_AdmissionStillPaced proves the concurrency fix did not
+// remove request-rate pacing: with 1 rps and burst 1, the second call must
+// start roughly a second after the first.
+func TestRateLimiter_AdmissionStillPaced(t *testing.T) {
+	rl := NewRateLimiter(RateLimiterConfig{
+		Enabled:           true,
+		RequestsPerSecond: 1,
+		BurstCapacity:     1,
+		MinDelay:          time.Millisecond,
+		Logger:            zap.NewNop(),
+	})
+	defer func() { _ = rl.Close() }()
+
+	var mu sync.Mutex
+	var starts []time.Time
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := rl.Do(context.Background(), func(context.Context) (interface{}, error) {
+				mu.Lock()
+				starts = append(starts, time.Now())
+				mu.Unlock()
+				return "ok", nil
+			})
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+	require.Len(t, starts, 2)
+	gap := starts[1].Sub(starts[0])
+	if gap < 0 {
+		gap = -gap
+	}
+	assert.GreaterOrEqual(t, gap, 700*time.Millisecond,
+		"1 rps with burst 1 must space the second admission ~1s after the first, got %v", gap)
+}

--- a/pkg/llm/rate_limiter_test.go
+++ b/pkg/llm/rate_limiter_test.go
@@ -99,7 +99,8 @@ func TestRateLimiter_Do_Success(t *testing.T) {
 func TestRateLimiter_Do_ThrottlingRetry(t *testing.T) {
 	config := DefaultRateLimiterConfig()
 	config.Logger = zaptest.NewLogger(t)
-	config.RequestsPerSecond = 10
+	config.RequestsPerSecond = 100
+	config.MinDelay = time.Millisecond // retries re-enter admission; keep spacing small
 	config.MaxRetries = 3
 	config.RetryBackoff = 10 * time.Millisecond // Fast for testing
 
@@ -127,7 +128,8 @@ func TestRateLimiter_Do_ThrottlingRetry(t *testing.T) {
 func TestRateLimiter_Do_ThrottlingExhausted(t *testing.T) {
 	config := DefaultRateLimiterConfig()
 	config.Logger = zaptest.NewLogger(t)
-	config.RequestsPerSecond = 10
+	config.RequestsPerSecond = 100
+	config.MinDelay = time.Millisecond // retries re-enter admission; keep spacing small
 	config.MaxRetries = 2
 	config.RetryBackoff = 10 * time.Millisecond
 
@@ -386,6 +388,11 @@ func TestIsThrottlingError(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "typed ThrottleError with no keyword in message",
+			err:      fmt.Errorf("wrapped: %w", NewThrottleError(errors.New("slow down"), time.Second)),
+			expected: true,
+		},
+		{
 			name:     "other error",
 			err:      errors.New("connection timeout"),
 			expected: false,
@@ -434,7 +441,9 @@ func TestRateLimiter_MinDelay(t *testing.T) {
 func TestRateLimiter_Metrics(t *testing.T) {
 	config := DefaultRateLimiterConfig()
 	config.Logger = zaptest.NewLogger(t)
-	config.RequestsPerSecond = 50 // Fast for testing
+	config.RequestsPerSecond = 50          // Fast for testing
+	config.MinDelay = time.Millisecond     // retries re-enter admission; keep spacing small
+	config.RetryBackoff = time.Millisecond // keep retry waits short
 
 	rl := NewRateLimiter(config)
 	defer func() { _ = rl.Close() }()
@@ -466,8 +475,9 @@ func TestRateLimiter_Metrics(t *testing.T) {
 func TestRateLimiter_ConcurrentThrottling(t *testing.T) {
 	config := DefaultRateLimiterConfig()
 	config.Logger = zaptest.NewLogger(t)
-	config.RequestsPerSecond = 20
+	config.RequestsPerSecond = 100
 	config.BurstCapacity = 10
+	config.MinDelay = time.Millisecond // retries re-enter admission; keep spacing small
 	config.MaxRetries = 2
 	config.RetryBackoff = 10 * time.Millisecond
 
@@ -557,6 +567,9 @@ func TestRateLimiter_TokenWindowPruning(t *testing.T) {
 func TestRateLimiter_ExponentialBackoff(t *testing.T) {
 	config := DefaultRateLimiterConfig()
 	config.Logger = zaptest.NewLogger(t)
+	config.RequestsPerSecond = 1000
+	config.BurstCapacity = 10
+	config.MinDelay = time.Millisecond // retries re-enter admission; keep spacing small
 	config.MaxRetries = 3
 	config.RetryBackoff = 50 * time.Millisecond
 
@@ -572,18 +585,18 @@ func TestRateLimiter_ExponentialBackoff(t *testing.T) {
 	require.Error(t, err)
 	require.Len(t, callTimes, 4) // 1 initial + 3 retries
 
-	// Verify exponential backoff: ~50ms, ~100ms, ~200ms
+	// Backoff is exponential (base doubles per attempt: 50ms, 100ms, 200ms)
+	// with uniform ±50% jitter, so each observed gap must be at least half its
+	// attempt's base. Admission and scheduling only add delay, never remove
+	// it, so the lower bounds are strict. Exact jitter bounds are covered by
+	// TestRateLimiter_RetryDelayJitter (no sleeping, no scheduling noise).
 	delay1 := callTimes[1].Sub(callTimes[0])
 	delay2 := callTimes[2].Sub(callTimes[1])
 	delay3 := callTimes[3].Sub(callTimes[2])
 
-	assert.GreaterOrEqual(t, delay1, 50*time.Millisecond)
-	assert.GreaterOrEqual(t, delay2, 100*time.Millisecond)
-	assert.GreaterOrEqual(t, delay3, 200*time.Millisecond)
-
-	// Verify exponential growth
-	assert.Greater(t, delay2, delay1)
-	assert.Greater(t, delay3, delay2)
+	assert.GreaterOrEqual(t, delay1, 25*time.Millisecond)
+	assert.GreaterOrEqual(t, delay2, 50*time.Millisecond)
+	assert.GreaterOrEqual(t, delay3, 100*time.Millisecond)
 }
 
 func TestRateLimiter_RaceConditions(t *testing.T) {

--- a/pkg/llm/throttle.go
+++ b/pkg/llm/throttle.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package llm
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ThrottleError is a throttling (HTTP 429) error that optionally carries the
+// server-specified wait before the next attempt (Retry-After and related
+// headers). Provider clients construct it in their sendOnce paths so the rate
+// limiter's retry can wait max(RetryAfter, computed backoff): with a small
+// configured retry_backoff_ms, retrying inside the server's throttle window
+// just burns attempts and turns a recoverable throttle into a hard failure.
+type ThrottleError struct {
+	Err        error
+	RetryAfter time.Duration // 0 when the server did not specify a wait
+}
+
+// Error returns the underlying error message.
+func (e *ThrottleError) Error() string {
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return "throttled (HTTP 429)"
+}
+
+// Unwrap exposes the underlying error for errors.Is/As chains.
+func (e *ThrottleError) Unwrap() error { return e.Err }
+
+// NewThrottleError wraps err as a ThrottleError carrying retryAfter.
+func NewThrottleError(err error, retryAfter time.Duration) *ThrottleError {
+	return &ThrottleError{Err: err, RetryAfter: retryAfter}
+}
+
+// RetryAfter extracts the server-specified wait carried on err (via a
+// ThrottleError anywhere in its chain), or 0 when none was specified.
+func RetryAfter(err error) time.Duration {
+	var te *ThrottleError
+	if errors.As(err, &te) && te.RetryAfter > 0 {
+		return te.RetryAfter
+	}
+	return 0
+}
+
+// RetryAfterFromHeaders parses the server-specified wait from a throttled
+// response's headers. It understands, in priority order:
+//   - retry-after-ms (Azure): integer/decimal milliseconds
+//   - Retry-After: delta-seconds or an HTTP-date (RFC 9110 §10.2.3)
+//   - x-ratelimit-reset-requests / x-ratelimit-reset-tokens (OpenAI/Azure):
+//     duration strings ("1s", "6m0s", "120ms") or bare seconds
+//
+// Returns 0 when no header yields a positive wait.
+func RetryAfterFromHeaders(h http.Header) time.Duration {
+	if h == nil {
+		return 0
+	}
+
+	if v := strings.TrimSpace(h.Get("retry-after-ms")); v != "" {
+		if ms, err := strconv.ParseFloat(v, 64); err == nil && ms > 0 {
+			return time.Duration(ms * float64(time.Millisecond))
+		}
+	}
+
+	if v := strings.TrimSpace(h.Get("Retry-After")); v != "" {
+		if secs, err := strconv.ParseFloat(v, 64); err == nil && secs > 0 {
+			return time.Duration(secs * float64(time.Second))
+		}
+		if t, err := http.ParseTime(v); err == nil {
+			if d := time.Until(t); d > 0 {
+				return d
+			}
+		}
+	}
+
+	for _, name := range []string{"x-ratelimit-reset-requests", "x-ratelimit-reset-tokens"} {
+		v := strings.TrimSpace(h.Get(name))
+		if v == "" {
+			continue
+		}
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+		if secs, err := strconv.ParseFloat(v, 64); err == nil && secs > 0 {
+			return time.Duration(secs * float64(time.Second))
+		}
+	}
+
+	return 0
+}

--- a/pkg/llm/throttle_test.go
+++ b/pkg/llm/throttle_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package llm
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryAfterFromHeaders(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+		wantMin time.Duration
+		wantMax time.Duration
+	}{
+		{
+			name:    "nil headers",
+			headers: nil,
+			wantMin: 0, wantMax: 0,
+		},
+		{
+			name:    "no relevant headers",
+			headers: map[string]string{"Content-Type": "application/json"},
+			wantMin: 0, wantMax: 0,
+		},
+		{
+			name:    "Retry-After delta-seconds",
+			headers: map[string]string{"Retry-After": "7"},
+			wantMin: 7 * time.Second, wantMax: 7 * time.Second,
+		},
+		{
+			name:    "Retry-After decimal seconds",
+			headers: map[string]string{"Retry-After": "1.5"},
+			wantMin: 1500 * time.Millisecond, wantMax: 1500 * time.Millisecond,
+		},
+		{
+			name:    "Retry-After HTTP-date in the future",
+			headers: map[string]string{"Retry-After": time.Now().Add(30 * time.Second).UTC().Format(http.TimeFormat)},
+			wantMin: 25 * time.Second, wantMax: 30 * time.Second,
+		},
+		{
+			name:    "Retry-After HTTP-date in the past yields zero",
+			headers: map[string]string{"Retry-After": time.Now().Add(-30 * time.Second).UTC().Format(http.TimeFormat)},
+			wantMin: 0, wantMax: 0,
+		},
+		{
+			name:    "azure retry-after-ms wins over Retry-After",
+			headers: map[string]string{"retry-after-ms": "250", "Retry-After": "9"},
+			wantMin: 250 * time.Millisecond, wantMax: 250 * time.Millisecond,
+		},
+		{
+			name:    "openai x-ratelimit-reset-requests duration string",
+			headers: map[string]string{"x-ratelimit-reset-requests": "1s"},
+			wantMin: time.Second, wantMax: time.Second,
+		},
+		{
+			name:    "openai x-ratelimit-reset-requests compound duration",
+			headers: map[string]string{"x-ratelimit-reset-requests": "6m0s"},
+			wantMin: 6 * time.Minute, wantMax: 6 * time.Minute,
+		},
+		{
+			name:    "x-ratelimit-reset-tokens bare seconds",
+			headers: map[string]string{"x-ratelimit-reset-tokens": "3"},
+			wantMin: 3 * time.Second, wantMax: 3 * time.Second,
+		},
+		{
+			name:    "garbage values yield zero",
+			headers: map[string]string{"Retry-After": "soon", "retry-after-ms": "many"},
+			wantMin: 0, wantMax: 0,
+		},
+		{
+			name:    "negative values yield zero",
+			headers: map[string]string{"Retry-After": "-5"},
+			wantMin: 0, wantMax: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var h http.Header
+			if tt.headers != nil {
+				h = http.Header{}
+				for k, v := range tt.headers {
+					h.Set(k, v)
+				}
+			}
+			got := RetryAfterFromHeaders(h)
+			assert.GreaterOrEqual(t, got, tt.wantMin)
+			assert.LessOrEqual(t, got, tt.wantMax)
+		})
+	}
+}
+
+func TestThrottleError(t *testing.T) {
+	inner := errors.New("API error (status 429): busy")
+	te := NewThrottleError(inner, 2*time.Second)
+
+	assert.Equal(t, inner.Error(), te.Error())
+	assert.ErrorIs(t, te, inner)
+
+	// RetryAfter must survive wrapping.
+	wrapped := fmt.Errorf("HTTP request failed: %w", te)
+	assert.Equal(t, 2*time.Second, RetryAfter(wrapped))
+
+	// Errors without a ThrottleError in the chain carry no wait.
+	assert.Equal(t, time.Duration(0), RetryAfter(nil))
+	assert.Equal(t, time.Duration(0), RetryAfter(errors.New("HTTP 429")))
+	assert.Equal(t, time.Duration(0), RetryAfter(NewThrottleError(inner, 0)))
+
+	// Nil inner error still renders a message.
+	assert.NotEmpty(t, (&ThrottleError{}).Error())
+}

--- a/proto/loom/v1/agent_config.proto
+++ b/proto/loom/v1/agent_config.proto
@@ -165,11 +165,10 @@ message LLMRateLimitConfig {
   // 0 = use default (2.0 RPS).
   double requests_per_second = 2;
 
-  // Maximum input+output tokens per minute for token-based throttling.
-  // 0 = use default (40000 TPM).
-  // Set this to match your API tier:
-  //   Anthropic free: 30000, Tier 1: 100000
-  //   Bedrock: varies by model (40000-400000)
+  // Maximum input+output tokens per minute. OBSERVATIONAL ONLY today: token
+  // consumption is tracked and reported in rate-limiter metrics, but this
+  // value is never enforced — only requests_per_second, burst_capacity, and
+  // min_delay_ms gate requests. 0 = use default (40000 TPM metrics baseline).
   int64 tokens_per_minute = 3;
 
   // Burst capacity: maximum concurrent requests allowed before queuing.


### PR DESCRIPTION
Fixes #348. Fixes #349.

## #348 — custom-LLM path builds unthrottled, retry-less clients

`createLLMProviderFromProtoConfig` (cmd/looms/cmd_serve.go) built every provider client with **no `RateLimiterConfig`**: nil limiter means no pacing and no 429 retry (retry lives inside the limiter). Its azure branch also read only `serverConfig` with no env fallback, so an env-only key failed this path and agents *accidentally* fell through to the registry path that does attach a limiter — where the API key lived silently decided whether a fleet was throttled.

Field evidence: 512 agents from a looms whose azure key was in YAML (→ this path) died 503/512 on real Azure 429s within six minutes (419 in a single minute), bursting ~1.7M TPM over a 1.5M quota. The identical binary and agent YAMLs with an env-only key (→ registry path) had zero 429s.

**Fix:**
- `pkg/agent.BuildRateLimiterConfig` exported; `Registry.buildRateLimiterConfig` delegates to it, so both construction paths share one semantics.
- `rlCfg` threaded through all nine provider branches (anthropic, bedrock, ollama, openai, azure-openai, mistral, gemini, huggingface, litellm).
- Azure branch gains `AZURE_OPENAI_{API_KEY,ENDPOINT,ENTRA_TOKEN}` env fallbacks for parity with the anthropic/openai branches and the registry path.

## #349 — serial dispatch capped fleets at ~1 call/s

`RateLimiter.processQueue` was one goroutine running each call **to completion** (MinDelay sleep + the full LLM round-trip) before dequeuing the next. Fleet-wide throughput ≈ 1 request per (MinDelay + call latency), regardless of `requests_per_second`/`tokens_per_minute`. Field evidence: 512 agents configured at 100 rps pushed only 88K TPM to Azure (Azure's own meter) while 88 died on `queue timeout after 5m0s` waiting to enter the tiny queue channel (capacity burst×2) and 253 more hit their 40-minute deadlines.

**Fix:** the dispatch loop now paces **admission** — request-token bucket, then MinDelay as inter-admission spacing — and hands execution to a goroutine. Documented semantics preserved: `RequestsPerSecond`/`BurstCapacity`/`MinDelay` gate request starts exactly as before; `QueueTimeout` unchanged; `Close()` still drains (the queue goroutine holds a waitgroup count while adding, so Add cannot race Wait at zero).

**Noted, deliberately not changed here:** `TokensPerMinute` was and remains metrics-only — the sliding window is reported in debug logs but never enforced. Making it a real gate is a behavior change deserving its own PR.

## Tests

- `TestRateLimiter_ConcurrentDispatch`: 8 × 200ms calls complete in <half the serial time (measured 0.21s vs 1.6s serial).
- `TestRateLimiter_AdmissionStillPaced`: 1 rps / burst 1 spaces the second start ~1s after the first.
- `TestCreateLLMProviderFromProtoConfigAzureEnvFallback` / `...YAMLKeyStillWorks`: key placement no longer breaks the path.
- `TestBuildRateLimiterConfigDefaults`: enabled-by-default, explicit disable, pass-through numbers.
- Full `just check` green (`-race` suites for pkg/llm, pkg/agent, cmd/looms; one unrelated npx-download conformance flake reproduced and cleared by cache warmup).

Relates to #346 / #347 (keyed shared limiters): independent branches; whichever merges second rebases trivially — #347 touches `NewRateLimiter`/client singletons, this touches dispatch and the cmd_serve construction path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Two more links in the same chain (added after field testing the branch)

**`spec.llm.rate_limit` was silently dropped by the YAML loader.** `LLMConfigYAML` had no field for it, so the proto `RateLimit` was never populated from agent YAML — every rate-limit block anyone ever wrote was discarded at load, and both construction paths fell back to provider defaults regardless of configuration. Now mapped in both YAML formats (legacy `agent:` and k8s-style `spec:`), with a round-trip test.

**HTTP 429 never reached the retry machinery.** The azureopenai client wrapped only the raw `httpClient.Do` in the rate limiter — which returns *nil error* for any HTTP status — so `executeWithRetry` never saw throttling and 429s went straight to the caller un-retried (field evidence: 503/512 agents dead on first-attempt 429s, zero "throttled, retrying" log lines). `callAPI` and `ChatStream` now build a fresh request per attempt and surface 429 as an error from inside the rate-limited call. Regression test: two 429s then success = three server calls, no error to the caller. The same wrap-the-raw-send pattern exists in other provider clients and should get the same treatment in a follow-up.

Field validation of the full branch: 512 concurrent agents, YAML-configured limits now provably reach the keyed limiter (creation log shows the configured 15 rps instance alongside the weaver's default), no thundering herd.
