### PR TITLE
fix(mcp): map LLM parameter names onto the schema's declared names

### DIFF
--- a/pkg/mcp/adapter/shuttle.go
+++ b/pkg/mcp/adapter/shuttle.go
@@ -194,13 +194,14 @@ func (a *MCPToolAdapter) InputSchema() *shuttle.JSONSchema {
 func (a *MCPToolAdapter) Execute(ctx context.Context, params map[string]interface{}) (*shuttle.Result, error) {
 	startTime := time.Now()
 
-	// Convert parameter names from snake_case back to camelCase for MCP tools
-	// LLMs naturally use snake_case but MCP tools expect camelCase
-	camelCaseParams := normalizeParametersToCamelCase(params)
+	// Map the LLM's parameter names onto the names the tool's schema
+	// declares (snake_case kept for snake_case servers, camelized only
+	// when the schema itself is camelCase).
+	serverParams := a.normalizeParametersToSchema(params)
 
 	// Check schema cache for schema-related tools (#4: Schema Caching)
 	if a.isSchemaLookupTool() {
-		cacheKey := a.buildSchemaCacheKey(camelCaseParams)
+		cacheKey := a.buildSchemaCacheKey(serverParams)
 		if cached, ok := globalSchemaCache.get(cacheKey); ok {
 			return &shuttle.Result{
 				Success:         true,
@@ -216,8 +217,8 @@ func (a *MCPToolAdapter) Execute(ctx context.Context, params map[string]interfac
 		}
 	}
 
-	// Call MCP tool with camelCase parameters
-	mcpResultInterface, err := a.client.CallTool(ctx, a.tool.Name, camelCaseParams)
+	// Call MCP tool with the schema-declared parameter names.
+	mcpResultInterface, err := a.client.CallTool(ctx, a.tool.Name, serverParams)
 	executionTime := time.Since(startTime).Milliseconds()
 
 	if err != nil {
@@ -255,7 +256,7 @@ func (a *MCPToolAdapter) Execute(ctx context.Context, params map[string]interfac
 
 	// Cache schema results (#4: Schema Caching)
 	if a.isSchemaLookupTool() {
-		cacheKey := a.buildSchemaCacheKey(camelCaseParams)
+		cacheKey := a.buildSchemaCacheKey(serverParams)
 		if str, ok := data.(string); ok {
 			globalSchemaCache.set(cacheKey, str)
 		}
@@ -449,6 +450,37 @@ func normalizeParametersToCamelCase(params map[string]interface{}) map[string]in
 	normalized := make(map[string]interface{}, len(params))
 	for key, value := range params {
 		normalized[toCamelCase(key)] = value
+	}
+	return normalized
+}
+
+// normalizeParametersToSchema maps LLM-supplied parameter names onto the
+// names the tool's schema actually declares. InputSchema shows the LLM
+// snake_case names, so a key is kept as-is when the schema declares it
+// (snake_case servers), converted to camelCase when the schema declares
+// only the camelCase form (camelCase servers), and passed through
+// untouched otherwise so schema validation reports it under the name the
+// model used. Blind camelization corrupted snake_case servers: a strict
+// schema rejected the renamed key, and a lenient decoder silently dropped
+// it (session_handle → sessionHandle → ignored → leaked handles).
+func (a *MCPToolAdapter) normalizeParametersToSchema(params map[string]interface{}) map[string]interface{} {
+	if params == nil {
+		return nil
+	}
+	props, _ := a.tool.InputSchema["properties"].(map[string]interface{})
+	normalized := make(map[string]interface{}, len(params))
+	for key, value := range params {
+		if _, declared := props[key]; declared {
+			normalized[key] = value
+			continue
+		}
+		if camel := toCamelCase(key); camel != key {
+			if _, declared := props[camel]; declared {
+				normalized[camel] = value
+				continue
+			}
+		}
+		normalized[key] = value
 	}
 	return normalized
 }

--- a/pkg/mcp/adapter/shuttle.go
+++ b/pkg/mcp/adapter/shuttle.go
@@ -440,20 +440,6 @@ func toCamelCase(s string) string {
 	return result.String()
 }
 
-// normalizeParametersToCamelCase converts all parameter keys in a map from snake_case to camelCase.
-// This restores the original parameter names expected by MCP tools.
-func normalizeParametersToCamelCase(params map[string]interface{}) map[string]interface{} {
-	if params == nil {
-		return nil
-	}
-
-	normalized := make(map[string]interface{}, len(params))
-	for key, value := range params {
-		normalized[toCamelCase(key)] = value
-	}
-	return normalized
-}
-
 // normalizeParametersToSchema maps LLM-supplied parameter names onto the
 // names the tool's schema actually declares. InputSchema shows the LLM
 // snake_case names, so a key is kept as-is when the schema declares it

--- a/pkg/mcp/adapter/shuttle_test.go
+++ b/pkg/mcp/adapter/shuttle_test.go
@@ -931,12 +931,77 @@ func TestNormalizeParametersToCamelCase_RoundTrip(t *testing.T) {
 		"max_rows":      100,
 	}
 
-	// Step 3: Normalize back to camelCase (what Execute does)
-	normalized := normalizeParametersToCamelCase(params)
+	// Step 3: Map back onto the schema's declared (camelCase) names,
+	// exactly as Execute does for a camelCase server.
+	adapter := NewMCPToolAdapter(nil, protocol.Tool{
+		Name: "query_tool",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"databaseName": map[string]interface{}{"type": "string"},
+				"tableName":    map[string]interface{}{"type": "string"},
+				"maxRows":      map[string]interface{}{"type": "integer"},
+			},
+		},
+	}, "test")
+	normalized := adapter.normalizeParametersToSchema(params)
 
 	assert.Equal(t, "mydb", normalized["databaseName"])
 	assert.Equal(t, "users", normalized["tableName"])
 	assert.Equal(t, 100, normalized["maxRows"])
+}
+
+// A snake_case server's parameter names must pass through untouched: blind
+// camelization made strict servers reject the call and lenient servers
+// silently drop the parameter (the session_handle leak).
+func TestNormalizeParametersToSchema_SnakeCaseServer(t *testing.T) {
+	adapter := NewMCPToolAdapter(nil, protocol.Tool{
+		Name: "execute_statement",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"sql":            map[string]interface{}{"type": "string"},
+				"session_handle": map[string]interface{}{"type": "string"},
+			},
+			"additionalProperties": false,
+		},
+	}, "teradata")
+
+	normalized := adapter.normalizeParametersToSchema(map[string]interface{}{
+		"sql":            "SELECT 1",
+		"session_handle": "h-123",
+	})
+
+	assert.Equal(t, "SELECT 1", normalized["sql"])
+	assert.Equal(t, "h-123", normalized["session_handle"])
+	_, leaked := normalized["sessionHandle"]
+	assert.False(t, leaked, "snake_case key must not be camelized when the schema declares it")
+}
+
+// A key the schema doesn't declare in either form passes through under the
+// name the model used, so validation errors name what the model actually sent.
+func TestNormalizeParametersToSchema_UnknownKeyUntouched(t *testing.T) {
+	adapter := NewMCPToolAdapter(nil, protocol.Tool{
+		Name: "connect",
+		InputSchema: map[string]interface{}{
+			"type":       "object",
+			"properties": map[string]interface{}{"host": map[string]interface{}{"type": "string"}},
+		},
+	}, "teradata")
+
+	normalized := adapter.normalizeParametersToSchema(map[string]interface{}{
+		"host":      "db1",
+		"bogus_key": 1,
+	})
+	assert.Equal(t, "db1", normalized["host"])
+	assert.Equal(t, 1, normalized["bogus_key"])
+}
+
+// With no schema at all, names pass through unchanged.
+func TestNormalizeParametersToSchema_NoSchema(t *testing.T) {
+	adapter := NewMCPToolAdapter(nil, protocol.Tool{Name: "tool"}, "test")
+	normalized := adapter.normalizeParametersToSchema(map[string]interface{}{"some_key": "v"})
+	assert.Equal(t, "v", normalized["some_key"])
 }
 
 // =============================================================================
@@ -968,9 +1033,8 @@ func TestExecute_SchemaToolCacheHit_ReturnsEarly(t *testing.T) {
 	}
 
 	// Pre-populate the cache with what Execute would store
-	// normalizeParametersToCamelCase converts the keys
-	camelParams := normalizeParametersToCamelCase(params)
-	cacheKey := adapter.buildSchemaCacheKey(camelParams)
+	// (schema-aware mapping; no schema here, so names pass through)
+	cacheKey := adapter.buildSchemaCacheKey(adapter.normalizeParametersToSchema(params))
 	globalSchemaCache.set(cacheKey, "CREATE TABLE users (id INT)")
 
 	// Execute should return cached result without calling the client
@@ -1021,9 +1085,8 @@ func TestExecute_ParameterNormalization(t *testing.T) {
 		"table_name":    "users",
 	}
 
-	// Build the cache key using camelCase (what Execute internally does)
-	camelParams := normalizeParametersToCamelCase(snakeParams)
-	cacheKey := adapter.buildSchemaCacheKey(camelParams)
+	// Build the cache key the way Execute internally does
+	cacheKey := adapter.buildSchemaCacheKey(adapter.normalizeParametersToSchema(snakeParams))
 
 	// Pre-populate cache
 	globalSchemaCache.set(cacheKey, "schema result")

--- a/pkg/mcp/adapter/shuttle_test.go
+++ b/pkg/mcp/adapter/shuttle_test.go
@@ -621,7 +621,7 @@ func TestAdaptMCPTools_PreservesUIMetadata(t *testing.T) {
 }
 
 // =============================================================================
-// Tests for toSnakeCase, toCamelCase, normalizeParametersToCamelCase,
+// Tests for toSnakeCase, toCamelCase, normalizeParametersToSchema,
 // detectAndExtractSQLResult, and Execute integration scenarios
 // =============================================================================
 
@@ -681,24 +681,44 @@ func TestToCamelCase(t *testing.T) {
 	}
 }
 
