### PR TITLE
feat(scheduler): door admission control — queue batch turns at the front door

### DIFF
--- a/cmd/looms/cmd_serve.go
+++ b/cmd/looms/cmd_serve.go
@@ -1051,6 +1051,7 @@ func runServe(cmd *cobra.Command, args []string) {
 	// construction: clients attach their CapacityObserver at build time,
 	// and agents are loaded well before gRPC service registration.
 	llmscheduler.SetEnabled(config.LLM.SchedulerEnabled)
+	llmscheduler.SetDoorLimits(config.LLM.MaxActiveConversations, config.LLM.MaxDoorQueue)
 
 	// Export config values to environment variables for tools
 	exportConfigToEnv(config)

--- a/cmd/looms/config.go
+++ b/cmd/looms/config.go
@@ -1675,6 +1675,17 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("unsupported LLM provider: %s (must be anthropic, bedrock, ollama, openai, azure-openai, mistral, gemini, huggingface, or litellm)", c.LLM.Provider)
 	}
 
+	// Door admission knobs: a negative value is a configuration error, not a
+	// silent disable (max_active_conversations) or an unbounded queue
+	// (max_door_queue). Zero keeps its documented meaning: gate off /
+	// unbounded queueing.
+	if c.LLM.MaxActiveConversations < 0 {
+		return fmt.Errorf("llm.max_active_conversations must be >= 0, got %d (0 disables the door gate)", c.LLM.MaxActiveConversations)
+	}
+	if c.LLM.MaxDoorQueue < 0 {
+		return fmt.Errorf("llm.max_door_queue must be >= 0, got %d (0 means unbounded queueing)", c.LLM.MaxDoorQueue)
+	}
+
 	// Validate storage config
 	switch c.Storage.Backend {
 	case "sqlite", "":

--- a/cmd/looms/config.go
+++ b/cmd/looms/config.go
@@ -320,6 +320,14 @@ type LLMConfig struct {
 	// (docs/architecture/llm-slot-scheduler.md). Default off.
 	SchedulerEnabled bool `mapstructure:"scheduler_enabled"`
 
+	// MaxActiveConversations caps concurrently active batch conversation
+	// turns; excess queues FIFO at the door. 0 = unlimited (gate off).
+	MaxActiveConversations int `mapstructure:"max_active_conversations"`
+
+	// MaxDoorQueue caps the door queue; beyond it new batch turns are
+	// rejected with RESOURCE_EXHAUSTED. 0 = unbounded queueing.
+	MaxDoorQueue int `mapstructure:"max_door_queue"`
+
 	// Ollama-specific
 	OllamaEndpoint string `mapstructure:"ollama_endpoint"`
 	OllamaModel    string `mapstructure:"ollama_model"`
@@ -1133,6 +1141,8 @@ func setDefaults() {
 	// LLM defaults
 	viper.SetDefault("llm.provider", "anthropic")
 	viper.SetDefault("llm.scheduler_enabled", false)
+	viper.SetDefault("llm.max_active_conversations", 0)
+	viper.SetDefault("llm.max_door_queue", 0)
 	viper.SetDefault("llm.anthropic_model", "claude-sonnet-4-5-20250929")
 	viper.SetDefault("llm.bedrock_region", "us-west-2")
 	viper.SetDefault("llm.bedrock_model_id", "us.anthropic.claude-sonnet-4-5-20250929-v1:0") // Cross-region inference profile

--- a/cmd/looms/config_test.go
+++ b/cmd/looms/config_test.go
@@ -510,6 +510,47 @@ func TestValidate_ObservabilityMode(t *testing.T) {
 	})
 }
 
+// TestValidate_DoorKnobs (review finding 5, PR #353): negative door knobs
+// are startup errors, not a silent disable (max_active_conversations) or an
+// unbounded queue (max_door_queue).
+func TestValidate_DoorKnobs(t *testing.T) {
+	validBase := func() *Config {
+		return &Config{
+			Server:  ServerConfig{Port: 60051},
+			LLM:     LLMConfig{Provider: "ollama", OllamaEndpoint: "http://localhost:11434", OllamaModel: "test"},
+			Storage: StorageBackendConfig{Backend: "sqlite", SQLite: SQLiteConfig{Path: "/tmp/test.db"}},
+		}
+	}
+
+	t.Run("zero knobs -> valid (gate off, unbounded queue)", func(t *testing.T) {
+		cfg := validBase()
+		assert.NoError(t, cfg.Validate())
+	})
+
+	t.Run("positive knobs -> valid", func(t *testing.T) {
+		cfg := validBase()
+		cfg.LLM.MaxActiveConversations = 8
+		cfg.LLM.MaxDoorQueue = 64
+		assert.NoError(t, cfg.Validate())
+	})
+
+	t.Run("negative max_active_conversations -> error", func(t *testing.T) {
+		cfg := validBase()
+		cfg.LLM.MaxActiveConversations = -1
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "llm.max_active_conversations")
+	})
+
+	t.Run("negative max_door_queue -> error", func(t *testing.T) {
+		cfg := validBase()
+		cfg.LLM.MaxDoorQueue = -5
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "llm.max_door_queue")
+	})
+}
+
 func TestValidate_StorageBackend(t *testing.T) {
 	// Helper to create a config with valid LLM settings
 	validBase := func() *Config {

--- a/docs/reference/streaming.md
+++ b/docs/reference/streaming.md
@@ -75,6 +75,29 @@ looms serve
 # Log output includes: {"level":"info","msg":"HTTP/REST+SSE endpoints available","sse_endpoint":"http://0.0.0.0:5006/v1/weave:stream"}
 ```
 
+**Request headers**:
+
+| Header | Values | Meaning |
+|--------|--------|---------|
+| `X-Loom-Slot-Origin` | `interactive`, `batch` (default when absent) | Asserts this turn's scheduling band for the LLM slot scheduler and door admission control. |
+
+When door admission is enabled (`llm.max_active_conversations` > 0),
+batch-origin turns queue FIFO at the admission door once the active-turn
+ceiling is reached. Send `X-Loom-Slot-Origin: interactive` when a human is
+actively waiting on the response: interactive turns bypass the door and ride
+the scheduler's interactive band. The value is client-asserted and trusted
+as-is — the same trust model as the gRPC metadata key `loom-slot-origin`
+used by the CLI/TUI. A full door queue rejects the request with
+`RESOURCE_EXHAUSTED` (retry later).
+
+```bash
+# A human-facing web client marks its turns interactive:
+curl -N -X POST http://localhost:5006/v1/weave:stream \
+  -H "Content-Type: application/json" \
+  -H "X-Loom-Slot-Origin: interactive" \
+  -d '{"query": "What is 2+2?", "session_id": "sess_123"}'
+```
+
 
 ## Progress Events
 

--- a/gen/go/loom/v1/llm_scheduler.pb.go
+++ b/gen/go/loom/v1/llm_scheduler.pb.go
@@ -170,13 +170,14 @@ type LLMSchedulerConfig struct {
 	ReservationTokensPerCall int32 `protobuf:"varint,2,opt,name=reservation_tokens_per_call,json=reservationTokensPerCall,proto3" json:"reservation_tokens_per_call,omitempty"`
 	// Ceiling on concurrently active (admitted, not parked) conversations.
 	// 0 = derive from measured capacity; see the design doc for the formula.
-	// Enforced only when door admission is enabled; the door layer is not yet
-	// wired, so this field is currently ignored.
+	// The door gate is wired process-wide and configured at boot via looms
+	// config (llm.max_active_conversations); this per-scope field is not yet
+	// read.
 	MaxActiveConversations int32 `protobuf:"varint,3,opt,name=max_active_conversations,json=maxActiveConversations,proto3" json:"max_active_conversations,omitempty"`
 	// Door-queue depth beyond which new conversations are rejected with
 	// RESOURCE_EXHAUSTED instead of queued.
-	// Enforced only when door admission is enabled; the door layer is not yet
-	// wired, so this field is currently ignored.
+	// The door gate is wired process-wide and configured at boot via looms
+	// config (llm.max_door_queue); this per-scope field is not yet read.
 	MaxDoorQueue int32 `protobuf:"varint,4,opt,name=max_door_queue,json=maxDoorQueue,proto3" json:"max_door_queue,omitempty"`
 	// Seconds after which a waiting slot request is promoted one priority
 	// class. Bounds starvation: any waiter reaches the top class in at most
@@ -277,14 +278,16 @@ type SlotState struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The provider quota scope this scheduler protects.
 	Scope string `protobuf:"bytes,1,opt,name=scope,proto3" json:"scope,omitempty"`
-	// Conversations currently holding at least one grant or eligible to
-	// request one. Populated when door admission is enabled (door layer not
-	// yet wired).
+	// Conversation turns currently admitted through the process-wide door
+	// gate. Populated from the door gate's live counters; the door is one gate
+	// in front of every scope, so all scopes report the same value. Zero when
+	// door admission is disabled (llm.max_active_conversations = 0).
 	ActiveConversations int32 `protobuf:"varint,2,opt,name=active_conversations,json=activeConversations,proto3" json:"active_conversations,omitempty"`
 	// Slot requests currently parked waiting for capacity.
 	ParkedRequests int32 `protobuf:"varint,3,opt,name=parked_requests,json=parkedRequests,proto3" json:"parked_requests,omitempty"`
-	// Conversations queued at the admission door. Populated when door
-	// admission is enabled (door layer not yet wired).
+	// Conversation turns parked at the admission door. Populated from the
+	// process-wide door gate's live counters (same value on every scope);
+	// zero when door admission is disabled or nothing is queued.
 	DoorQueueDepth int32 `protobuf:"varint,4,opt,name=door_queue_depth,json=doorQueueDepth,proto3" json:"door_queue_depth,omitempty"`
 	// Effective tokens-per-minute after provider-telemetry calibration (or
 	// AIMD for signal-free providers). This is the enforced number.

--- a/gen/openapiv2/loom/v1/llm_scheduler.swagger.json
+++ b/gen/openapiv2/loom/v1/llm_scheduler.swagger.json
@@ -73,12 +73,12 @@
         "maxActiveConversations": {
           "type": "integer",
           "format": "int32",
-          "description": "Ceiling on concurrently active (admitted, not parked) conversations.\n0 = derive from measured capacity; see the design doc for the formula.\nEnforced only when door admission is enabled; the door layer is not yet\nwired, so this field is currently ignored."
+          "description": "Ceiling on concurrently active (admitted, not parked) conversations.\n0 = derive from measured capacity; see the design doc for the formula.\nThe door gate is wired process-wide and configured at boot via looms\nconfig (llm.max_active_conversations); this per-scope field is not yet\nread."
         },
         "maxDoorQueue": {
           "type": "integer",
           "format": "int32",
-          "description": "Door-queue depth beyond which new conversations are rejected with\nRESOURCE_EXHAUSTED instead of queued.\nEnforced only when door admission is enabled; the door layer is not yet\nwired, so this field is currently ignored."
+          "description": "Door-queue depth beyond which new conversations are rejected with\nRESOURCE_EXHAUSTED instead of queued.\nThe door gate is wired process-wide and configured at boot via looms\nconfig (llm.max_door_queue); this per-scope field is not yet read."
         },
         "starvationAgeS": {
           "type": "integer",
@@ -149,7 +149,7 @@
         "activeConversations": {
           "type": "integer",
           "format": "int32",
-          "description": "Conversations currently holding at least one grant or eligible to\nrequest one. Populated when door admission is enabled (door layer not\nyet wired)."
+          "description": "Conversation turns currently admitted through the process-wide door\ngate. Populated from the door gate's live counters; the door is one gate\nin front of every scope, so all scopes report the same value. Zero when\ndoor admission is disabled (llm.max_active_conversations = 0)."
         },
         "parkedRequests": {
           "type": "integer",
@@ -159,7 +159,7 @@
         "doorQueueDepth": {
           "type": "integer",
           "format": "int32",
-          "description": "Conversations queued at the admission door. Populated when door\nadmission is enabled (door layer not yet wired)."
+          "description": "Conversation turns parked at the admission door. Populated from the\nprocess-wide door gate's live counters (same value on every scope);\nzero when door admission is disabled or nothing is queued."
         },
         "effectiveTokensPerMinute": {
           "type": "string",

--- a/pkg/llm/scheduler/door.go
+++ b/pkg/llm/scheduler/door.go
@@ -65,7 +65,9 @@ func (g *DoorGate) Enter(ctx context.Context) (func(), error) {
 
 	select {
 	case <-admit:
-		// The releaser incremented active on our behalf before signalling.
+		// The releaser handed its slot directly to us before signalling:
+		// active stays constant across the hand-off (see releaseFunc), so no
+		// counter update happens here.
 		return g.releaseFunc(), nil
 	case <-ctx.Done():
 		g.mu.Lock()

--- a/pkg/llm/scheduler/door.go
+++ b/pkg/llm/scheduler/door.go
@@ -1,0 +1,119 @@
+// Copyright © 2026 Teradata Corporation - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// ErrDoorFull is returned when the door queue itself is at capacity: the
+// caller should surface backpressure (RESOURCE_EXHAUSTED + retry-later)
+// instead of queueing more work. This is the ONLY capacity-shaped error in
+// the scheduler, and it exists precisely because it fires BEFORE any work
+// starts — starving a conversation at the door is free; starving it
+// mid-task wastes held resources and partial work.
+var ErrDoorFull = errors.New("scheduler: door queue full")
+
+// DoorGate caps concurrently active conversation turns. Batch turns beyond
+// MaxActive queue FIFO at the door until a running turn completes;
+// interactive turns bypass the gate entirely (the slot scheduler's
+// interactive headroom protects their capacity). Zero-value MaxActive
+// disables the gate.
+type DoorGate struct {
+	mu sync.Mutex
+	// maxActive is the active-turn ceiling; <= 0 disables gating.
+	maxActive int
+	// maxQueue caps the door queue; <= 0 means unbounded queueing.
+	maxQueue int
+	active   int
+	queue    []chan struct{}
+}
+
+// NewDoorGate builds a gate. maxActive <= 0 disables it.
+func NewDoorGate(maxActive, maxQueue int) *DoorGate {
+	return &DoorGate{maxActive: maxActive, maxQueue: maxQueue}
+}
+
+// Enter admits one conversation turn, blocking FIFO at the door while the
+// active ceiling is reached. It returns a release function that MUST be
+// called when the turn completes (idempotent). Waiting is bounded only by
+// ctx; the only capacity error is ErrDoorFull, raised before any waiting
+// when the door queue itself is at its cap.
+func (g *DoorGate) Enter(ctx context.Context) (func(), error) {
+	g.mu.Lock()
+	if g.maxActive <= 0 {
+		g.mu.Unlock()
+		return func() {}, nil
+	}
+	if g.active < g.maxActive {
+		g.active++
+		g.mu.Unlock()
+		return g.releaseFunc(), nil
+	}
+	if g.maxQueue > 0 && len(g.queue) >= g.maxQueue {
+		g.mu.Unlock()
+		return nil, ErrDoorFull
+	}
+	admit := make(chan struct{})
+	g.queue = append(g.queue, admit)
+	g.mu.Unlock()
+
+	select {
+	case <-admit:
+		// The releaser incremented active on our behalf before signalling.
+		return g.releaseFunc(), nil
+	case <-ctx.Done():
+		g.mu.Lock()
+		for i, ch := range g.queue {
+			if ch == admit {
+				g.queue = append(g.queue[:i], g.queue[i+1:]...)
+				break
+			}
+		}
+		g.mu.Unlock()
+		// The admit signal may have raced the cancellation: if it did, the
+		// slot was transferred to us and must be returned.
+		select {
+		case <-admit:
+			g.releaseFunc()()
+		default:
+		}
+		return nil, ctx.Err()
+	}
+}
+
+// releaseFunc returns the idempotent completion callback for one admission.
+func (g *DoorGate) releaseFunc() func() {
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			g.mu.Lock()
+			defer g.mu.Unlock()
+			if len(g.queue) > 0 {
+				// Hand the slot directly to the next waiter (FIFO): active
+				// stays constant, so the ceiling cannot be overshot by a
+				// release/enter race.
+				next := g.queue[0]
+				g.queue = g.queue[1:]
+				close(next)
+				return
+			}
+			g.active--
+			if g.active < 0 {
+				g.active = 0
+			}
+		})
+	}
+}
+
+// DoorState reports the gate's live counters.
+func (g *DoorGate) DoorState() (active, queued int) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.active, len(g.queue)
+}

--- a/pkg/llm/scheduler/door_test.go
+++ b/pkg/llm/scheduler/door_test.go
@@ -15,6 +15,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// waitQueued blocks until the gate reports exactly n parked waiters.
+// Readiness is observed through DoorState instead of sleeps: pathological
+// scheduling fails the Eventually assertion instead of deadlocking the test
+// or silently testing the wrong interleaving.
+func waitQueued(t *testing.T, g *DoorGate, n int) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		_, queued := g.DoorState()
+		return queued == n
+	}, 5*time.Second, time.Millisecond, "expected %d parked waiter(s) at the door", n)
+}
+
 func TestDoorGateDisabledIsTransparent(t *testing.T) {
 	g := NewDoorGate(0, 0)
 	rel, err := g.Enter(context.Background())
@@ -37,13 +49,18 @@ func TestDoorGateCapsAndAdmitsFIFO(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			rel, err := g.Enter(context.Background())
-			require.NoError(t, err)
+			if err != nil {
+				t.Errorf("waiter %d: unexpected enter error: %v", i, err)
+				return
+			}
 			mu.Lock()
 			order = append(order, i)
 			mu.Unlock()
 			rel()
 		}(i)
-		time.Sleep(50 * time.Millisecond) // deterministic queue order
+		// Deterministic queue order: waiter i must be parked before waiter
+		// i+1 is spawned.
+		waitQueued(t, g, i)
 	}
 
 	active, queued := g.DoorState()
@@ -67,20 +84,25 @@ func TestDoorGateQueueCapRejects(t *testing.T) {
 	g := NewDoorGate(1, 1)
 	r1, err := g.Enter(context.Background())
 	require.NoError(t, err)
-	defer r1()
 
 	// One waiter fits the queue.
+	waiterErr := make(chan error, 1)
 	go func() {
 		rel, err := g.Enter(context.Background())
 		if err == nil {
 			rel()
 		}
+		waiterErr <- err
 	}()
-	time.Sleep(100 * time.Millisecond)
+	waitQueued(t, g, 1)
 
 	// The next is refused with backpressure, before any waiting.
 	_, err = g.Enter(context.Background())
 	require.ErrorIs(t, err, ErrDoorFull)
+
+	// Releasing the active slot admits the parked waiter normally.
+	r1()
+	require.NoError(t, <-waiterErr, "parked waiter must be admitted after release")
 }
 
 func TestDoorGateCtxCancelLeavesNoLeak(t *testing.T) {
@@ -114,21 +136,22 @@ func TestDoorGateReleaseIdempotent(t *testing.T) {
 
 	r1, err := g.Enter(context.Background())
 	require.NoError(t, err)
-	defer r1()
-	done := make(chan struct{})
+	done := make(chan error, 1)
 	go func() {
 		r2, err := g.Enter(context.Background())
-		require.NoError(t, err)
-		r2()
-		close(done)
+		if err == nil {
+			r2()
+		}
+		done <- err
 	}()
+	waitQueued(t, g, 1)
 	select {
 	case <-done:
 		t.Fatal("second enter must wait: double release created a phantom slot")
 	case <-time.After(200 * time.Millisecond):
 	}
 	r1()
-	<-done
+	require.NoError(t, <-done)
 }
 
 func TestDoorGateConcurrentChurnRace(t *testing.T) {
@@ -151,4 +174,40 @@ func TestDoorGateConcurrentChurnRace(t *testing.T) {
 	active, queued := g.DoorState()
 	assert.Equal(t, 0, active)
 	assert.Equal(t, 0, queued)
+}
+
+// TestGetSlotStatePopulatesDoorCounters: the LLMSchedulerService surfaces the
+// process-wide door gate's live counters on every scope's SlotState.
+func TestGetSlotStatePopulatesDoorCounters(t *testing.T) {
+	SetDoorLimits(1, 0)
+	defer SetDoorLimits(0, 0)
+
+	rel, err := Door().Enter(context.Background())
+	require.NoError(t, err)
+
+	parkedErr := make(chan error, 1)
+	go func() {
+		r, err := Door().Enter(context.Background())
+		if err == nil {
+			r()
+		}
+		parkedErr <- err
+	}()
+	waitQueued(t, Door(), 1)
+
+	reg := NewRegistry(nil)
+	defer reg.Close()
+	reg.For("scope-a", Config{})
+	svc := NewService(reg)
+
+	resp, err := svc.GetSlotState(context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, resp.States, 1)
+	assert.Equal(t, int32(1), resp.States[0].ActiveConversations,
+		"SlotState must report the door gate's active-conversation count")
+	assert.Equal(t, int32(1), resp.States[0].DoorQueueDepth,
+		"SlotState must report the door gate's queue depth")
+
+	rel()
+	require.NoError(t, <-parkedErr)
 }

--- a/pkg/llm/scheduler/door_test.go
+++ b/pkg/llm/scheduler/door_test.go
@@ -1,0 +1,154 @@
+// Copyright © 2026 Teradata Corporation - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package scheduler
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDoorGateDisabledIsTransparent(t *testing.T) {
+	g := NewDoorGate(0, 0)
+	rel, err := g.Enter(context.Background())
+	require.NoError(t, err)
+	rel()
+}
+
+func TestDoorGateCapsAndAdmitsFIFO(t *testing.T) {
+	g := NewDoorGate(2, 0)
+	r1, err := g.Enter(context.Background())
+	require.NoError(t, err)
+	r2, err := g.Enter(context.Background())
+	require.NoError(t, err)
+
+	var mu sync.Mutex
+	var order []int
+	var wg sync.WaitGroup
+	for i := 1; i <= 2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			rel, err := g.Enter(context.Background())
+			require.NoError(t, err)
+			mu.Lock()
+			order = append(order, i)
+			mu.Unlock()
+			rel()
+		}(i)
+		time.Sleep(50 * time.Millisecond) // deterministic queue order
+	}
+
+	active, queued := g.DoorState()
+	assert.Equal(t, 2, active)
+	assert.Equal(t, 2, queued)
+
+	// A single release drives the whole chain deterministically: waiter 1 is
+	// admitted by r1, and waiter 2 only by waiter 1's own release — so the
+	// recorded order proves FIFO hand-off, not goroutine scheduling.
+	r1()
+	wg.Wait()
+	assert.Equal(t, []int{1, 2}, order, "door admission must be FIFO")
+	r2()
+
+	active, queued = g.DoorState()
+	assert.Equal(t, 0, active)
+	assert.Equal(t, 0, queued)
+}
+
+func TestDoorGateQueueCapRejects(t *testing.T) {
+	g := NewDoorGate(1, 1)
+	r1, err := g.Enter(context.Background())
+	require.NoError(t, err)
+	defer r1()
+
+	// One waiter fits the queue.
+	go func() {
+		rel, err := g.Enter(context.Background())
+		if err == nil {
+			rel()
+		}
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	// The next is refused with backpressure, before any waiting.
+	_, err = g.Enter(context.Background())
+	require.ErrorIs(t, err, ErrDoorFull)
+}
+
+func TestDoorGateCtxCancelLeavesNoLeak(t *testing.T) {
+	g := NewDoorGate(1, 0)
+	r1, err := g.Enter(context.Background())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	_, err = g.Enter(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	_, queued := g.DoorState()
+	assert.Equal(t, 0, queued, "cancelled waiter must leave the queue")
+
+	r1()
+	// The gate must still admit normally.
+	r2, err := g.Enter(context.Background())
+	require.NoError(t, err)
+	r2()
+}
+
+func TestDoorGateReleaseIdempotent(t *testing.T) {
+	g := NewDoorGate(1, 0)
+	rel, err := g.Enter(context.Background())
+	require.NoError(t, err)
+	rel()
+	rel() // double release must not free a phantom slot
+	active, _ := g.DoorState()
+	assert.Equal(t, 0, active)
+
+	r1, err := g.Enter(context.Background())
+	require.NoError(t, err)
+	defer r1()
+	done := make(chan struct{})
+	go func() {
+		r2, err := g.Enter(context.Background())
+		require.NoError(t, err)
+		r2()
+		close(done)
+	}()
+	select {
+	case <-done:
+		t.Fatal("second enter must wait: double release created a phantom slot")
+	case <-time.After(200 * time.Millisecond):
+	}
+	r1()
+	<-done
+}
+
+func TestDoorGateConcurrentChurnRace(t *testing.T) {
+	g := NewDoorGate(4, 0)
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rel, err := g.Enter(context.Background())
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			time.Sleep(time.Millisecond)
+			rel()
+		}()
+	}
+	wg.Wait()
+	active, queued := g.DoorState()
+	assert.Equal(t, 0, active)
+	assert.Equal(t, 0, queued)
+}

--- a/pkg/llm/scheduler/registry.go
+++ b/pkg/llm/scheduler/registry.go
@@ -100,19 +100,27 @@ func NewService(reg *Registry) *Service {
 	return &Service{reg: reg}
 }
 
-// GetSlotState returns the live state of one scope, or all scopes.
+// GetSlotState returns the live state of one scope, or all scopes. Every
+// returned state also carries the process-wide door gate's live counters
+// (active_conversations / door_queue_depth): the door is one gate in front
+// of every scope, so all scopes report the same values.
 func (s *Service) GetSlotState(_ context.Context, req *loomv1.GetSlotStateRequest) (*loomv1.GetSlotStateResponse, error) {
 	resp := &loomv1.GetSlotStateResponse{}
 	if scope := req.GetScope(); scope != "" {
 		if sched, ok := s.reg.Get(scope); ok {
 			resp.States = append(resp.States, sched.State())
 		}
-		return resp, nil
-	}
-	for _, scope := range s.reg.Scopes() {
-		if sched, ok := s.reg.Get(scope); ok {
-			resp.States = append(resp.States, sched.State())
+	} else {
+		for _, scope := range s.reg.Scopes() {
+			if sched, ok := s.reg.Get(scope); ok {
+				resp.States = append(resp.States, sched.State())
+			}
 		}
+	}
+	doorActive, doorQueued := Door().DoorState()
+	for _, st := range resp.States {
+		st.ActiveConversations = int32(doorActive) // #nosec G115 -- bounded by the operator-set ceiling
+		st.DoorQueueDepth = int32(doorQueued)      // #nosec G115 -- bounded by the operator-set queue cap / live request count
 	}
 	return resp, nil
 }

--- a/pkg/llm/scheduler/wiring.go
+++ b/pkg/llm/scheduler/wiring.go
@@ -7,6 +7,7 @@ package scheduler
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -162,4 +163,26 @@ func ObserveSuccessForScope(scope string) {
 		return
 	}
 	defaultRegistry.For(scope, Config{}).ObserveSuccess()
+}
+
+// defaultDoor is the process-wide conversation-turn gate. Disabled until
+// looms configures it (SetDoorLimits).
+var (
+	doorMu      sync.Mutex
+	defaultDoor = NewDoorGate(0, 0)
+)
+
+// Door returns the process-wide door gate.
+func Door() *DoorGate {
+	doorMu.Lock()
+	defer doorMu.Unlock()
+	return defaultDoor
+}
+
+// SetDoorLimits configures the process-wide door gate. maxActive <= 0
+// disables gating.
+func SetDoorLimits(maxActive, maxQueue int) {
+	doorMu.Lock()
+	defer doorMu.Unlock()
+	defaultDoor = NewDoorGate(maxActive, maxQueue)
 }

--- a/pkg/llm/scheduler/wiring.go
+++ b/pkg/llm/scheduler/wiring.go
@@ -180,7 +180,13 @@ func Door() *DoorGate {
 }
 
 // SetDoorLimits configures the process-wide door gate. maxActive <= 0
-// disables gating.
+// disables gating; maxQueue <= 0 means unbounded queueing.
+//
+// The gate is swapped wholesale, not resized: turns already admitted (or
+// parked) drain on the previous gate while the new gate admits from zero, so
+// reconfiguring under load transiently over-admits up to the sum of the old
+// and new ceilings. Call it once at boot — before the server starts
+// admitting turns — which is what cmd_serve.go does.
 func SetDoorLimits(maxActive, maxQueue int) {
 	doorMu.Lock()
 	defer doorMu.Unlock()

--- a/pkg/server/door_admission_test.go
+++ b/pkg/server/door_admission_test.go
@@ -1,0 +1,309 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Tests for door admission at the turn-executing entry points: EVERY entry
+// point (unary Weave included) must respect max_active_conversations, door
+// rejections must never be cached as durable dedupe outcomes, and HTTP/SSE
+// clients must be able to assert the interactive band via header.
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"github.com/teradata-labs/loom/pkg/agent"
+	llmscheduler "github.com/teradata-labs/loom/pkg/llm/scheduler"
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// withDoorLimits configures the process-wide door gate for one test and
+// restores the disabled default afterwards (the gate is global state shared
+// by every test in the package).
+func withDoorLimits(t *testing.T, maxActive, maxQueue int) {
+	t.Helper()
+	llmscheduler.SetDoorLimits(maxActive, maxQueue)
+	t.Cleanup(func() { llmscheduler.SetDoorLimits(0, 0) })
+}
+
+// waitDoorQueued blocks until the process-wide door gate reports exactly n
+// parked waiters — readiness signaling instead of sleeps.
+func waitDoorQueued(t *testing.T, n int) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		_, queued := llmscheduler.Door().DoorState()
+		return queued == n
+	}, 5*time.Second, time.Millisecond, "expected %d turn(s) parked at the door", n)
+}
+
+// blockingLLMProvider signals when a Chat call begins and holds it until
+// release is closed, so tests can pin a conversation turn in its active
+// phase.
+type blockingLLMProvider struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func newBlockingLLMProvider() *blockingLLMProvider {
+	return &blockingLLMProvider{
+		entered: make(chan struct{}, 8),
+		release: make(chan struct{}),
+	}
+}
+
+func (m *blockingLLMProvider) Chat(ctx context.Context, messages []llmtypes.Message, tools []shuttle.Tool) (*llmtypes.LLMResponse, error) {
+	m.entered <- struct{}{}
+	select {
+	case <-m.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return &llmtypes.LLMResponse{
+		Content: "done",
+		Usage:   llmtypes.Usage{InputTokens: 10, OutputTokens: 5, CostUSD: 0.001},
+	}, nil
+}
+
+func (m *blockingLLMProvider) Name() string  { return "mock-blocking" }
+func (m *blockingLLMProvider) Model() string { return "mock-blocking-v1" }
+
+// TestUnaryWeaveRespectsDoorCeiling (review finding 1, PR #353): unary Weave
+// — the MCP bridge, TUI unary path, and grpc-gateway /v1/weave all drive it —
+// must park at the door exactly like StreamWeave, so
+// max_active_conversations is a real ceiling. Two concurrent unary Weaves
+// against maxActive=1: the second must park at the door (never reaching the
+// agent) until the first releases.
+func TestUnaryWeaveRespectsDoorCeiling(t *testing.T) {
+	withDoorLimits(t, 1, 0)
+
+	llm := newBlockingLLMProvider()
+	ag := agent.NewAgent(&mockBackend{}, llm)
+	srv := NewMultiAgentServer(map[string]*agent.Agent{"agent-1": ag}, nil)
+
+	type result struct {
+		resp *loomv1.WeaveResponse
+		err  error
+	}
+	results := make(chan result, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			resp, err := srv.Weave(context.Background(), &loomv1.WeaveRequest{Query: "q"})
+			results <- result{resp, err}
+		}()
+	}
+
+	// Exactly one turn reaches the LLM; the other parks at the door.
+	<-llm.entered
+	waitDoorQueued(t, 1)
+	select {
+	case <-llm.entered:
+		t.Fatal("second unary Weave reached the agent past the max_active ceiling")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Releasing the first turn admits the second; both complete.
+	close(llm.release)
+	for i := 0; i < 2; i++ {
+		r := <-results
+		require.NoError(t, r.err)
+		require.NotNil(t, r.resp)
+		assert.Equal(t, "done", r.resp.Text)
+	}
+
+	active, queued := llmscheduler.Door().DoorState()
+	assert.Equal(t, 0, active, "all turns released their door slot")
+	assert.Equal(t, 0, queued)
+}
+
+// TestSingleAgentUnaryWeaveRespectsDoorCeiling: the single-agent Server's
+// unary Weave is its own entry point and must also go through the door.
+func TestSingleAgentUnaryWeaveRespectsDoorCeiling(t *testing.T) {
+	withDoorLimits(t, 1, 0)
+
+	llm := newBlockingLLMProvider()
+	ag := agent.NewAgent(&mockBackend{}, llm)
+	srv := NewServer(ag, nil)
+
+	errs := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			_, err := srv.Weave(context.Background(), &loomv1.WeaveRequest{Query: "q"})
+			errs <- err
+		}()
+	}
+
+	<-llm.entered
+	waitDoorQueued(t, 1)
+	select {
+	case <-llm.entered:
+		t.Fatal("second unary Weave reached the agent past the max_active ceiling")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(llm.release)
+	for i := 0; i < 2; i++ {
+		require.NoError(t, <-errs)
+	}
+}
+
+// TestEnterTurnDoorInteractiveBypassesFullDoor: interactive turns bypass the
+// gate entirely, even when the door is saturated — a web or terminal human
+// never parks behind fleets.
+func TestEnterTurnDoorInteractiveBypassesFullDoor(t *testing.T) {
+	withDoorLimits(t, 1, 1)
+
+	// Saturate the active slot.
+	rel, err := llmscheduler.Door().Enter(context.Background())
+	require.NoError(t, err)
+	defer rel()
+
+	release, err := enterTurnDoor(mdCtx(SlotOriginMetadataKey, "interactive"), nil)
+	require.NoError(t, err, "interactive turns must bypass the door")
+	release()
+}
+
+// TestEnterTurnDoorFullRejectsResourceExhausted: a full door queue surfaces
+// as RESOURCE_EXHAUSTED backpressure at the admission helper.
+func TestEnterTurnDoorFullRejectsResourceExhausted(t *testing.T) {
+	withDoorLimits(t, 1, 1)
+
+	rel, err := llmscheduler.Door().Enter(context.Background())
+	require.NoError(t, err)
+
+	parkedErr := make(chan error, 1)
+	go func() {
+		r, err := llmscheduler.Door().Enter(context.Background())
+		if err == nil {
+			r()
+		}
+		parkedErr <- err
+	}()
+	waitDoorQueued(t, 1)
+
+	_, err = enterTurnDoor(context.Background(), nil)
+	require.Error(t, err)
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
+
+	rel()
+	require.NoError(t, <-parkedErr)
+}
+
+// TestDoorRejectionNotCachedByDedupe (review finding 2, PR #353): a
+// door-full rejection is transient backpressure, not a durable outcome. A
+// client retrying with the same idempotency key after capacity frees must
+// re-attempt admission and succeed — never be served the stale
+// RESOURCE_EXHAUSTED from the dedupe cache for the 10-minute TTL.
+func TestDoorRejectionNotCachedByDedupe(t *testing.T) {
+	withDoorLimits(t, 1, 1)
+
+	llm := &mockLLMProvider{responses: []string{"answer"}}
+	srv := newDedupeServer(llm)
+
+	// Occupy the active slot and fill the one-deep queue.
+	rel, err := llmscheduler.Door().Enter(context.Background())
+	require.NoError(t, err)
+	parkedErr := make(chan error, 1)
+	go func() {
+		r, err := llmscheduler.Door().Enter(context.Background())
+		if err == nil {
+			r()
+		}
+		parkedErr <- err
+	}()
+	waitDoorQueued(t, 1)
+
+	// Door full: the keyed request is rejected with backpressure.
+	_, err = srv.Weave(keyedCtx("user-a", "door-retry-key"), &loomv1.WeaveRequest{Query: "q"})
+	require.Error(t, err)
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+
+	// Capacity frees: the direct holders drain.
+	rel()
+	require.NoError(t, <-parkedErr)
+	waitDoorQueued(t, 0)
+
+	// Same-key retry must re-attempt admission and succeed, not join the
+	// cached rejection.
+	resp, err := srv.Weave(keyedCtx("user-a", "door-retry-key"), &loomv1.WeaveRequest{Query: "q"})
+	require.NoError(t, err, "same-key retry after the queue drained must re-execute, not replay the cached RESOURCE_EXHAUSTED")
+	require.NotNil(t, resp)
+	assert.Equal(t, "answer", resp.Text)
+}
+
+// TestIsTransientOutcomeResourceExhausted: the dedupe release classifier
+// treats capacity backpressure as transient alongside cancel/deadline.
+func TestIsTransientOutcomeResourceExhausted(t *testing.T) {
+	assert.True(t, isTransientOutcome(status.Error(codes.ResourceExhausted, "door queue full")))
+	assert.True(t, isTransientOutcome(context.Canceled))
+	assert.True(t, isTransientOutcome(status.Error(codes.DeadlineExceeded, "deadline")))
+	assert.False(t, isTransientOutcome(status.Error(codes.InvalidArgument, "bad query")))
+	assert.False(t, isTransientOutcome(nil))
+}
+
+// TestWithHTTPSlotOriginMapsHeader (review finding 3, PR #353): the HTTP/SSE
+// path carries no gRPC metadata, so the X-Loom-Slot-Origin header must be
+// mapped into the context for slotOriginFromMetadata to see — otherwise web
+// humans can never be INTERACTIVE.
+func TestWithHTTPSlotOriginMapsHeader(t *testing.T) {
+	newReq := func(headerVal string) *http.Request {
+		r := httptest.NewRequest(http.MethodPost, "/v1/weave:stream", nil)
+		if headerVal != "" {
+			r.Header.Set(SlotOriginHTTPHeader, headerVal)
+		}
+		return r
+	}
+
+	r := newReq("interactive")
+	assert.Equal(t, loomv1.SlotOrigin_SLOT_ORIGIN_INTERACTIVE,
+		slotOriginFromMetadata(withHTTPSlotOrigin(r.Context(), r)),
+		"X-Loom-Slot-Origin: interactive must band INTERACTIVE")
+
+	r = newReq("Interactive")
+	assert.Equal(t, loomv1.SlotOrigin_SLOT_ORIGIN_INTERACTIVE,
+		slotOriginFromMetadata(withHTTPSlotOrigin(r.Context(), r)),
+		"header values are case-insensitive")
+
+	r = newReq("batch")
+	assert.Equal(t, loomv1.SlotOrigin_SLOT_ORIGIN_BATCH,
+		slotOriginFromMetadata(withHTTPSlotOrigin(r.Context(), r)))
+
+	r = newReq("")
+	assert.Equal(t, loomv1.SlotOrigin_SLOT_ORIGIN_BATCH,
+		slotOriginFromMetadata(withHTTPSlotOrigin(r.Context(), r)),
+		"absent header defaults to BATCH")
+}
+
+// TestHTTPInteractiveHeaderBypassesFullDoor composes the header mapping with
+// the admission helper: an SSE turn asserting interactive walks past a
+// saturated door.
+func TestHTTPInteractiveHeaderBypassesFullDoor(t *testing.T) {
+	withDoorLimits(t, 1, 1)
+
+	rel, err := llmscheduler.Door().Enter(context.Background())
+	require.NoError(t, err)
+	defer rel()
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/weave:stream", nil)
+	r.Header.Set(SlotOriginHTTPHeader, "interactive")
+	release, err := enterTurnDoor(withHTTPSlotOrigin(r.Context(), r), nil)
+	require.NoError(t, err, "an interactive HTTP turn must bypass a full door")
+	release()
+}

--- a/pkg/server/http.go
+++ b/pkg/server/http.go
@@ -307,6 +307,34 @@ func (h *HTTPServer) handleOpenAPISpec(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(spec)
 }
 
+// SlotOriginHTTPHeader is the HTTP request header SSE clients use to assert
+// this turn's scheduling band — "interactive" (a human is waiting on the
+// response) or "batch" (the default when absent). It mirrors the gRPC
+// metadata key (SlotOriginMetadataKey) under the same trust model: the value
+// is client-asserted and trusted as-is.
+const SlotOriginHTTPHeader = "X-Loom-Slot-Origin"
+
+// withHTTPSlotOrigin maps the client-asserted X-Loom-Slot-Origin header into
+// incoming gRPC metadata on ctx, so slotOriginFromMetadata — and with it
+// slot scheduling and door admission — sees the HTTP turn's band. Without
+// this mapping an HTTP request context carries no gRPC metadata, every
+// HTTP/SSE client classifies BATCH, and a web human parks at the door
+// behind fleets.
+func withHTTPSlotOrigin(ctx context.Context, r *http.Request) context.Context {
+	origin := strings.ToLower(strings.TrimSpace(r.Header.Get(SlotOriginHTTPHeader)))
+	if origin == "" {
+		return ctx
+	}
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		md = md.Copy()
+	} else {
+		md = metadata.MD{}
+	}
+	md.Set(SlotOriginMetadataKey, origin)
+	return metadata.NewIncomingContext(ctx, md)
+}
+
 // handleStreamWeaveSSE handles SSE streaming for /v1/weave:stream
 func (h *HTTPServer) handleStreamWeaveSSE(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -332,9 +360,11 @@ func (h *HTTPServer) handleStreamWeaveSSE(w http.ResponseWriter, r *http.Request
 		flusher.Flush()
 	}
 
-	// Create gRPC stream
+	// Create gRPC stream. The context carries the client-asserted slot
+	// origin (X-Loom-Slot-Origin) as incoming gRPC metadata so interactive
+	// HTTP turns bypass door admission exactly like interactive gRPC turns.
 	stream := &sseStreamWrapper{
-		ctx:     r.Context(),
+		ctx:     withHTTPSlotOrigin(r.Context(), r),
 		writer:  w,
 		flusher: w.(http.Flusher),
 		logger:  h.logger,

--- a/pkg/server/multi_agent.go
+++ b/pkg/server/multi_agent.go
@@ -7,7 +7,6 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -23,7 +22,6 @@ import (
 	"github.com/teradata-labs/loom/pkg/communication"
 	"github.com/teradata-labs/loom/pkg/evals"
 	"github.com/teradata-labs/loom/pkg/llm/factory"
-	llmscheduler "github.com/teradata-labs/loom/pkg/llm/scheduler"
 	"github.com/teradata-labs/loom/pkg/mcp/manager"
 	"github.com/teradata-labs/loom/pkg/metaagent"
 	"github.com/teradata-labs/loom/pkg/metaagent/learning"
@@ -893,6 +891,16 @@ func (s *MultiAgentServer) Weave(ctx context.Context, req *loomv1.WeaveRequest) 
 	// turn-executing entry point, unary and streaming alike.
 	ctx = installTurnSlotInfo(ctx, sessionResumed)
 
+	// Door admission (see enterTurnDoor): batch turns queue at the front
+	// door when the active ceiling is reached; interactive turns bypass.
+	// Without this, unary callers (MCP bridge, TUI, grpc-gateway) would
+	// slip past max_active_conversations entirely.
+	releaseDoor, doorErr := enterTurnDoor(ctx, s.logger)
+	if doorErr != nil {
+		return nil, doorErr
+	}
+	defer releaseDoor()
+
 	// Add progress multiplexer to context if available for this agent
 	s.mu.RLock()
 	if pm, ok := s.progressMultiplexers[agentID]; ok {
@@ -1107,21 +1115,13 @@ func (s *MultiAgentServer) StreamWeave(req *loomv1.WeaveRequest, stream loomv1.L
 	// resumed session classifies IN_FLIGHT from its first call of the turn.
 	ctx = installTurnSlotInfo(ctx, sessionResumed)
 
-	// Door admission: batch turns queue at the front door when the active
-	// ceiling is reached — starving at the door is free, starving mid-task
-	// wastes held resources. Interactive turns bypass (the scheduler's
-	// interactive headroom protects their capacity). A full door queue is
-	// backpressure, not silence.
-	if slotOriginFromMetadata(ctx) != loomv1.SlotOrigin_SLOT_ORIGIN_INTERACTIVE {
-		releaseDoor, doorErr := llmscheduler.Door().Enter(ctx)
-		if doorErr != nil {
-			if errors.Is(doorErr, llmscheduler.ErrDoorFull) {
-				return status.Error(codes.ResourceExhausted, "server at capacity: conversation door queue full, retry later")
-			}
-			return doorErr
-		}
-		defer releaseDoor()
+	// Door admission (see enterTurnDoor): batch turns queue at the front
+	// door when the active ceiling is reached; interactive turns bypass.
+	releaseDoor, doorErr := enterTurnDoor(ctx, s.logger)
+	if doorErr != nil {
+		return doorErr
 	}
+	defer releaseDoor()
 
 	// Register manage_ephemeral_agents tool if not already registered
 	// This allows agents to spawn and despawn sub-agents dynamically

--- a/pkg/server/multi_agent.go
+++ b/pkg/server/multi_agent.go
@@ -7,6 +7,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -22,6 +23,7 @@ import (
 	"github.com/teradata-labs/loom/pkg/communication"
 	"github.com/teradata-labs/loom/pkg/evals"
 	"github.com/teradata-labs/loom/pkg/llm/factory"
+	llmscheduler "github.com/teradata-labs/loom/pkg/llm/scheduler"
 	"github.com/teradata-labs/loom/pkg/mcp/manager"
 	"github.com/teradata-labs/loom/pkg/metaagent"
 	"github.com/teradata-labs/loom/pkg/metaagent/learning"
@@ -1104,6 +1106,22 @@ func (s *MultiAgentServer) StreamWeave(req *loomv1.WeaveRequest, stream loomv1.L
 	// is per-request — edge-triggered, never a conversation-lifetime mark. A
 	// resumed session classifies IN_FLIGHT from its first call of the turn.
 	ctx = installTurnSlotInfo(ctx, sessionResumed)
+
+	// Door admission: batch turns queue at the front door when the active
+	// ceiling is reached — starving at the door is free, starving mid-task
+	// wastes held resources. Interactive turns bypass (the scheduler's
+	// interactive headroom protects their capacity). A full door queue is
+	// backpressure, not silence.
+	if slotOriginFromMetadata(ctx) != loomv1.SlotOrigin_SLOT_ORIGIN_INTERACTIVE {
+		releaseDoor, doorErr := llmscheduler.Door().Enter(ctx)
+		if doorErr != nil {
+			if errors.Is(doorErr, llmscheduler.ErrDoorFull) {
+				return status.Error(codes.ResourceExhausted, "server at capacity: conversation door queue full, retry later")
+			}
+			return doorErr
+		}
+		defer releaseDoor()
+	}
 
 	// Register manage_ephemeral_agents tool if not already registered
 	// This allows agents to spawn and despawn sub-agents dynamically

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -141,6 +141,14 @@ func (s *Server) Weave(ctx context.Context, req *loomv1.WeaveRequest) (*loomv1.W
 	_, sessionResumed := s.agent.GetSession(sessionID)
 	ctx = installTurnSlotInfo(ctx, sessionResumed)
 
+	// Door admission (see enterTurnDoor): batch turns queue at the front
+	// door when the active ceiling is reached; interactive turns bypass.
+	releaseDoor, doorErr := enterTurnDoor(ctx, nil)
+	if doorErr != nil {
+		return nil, doorErr
+	}
+	defer releaseDoor()
+
 	// Reset context window if requested (before processing the message)
 	if req.ResetContext {
 		s.agent.ResetSessionContext(sessionID)
@@ -209,6 +217,14 @@ func (s *Server) StreamWeave(req *loomv1.WeaveRequest, stream loomv1.LoomService
 	// turn-executing entry point installs it).
 	_, sessionResumed := s.agent.GetSession(sessionID)
 	ctx = installTurnSlotInfo(ctx, sessionResumed)
+
+	// Door admission (see enterTurnDoor): batch turns queue at the front
+	// door when the active ceiling is reached; interactive turns bypass.
+	releaseDoor, doorErr := enterTurnDoor(ctx, nil)
+	if doorErr != nil {
+		return doorErr
+	}
+	defer releaseDoor()
 
 	// Reset context window if requested (before processing the message)
 	if req.ResetContext {

--- a/pkg/server/weave_dedupe.go
+++ b/pkg/server/weave_dedupe.go
@@ -34,6 +34,7 @@ import (
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
 	llmscheduler "github.com/teradata-labs/loom/pkg/llm/scheduler"
 	"github.com/teradata-labs/loom/pkg/types"
+	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -123,7 +124,11 @@ func wrapAgentError(err error) error {
 }
 
 // isTransientOutcome reports whether err reflects an interrupted run
-// (caller disconnect, deadline) rather than a deterministic result.
+// (caller disconnect, deadline) or a capacity rejection rather than a
+// deterministic result. RESOURCE_EXHAUSTED — the door-full backpressure code
+// — means "retry later" by definition: caching it for the dedupe TTL would
+// keep serving the stale rejection to a same-key retry long after the door
+// queue drained, so it must be released, never cached.
 func isTransientOutcome(err error) bool {
 	if err == nil {
 		return false
@@ -132,7 +137,7 @@ func isTransientOutcome(err error) bool {
 		return true
 	}
 	switch status.Code(err) {
-	case codes.Canceled, codes.DeadlineExceeded:
+	case codes.Canceled, codes.DeadlineExceeded, codes.ResourceExhausted:
 		return true
 	}
 	return false
@@ -304,4 +309,58 @@ func installTurnSlotInfo(ctx context.Context, resumed bool) context.Context {
 		priorCalls = 1
 	}
 	return llmscheduler.WithSlotInfo(ctx, slotOriginFromMetadata(ctx), priorCalls)
+}
+
+// doorParkLogThreshold separates the un-parked fast path (a mutex
+// acquisition, microseconds) from an actual park at the door: an admission
+// that took at least this long waited behind the active ceiling and is worth
+// a debug line.
+const doorParkLogThreshold = time.Millisecond
+
+// enterTurnDoor admits one batch-origin conversation turn through the
+// process-wide door gate (llmscheduler.Door): batch turns beyond the
+// configured active ceiling park FIFO at the front door — starving a turn at
+// the door is free, starving it mid-task wastes held resources and partial
+// work. Interactive turns bypass entirely (the slot scheduler's interactive
+// headroom protects their capacity). A full door queue surfaces as
+// RESOURCE_EXHAUSTED backpressure, never silence.
+//
+// EVERY turn-executing entry point (Weave and StreamWeave, single- and
+// multi-agent alike) must call this right after installTurnSlotInfo: a
+// bypassed entry point would make max_active_conversations a suggestion, not
+// a ceiling. On success the returned release is non-nil and idempotent;
+// callers defer it for the life of the turn. logger may be nil.
+//
+// Observability: rejections log at Warn with the live door counters; a turn
+// that actually parked logs its door wait at Debug. There is no span seam
+// before admission (entry-point spans start after the turn is admitted), so
+// the wait is surfaced through the door_wait log field and the SlotState
+// proto counters rather than a new tracing seam.
+func enterTurnDoor(ctx context.Context, logger *zap.Logger) (release func(), err error) {
+	if slotOriginFromMetadata(ctx) == loomv1.SlotOrigin_SLOT_ORIGIN_INTERACTIVE {
+		return func() {}, nil
+	}
+	door := llmscheduler.Door()
+	start := time.Now()
+	release, err = door.Enter(ctx)
+	if err != nil {
+		if errors.Is(err, llmscheduler.ErrDoorFull) {
+			if logger != nil {
+				active, queued := door.DoorState()
+				logger.Warn("door admission rejected: queue full",
+					zap.Int("active_conversations", active),
+					zap.Int("door_queue_depth", queued))
+			}
+			return nil, status.Error(codes.ResourceExhausted, "server at capacity: conversation door queue full, retry later")
+		}
+		return nil, err
+	}
+	if wait := time.Since(start); wait >= doorParkLogThreshold && logger != nil {
+		active, queued := door.DoorState()
+		logger.Debug("door admission: turn parked at the front door",
+			zap.Duration("door_wait", wait),
+			zap.Int("active_conversations", active),
+			zap.Int("door_queue_depth", queued))
+	}
+	return release, nil
 }

--- a/proto/loom/v1/llm_scheduler.proto
+++ b/proto/loom/v1/llm_scheduler.proto
@@ -73,14 +73,15 @@ message LLMSchedulerConfig {
 
   // Ceiling on concurrently active (admitted, not parked) conversations.
   // 0 = derive from measured capacity; see the design doc for the formula.
-  // Enforced only when door admission is enabled; the door layer is not yet
-  // wired, so this field is currently ignored.
+  // The door gate is wired process-wide and configured at boot via looms
+  // config (llm.max_active_conversations); this per-scope field is not yet
+  // read.
   int32 max_active_conversations = 3;
 
   // Door-queue depth beyond which new conversations are rejected with
   // RESOURCE_EXHAUSTED instead of queued.
-  // Enforced only when door admission is enabled; the door layer is not yet
-  // wired, so this field is currently ignored.
+  // The door gate is wired process-wide and configured at boot via looms
+  // config (llm.max_door_queue); this per-scope field is not yet read.
   int32 max_door_queue = 4;
 
   // Seconds after which a waiting slot request is promoted one priority
@@ -103,16 +104,18 @@ message SlotState {
   // The provider quota scope this scheduler protects.
   string scope = 1;
 
-  // Conversations currently holding at least one grant or eligible to
-  // request one. Populated when door admission is enabled (door layer not
-  // yet wired).
+  // Conversation turns currently admitted through the process-wide door
+  // gate. Populated from the door gate's live counters; the door is one gate
+  // in front of every scope, so all scopes report the same value. Zero when
+  // door admission is disabled (llm.max_active_conversations = 0).
   int32 active_conversations = 2;
 
   // Slot requests currently parked waiting for capacity.
   int32 parked_requests = 3;
 
-  // Conversations queued at the admission door. Populated when door
-  // admission is enabled (door layer not yet wired).
+  // Conversation turns parked at the admission door. Populated from the
+  // process-wide door gate's live counters (same value on every scope);
+  // zero when door admission is disabled or nothing is queued.
   int32 door_queue_depth = 4;
 
   // Effective tokens-per-minute after provider-telemetry calibration (or


### PR DESCRIPTION
**Stacked on #352** (base branch is `feat/llm-slot-scheduler`); Phase-2b of the #351 design.

Starving a conversation at the door is free; starving it mid-task wastes held resources and partial work — az512c demonstrated the mid-task version (0/512 completions from uniform admission). This adds the front door:

- **`DoorGate`**: caps concurrently active batch conversation turns. Excess queues FIFO, and a released slot is handed *directly* to the next waiter — the active count never dips, so no release/enter race can overshoot the ceiling. Waiting is bounded only by the caller's context. The one capacity error, `ErrDoorFull`, fires *before* any waiting, when the door queue itself is at cap.
- **StreamWeave wiring**: batch turns pass the gate with a deferred release at turn end; a full door surfaces as `RESOURCE_EXHAUSTED` with retry guidance. **Interactive turns bypass entirely** — a human must never queue behind a fleet (the slot scheduler's interactive headroom protects their capacity; validated live: a pure-LLM human probe answered in 26s through 261-agent saturation).
- **Config**: `llm.max_active_conversations` (0 = gate off, the default) and `llm.max_door_queue` (0 = unbounded queueing).

Tests (`-race`): disabled transparency; ceiling + deterministic FIFO hand-off (a single release drives the whole admission cascade); queue-cap rejection; ctx-cancel leaves no queue leak including the admit/cancel race; idempotent release (a double release must not mint a phantom slot); 64-goroutine churn. Full `just check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)