### PR TITLE
feat(mcp): freeze tool calls on capacity backpressure — flow control never reaches the model

### DIFF
--- a/pkg/agent/mcp_integration.go
+++ b/pkg/agent/mcp_integration.go
@@ -38,6 +38,10 @@ type MCPServerConfig struct {
 	// AutoClose determines if the client should be closed when agent is done
 	// Default: false (client lifecycle managed externally)
 	AutoClose bool
+
+	// Logger receives registration events and is handed to every tool
+	// adapter (backpressure freezes, resource-wait parks). Nil = no-op.
+	Logger *zap.Logger
 }
 
 // RegisterMCPTools connects to an MCP server and registers all its tools with the agent.
@@ -75,12 +79,12 @@ func (a *Agent) RegisterMCPTools(ctx context.Context, config MCPServerConfig) er
 		return fmt.Errorf("MCP client must be initialized before registering tools (call client.Initialize first)")
 	}
 
-	// Get logger (use agent's tracer logger if available, otherwise create new one)
-	logger := zap.NewNop()
-	if a.tracer != nil {
-		// Tracer might have a logger we can use
-		// For now, just use nop logger
-		logger = zap.NewNop()
+	logger := config.Logger
+	if logger == nil {
+		// Fall back to the process-global logger, not a nop: adapter
+		// lifecycle events (park entry/exit, session-handle release
+		// attempts and skips) must stay visible in production logs.
+		logger = zap.L()
 	}
 
 	logger.Info("registering MCP tools",
@@ -98,9 +102,7 @@ func (a *Agent) RegisterMCPTools(ctx context.Context, config MCPServerConfig) er
 	tools := make([]shuttle.Tool, len(mcpTools))
 	for i, mcpTool := range mcpTools {
 		mcpAdapter := adapter.NewMCPToolAdapter(config.Client, mcpTool, config.Name)
-		// Adapter lifecycle events (park entry/exit, session-handle release
-		// attempts and skips) must be visible in production logs.
-		mcpAdapter.SetLogger(zap.L())
+		mcpAdapter.SetLogger(logger)
 		tools[i] = mcpAdapter
 	}
 
@@ -182,7 +184,7 @@ func (a *Agent) RegisterMCPServer(ctx context.Context, mcpMgr *manager.Manager, 
 		return fmt.Errorf("failed to get server config: %w", err)
 	}
 
-	logger := zap.NewNop()
+	logger := mcpMgr.Logger()
 	logger.Info("Registering MCP server tools", zap.String("server", serverName))
 
 	// List all available tools
@@ -202,7 +204,7 @@ func (a *Agent) RegisterMCPServer(ctx context.Context, mcpMgr *manager.Manager, 
 	// Register filtered tools. Results ride whole (HLD §4).
 	for _, tool := range toolsToRegister {
 		mcpAdapter := adapter.NewMCPToolAdapter(client, tool, serverName)
-		mcpAdapter.SetLogger(zap.L())
+		mcpAdapter.SetLogger(logger)
 		a.RegisterTool(mcpAdapter)
 		logger.Debug("registered MCP tool",
 			zap.String("server", serverName),
@@ -239,7 +241,7 @@ func (a *Agent) RegisterMCPTool(ctx context.Context, mcpMgr *manager.Manager, se
 		return fmt.Errorf("server %s not found: %w", serverName, err)
 	}
 
-	logger := zap.NewNop()
+	logger := mcpMgr.Logger()
 
 	// Get tool definition
 	tools, err := client.ListTools(ctx)
@@ -251,7 +253,7 @@ func (a *Agent) RegisterMCPTool(ctx context.Context, mcpMgr *manager.Manager, se
 	for _, tool := range tools {
 		if tool.Name == toolName {
 			mcpAdapter := adapter.NewMCPToolAdapter(client, tool, serverName)
-			mcpAdapter.SetLogger(zap.L())
+			mcpAdapter.SetLogger(logger)
 			shuttleTool := mcpAdapter
 			a.RegisterTool(shuttleTool)
 

--- a/pkg/mcp/adapter/backpressure_wait.go
+++ b/pkg/mcp/adapter/backpressure_wait.go
@@ -1,0 +1,178 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package adapter
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/teradata-labs/loom/pkg/mcp/client"
+)
+
+// Backpressure freeze (issue #354). A 512-agent run measured what happens
+// when capacity flow control reaches a model: 27% of the fleet met a full
+// session-handle pool, retried connect politely twice, and gave up — locked
+// out for the whole run. Flow control is the runtime's job: a tool call that
+// fails with the machine-readable backpressure contract
+// (client.BackpressureHint) freezes HERE, below the LLM, and re-invokes
+// until capacity frees or the conversation's own deadline expires. The model
+// just sees a tool call that took longer.
+const (
+	// defaultBackpressureBudget bounds the total freeze when the caller's
+	// context carries no deadline. Agent conversations normally do (the
+	// caller's timeout becomes the ctx deadline) and the budget is always
+	// clipped to it when present.
+	defaultBackpressureBudget = 15 * time.Minute
+	// backpressureDeadlineMargin is reserved from the ctx deadline so the
+	// final outcome can still travel back to the loop before ctx death.
+	backpressureDeadlineMargin = 2 * time.Second
+	// backpressurePollFloor/Ceil bound the sleep between re-invokes when the
+	// server names no wait_param. retry_after_s is a worst-case hint —
+	// capacity may free sooner — so polls never sleep past the ceiling.
+	backpressurePollFloor = time.Second
+	backpressurePollCeil  = 30 * time.Second
+)
+
+// isBackpressure reports whether a tool-call failure carries the
+// machine-readable backpressure contract.
+func isBackpressure(err error) bool {
+	var terr *client.ToolResultError
+	return errors.As(err, &terr) && terr.Backpressure() != nil
+}
+
+// awaitBackpressure freezes a tool call that failed with capacity
+// backpressure and re-invokes it until it succeeds, fails differently, or
+// the budget/context expires — then surfaces the newest error unchanged.
+//
+// When the server names a wait_param, each re-invoke passes it the remaining
+// budget (clamped to the server's max_wait_s), so the retry parks
+// SERVER-side in the server's FIFO wait queue and wakes on a freed slot:
+// one parked call holds one queue position for the whole wait. Without a
+// wait_param the retry polls, sleeping retry_after_s between attempts
+// (clamped to the poll bounds).
+func (a *MCPToolAdapter) awaitBackpressure(ctx context.Context, params map[string]interface{}, callErr error) (interface{}, error) {
+	var terr *client.ToolResultError
+	if !errors.As(callErr, &terr) {
+		return nil, callErr
+	}
+	hint := terr.Backpressure()
+	if hint == nil {
+		return nil, callErr
+	}
+
+	budget := defaultBackpressureBudget
+	if deadline, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(deadline) - backpressureDeadlineMargin; remaining < budget {
+			budget = remaining
+		}
+	}
+	if budget <= 0 {
+		return nil, callErr
+	}
+	waitDeadline := time.Now().Add(budget)
+	start := time.Now()
+
+	a.logger.Info("backpressure: froze tool call until capacity frees",
+		zap.String("tool", a.tool.Name),
+		zap.String("server", a.serverName),
+		zap.String("code", hint.Code),
+		zap.String("wait_param", hint.WaitParam),
+		zap.Duration("budget", budget))
+
+	attempts := 0
+	lastErr := callErr
+	for {
+		remaining := time.Until(waitDeadline)
+		if remaining <= 0 {
+			a.logger.Warn("backpressure: budget exhausted; surfacing the error",
+				zap.String("tool", a.tool.Name),
+				zap.String("code", hint.Code),
+				zap.Int("attempts", attempts),
+				zap.Duration("waited", time.Since(start)))
+			return nil, lastErr
+		}
+
+		if hint.WaitParam != "" {
+			// Server-side park: ask the server to hold this call until a
+			// slot frees, for as much of the remaining budget as it allows.
+			waitS := int64(remaining / time.Second)
+			if hint.MaxWaitS > 0 && waitS > hint.MaxWaitS {
+				waitS = hint.MaxWaitS
+			}
+			if waitS < 1 {
+				waitS = 1
+			}
+			params[hint.WaitParam] = waitS
+		} else {
+			sleep := time.Duration(hint.RetryAfterS) * time.Second
+			if sleep < backpressurePollFloor {
+				sleep = backpressurePollFloor
+			}
+			if sleep > backpressurePollCeil {
+				sleep = backpressurePollCeil
+			}
+			if sleep > remaining {
+				sleep = remaining
+			}
+			timer := time.NewTimer(sleep)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, lastErr
+			case <-timer.C:
+			}
+		}
+
+		attempts++
+		attemptStart := time.Now()
+		result, err := a.client.CallTool(ctx, a.tool.Name, params)
+		if err == nil {
+			a.logger.Info("backpressure: call succeeded after freeze",
+				zap.String("tool", a.tool.Name),
+				zap.String("code", hint.Code),
+				zap.Int("attempts", attempts),
+				zap.Duration("waited", time.Since(start)))
+			return result, nil
+		}
+		lastErr = err
+
+		var again *client.ToolResultError
+		if !errors.As(err, &again) {
+			// Transport/context failure: nothing to wait out.
+			return nil, err
+		}
+		next := again.Backpressure()
+		if next == nil {
+			// The condition changed to a task-level failure: the model must
+			// see it.
+			return nil, err
+		}
+		if hint.WaitParam != "" && time.Since(attemptStart) < backpressurePollFloor {
+			// The server advertised parking but refused instantly instead of
+			// holding the call: degrade to polling pace so the loop can't
+			// spin hot against a server that doesn't honor its own contract.
+			timer := time.NewTimer(backpressurePollFloor)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, err
+			case <-timer.C:
+			}
+		}
+		hint = next // refresh retry_after / wait caps from the newest error
+	}
+}

--- a/pkg/mcp/adapter/backpressure_wait.go
+++ b/pkg/mcp/adapter/backpressure_wait.go
@@ -32,10 +32,13 @@ import (
 // until capacity frees or the conversation's own deadline expires. The model
 // just sees a tool call that took longer.
 const (
-	// defaultBackpressureBudget bounds the total freeze when the caller's
-	// context carries no deadline. Agent conversations normally do (the
-	// caller's timeout becomes the ctx deadline) and the budget is always
-	// clipped to it when present.
+	// defaultBackpressureBudget bounds the total freeze ONLY when the
+	// caller's context carries no deadline. When a deadline exists the
+	// freeze rides it entirely: a parked call is making progress — it holds
+	// a queue position — so nothing shorter than the conversation's own
+	// deadline may cut it loose. (az512f measured the alternative: capping
+	// the freeze at 15 min under a 40-min deadline surfaced 44 budget-full
+	// errors whose slots would have freed minutes later.)
 	defaultBackpressureBudget = 15 * time.Minute
 	// backpressureDeadlineMargin is reserved from the ctx deadline so the
 	// final outcome can still travel back to the loop before ctx death.
@@ -46,6 +49,16 @@ const (
 	backpressurePollFloor = time.Second
 	backpressurePollCeil  = 30 * time.Second
 )
+
+// backpressureBudget is how long a frozen call may wait in total: the
+// caller's own deadline (minus a margin for the outcome to travel back)
+// when one exists, else the conservative default.
+func backpressureBudget(ctx context.Context) time.Duration {
+	if deadline, ok := ctx.Deadline(); ok {
+		return time.Until(deadline) - backpressureDeadlineMargin
+	}
+	return defaultBackpressureBudget
+}
 
 // isBackpressure reports whether a tool-call failure carries the
 // machine-readable backpressure contract.
@@ -74,12 +87,7 @@ func (a *MCPToolAdapter) awaitBackpressure(ctx context.Context, params map[strin
 		return nil, callErr
 	}
 
-	budget := defaultBackpressureBudget
-	if deadline, ok := ctx.Deadline(); ok {
-		if remaining := time.Until(deadline) - backpressureDeadlineMargin; remaining < budget {
-			budget = remaining
-		}
-	}
+	budget := backpressureBudget(ctx)
 	if budget <= 0 {
 		return nil, callErr
 	}

--- a/pkg/mcp/adapter/backpressure_wait.go
+++ b/pkg/mcp/adapter/backpressure_wait.go
@@ -101,6 +101,16 @@ func (a *MCPToolAdapter) awaitBackpressure(ctx context.Context, params map[strin
 		zap.String("wait_param", hint.WaitParam),
 		zap.Duration("budget", budget))
 
+	// The re-invoke params are a private copy: params aliases the model's
+	// toolCall.Input whenever no schema case-restore happened, and injecting
+	// wait_s into that map would leak flow control into the model's replayed
+	// tool history and the persisted tool-execution record — the exact leak
+	// this freeze exists to prevent.
+	reinvoke := make(map[string]interface{}, len(params)+1)
+	for k, v := range params {
+		reinvoke[k] = v
+	}
+
 	attempts := 0
 	lastErr := callErr
 	for {
@@ -124,7 +134,7 @@ func (a *MCPToolAdapter) awaitBackpressure(ctx context.Context, params map[strin
 			if waitS < 1 {
 				waitS = 1
 			}
-			params[hint.WaitParam] = waitS
+			reinvoke[hint.WaitParam] = waitS
 		} else {
 			sleep := time.Duration(hint.RetryAfterS) * time.Second
 			if sleep < backpressurePollFloor {
@@ -147,7 +157,7 @@ func (a *MCPToolAdapter) awaitBackpressure(ctx context.Context, params map[strin
 
 		attempts++
 		attemptStart := time.Now()
-		result, err := a.client.CallTool(ctx, a.tool.Name, params)
+		result, err := a.client.CallTool(ctx, a.tool.Name, reinvoke)
 		if err == nil {
 			a.logger.Info("backpressure: call succeeded after freeze",
 				zap.String("tool", a.tool.Name),
@@ -171,15 +181,32 @@ func (a *MCPToolAdapter) awaitBackpressure(ctx context.Context, params map[strin
 		}
 		if hint.WaitParam != "" && time.Since(attemptStart) < backpressurePollFloor {
 			// The server advertised parking but refused instantly instead of
-			// holding the call: degrade to polling pace so the loop can't
-			// spin hot against a server that doesn't honor its own contract.
-			timer := time.NewTimer(backpressurePollFloor)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return nil, err
-			case <-timer.C:
+			// holding the call: degrade to polling pace — honoring the
+			// server's own retry_after estimate when it exceeds the floor —
+			// so the loop can't spin hot against a server that doesn't
+			// honor its own contract.
+			sleep := backpressurePollFloor
+			if ra := time.Duration(next.RetryAfterS) * time.Second; ra > sleep {
+				sleep = ra
 			}
+			if remaining := time.Until(waitDeadline); sleep > remaining {
+				sleep = remaining
+			}
+			if sleep > 0 {
+				timer := time.NewTimer(sleep)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return nil, err
+				case <-timer.C:
+				}
+			}
+		}
+		if hint.WaitParam != "" && hint.WaitParam != next.WaitParam {
+			// The contract changed: drop the previously injected wait key so
+			// later polling re-invokes don't carry a stale server-side park
+			// request on top of the client-side pacing.
+			delete(reinvoke, hint.WaitParam)
 		}
 		hint = next // refresh retry_after / wait caps from the newest error
 	}

--- a/pkg/mcp/adapter/backpressure_wait_test.go
+++ b/pkg/mcp/adapter/backpressure_wait_test.go
@@ -184,3 +184,30 @@ func TestBackpressureBudgetRidesDeadline(t *testing.T) {
 	time.Sleep(2 * time.Millisecond)
 	assert.LessOrEqual(t, backpressureBudget(dead), time.Duration(0))
 }
+
+// TestBackpressureCallerParamsNotMutated pins the map-isolation invariant:
+// the freeze loop injects wait_s into its own private copy, never into the
+// caller's params map — that map aliases the model's toolCall.Input whenever
+// no schema case-restore happened, and mutating it would leak flow control
+// into the model's replayed tool history and the persisted execution record.
+func TestBackpressureCallerParamsNotMutated(t *testing.T) {
+	ft := newWaitTransport(
+		backpressureResult("session_handle_budget_full", 412, "wait_s", 300),
+		successResult("connected"),
+	)
+	adapter := waitAdapter(t, ft)
+
+	callerParams := map[string]interface{}{"query": "SELECT 1"}
+	res, err := adapter.Execute(context.Background(), callerParams)
+	require.NoError(t, err)
+	require.True(t, res.Success)
+
+	// The re-invoke carried wait_s on the wire…
+	wire := ft.lastCallParams()
+	require.NotNil(t, wire)
+	assert.Contains(t, wire, "wait_s", "server-side park must be requested on the wire")
+	// …but the caller's map is untouched.
+	assert.NotContains(t, callerParams, "wait_s",
+		"the model-owned params map must never see injected flow control")
+	assert.Equal(t, map[string]interface{}{"query": "SELECT 1"}, callerParams)
+}

--- a/pkg/mcp/adapter/backpressure_wait_test.go
+++ b/pkg/mcp/adapter/backpressure_wait_test.go
@@ -160,3 +160,27 @@ func TestBackpressureBudgetExhausted(t *testing.T) {
 	assert.Less(t, time.Since(start), 3*time.Second, "must give up before the context dies")
 	assert.GreaterOrEqual(t, ft.calls(), 2, "at least one frozen re-invoke happened")
 }
+
+// TestBackpressureBudgetRidesDeadline: the freeze budget is the caller's
+// deadline when one exists — even one longer than the no-deadline default —
+// and the default only applies without a deadline (az512f regression: a
+// 15-min cap under a 40-min deadline surfaced 44 avoidable errors).
+func TestBackpressureBudgetRidesDeadline(t *testing.T) {
+	assert.Equal(t, defaultBackpressureBudget, backpressureBudget(context.Background()))
+
+	long, cancel := context.WithTimeout(context.Background(), 40*time.Minute)
+	defer cancel()
+	got := backpressureBudget(long)
+	assert.Greater(t, got, 35*time.Minute, "a 40m deadline must yield a ~40m budget, not the 15m default")
+
+	short, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel2()
+	got = backpressureBudget(short)
+	assert.Less(t, got, 5*time.Second)
+	assert.Greater(t, got, 2*time.Second)
+
+	dead, cancel3 := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel3()
+	time.Sleep(2 * time.Millisecond)
+	assert.LessOrEqual(t, backpressureBudget(dead), time.Duration(0))
+}

--- a/pkg/mcp/adapter/backpressure_wait_test.go
+++ b/pkg/mcp/adapter/backpressure_wait_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package adapter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/teradata-labs/loom/pkg/mcp/protocol"
+)
+
+// backpressureResult builds a tool error carrying the machine-readable
+// park-and-wake contract (the shape teradata-mcp's fail() emits).
+func backpressureResult(code string, retryAfterS int64, waitParam string, maxWaitS int64) json.RawMessage {
+	payload := map[string]any{"code": code, "message": "capacity", "retryable": true}
+	if retryAfterS > 0 {
+		payload["retry_after_s"] = retryAfterS
+	}
+	if waitParam != "" {
+		payload["wait_param"] = waitParam
+		payload["max_wait_s"] = maxWaitS
+	}
+	text, _ := json.Marshal(payload)
+	r, _ := json.Marshal(protocol.CallToolResult{IsError: true, Content: []protocol.Content{
+		{Type: "text", Text: string(text)},
+	}})
+	return r
+}
+
+func plainCodeResult(code string) json.RawMessage {
+	r, _ := json.Marshal(protocol.CallToolResult{IsError: true, Content: []protocol.Content{
+		{Type: "text", Text: fmt.Sprintf(`{"code":%q,"message":"task failure"}`, code)},
+	}})
+	return r
+}
+
+// TestBackpressureServerPark: a budget-full error naming wait_param re-invokes
+// immediately with the wait argument set, so the retry parks server-side. One
+// Execute call, two wire attempts, the model sees only success (issue #354).
+func TestBackpressureServerPark(t *testing.T) {
+	ft := newWaitTransport(
+		backpressureResult("session_handle_budget_full", 412, "wait_s", 300),
+		successResult("connected"),
+	)
+	adapter := waitAdapter(t, ft)
+
+	res, err := adapter.Execute(context.Background(), map[string]interface{}{})
+	require.NoError(t, err)
+	require.True(t, res.Success, "frozen call must succeed after server park: %+v", res)
+	assert.Equal(t, 2, ft.calls(), "exactly one re-invoke")
+
+	// The retry parked server-side: wait_s set, clamped to the server's cap
+	// (no ctx deadline → remaining budget far exceeds max_wait_s).
+	params := ft.lastCallParams()
+	require.NotNil(t, params)
+	assert.Equal(t, float64(300), params["wait_s"], "wait_s = min(remaining, max_wait_s)")
+}
+
+// TestBackpressureWaitClampsToDeadline: with a context deadline tighter than
+// the server's max_wait_s, the parked wait asks only for the time the caller
+// actually has.
+func TestBackpressureWaitClampsToDeadline(t *testing.T) {
+	ft := newWaitTransport(
+		backpressureResult("session_handle_budget_full", 0, "wait_s", 300),
+		successResult("connected"),
+	)
+	adapter := waitAdapter(t, ft)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	res, err := adapter.Execute(ctx, map[string]interface{}{})
+	require.NoError(t, err)
+	require.True(t, res.Success)
+
+	params := ft.lastCallParams()
+	require.NotNil(t, params)
+	waitS, ok := params["wait_s"].(float64)
+	require.True(t, ok, "wait_s missing: %v", params)
+	assert.LessOrEqual(t, waitS, float64(8), "wait_s must not exceed remaining budget (deadline - margin)")
+	assert.GreaterOrEqual(t, waitS, float64(1))
+}
+
+// TestBackpressurePollWithoutWaitParam: a retryable error with no wait_param
+// polls client-side — sleeping retry_after_s (floored at 1s) — and succeeds
+// on the re-invoke.
+func TestBackpressurePollWithoutWaitParam(t *testing.T) {
+	ft := newWaitTransport(
+		backpressureResult("server_busy", 1, "", 0),
+		successResult("ok"),
+	)
+	adapter := waitAdapter(t, ft)
+
+	start := time.Now()
+	res, err := adapter.Execute(context.Background(), map[string]interface{}{})
+	require.NoError(t, err)
+	require.True(t, res.Success)
+	assert.Equal(t, 2, ft.calls())
+	assert.GreaterOrEqual(t, time.Since(start), time.Second, "poll path must sleep retry_after_s first")
+	_, has := ft.lastCallParams()["wait_s"]
+	assert.False(t, has, "no wait param may be invented")
+}
+
+// TestBackpressureConditionChangeSurfaces: when the retried call fails with a
+// task-level (non-retryable) error, the freeze ends and that error reaches
+// the model — waiting out someone else's SQL mistake helps nobody.
+func TestBackpressureConditionChangeSurfaces(t *testing.T) {
+	ft := newWaitTransport(
+		backpressureResult("session_handle_budget_full", 0, "wait_s", 300),
+		plainCodeResult("unknown_session_handle"),
+	)
+	adapter := waitAdapter(t, ft)
+
+	res, err := adapter.Execute(context.Background(), map[string]interface{}{})
+	require.NoError(t, err)
+	require.False(t, res.Success)
+	require.NotNil(t, res.Error)
+	assert.Contains(t, res.Error.Message, "unknown_session_handle")
+	assert.Equal(t, 2, ft.calls(), "the changed condition must not be retried")
+}
+
+// TestBackpressureBudgetExhausted: a condition that never clears surfaces the
+// newest backpressure error once the ctx-derived budget runs out, well before
+// the context itself dies.
+func TestBackpressureBudgetExhausted(t *testing.T) {
+	// Enough scripted refusals to outlast the budget; wait_param scripted so
+	// each attempt is an immediate re-invoke (the fake answers instantly).
+	results := make([]json.RawMessage, 0, 16)
+	for i := 0; i < 16; i++ {
+		results = append(results, backpressureResult("session_handle_budget_full", 0, "wait_s", 300))
+	}
+	ft := newWaitTransport(results...)
+	adapter := waitAdapter(t, ft)
+
+	// deadline 3s − 2s margin → ~1s budget → wait_s floors at 1 per attempt.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	start := time.Now()
+	res, err := adapter.Execute(ctx, map[string]interface{}{})
+	require.NoError(t, err)
+	require.False(t, res.Success)
+	require.NotNil(t, res.Error)
+	assert.Contains(t, res.Error.Message, "session_handle_budget_full")
+	assert.Less(t, time.Since(start), 3*time.Second, "must give up before the context dies")
+	assert.GreaterOrEqual(t, ft.calls(), 2, "at least one frozen re-invoke happened")
+}

--- a/pkg/mcp/adapter/shuttle.go
+++ b/pkg/mcp/adapter/shuttle.go
@@ -285,9 +285,18 @@ func (a *MCPToolAdapter) Execute(ctx context.Context, params map[string]interfac
 	// Call MCP tool with camelCase parameters
 	mcpResultInterface, err := a.client.CallTool(ctx, a.tool.Name, restoredParams)
 	if err != nil {
-		// Park-and-wake (issue #343): a failure that links a resource parks
-		// here and retries when the resource updates; otherwise unchanged.
-		mcpResultInterface, err = a.awaitLinkedResource(ctx, restoredParams, err)
+		if isBackpressure(err) {
+			// Backpressure freeze (issue #354): capacity flow control never
+			// reaches the model — the call re-invokes, parked server-side
+			// via the error's wait_param when named, until capacity frees
+			// or the conversation's deadline expires.
+			mcpResultInterface, err = a.awaitBackpressure(ctx, restoredParams, err)
+		} else {
+			// Park-and-wake (issue #343): a failure that links a resource
+			// parks here and retries when the resource updates; otherwise
+			// unchanged.
+			mcpResultInterface, err = a.awaitLinkedResource(ctx, restoredParams, err)
+		}
 	}
 	executionTime := time.Since(startTime).Milliseconds()
 

--- a/pkg/mcp/adapter/shuttle.go
+++ b/pkg/mcp/adapter/shuttle.go
@@ -285,6 +285,11 @@ func (a *MCPToolAdapter) Execute(ctx context.Context, params map[string]interfac
 	// Call MCP tool with camelCase parameters
 	mcpResultInterface, err := a.client.CallTool(ctx, a.tool.Name, restoredParams)
 	if err != nil {
+		// The mechanism is chosen once, on the first error: a resource-wait
+		// retry that then fails with a backpressure hint (or a freeze
+		// re-invoke that fails with a resource link) surfaces that second
+		// error to the model rather than chaining waits — deliberate
+		// recursion bounding, one wait mechanism per tool call.
 		if isBackpressure(err) {
 			// Backpressure freeze (issue #354): capacity flow control never
 			// reaches the model — the call re-invokes, parked server-side

--- a/pkg/mcp/client/backpressure_hint_test.go
+++ b/pkg/mcp/client/backpressure_hint_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/teradata-labs/loom/pkg/mcp/protocol"
+)
+
+func toolErr(text string) *ToolResultError {
+	return &ToolResultError{Result: &protocol.CallToolResult{
+		IsError: true,
+		Content: []protocol.Content{{Type: "text", Text: text}},
+	}}
+}
+
+func TestBackpressureHintParsing(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want *BackpressureHint
+	}{
+		{
+			name: "full contract",
+			text: `{"code":"session_handle_budget_full","message":"m","retryable":true,"retry_after_s":42,"wait_param":"wait_s","max_wait_s":300}`,
+			want: &BackpressureHint{Code: "session_handle_budget_full", RetryAfterS: 42, WaitParam: "wait_s", MaxWaitS: 300},
+		},
+		{
+			name: "retryable without parking",
+			text: `{"code":"server_busy","message":"m","retryable":true}`,
+			want: &BackpressureHint{Code: "server_busy"},
+		},
+		{
+			name: "task-level failure: no contract",
+			text: `{"code":"db_error","message":"[Error 2616] Numeric overflow"}`,
+			want: nil,
+		},
+		{
+			name: "explicit retryable false",
+			text: `{"code":"server_busy","retryable":false}`,
+			want: nil,
+		},
+		{
+			name: "non-JSON error text",
+			text: "something went wrong",
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toolErr(tt.text).Backpressure()
+			if tt.want == nil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, *tt.want, *got)
+		})
+	}
+}
+
+func TestBackpressureNilAndNonTextContent(t *testing.T) {
+	assert.Nil(t, (&ToolResultError{}).Backpressure())
+	e := &ToolResultError{Result: &protocol.CallToolResult{IsError: true, Content: []protocol.Content{
+		{Type: "resource_link", URI: "test://slots"},
+	}}}
+	assert.Nil(t, e.Backpressure())
+}

--- a/pkg/mcp/client/tools.go
+++ b/pkg/mcp/client/tools.go
@@ -205,6 +205,52 @@ func (e *ToolResultError) Error() string {
 	return "tool returned error"
 }
 
+// BackpressureHint is the machine-readable park-and-wake contract a server
+// may embed in a tool error's payload (JSON in the first text content block):
+//
+//	{"code": "session_handle_budget_full", "message": "…",
+//	 "retryable": true, "retry_after_s": 42,
+//	 "wait_param": "wait_s", "max_wait_s": 300}
+//
+// retryable marks capacity backpressure: the identical call, re-issued after
+// a wait, is expected to succeed once load drains or a slot frees — flow
+// control, not a fault, so a runtime freezes the calling conversation and
+// re-invokes instead of surfacing the error to a model. retry_after_s is the
+// server's worst-case estimate of when (capacity may free sooner). wait_param
+// names a tool argument that parks the retry server-side for up to max_wait_s
+// seconds, waking on freed capacity instead of polling.
+type BackpressureHint struct {
+	Code        string
+	RetryAfterS int64
+	WaitParam   string
+	MaxWaitS    int64
+}
+
+// Backpressure parses the contract from the failed result. Nil when the
+// error does not declare retryable: true — task-level failures (SQL errors,
+// timeouts, deadlocks) never carry the contract and must reach the model.
+func (e *ToolResultError) Backpressure() *BackpressureHint {
+	if e.Result == nil || len(e.Result.Content) == 0 || e.Result.Content[0].Type != "text" {
+		return nil
+	}
+	var payload struct {
+		Code        string `json:"code"`
+		Retryable   bool   `json:"retryable"`
+		RetryAfterS int64  `json:"retry_after_s"`
+		WaitParam   string `json:"wait_param"`
+		MaxWaitS    int64  `json:"max_wait_s"`
+	}
+	if err := json.Unmarshal([]byte(e.Result.Content[0].Text), &payload); err != nil || !payload.Retryable {
+		return nil
+	}
+	return &BackpressureHint{
+		Code:        payload.Code,
+		RetryAfterS: payload.RetryAfterS,
+		WaitParam:   payload.WaitParam,
+		MaxWaitS:    payload.MaxWaitS,
+	}
+}
+
 // RetryResourceURI returns the URI of a resource the failed result links as
 // its retry condition: the first resource_link in the error content. Empty
 // when the result links nothing — the convention is opt-in per server, per

--- a/pkg/mcp/manager/manager.go
+++ b/pkg/mcp/manager/manager.go
@@ -54,11 +54,11 @@ type watcherHandle struct {
 	done chan struct{}
 }
 
-// NewManager creates a new MCP manager.
 // Logger returns the manager's structured logger (never nil), so
 // registration paths can hand adapters a real logger instead of a no-op.
 func (m *Manager) Logger() *zap.Logger { return m.logger }
 
+// NewManager creates a new MCP manager.
 func NewManager(config Config, logger *zap.Logger) (*Manager, error) {
 	if err := config.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)

--- a/pkg/mcp/manager/manager.go
+++ b/pkg/mcp/manager/manager.go
@@ -55,6 +55,10 @@ type watcherHandle struct {
 }
 
 // NewManager creates a new MCP manager.
+// Logger returns the manager's structured logger (never nil), so
+// registration paths can hand adapters a real logger instead of a no-op.
+func (m *Manager) Logger() *zap.Logger { return m.logger }
+
 func NewManager(config Config, logger *zap.Logger) (*Manager, error) {
 	if err := config.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)


### PR DESCRIPTION
Closes #354. Stacked on #344 (base: `feat/mcp-resource-wait-343`) — review only the top commit.

## Measured problem (az512e: 512 gpt-5.2 agents, one teradata-mcp server)

**139/512 agents (27%) never obtained a session handle.** Their connects met the full 256-handle pool, the budget-full error was surfaced to the model, and the models retried politely ~2.4 times and gave up. Agents that discovered `wait_s` from the error prose asked for 3600s and were silently clamped to the server's 300s cap — far below the ~20-min median slot dwell.

## Change

A tool failure carrying the machine-readable backpressure contract freezes in the MCP adapter — below the LLM — and re-invokes until it succeeds, fails differently, or the conversation's ctx deadline expires. The model sees a tool call that took longer, never the flow control.

```json
{"code": "session_handle_budget_full", "message": "…",
 "retryable": true, "retry_after_s": 412,
 "wait_param": "wait_s", "max_wait_s": 300}
```

- **`client.BackpressureHint`** — contract parsing on `ToolResultError`. Task-level failures (SQL errors, timeouts, deadlocks) never carry it and reach the model unchanged.
- **`adapter.awaitBackpressure`** — with a `wait_param`, each re-invoke passes the remaining ctx budget clamped to `max_wait_s`, parking the retry **server-side** in the FIFO wait queue: one parked call holds one queue position for the whole wait. Without one, polls with `retry_after_s` clamped to [1s, 30s].
- **Degraded-park guard** — a server that advertises parking but refuses instantly gets polling pace, never a hot spin.
- Contract-less failures keep #343's resource-link park; the circuit breaker is untouched (tool-level errors never reached it).

## Server half (shipped separately)

teradata-mcp-v2 `5a6b357`: `fail()` emits the contract on `budget_full`/`server_busy`/`admission_timeout`; new `--connect-max-wait-s` makes the wait ceiling operator-configurable (raise to agent scale for fleets).

## Tests

Scripted-transport tests (`-race`): server-park with cap clamping, ctx-deadline clamping, poll path timing, condition-change surfacing, budget exhaustion before ctx death, contract parsing table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)