-func TestNormalizeParametersToCamelCase(t *testing.T) {
+// normalizeParametersToSchema maps LLM-supplied names onto whatever the
+// schema declares, so the same snake_case input lands differently depending
+// on the server's own naming. Table covers both server styles plus the
+// edge cases (nil, absent properties, nested values).
+func TestNormalizeParametersToSchema(t *testing.T) {
+	camelSchema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"databaseName": map[string]interface{}{"type": "string"},
+			"tableName":    map[string]interface{}{"type": "string"},
+			"includeMeta":  map[string]interface{}{"type": "boolean"},
+			"limit":        map[string]interface{}{"type": "integer"},
+			"filterConfig": map[string]interface{}{"type": "object"},
+		},
+	}
+	snakeSchema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"database_name": map[string]interface{}{"type": "string"},
+			"table_name":    map[string]interface{}{"type": "string"},
+		},
+	}
+
 	tests := []struct {
 		name     string
+		schema   map[string]interface{}
 		input    map[string]interface{}
 		expected map[string]interface{}
 	}{
 		{
-			name:     "nil input",
+			name:     "nil params",
+			schema:   camelSchema,
 			input:    nil,
 			expected: nil,
 		},
 		{
-			name:     "empty map",
-			input:    map[string]interface{}{},
-			expected: map[string]interface{}{},
-		},
-		{
-			name: "snake_case keys converted",
+			name:   "camelCase server: snake_case keys mapped to declared names",
+			schema: camelSchema,
 			input: map[string]interface{}{
 				"database_name": "test_db",
 				"table_name":    "users",
@@ -709,7 +729,8 @@ func TestNormalizeParametersToCamelCase(t *testing.T) {
 			},
 		},
 		{
-			name: "already camelCase passes through",
+			name:   "camelCase server: already-declared keys pass through",
+			schema: camelSchema,
 			input: map[string]interface{}{
 				"databaseName": "test_db",
 				"tableName":    "users",
@@ -720,7 +741,8 @@ func TestNormalizeParametersToCamelCase(t *testing.T) {
 			},
 		},
 		{
-			name: "mixed keys",
+			name:   "camelCase server: mixed keys",
+			schema: camelSchema,
 			input: map[string]interface{}{
 				"database_name": "mydb",
 				"limit":         10,
@@ -733,7 +755,8 @@ func TestNormalizeParametersToCamelCase(t *testing.T) {
 			},
 		},
 		{
-			name: "values preserved including nested structures",
+			name:   "values preserved including nested structures",
+			schema: camelSchema,
 			input: map[string]interface{}{
 				"filter_config": map[string]interface{}{
 					"inner_key": "value",
@@ -741,15 +764,42 @@ func TestNormalizeParametersToCamelCase(t *testing.T) {
 			},
 			expected: map[string]interface{}{
 				"filterConfig": map[string]interface{}{
-					"inner_key": "value", // only top-level keys are converted
+					"inner_key": "value", // only top-level keys are mapped
 				},
+			},
+		},
+		{
+			name:   "snake_case server: declared names kept verbatim",
+			schema: snakeSchema,
+			input: map[string]interface{}{
+				"database_name": "mydb",
+				"table_name":    "users",
+			},
+			expected: map[string]interface{}{
+				"database_name": "mydb",
+				"table_name":    "users",
+			},
+		},
+		{
+			name:   "schema without a properties key leaves names untouched",
+			schema: map[string]interface{}{"type": "object"},
+			input: map[string]interface{}{
+				"database_name": "mydb",
+			},
+			expected: map[string]interface{}{
+				"database_name": "mydb",
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := normalizeParametersToCamelCase(tt.input)
+			adapter := NewMCPToolAdapter(nil, protocol.Tool{
+				Name:        "query_tool",
+				InputSchema: tt.schema,
+			}, "test")
+
+			result := adapter.normalizeParametersToSchema(tt.input)
 			if tt.expected == nil {
 				assert.Nil(t, result)
 			} else {
@@ -912,8 +962,8 @@ func TestInputSchema_CamelCaseToSnakeCase_Conversion(t *testing.T) {
 	assert.Contains(t, schema.Required, "table_name")
 }
 
-func TestNormalizeParametersToCamelCase_RoundTrip(t *testing.T) {
-	// Test the round-trip: camelCase -> snake_case (InputSchema) -> camelCase (normalizeParametersToCamelCase)
+func TestNormalizeParametersToSchema_RoundTrip(t *testing.T) {
+	// Test the round-trip: camelCase -> snake_case (InputSchema) -> camelCase (normalizeParametersToSchema)
 	// This validates that the LLM sees snake_case but the MCP server receives camelCase
 	originalKeys := []string{"databaseName", "tableName", "maxRows"}
 


### PR DESCRIPTION
## Problem

`MCPToolAdapter.Execute` has always blindly converted every outgoing parameter key from snake_case to camelCase (`normalizeParametersToCamelCase`), assuming MCP servers expect camelCase. For servers whose input schemas declare snake_case names this corrupts every call that carries a multi-word parameter:

- **Strict servers / strict client validation** (MCP 2026 client): the renamed key is rejected — `invalid arguments for tool execute_statement: Additional property sessionHandle is not allowed`.
- **Lenient decoders**: the renamed key is silently **dropped**. Observed in production-scale testing against a snake_case Teradata MCP server: `session_handle` → `sessionHandle` → ignored, so sessions were never pinned and `release_handle` never released — leaking server-side session handles until the budget filled.

The bug was masked until the MCP 2026-07-28 client migration made schema parsing and argument validation strict; then every snake_case parameter became a hard failure.

## Fix

Replace blind camelization with schema-aware mapping (`normalizeParametersToSchema`): a parameter name is kept as-is when the tool's `inputSchema` declares it, converted to camelCase only when the schema declares the camelCase form (preserving the existing LLM-sees-snake_case / camelCase-server behavior), and passed through untouched otherwise so validation errors name exactly what the model sent.

`InputSchema()` still presents snake_case names to the LLM; this change only fixes the reverse direction.

## Testing

- New regression tests: snake_case server params pass through untouched (the `session_handle` case), camelCase servers still get camelCase, unknown keys untouched, no-schema tools untouched.
- Updated cache-key tests to the schema-aware mapping.
- `go test -tags fts5 -race ./pkg/mcp/...` clean.
- Verified end-to-end against a live snake_case MCP server (Teradata, 12-agent fleet): rejections disappeared, sessions pin, handles release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)