### PR TITLE
feat(scheduler): add CancelScheduledExecution

### DIFF
--- a/gen/go/loom/v1/loom.pb.go
+++ b/gen/go/loom/v1/loom.pb.go
@@ -6901,11 +6901,16 @@ func (x *GetScheduleHistoryResponse) GetExecutions() []*ScheduleExecution {
 	return nil
 }
 
-// CancelWorkflowExecutionRequest stops a running execution.
-type CancelWorkflowExecutionRequest struct {
+// CancelScheduledExecutionRequest stops a scheduled execution that is in
+// flight.
+//
+// The ID must be one the scheduler minted. IDs returned by ExecuteWorkflow and
+// StreamWorkflow belong to a different namespace and yield NOT_FOUND.
+type CancelScheduledExecutionRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Execution ID to cancel, as reported by ScheduledWorkflow.current_execution_id
-	// or by the response to TriggerScheduledWorkflow.
+	// or by the response to TriggerScheduledWorkflow. An ID that names no
+	// scheduled execution — in flight or in history — returns NOT_FOUND.
 	ExecutionId string `protobuf:"bytes,1,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
 	// Optional human-readable reason, recorded in the execution history so the
 	// record distinguishes an operator stop from a crash.
@@ -6914,20 +6919,20 @@ type CancelWorkflowExecutionRequest struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *CancelWorkflowExecutionRequest) Reset() {
-	*x = CancelWorkflowExecutionRequest{}
+func (x *CancelScheduledExecutionRequest) Reset() {
+	*x = CancelScheduledExecutionRequest{}
 	mi := &file_loom_v1_loom_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *CancelWorkflowExecutionRequest) String() string {
+func (x *CancelScheduledExecutionRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*CancelWorkflowExecutionRequest) ProtoMessage() {}
+func (*CancelScheduledExecutionRequest) ProtoMessage() {}
 
-func (x *CancelWorkflowExecutionRequest) ProtoReflect() protoreflect.Message {
+func (x *CancelScheduledExecutionRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_loom_v1_loom_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -6939,52 +6944,61 @@ func (x *CancelWorkflowExecutionRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use CancelWorkflowExecutionRequest.ProtoReflect.Descriptor instead.
-func (*CancelWorkflowExecutionRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use CancelScheduledExecutionRequest.ProtoReflect.Descriptor instead.
+func (*CancelScheduledExecutionRequest) Descriptor() ([]byte, []int) {
 	return file_loom_v1_loom_proto_rawDescGZIP(), []int{88}
 }
 
-func (x *CancelWorkflowExecutionRequest) GetExecutionId() string {
+func (x *CancelScheduledExecutionRequest) GetExecutionId() string {
 	if x != nil {
 		return x.ExecutionId
 	}
 	return ""
 }
 
-func (x *CancelWorkflowExecutionRequest) GetReason() string {
+func (x *CancelScheduledExecutionRequest) GetReason() string {
 	if x != nil {
 		return x.Reason
 	}
 	return ""
 }
 
-// CancelWorkflowExecutionResponse reports what the cancellation did.
-type CancelWorkflowExecutionResponse struct {
+// CancelScheduledExecutionResponse reports what the cancellation did.
+//
+// Reaching this message at all means the execution exists in the scheduler's
+// namespace; an unknown ID is a NOT_FOUND error instead.
+type CancelScheduledExecutionResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when a running execution was found and signalled. False means the
-	// execution was already finished or was never running — not an error, since
-	// a user cancelling a run that just completed has got what they wanted.
-	Cancelled bool `protobuf:"varint,1,opt,name=cancelled,proto3" json:"cancelled,omitempty"`
-	// Human-readable outcome, suitable for showing directly.
+	// True when the execution was in flight and its context was canceled; the
+	// run is recorded as canceled once it unwinds. False means the execution had
+	// already reached its verdict before the request arrived, so nothing was
+	// signaled and the recorded outcome stands — not an error, since a caller
+	// stopping a run that just completed got the state it asked for.
+	//
+	// Cancellation is cooperative: true says the signal was delivered, not that
+	// the run has stopped yet, and work already committed is not rolled back.
+	Canceled bool `protobuf:"varint,1,opt,name=canceled,proto3" json:"canceled,omitempty"`
+	// Human-readable outcome, suitable for showing directly. It is the only thing
+	// that distinguishes "signaled" from "already finished" beyond the boolean.
 	Message       string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *CancelWorkflowExecutionResponse) Reset() {
-	*x = CancelWorkflowExecutionResponse{}
+func (x *CancelScheduledExecutionResponse) Reset() {
+	*x = CancelScheduledExecutionResponse{}
 	mi := &file_loom_v1_loom_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *CancelWorkflowExecutionResponse) String() string {
+func (x *CancelScheduledExecutionResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*CancelWorkflowExecutionResponse) ProtoMessage() {}
+func (*CancelScheduledExecutionResponse) ProtoMessage() {}
 
-func (x *CancelWorkflowExecutionResponse) ProtoReflect() protoreflect.Message {
+func (x *CancelScheduledExecutionResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_loom_v1_loom_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -6996,19 +7010,19 @@ func (x *CancelWorkflowExecutionResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use CancelWorkflowExecutionResponse.ProtoReflect.Descriptor instead.
-func (*CancelWorkflowExecutionResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use CancelScheduledExecutionResponse.ProtoReflect.Descriptor instead.
+func (*CancelScheduledExecutionResponse) Descriptor() ([]byte, []int) {
 	return file_loom_v1_loom_proto_rawDescGZIP(), []int{89}
 }
 
-func (x *CancelWorkflowExecutionResponse) GetCancelled() bool {
+func (x *CancelScheduledExecutionResponse) GetCanceled() bool {
 	if x != nil {
-		return x.Cancelled
+		return x.Canceled
 	}
 	return false
 }
 
-func (x *CancelWorkflowExecutionResponse) GetMessage() string {
+func (x *CancelScheduledExecutionResponse) GetMessage() string {
 	if x != nil {
 		return x.Message
 	}
@@ -7024,7 +7038,9 @@ type ScheduleExecution struct {
 	StartedAt int64 `protobuf:"varint,2,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
 	// Completed at timestamp (Unix seconds)
 	CompletedAt int64 `protobuf:"varint,3,opt,name=completed_at,json=completedAt,proto3" json:"completed_at,omitempty"`
-	// Status: "success", "failed", "skipped"
+	// Status: "success", "failed", "skipped", "canceled"
+	// The US spelling matches WorkflowStatus "canceled" in the workflow-execution
+	// namespace, so both surfaces report the same word for the same outcome.
 	Status string `protobuf:"bytes,4,opt,name=status,proto3" json:"status,omitempty"`
 	// Error message (if failed)
 	Error string `protobuf:"bytes,5,opt,name=error,proto3" json:"error,omitempty"`
@@ -11466,12 +11482,12 @@ const file_loom_v1_loom_proto_rawDesc = "" +
 	"\x1aGetScheduleHistoryResponse\x12:\n" +
 	"\n" +
 	"executions\x18\x01 \x03(\v2\x1a.loom.v1.ScheduleExecutionR\n" +
-	"executions\"[\n" +
-	"\x1eCancelWorkflowExecutionRequest\x12!\n" +
+	"executions\"\\\n" +
+	"\x1fCancelScheduledExecutionRequest\x12!\n" +
 	"\fexecution_id\x18\x01 \x01(\tR\vexecutionId\x12\x16\n" +
-	"\x06reason\x18\x02 \x01(\tR\x06reason\"Y\n" +
-	"\x1fCancelWorkflowExecutionResponse\x12\x1c\n" +
-	"\tcancelled\x18\x01 \x01(\bR\tcancelled\x12\x18\n" +
+	"\x06reason\x18\x02 \x01(\tR\x06reason\"X\n" +
+	" CancelScheduledExecutionResponse\x12\x1a\n" +
+	"\bcanceled\x18\x01 \x01(\bR\bcanceled\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\"\xe8\x01\n" +
 	"\x11ScheduleExecution\x12!\n" +
 	"\fexecution_id\x18\x01 \x01(\tR\vexecutionId\x12\x1d\n" +
@@ -11830,7 +11846,7 @@ const file_loom_v1_loom_proto_rawDesc = "" +
 	"\x18AB_TEST_MODE_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19AB_TEST_MODE_SIDE_BY_SIDE\x10\x01\x12\"\n" +
 	"\x1eAB_TEST_MODE_SEQUENTIAL_SCORED\x10\x02\x12\x17\n" +
-	"\x13AB_TEST_MODE_SHADOW\x10\x032\xe8O\n" +
+	"\x13AB_TEST_MODE_SHADOW\x10\x032\xf5O\n" +
 	"\vLoomService\x12L\n" +
 	"\x05Weave\x12\x15.loom.v1.WeaveRequest\x1a\x16.loom.v1.WeaveResponse\"\x14\x82\xd3\xe4\x93\x02\x0e:\x01*\"\t/v1/weave\x12[\n" +
 	"\vStreamWeave\x12\x15.loom.v1.WeaveRequest\x1a\x16.loom.v1.WeaveProgress\"\x1b\x82\xd3\xe4\x93\x02\x15:\x01*\"\x10/v1/weave:stream0\x01\x12i\n" +
@@ -11897,8 +11913,8 @@ const file_loom_v1_loom_proto_rawDesc = "" +
 	"\x18TriggerScheduledWorkflow\x12(.loom.v1.TriggerScheduledWorkflowRequest\x1a .loom.v1.ExecuteWorkflowResponse\"8\x82\xd3\xe4\x93\x022:\x01*\"-/v1/workflows/schedules/{schedule_id}:trigger\x12~\n" +
 	"\rPauseSchedule\x12\x1d.loom.v1.PauseScheduleRequest\x1a\x16.google.protobuf.Empty\"6\x82\xd3\xe4\x93\x020:\x01*\"+/v1/workflows/schedules/{schedule_id}:pause\x12\x81\x01\n" +
 	"\x0eResumeSchedule\x12\x1e.loom.v1.ResumeScheduleRequest\x1a\x16.google.protobuf.Empty\"7\x82\xd3\xe4\x93\x021:\x01*\",/v1/workflows/schedules/{schedule_id}:resume\x12\x94\x01\n" +
-	"\x12GetScheduleHistory\x12\".loom.v1.GetScheduleHistoryRequest\x1a#.loom.v1.GetScheduleHistoryResponse\"5\x82\xd3\xe4\x93\x02/\x12-/v1/workflows/schedules/{schedule_id}/history\x12\xa7\x01\n" +
-	"\x17CancelWorkflowExecution\x12'.loom.v1.CancelWorkflowExecutionRequest\x1a(.loom.v1.CancelWorkflowExecutionResponse\"9\x82\xd3\xe4\x93\x023:\x01*\"./v1/workflows/executions/{execution_id}:cancel\x12X\n" +
+	"\x12GetScheduleHistory\x12\".loom.v1.GetScheduleHistoryRequest\x1a#.loom.v1.GetScheduleHistoryResponse\"5\x82\xd3\xe4\x93\x02/\x12-/v1/workflows/schedules/{schedule_id}/history\x12\xb4\x01\n" +
+	"\x18CancelScheduledExecution\x12(.loom.v1.CancelScheduledExecutionRequest\x1a).loom.v1.CancelScheduledExecutionResponse\"C\x82\xd3\xe4\x93\x02=:\x01*\"8/v1/workflows/schedules/executions/{execution_id}:cancel\x12X\n" +
 	"\aPublish\x12\x17.loom.v1.PublishRequest\x1a\x18.loom.v1.PublishResponse\"\x1a\x82\xd3\xe4\x93\x02\x14:\x01*\"\x0f/v1/bus/publish\x12[\n" +
 	"\tSubscribe\x12\x19.loom.v1.SubscribeRequest\x1a\x13.loom.v1.BusMessage\"\x1c\x82\xd3\xe4\x93\x02\x16:\x01*\"\x11/v1/bus/subscribe0\x01\x12h\n" +
 	"\vUnsubscribe\x12\x1b.loom.v1.UnsubscribeRequest\x1a\x1c.loom.v1.UnsubscribeResponse\"\x1e\x82\xd3\xe4\x93\x02\x18:\x01*\"\x13/v1/bus/unsubscribe\x12]\n" +
@@ -12043,8 +12059,8 @@ var file_loom_v1_loom_proto_goTypes = []any{
 	(*ResumeScheduleRequest)(nil),              // 89: loom.v1.ResumeScheduleRequest
 	(*GetScheduleHistoryRequest)(nil),          // 90: loom.v1.GetScheduleHistoryRequest
 	(*GetScheduleHistoryResponse)(nil),         // 91: loom.v1.GetScheduleHistoryResponse
-	(*CancelWorkflowExecutionRequest)(nil),     // 92: loom.v1.CancelWorkflowExecutionRequest
-	(*CancelWorkflowExecutionResponse)(nil),    // 93: loom.v1.CancelWorkflowExecutionResponse
+	(*CancelScheduledExecutionRequest)(nil),    // 92: loom.v1.CancelScheduledExecutionRequest
+	(*CancelScheduledExecutionResponse)(nil),   // 93: loom.v1.CancelScheduledExecutionResponse
 	(*ScheduleExecution)(nil),                  // 94: loom.v1.ScheduleExecution
 	(*GetServerConfigRequest)(nil),             // 95: loom.v1.GetServerConfigRequest
 	(*GetTLSStatusRequest)(nil),                // 96: loom.v1.GetTLSStatusRequest
@@ -12349,7 +12365,7 @@ var file_loom_v1_loom_proto_depIdxs = []int32{
 	88,  // 154: loom.v1.LoomService.PauseSchedule:input_type -> loom.v1.PauseScheduleRequest
 	89,  // 155: loom.v1.LoomService.ResumeSchedule:input_type -> loom.v1.ResumeScheduleRequest
 	90,  // 156: loom.v1.LoomService.GetScheduleHistory:input_type -> loom.v1.GetScheduleHistoryRequest
-	92,  // 157: loom.v1.LoomService.CancelWorkflowExecution:input_type -> loom.v1.CancelWorkflowExecutionRequest
+	92,  // 157: loom.v1.LoomService.CancelScheduledExecution:input_type -> loom.v1.CancelScheduledExecutionRequest
 	188, // 158: loom.v1.LoomService.Publish:input_type -> loom.v1.PublishRequest
 	189, // 159: loom.v1.LoomService.Subscribe:input_type -> loom.v1.SubscribeRequest
 	190, // 160: loom.v1.LoomService.Unsubscribe:input_type -> loom.v1.UnsubscribeRequest
@@ -12440,7 +12456,7 @@ var file_loom_v1_loom_proto_depIdxs = []int32{
 	216, // 245: loom.v1.LoomService.PauseSchedule:output_type -> google.protobuf.Empty
 	216, // 246: loom.v1.LoomService.ResumeSchedule:output_type -> google.protobuf.Empty
 	91,  // 247: loom.v1.LoomService.GetScheduleHistory:output_type -> loom.v1.GetScheduleHistoryResponse
-	93,  // 248: loom.v1.LoomService.CancelWorkflowExecution:output_type -> loom.v1.CancelWorkflowExecutionResponse
+	93,  // 248: loom.v1.LoomService.CancelScheduledExecution:output_type -> loom.v1.CancelScheduledExecutionResponse
 	217, // 249: loom.v1.LoomService.Publish:output_type -> loom.v1.PublishResponse
 	218, // 250: loom.v1.LoomService.Subscribe:output_type -> loom.v1.BusMessage
 	219, // 251: loom.v1.LoomService.Unsubscribe:output_type -> loom.v1.UnsubscribeResponse

--- a/gen/go/loom/v1/loom.pb.go
+++ b/gen/go/loom/v1/loom.pb.go
@@ -6901,6 +6901,120 @@ func (x *GetScheduleHistoryResponse) GetExecutions() []*ScheduleExecution {
 	return nil
 }
 
+// CancelWorkflowExecutionRequest stops a running execution.
+type CancelWorkflowExecutionRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Execution ID to cancel, as reported by ScheduledWorkflow.current_execution_id
+	// or by the response to TriggerScheduledWorkflow.
+	ExecutionId string `protobuf:"bytes,1,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
+	// Optional human-readable reason, recorded in the execution history so the
+	// record distinguishes an operator stop from a crash.
+	Reason        string `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CancelWorkflowExecutionRequest) Reset() {
+	*x = CancelWorkflowExecutionRequest{}
+	mi := &file_loom_v1_loom_proto_msgTypes[88]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CancelWorkflowExecutionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CancelWorkflowExecutionRequest) ProtoMessage() {}
+
+func (x *CancelWorkflowExecutionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_loom_v1_loom_proto_msgTypes[88]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CancelWorkflowExecutionRequest.ProtoReflect.Descriptor instead.
+func (*CancelWorkflowExecutionRequest) Descriptor() ([]byte, []int) {
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{88}
+}
+
+func (x *CancelWorkflowExecutionRequest) GetExecutionId() string {
+	if x != nil {
+		return x.ExecutionId
+	}
+	return ""
+}
+
+func (x *CancelWorkflowExecutionRequest) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+// CancelWorkflowExecutionResponse reports what the cancellation did.
+type CancelWorkflowExecutionResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// True when a running execution was found and signalled. False means the
+	// execution was already finished or was never running — not an error, since
+	// a user cancelling a run that just completed has got what they wanted.
+	Cancelled bool `protobuf:"varint,1,opt,name=cancelled,proto3" json:"cancelled,omitempty"`
+	// Human-readable outcome, suitable for showing directly.
+	Message       string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CancelWorkflowExecutionResponse) Reset() {
+	*x = CancelWorkflowExecutionResponse{}
+	mi := &file_loom_v1_loom_proto_msgTypes[89]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CancelWorkflowExecutionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CancelWorkflowExecutionResponse) ProtoMessage() {}
+
+func (x *CancelWorkflowExecutionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_loom_v1_loom_proto_msgTypes[89]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CancelWorkflowExecutionResponse.ProtoReflect.Descriptor instead.
+func (*CancelWorkflowExecutionResponse) Descriptor() ([]byte, []int) {
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{89}
+}
+
+func (x *CancelWorkflowExecutionResponse) GetCancelled() bool {
+	if x != nil {
+		return x.Cancelled
+	}
+	return false
+}
+
+func (x *CancelWorkflowExecutionResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
 // ScheduleExecution represents a single execution of a scheduled workflow.
 type ScheduleExecution struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -6924,7 +7038,7 @@ type ScheduleExecution struct {
 
 func (x *ScheduleExecution) Reset() {
 	*x = ScheduleExecution{}
-	mi := &file_loom_v1_loom_proto_msgTypes[88]
+	mi := &file_loom_v1_loom_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6936,7 +7050,7 @@ func (x *ScheduleExecution) String() string {
 func (*ScheduleExecution) ProtoMessage() {}
 
 func (x *ScheduleExecution) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[88]
+	mi := &file_loom_v1_loom_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6949,7 +7063,7 @@ func (x *ScheduleExecution) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScheduleExecution.ProtoReflect.Descriptor instead.
 func (*ScheduleExecution) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{88}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *ScheduleExecution) GetExecutionId() string {
@@ -7010,7 +7124,7 @@ type GetServerConfigRequest struct {
 
 func (x *GetServerConfigRequest) Reset() {
 	*x = GetServerConfigRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[89]
+	mi := &file_loom_v1_loom_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7022,7 +7136,7 @@ func (x *GetServerConfigRequest) String() string {
 func (*GetServerConfigRequest) ProtoMessage() {}
 
 func (x *GetServerConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[89]
+	mi := &file_loom_v1_loom_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7035,7 +7149,7 @@ func (x *GetServerConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetServerConfigRequest.ProtoReflect.Descriptor instead.
 func (*GetServerConfigRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{89}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{91}
 }
 
 // GetTLSStatusRequest retrieves TLS status.
@@ -7047,7 +7161,7 @@ type GetTLSStatusRequest struct {
 
 func (x *GetTLSStatusRequest) Reset() {
 	*x = GetTLSStatusRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[90]
+	mi := &file_loom_v1_loom_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7059,7 +7173,7 @@ func (x *GetTLSStatusRequest) String() string {
 func (*GetTLSStatusRequest) ProtoMessage() {}
 
 func (x *GetTLSStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[90]
+	mi := &file_loom_v1_loom_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7072,7 +7186,7 @@ func (x *GetTLSStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTLSStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetTLSStatusRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{90}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{92}
 }
 
 // RenewCertificateRequest manually triggers certificate renewal.
@@ -7086,7 +7200,7 @@ type RenewCertificateRequest struct {
 
 func (x *RenewCertificateRequest) Reset() {
 	*x = RenewCertificateRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[91]
+	mi := &file_loom_v1_loom_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7098,7 +7212,7 @@ func (x *RenewCertificateRequest) String() string {
 func (*RenewCertificateRequest) ProtoMessage() {}
 
 func (x *RenewCertificateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[91]
+	mi := &file_loom_v1_loom_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7111,7 +7225,7 @@ func (x *RenewCertificateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenewCertificateRequest.ProtoReflect.Descriptor instead.
 func (*RenewCertificateRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{91}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *RenewCertificateRequest) GetForce() bool {
@@ -7136,7 +7250,7 @@ type RenewCertificateResponse struct {
 
 func (x *RenewCertificateResponse) Reset() {
 	*x = RenewCertificateResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[92]
+	mi := &file_loom_v1_loom_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7148,7 +7262,7 @@ func (x *RenewCertificateResponse) String() string {
 func (*RenewCertificateResponse) ProtoMessage() {}
 
 func (x *RenewCertificateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[92]
+	mi := &file_loom_v1_loom_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7161,7 +7275,7 @@ func (x *RenewCertificateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenewCertificateResponse.ProtoReflect.Descriptor instead.
 func (*RenewCertificateResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{92}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *RenewCertificateResponse) GetSuccess() bool {
@@ -7210,7 +7324,7 @@ type SwitchModelRequest struct {
 
 func (x *SwitchModelRequest) Reset() {
 	*x = SwitchModelRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[93]
+	mi := &file_loom_v1_loom_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7222,7 +7336,7 @@ func (x *SwitchModelRequest) String() string {
 func (*SwitchModelRequest) ProtoMessage() {}
 
 func (x *SwitchModelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[93]
+	mi := &file_loom_v1_loom_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7235,7 +7349,7 @@ func (x *SwitchModelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SwitchModelRequest.ProtoReflect.Descriptor instead.
 func (*SwitchModelRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{93}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *SwitchModelRequest) GetSessionId() string {
@@ -7304,7 +7418,7 @@ type SwitchModelResponse struct {
 
 func (x *SwitchModelResponse) Reset() {
 	*x = SwitchModelResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[94]
+	mi := &file_loom_v1_loom_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7316,7 +7430,7 @@ func (x *SwitchModelResponse) String() string {
 func (*SwitchModelResponse) ProtoMessage() {}
 
 func (x *SwitchModelResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[94]
+	mi := &file_loom_v1_loom_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7329,7 +7443,7 @@ func (x *SwitchModelResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SwitchModelResponse.ProtoReflect.Descriptor instead.
 func (*SwitchModelResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{94}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *SwitchModelResponse) GetSuccess() bool {
@@ -7373,7 +7487,7 @@ type ListAvailableModelsRequest struct {
 
 func (x *ListAvailableModelsRequest) Reset() {
 	*x = ListAvailableModelsRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[95]
+	mi := &file_loom_v1_loom_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7385,7 +7499,7 @@ func (x *ListAvailableModelsRequest) String() string {
 func (*ListAvailableModelsRequest) ProtoMessage() {}
 
 func (x *ListAvailableModelsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[95]
+	mi := &file_loom_v1_loom_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7398,7 +7512,7 @@ func (x *ListAvailableModelsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAvailableModelsRequest.ProtoReflect.Descriptor instead.
 func (*ListAvailableModelsRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{95}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *ListAvailableModelsRequest) GetProviderFilter() string {
@@ -7428,7 +7542,7 @@ type ListAvailableModelsResponse struct {
 
 func (x *ListAvailableModelsResponse) Reset() {
 	*x = ListAvailableModelsResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[96]
+	mi := &file_loom_v1_loom_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7440,7 +7554,7 @@ func (x *ListAvailableModelsResponse) String() string {
 func (*ListAvailableModelsResponse) ProtoMessage() {}
 
 func (x *ListAvailableModelsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[96]
+	mi := &file_loom_v1_loom_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7453,7 +7567,7 @@ func (x *ListAvailableModelsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAvailableModelsResponse.ProtoReflect.Descriptor instead.
 func (*ListAvailableModelsResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{96}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *ListAvailableModelsResponse) GetModels() []*ModelInfo {
@@ -7482,7 +7596,7 @@ type ListProvidersRequest struct {
 
 func (x *ListProvidersRequest) Reset() {
 	*x = ListProvidersRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[97]
+	mi := &file_loom_v1_loom_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7494,7 +7608,7 @@ func (x *ListProvidersRequest) String() string {
 func (*ListProvidersRequest) ProtoMessage() {}
 
 func (x *ListProvidersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[97]
+	mi := &file_loom_v1_loom_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7507,7 +7621,7 @@ func (x *ListProvidersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListProvidersRequest.ProtoReflect.Descriptor instead.
 func (*ListProvidersRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{97}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *ListProvidersRequest) GetAgentId() string {
@@ -7535,7 +7649,7 @@ type ListProvidersResponse struct {
 
 func (x *ListProvidersResponse) Reset() {
 	*x = ListProvidersResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[98]
+	mi := &file_loom_v1_loom_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7547,7 +7661,7 @@ func (x *ListProvidersResponse) String() string {
 func (*ListProvidersResponse) ProtoMessage() {}
 
 func (x *ListProvidersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[98]
+	mi := &file_loom_v1_loom_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7560,7 +7674,7 @@ func (x *ListProvidersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListProvidersResponse.ProtoReflect.Descriptor instead.
 func (*ListProvidersResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{98}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *ListProvidersResponse) GetProviders() []*ProviderEntry {
@@ -7593,7 +7707,7 @@ type ABTestRequest struct {
 
 func (x *ABTestRequest) Reset() {
 	*x = ABTestRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[99]
+	mi := &file_loom_v1_loom_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7605,7 +7719,7 @@ func (x *ABTestRequest) String() string {
 func (*ABTestRequest) ProtoMessage() {}
 
 func (x *ABTestRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[99]
+	mi := &file_loom_v1_loom_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7618,7 +7732,7 @@ func (x *ABTestRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ABTestRequest.ProtoReflect.Descriptor instead.
 func (*ABTestRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{99}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *ABTestRequest) GetSessionId() string {
@@ -7675,7 +7789,7 @@ type ABTestEvent struct {
 
 func (x *ABTestEvent) Reset() {
 	*x = ABTestEvent{}
-	mi := &file_loom_v1_loom_proto_msgTypes[100]
+	mi := &file_loom_v1_loom_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7687,7 +7801,7 @@ func (x *ABTestEvent) String() string {
 func (*ABTestEvent) ProtoMessage() {}
 
 func (x *ABTestEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[100]
+	mi := &file_loom_v1_loom_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7700,7 +7814,7 @@ func (x *ABTestEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ABTestEvent.ProtoReflect.Descriptor instead.
 func (*ABTestEvent) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{100}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *ABTestEvent) GetProviderName() string {
@@ -7790,7 +7904,7 @@ type ModelInfo struct {
 
 func (x *ModelInfo) Reset() {
 	*x = ModelInfo{}
-	mi := &file_loom_v1_loom_proto_msgTypes[101]
+	mi := &file_loom_v1_loom_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7802,7 +7916,7 @@ func (x *ModelInfo) String() string {
 func (*ModelInfo) ProtoMessage() {}
 
 func (x *ModelInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[101]
+	mi := &file_loom_v1_loom_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7815,7 +7929,7 @@ func (x *ModelInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ModelInfo.ProtoReflect.Descriptor instead.
 func (*ModelInfo) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{101}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *ModelInfo) GetId() string {
@@ -7916,7 +8030,7 @@ type ToolPermissionRequest struct {
 
 func (x *ToolPermissionRequest) Reset() {
 	*x = ToolPermissionRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[102]
+	mi := &file_loom_v1_loom_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7928,7 +8042,7 @@ func (x *ToolPermissionRequest) String() string {
 func (*ToolPermissionRequest) ProtoMessage() {}
 
 func (x *ToolPermissionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[102]
+	mi := &file_loom_v1_loom_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7941,7 +8055,7 @@ func (x *ToolPermissionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ToolPermissionRequest.ProtoReflect.Descriptor instead.
 func (*ToolPermissionRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{102}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *ToolPermissionRequest) GetSessionId() string {
@@ -8003,7 +8117,7 @@ type ToolPermissionResponse struct {
 
 func (x *ToolPermissionResponse) Reset() {
 	*x = ToolPermissionResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[103]
+	mi := &file_loom_v1_loom_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8015,7 +8129,7 @@ func (x *ToolPermissionResponse) String() string {
 func (*ToolPermissionResponse) ProtoMessage() {}
 
 func (x *ToolPermissionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[103]
+	mi := &file_loom_v1_loom_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8028,7 +8142,7 @@ func (x *ToolPermissionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ToolPermissionResponse.ProtoReflect.Descriptor instead.
 func (*ToolPermissionResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{103}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *ToolPermissionResponse) GetGranted() bool {
@@ -8068,7 +8182,7 @@ type ListMCPServersRequest struct {
 
 func (x *ListMCPServersRequest) Reset() {
 	*x = ListMCPServersRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[104]
+	mi := &file_loom_v1_loom_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8080,7 +8194,7 @@ func (x *ListMCPServersRequest) String() string {
 func (*ListMCPServersRequest) ProtoMessage() {}
 
 func (x *ListMCPServersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[104]
+	mi := &file_loom_v1_loom_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8093,7 +8207,7 @@ func (x *ListMCPServersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMCPServersRequest.ProtoReflect.Descriptor instead.
 func (*ListMCPServersRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{104}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{106}
 }
 
 // ListMCPServersResponse returns MCP servers.
@@ -8109,7 +8223,7 @@ type ListMCPServersResponse struct {
 
 func (x *ListMCPServersResponse) Reset() {
 	*x = ListMCPServersResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[105]
+	mi := &file_loom_v1_loom_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8121,7 +8235,7 @@ func (x *ListMCPServersResponse) String() string {
 func (*ListMCPServersResponse) ProtoMessage() {}
 
 func (x *ListMCPServersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[105]
+	mi := &file_loom_v1_loom_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8134,7 +8248,7 @@ func (x *ListMCPServersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMCPServersResponse.ProtoReflect.Descriptor instead.
 func (*ListMCPServersResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{105}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *ListMCPServersResponse) GetServers() []*MCPServerInfo {
@@ -8162,7 +8276,7 @@ type GetMCPServerRequest struct {
 
 func (x *GetMCPServerRequest) Reset() {
 	*x = GetMCPServerRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[106]
+	mi := &file_loom_v1_loom_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8174,7 +8288,7 @@ func (x *GetMCPServerRequest) String() string {
 func (*GetMCPServerRequest) ProtoMessage() {}
 
 func (x *GetMCPServerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[106]
+	mi := &file_loom_v1_loom_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8187,7 +8301,7 @@ func (x *GetMCPServerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMCPServerRequest.ProtoReflect.Descriptor instead.
 func (*GetMCPServerRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{106}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *GetMCPServerRequest) GetServerName() string {
@@ -8228,7 +8342,7 @@ type MCPServerInfo struct {
 
 func (x *MCPServerInfo) Reset() {
 	*x = MCPServerInfo{}
-	mi := &file_loom_v1_loom_proto_msgTypes[107]
+	mi := &file_loom_v1_loom_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8240,7 +8354,7 @@ func (x *MCPServerInfo) String() string {
 func (*MCPServerInfo) ProtoMessage() {}
 
 func (x *MCPServerInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[107]
+	mi := &file_loom_v1_loom_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8253,7 +8367,7 @@ func (x *MCPServerInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MCPServerInfo.ProtoReflect.Descriptor instead.
 func (*MCPServerInfo) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{107}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *MCPServerInfo) GetName() string {
@@ -8348,7 +8462,7 @@ type ToolFilterConfig struct {
 
 func (x *ToolFilterConfig) Reset() {
 	*x = ToolFilterConfig{}
-	mi := &file_loom_v1_loom_proto_msgTypes[108]
+	mi := &file_loom_v1_loom_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8360,7 +8474,7 @@ func (x *ToolFilterConfig) String() string {
 func (*ToolFilterConfig) ProtoMessage() {}
 
 func (x *ToolFilterConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[108]
+	mi := &file_loom_v1_loom_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8373,7 +8487,7 @@ func (x *ToolFilterConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ToolFilterConfig.ProtoReflect.Descriptor instead.
 func (*ToolFilterConfig) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{108}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *ToolFilterConfig) GetAll() bool {
@@ -8430,7 +8544,7 @@ type AddMCPServerRequest struct {
 
 func (x *AddMCPServerRequest) Reset() {
 	*x = AddMCPServerRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[109]
+	mi := &file_loom_v1_loom_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8442,7 +8556,7 @@ func (x *AddMCPServerRequest) String() string {
 func (*AddMCPServerRequest) ProtoMessage() {}
 
 func (x *AddMCPServerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[109]
+	mi := &file_loom_v1_loom_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8455,7 +8569,7 @@ func (x *AddMCPServerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddMCPServerRequest.ProtoReflect.Descriptor instead.
 func (*AddMCPServerRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{109}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *AddMCPServerRequest) GetName() string {
@@ -8557,7 +8671,7 @@ type AddMCPServerResponse struct {
 
 func (x *AddMCPServerResponse) Reset() {
 	*x = AddMCPServerResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[110]
+	mi := &file_loom_v1_loom_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8569,7 +8683,7 @@ func (x *AddMCPServerResponse) String() string {
 func (*AddMCPServerResponse) ProtoMessage() {}
 
 func (x *AddMCPServerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[110]
+	mi := &file_loom_v1_loom_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8582,7 +8696,7 @@ func (x *AddMCPServerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddMCPServerResponse.ProtoReflect.Descriptor instead.
 func (*AddMCPServerResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{110}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *AddMCPServerResponse) GetSuccess() bool {
@@ -8641,7 +8755,7 @@ type UpdateMCPServerRequest struct {
 
 func (x *UpdateMCPServerRequest) Reset() {
 	*x = UpdateMCPServerRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[111]
+	mi := &file_loom_v1_loom_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8653,7 +8767,7 @@ func (x *UpdateMCPServerRequest) String() string {
 func (*UpdateMCPServerRequest) ProtoMessage() {}
 
 func (x *UpdateMCPServerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[111]
+	mi := &file_loom_v1_loom_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8666,7 +8780,7 @@ func (x *UpdateMCPServerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateMCPServerRequest.ProtoReflect.Descriptor instead.
 func (*UpdateMCPServerRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{111}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *UpdateMCPServerRequest) GetServerName() string {
@@ -8773,7 +8887,7 @@ type DeleteMCPServerRequest struct {
 
 func (x *DeleteMCPServerRequest) Reset() {
 	*x = DeleteMCPServerRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[112]
+	mi := &file_loom_v1_loom_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8785,7 +8899,7 @@ func (x *DeleteMCPServerRequest) String() string {
 func (*DeleteMCPServerRequest) ProtoMessage() {}
 
 func (x *DeleteMCPServerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[112]
+	mi := &file_loom_v1_loom_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8798,7 +8912,7 @@ func (x *DeleteMCPServerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteMCPServerRequest.ProtoReflect.Descriptor instead.
 func (*DeleteMCPServerRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{112}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *DeleteMCPServerRequest) GetServerName() string {
@@ -8828,7 +8942,7 @@ type DeleteMCPServerResponse struct {
 
 func (x *DeleteMCPServerResponse) Reset() {
 	*x = DeleteMCPServerResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[113]
+	mi := &file_loom_v1_loom_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8840,7 +8954,7 @@ func (x *DeleteMCPServerResponse) String() string {
 func (*DeleteMCPServerResponse) ProtoMessage() {}
 
 func (x *DeleteMCPServerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[113]
+	mi := &file_loom_v1_loom_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8853,7 +8967,7 @@ func (x *DeleteMCPServerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteMCPServerResponse.ProtoReflect.Descriptor instead.
 func (*DeleteMCPServerResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{113}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *DeleteMCPServerResponse) GetSuccess() bool {
@@ -8883,7 +8997,7 @@ type RestartMCPServerRequest struct {
 
 func (x *RestartMCPServerRequest) Reset() {
 	*x = RestartMCPServerRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[114]
+	mi := &file_loom_v1_loom_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8895,7 +9009,7 @@ func (x *RestartMCPServerRequest) String() string {
 func (*RestartMCPServerRequest) ProtoMessage() {}
 
 func (x *RestartMCPServerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[114]
+	mi := &file_loom_v1_loom_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8908,7 +9022,7 @@ func (x *RestartMCPServerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestartMCPServerRequest.ProtoReflect.Descriptor instead.
 func (*RestartMCPServerRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{114}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *RestartMCPServerRequest) GetServerName() string {
@@ -8934,7 +9048,7 @@ type HealthCheckMCPServersRequest struct {
 
 func (x *HealthCheckMCPServersRequest) Reset() {
 	*x = HealthCheckMCPServersRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[115]
+	mi := &file_loom_v1_loom_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8946,7 +9060,7 @@ func (x *HealthCheckMCPServersRequest) String() string {
 func (*HealthCheckMCPServersRequest) ProtoMessage() {}
 
 func (x *HealthCheckMCPServersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[115]
+	mi := &file_loom_v1_loom_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8959,7 +9073,7 @@ func (x *HealthCheckMCPServersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthCheckMCPServersRequest.ProtoReflect.Descriptor instead.
 func (*HealthCheckMCPServersRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{115}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{117}
 }
 
 // HealthCheckMCPServersResponse returns health status.
@@ -8973,7 +9087,7 @@ type HealthCheckMCPServersResponse struct {
 
 func (x *HealthCheckMCPServersResponse) Reset() {
 	*x = HealthCheckMCPServersResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[116]
+	mi := &file_loom_v1_loom_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8985,7 +9099,7 @@ func (x *HealthCheckMCPServersResponse) String() string {
 func (*HealthCheckMCPServersResponse) ProtoMessage() {}
 
 func (x *HealthCheckMCPServersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[116]
+	mi := &file_loom_v1_loom_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8998,7 +9112,7 @@ func (x *HealthCheckMCPServersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthCheckMCPServersResponse.ProtoReflect.Descriptor instead.
 func (*HealthCheckMCPServersResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{116}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *HealthCheckMCPServersResponse) GetServers() map[string]*MCPServerHealth {
@@ -9025,7 +9139,7 @@ type MCPServerHealth struct {
 
 func (x *MCPServerHealth) Reset() {
 	*x = MCPServerHealth{}
-	mi := &file_loom_v1_loom_proto_msgTypes[117]
+	mi := &file_loom_v1_loom_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9037,7 +9151,7 @@ func (x *MCPServerHealth) String() string {
 func (*MCPServerHealth) ProtoMessage() {}
 
 func (x *MCPServerHealth) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[117]
+	mi := &file_loom_v1_loom_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9050,7 +9164,7 @@ func (x *MCPServerHealth) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MCPServerHealth.ProtoReflect.Descriptor instead.
 func (*MCPServerHealth) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{117}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *MCPServerHealth) GetStatus() string {
@@ -9110,7 +9224,7 @@ type TestMCPServerConnectionRequest struct {
 
 func (x *TestMCPServerConnectionRequest) Reset() {
 	*x = TestMCPServerConnectionRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[118]
+	mi := &file_loom_v1_loom_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9122,7 +9236,7 @@ func (x *TestMCPServerConnectionRequest) String() string {
 func (*TestMCPServerConnectionRequest) ProtoMessage() {}
 
 func (x *TestMCPServerConnectionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[118]
+	mi := &file_loom_v1_loom_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9135,7 +9249,7 @@ func (x *TestMCPServerConnectionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TestMCPServerConnectionRequest.ProtoReflect.Descriptor instead.
 func (*TestMCPServerConnectionRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{118}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *TestMCPServerConnectionRequest) GetTransport() string {
@@ -9229,7 +9343,7 @@ type TestMCPServerConnectionResponse struct {
 
 func (x *TestMCPServerConnectionResponse) Reset() {
 	*x = TestMCPServerConnectionResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[119]
+	mi := &file_loom_v1_loom_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9241,7 +9355,7 @@ func (x *TestMCPServerConnectionResponse) String() string {
 func (*TestMCPServerConnectionResponse) ProtoMessage() {}
 
 func (x *TestMCPServerConnectionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[119]
+	mi := &file_loom_v1_loom_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9254,7 +9368,7 @@ func (x *TestMCPServerConnectionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TestMCPServerConnectionResponse.ProtoReflect.Descriptor instead.
 func (*TestMCPServerConnectionResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{119}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *TestMCPServerConnectionResponse) GetSuccess() bool {
@@ -9310,7 +9424,7 @@ type ListMCPServerToolsRequest struct {
 
 func (x *ListMCPServerToolsRequest) Reset() {
 	*x = ListMCPServerToolsRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[120]
+	mi := &file_loom_v1_loom_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9322,7 +9436,7 @@ func (x *ListMCPServerToolsRequest) String() string {
 func (*ListMCPServerToolsRequest) ProtoMessage() {}
 
 func (x *ListMCPServerToolsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[120]
+	mi := &file_loom_v1_loom_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9335,7 +9449,7 @@ func (x *ListMCPServerToolsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMCPServerToolsRequest.ProtoReflect.Descriptor instead.
 func (*ListMCPServerToolsRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{120}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{122}
 }
 
 func (x *ListMCPServerToolsRequest) GetServerName() string {
@@ -9360,7 +9474,7 @@ type ListMCPServerToolsResponse struct {
 
 func (x *ListMCPServerToolsResponse) Reset() {
 	*x = ListMCPServerToolsResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[121]
+	mi := &file_loom_v1_loom_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9372,7 +9486,7 @@ func (x *ListMCPServerToolsResponse) String() string {
 func (*ListMCPServerToolsResponse) ProtoMessage() {}
 
 func (x *ListMCPServerToolsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[121]
+	mi := &file_loom_v1_loom_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9385,7 +9499,7 @@ func (x *ListMCPServerToolsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMCPServerToolsResponse.ProtoReflect.Descriptor instead.
 func (*ListMCPServerToolsResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{121}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{123}
 }
 
 func (x *ListMCPServerToolsResponse) GetTools() []*ToolDefinition {
@@ -9455,7 +9569,7 @@ type Artifact struct {
 
 func (x *Artifact) Reset() {
 	*x = Artifact{}
-	mi := &file_loom_v1_loom_proto_msgTypes[122]
+	mi := &file_loom_v1_loom_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9467,7 +9581,7 @@ func (x *Artifact) String() string {
 func (*Artifact) ProtoMessage() {}
 
 func (x *Artifact) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[122]
+	mi := &file_loom_v1_loom_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9480,7 +9594,7 @@ func (x *Artifact) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Artifact.ProtoReflect.Descriptor instead.
 func (*Artifact) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{122}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *Artifact) GetId() string {
@@ -9629,7 +9743,7 @@ type ListArtifactsRequest struct {
 
 func (x *ListArtifactsRequest) Reset() {
 	*x = ListArtifactsRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[123]
+	mi := &file_loom_v1_loom_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9641,7 +9755,7 @@ func (x *ListArtifactsRequest) String() string {
 func (*ListArtifactsRequest) ProtoMessage() {}
 
 func (x *ListArtifactsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[123]
+	mi := &file_loom_v1_loom_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9654,7 +9768,7 @@ func (x *ListArtifactsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListArtifactsRequest.ProtoReflect.Descriptor instead.
 func (*ListArtifactsRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{123}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{125}
 }
 
 func (x *ListArtifactsRequest) GetSource() string {
@@ -9719,7 +9833,7 @@ type ListArtifactsResponse struct {
 
 func (x *ListArtifactsResponse) Reset() {
 	*x = ListArtifactsResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[124]
+	mi := &file_loom_v1_loom_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9731,7 +9845,7 @@ func (x *ListArtifactsResponse) String() string {
 func (*ListArtifactsResponse) ProtoMessage() {}
 
 func (x *ListArtifactsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[124]
+	mi := &file_loom_v1_loom_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9744,7 +9858,7 @@ func (x *ListArtifactsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListArtifactsResponse.ProtoReflect.Descriptor instead.
 func (*ListArtifactsResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{124}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *ListArtifactsResponse) GetArtifacts() []*Artifact {
@@ -9779,7 +9893,7 @@ type GetArtifactRequest struct {
 
 func (x *GetArtifactRequest) Reset() {
 	*x = GetArtifactRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[125]
+	mi := &file_loom_v1_loom_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9791,7 +9905,7 @@ func (x *GetArtifactRequest) String() string {
 func (*GetArtifactRequest) ProtoMessage() {}
 
 func (x *GetArtifactRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[125]
+	mi := &file_loom_v1_loom_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9804,7 +9918,7 @@ func (x *GetArtifactRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetArtifactRequest.ProtoReflect.Descriptor instead.
 func (*GetArtifactRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{125}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{127}
 }
 
 func (x *GetArtifactRequest) GetId() string {
@@ -9839,7 +9953,7 @@ type GetArtifactResponse struct {
 
 func (x *GetArtifactResponse) Reset() {
 	*x = GetArtifactResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[126]
+	mi := &file_loom_v1_loom_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9851,7 +9965,7 @@ func (x *GetArtifactResponse) String() string {
 func (*GetArtifactResponse) ProtoMessage() {}
 
 func (x *GetArtifactResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[126]
+	mi := &file_loom_v1_loom_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9864,7 +9978,7 @@ func (x *GetArtifactResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetArtifactResponse.ProtoReflect.Descriptor instead.
 func (*GetArtifactResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{126}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{128}
 }
 
 func (x *GetArtifactResponse) GetArtifact() *Artifact {
@@ -9895,7 +10009,7 @@ type UploadArtifactRequest struct {
 
 func (x *UploadArtifactRequest) Reset() {
 	*x = UploadArtifactRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[127]
+	mi := &file_loom_v1_loom_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9907,7 +10021,7 @@ func (x *UploadArtifactRequest) String() string {
 func (*UploadArtifactRequest) ProtoMessage() {}
 
 func (x *UploadArtifactRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[127]
+	mi := &file_loom_v1_loom_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9920,7 +10034,7 @@ func (x *UploadArtifactRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UploadArtifactRequest.ProtoReflect.Descriptor instead.
 func (*UploadArtifactRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{127}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{129}
 }
 
 func (x *UploadArtifactRequest) GetName() string {
@@ -9976,7 +10090,7 @@ type UploadArtifactResponse struct {
 
 func (x *UploadArtifactResponse) Reset() {
 	*x = UploadArtifactResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[128]
+	mi := &file_loom_v1_loom_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9988,7 +10102,7 @@ func (x *UploadArtifactResponse) String() string {
 func (*UploadArtifactResponse) ProtoMessage() {}
 
 func (x *UploadArtifactResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[128]
+	mi := &file_loom_v1_loom_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10001,7 +10115,7 @@ func (x *UploadArtifactResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UploadArtifactResponse.ProtoReflect.Descriptor instead.
 func (*UploadArtifactResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{128}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{130}
 }
 
 func (x *UploadArtifactResponse) GetArtifact() *Artifact {
@@ -10024,7 +10138,7 @@ type DeleteArtifactRequest struct {
 
 func (x *DeleteArtifactRequest) Reset() {
 	*x = DeleteArtifactRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[129]
+	mi := &file_loom_v1_loom_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10036,7 +10150,7 @@ func (x *DeleteArtifactRequest) String() string {
 func (*DeleteArtifactRequest) ProtoMessage() {}
 
 func (x *DeleteArtifactRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[129]
+	mi := &file_loom_v1_loom_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10049,7 +10163,7 @@ func (x *DeleteArtifactRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteArtifactRequest.ProtoReflect.Descriptor instead.
 func (*DeleteArtifactRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{129}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{131}
 }
 
 func (x *DeleteArtifactRequest) GetId() string {
@@ -10077,7 +10191,7 @@ type DeleteArtifactResponse struct {
 
 func (x *DeleteArtifactResponse) Reset() {
 	*x = DeleteArtifactResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[130]
+	mi := &file_loom_v1_loom_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10089,7 +10203,7 @@ func (x *DeleteArtifactResponse) String() string {
 func (*DeleteArtifactResponse) ProtoMessage() {}
 
 func (x *DeleteArtifactResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[130]
+	mi := &file_loom_v1_loom_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10102,7 +10216,7 @@ func (x *DeleteArtifactResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteArtifactResponse.ProtoReflect.Descriptor instead.
 func (*DeleteArtifactResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{130}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{132}
 }
 
 func (x *DeleteArtifactResponse) GetSuccess() bool {
@@ -10125,7 +10239,7 @@ type SearchArtifactsRequest struct {
 
 func (x *SearchArtifactsRequest) Reset() {
 	*x = SearchArtifactsRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[131]
+	mi := &file_loom_v1_loom_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10137,7 +10251,7 @@ func (x *SearchArtifactsRequest) String() string {
 func (*SearchArtifactsRequest) ProtoMessage() {}
 
 func (x *SearchArtifactsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[131]
+	mi := &file_loom_v1_loom_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10150,7 +10264,7 @@ func (x *SearchArtifactsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchArtifactsRequest.ProtoReflect.Descriptor instead.
 func (*SearchArtifactsRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{131}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{133}
 }
 
 func (x *SearchArtifactsRequest) GetQuery() string {
@@ -10178,7 +10292,7 @@ type SearchArtifactsResponse struct {
 
 func (x *SearchArtifactsResponse) Reset() {
 	*x = SearchArtifactsResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[132]
+	mi := &file_loom_v1_loom_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10190,7 +10304,7 @@ func (x *SearchArtifactsResponse) String() string {
 func (*SearchArtifactsResponse) ProtoMessage() {}
 
 func (x *SearchArtifactsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[132]
+	mi := &file_loom_v1_loom_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10203,7 +10317,7 @@ func (x *SearchArtifactsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchArtifactsResponse.ProtoReflect.Descriptor instead.
 func (*SearchArtifactsResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{132}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{134}
 }
 
 func (x *SearchArtifactsResponse) GetArtifacts() []*Artifact {
@@ -10228,7 +10342,7 @@ type GetArtifactContentRequest struct {
 
 func (x *GetArtifactContentRequest) Reset() {
 	*x = GetArtifactContentRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[133]
+	mi := &file_loom_v1_loom_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10240,7 +10354,7 @@ func (x *GetArtifactContentRequest) String() string {
 func (*GetArtifactContentRequest) ProtoMessage() {}
 
 func (x *GetArtifactContentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[133]
+	mi := &file_loom_v1_loom_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10253,7 +10367,7 @@ func (x *GetArtifactContentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetArtifactContentRequest.ProtoReflect.Descriptor instead.
 func (*GetArtifactContentRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{133}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{135}
 }
 
 func (x *GetArtifactContentRequest) GetId() string {
@@ -10290,7 +10404,7 @@ type GetArtifactContentResponse struct {
 
 func (x *GetArtifactContentResponse) Reset() {
 	*x = GetArtifactContentResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[134]
+	mi := &file_loom_v1_loom_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10302,7 +10416,7 @@ func (x *GetArtifactContentResponse) String() string {
 func (*GetArtifactContentResponse) ProtoMessage() {}
 
 func (x *GetArtifactContentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[134]
+	mi := &file_loom_v1_loom_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10315,7 +10429,7 @@ func (x *GetArtifactContentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetArtifactContentResponse.ProtoReflect.Descriptor instead.
 func (*GetArtifactContentResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{134}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{136}
 }
 
 func (x *GetArtifactContentResponse) GetContent() []byte {
@@ -10341,7 +10455,7 @@ type GetArtifactStatsRequest struct {
 
 func (x *GetArtifactStatsRequest) Reset() {
 	*x = GetArtifactStatsRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[135]
+	mi := &file_loom_v1_loom_proto_msgTypes[137]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10353,7 +10467,7 @@ func (x *GetArtifactStatsRequest) String() string {
 func (*GetArtifactStatsRequest) ProtoMessage() {}
 
 func (x *GetArtifactStatsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[135]
+	mi := &file_loom_v1_loom_proto_msgTypes[137]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10366,7 +10480,7 @@ func (x *GetArtifactStatsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetArtifactStatsRequest.ProtoReflect.Descriptor instead.
 func (*GetArtifactStatsRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{135}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{137}
 }
 
 // GetArtifactStatsResponse returns artifact storage stats.
@@ -10388,7 +10502,7 @@ type GetArtifactStatsResponse struct {
 
 func (x *GetArtifactStatsResponse) Reset() {
 	*x = GetArtifactStatsResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[136]
+	mi := &file_loom_v1_loom_proto_msgTypes[138]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10400,7 +10514,7 @@ func (x *GetArtifactStatsResponse) String() string {
 func (*GetArtifactStatsResponse) ProtoMessage() {}
 
 func (x *GetArtifactStatsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[136]
+	mi := &file_loom_v1_loom_proto_msgTypes[138]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10413,7 +10527,7 @@ func (x *GetArtifactStatsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetArtifactStatsResponse.ProtoReflect.Descriptor instead.
 func (*GetArtifactStatsResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{136}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{138}
 }
 
 func (x *GetArtifactStatsResponse) GetTotalFiles() int32 {
@@ -10464,7 +10578,7 @@ type ListAllSessionsRequest struct {
 
 func (x *ListAllSessionsRequest) Reset() {
 	*x = ListAllSessionsRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[137]
+	mi := &file_loom_v1_loom_proto_msgTypes[139]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10476,7 +10590,7 @@ func (x *ListAllSessionsRequest) String() string {
 func (*ListAllSessionsRequest) ProtoMessage() {}
 
 func (x *ListAllSessionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[137]
+	mi := &file_loom_v1_loom_proto_msgTypes[139]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10489,7 +10603,7 @@ func (x *ListAllSessionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAllSessionsRequest.ProtoReflect.Descriptor instead.
 func (*ListAllSessionsRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{137}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{139}
 }
 
 func (x *ListAllSessionsRequest) GetLimit() int32 {
@@ -10519,7 +10633,7 @@ type ListAllSessionsResponse struct {
 
 func (x *ListAllSessionsResponse) Reset() {
 	*x = ListAllSessionsResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[138]
+	mi := &file_loom_v1_loom_proto_msgTypes[140]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10531,7 +10645,7 @@ func (x *ListAllSessionsResponse) String() string {
 func (*ListAllSessionsResponse) ProtoMessage() {}
 
 func (x *ListAllSessionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[138]
+	mi := &file_loom_v1_loom_proto_msgTypes[140]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10544,7 +10658,7 @@ func (x *ListAllSessionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAllSessionsResponse.ProtoReflect.Descriptor instead.
 func (*ListAllSessionsResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{138}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{140}
 }
 
 func (x *ListAllSessionsResponse) GetSessions() []*Session {
@@ -10570,7 +10684,7 @@ type CountSessionsByUserRequest struct {
 
 func (x *CountSessionsByUserRequest) Reset() {
 	*x = CountSessionsByUserRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[139]
+	mi := &file_loom_v1_loom_proto_msgTypes[141]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10582,7 +10696,7 @@ func (x *CountSessionsByUserRequest) String() string {
 func (*CountSessionsByUserRequest) ProtoMessage() {}
 
 func (x *CountSessionsByUserRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[139]
+	mi := &file_loom_v1_loom_proto_msgTypes[141]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10595,7 +10709,7 @@ func (x *CountSessionsByUserRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CountSessionsByUserRequest.ProtoReflect.Descriptor instead.
 func (*CountSessionsByUserRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{139}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{141}
 }
 
 // CountSessionsByUserResponse returns session counts per user.
@@ -10609,7 +10723,7 @@ type CountSessionsByUserResponse struct {
 
 func (x *CountSessionsByUserResponse) Reset() {
 	*x = CountSessionsByUserResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[140]
+	mi := &file_loom_v1_loom_proto_msgTypes[142]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10621,7 +10735,7 @@ func (x *CountSessionsByUserResponse) String() string {
 func (*CountSessionsByUserResponse) ProtoMessage() {}
 
 func (x *CountSessionsByUserResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[140]
+	mi := &file_loom_v1_loom_proto_msgTypes[142]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10634,7 +10748,7 @@ func (x *CountSessionsByUserResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CountSessionsByUserResponse.ProtoReflect.Descriptor instead.
 func (*CountSessionsByUserResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{140}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{142}
 }
 
 func (x *CountSessionsByUserResponse) GetUserCounts() map[string]int32 {
@@ -10653,7 +10767,7 @@ type GetSystemStatsRequest struct {
 
 func (x *GetSystemStatsRequest) Reset() {
 	*x = GetSystemStatsRequest{}
-	mi := &file_loom_v1_loom_proto_msgTypes[141]
+	mi := &file_loom_v1_loom_proto_msgTypes[143]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10665,7 +10779,7 @@ func (x *GetSystemStatsRequest) String() string {
 func (*GetSystemStatsRequest) ProtoMessage() {}
 
 func (x *GetSystemStatsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[141]
+	mi := &file_loom_v1_loom_proto_msgTypes[143]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10678,7 +10792,7 @@ func (x *GetSystemStatsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSystemStatsRequest.ProtoReflect.Descriptor instead.
 func (*GetSystemStatsRequest) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{141}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{143}
 }
 
 // GetSystemStatsResponse returns aggregate system statistics.
@@ -10702,7 +10816,7 @@ type GetSystemStatsResponse struct {
 
 func (x *GetSystemStatsResponse) Reset() {
 	*x = GetSystemStatsResponse{}
-	mi := &file_loom_v1_loom_proto_msgTypes[142]
+	mi := &file_loom_v1_loom_proto_msgTypes[144]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10714,7 +10828,7 @@ func (x *GetSystemStatsResponse) String() string {
 func (*GetSystemStatsResponse) ProtoMessage() {}
 
 func (x *GetSystemStatsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_loom_v1_loom_proto_msgTypes[142]
+	mi := &file_loom_v1_loom_proto_msgTypes[144]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10727,7 +10841,7 @@ func (x *GetSystemStatsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSystemStatsResponse.ProtoReflect.Descriptor instead.
 func (*GetSystemStatsResponse) Descriptor() ([]byte, []int) {
-	return file_loom_v1_loom_proto_rawDescGZIP(), []int{142}
+	return file_loom_v1_loom_proto_rawDescGZIP(), []int{144}
 }
 
 func (x *GetSystemStatsResponse) GetTotalSessions() int32 {
@@ -11352,7 +11466,13 @@ const file_loom_v1_loom_proto_rawDesc = "" +
 	"\x1aGetScheduleHistoryResponse\x12:\n" +
 	"\n" +
 	"executions\x18\x01 \x03(\v2\x1a.loom.v1.ScheduleExecutionR\n" +
-	"executions\"\xe8\x01\n" +
+	"executions\"[\n" +
+	"\x1eCancelWorkflowExecutionRequest\x12!\n" +
+	"\fexecution_id\x18\x01 \x01(\tR\vexecutionId\x12\x16\n" +
+	"\x06reason\x18\x02 \x01(\tR\x06reason\"Y\n" +
+	"\x1fCancelWorkflowExecutionResponse\x12\x1c\n" +
+	"\tcancelled\x18\x01 \x01(\bR\tcancelled\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"\xe8\x01\n" +
 	"\x11ScheduleExecution\x12!\n" +
 	"\fexecution_id\x18\x01 \x01(\tR\vexecutionId\x12\x1d\n" +
 	"\n" +
@@ -11710,7 +11830,7 @@ const file_loom_v1_loom_proto_rawDesc = "" +
 	"\x18AB_TEST_MODE_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19AB_TEST_MODE_SIDE_BY_SIDE\x10\x01\x12\"\n" +
 	"\x1eAB_TEST_MODE_SEQUENTIAL_SCORED\x10\x02\x12\x17\n" +
-	"\x13AB_TEST_MODE_SHADOW\x10\x032\xbeN\n" +
+	"\x13AB_TEST_MODE_SHADOW\x10\x032\xe8O\n" +
 	"\vLoomService\x12L\n" +
 	"\x05Weave\x12\x15.loom.v1.WeaveRequest\x1a\x16.loom.v1.WeaveResponse\"\x14\x82\xd3\xe4\x93\x02\x0e:\x01*\"\t/v1/weave\x12[\n" +
 	"\vStreamWeave\x12\x15.loom.v1.WeaveRequest\x1a\x16.loom.v1.WeaveProgress\"\x1b\x82\xd3\xe4\x93\x02\x15:\x01*\"\x10/v1/weave:stream0\x01\x12i\n" +
@@ -11777,7 +11897,8 @@ const file_loom_v1_loom_proto_rawDesc = "" +
 	"\x18TriggerScheduledWorkflow\x12(.loom.v1.TriggerScheduledWorkflowRequest\x1a .loom.v1.ExecuteWorkflowResponse\"8\x82\xd3\xe4\x93\x022:\x01*\"-/v1/workflows/schedules/{schedule_id}:trigger\x12~\n" +
 	"\rPauseSchedule\x12\x1d.loom.v1.PauseScheduleRequest\x1a\x16.google.protobuf.Empty\"6\x82\xd3\xe4\x93\x020:\x01*\"+/v1/workflows/schedules/{schedule_id}:pause\x12\x81\x01\n" +
 	"\x0eResumeSchedule\x12\x1e.loom.v1.ResumeScheduleRequest\x1a\x16.google.protobuf.Empty\"7\x82\xd3\xe4\x93\x021:\x01*\",/v1/workflows/schedules/{schedule_id}:resume\x12\x94\x01\n" +
-	"\x12GetScheduleHistory\x12\".loom.v1.GetScheduleHistoryRequest\x1a#.loom.v1.GetScheduleHistoryResponse\"5\x82\xd3\xe4\x93\x02/\x12-/v1/workflows/schedules/{schedule_id}/history\x12X\n" +
+	"\x12GetScheduleHistory\x12\".loom.v1.GetScheduleHistoryRequest\x1a#.loom.v1.GetScheduleHistoryResponse\"5\x82\xd3\xe4\x93\x02/\x12-/v1/workflows/schedules/{schedule_id}/history\x12\xa7\x01\n" +
+	"\x17CancelWorkflowExecution\x12'.loom.v1.CancelWorkflowExecutionRequest\x1a(.loom.v1.CancelWorkflowExecutionResponse\"9\x82\xd3\xe4\x93\x023:\x01*\"./v1/workflows/executions/{execution_id}:cancel\x12X\n" +
 	"\aPublish\x12\x17.loom.v1.PublishRequest\x1a\x18.loom.v1.PublishResponse\"\x1a\x82\xd3\xe4\x93\x02\x14:\x01*\"\x0f/v1/bus/publish\x12[\n" +
 	"\tSubscribe\x12\x19.loom.v1.SubscribeRequest\x1a\x13.loom.v1.BusMessage\"\x1c\x82\xd3\xe4\x93\x02\x16:\x01*\"\x11/v1/bus/subscribe0\x01\x12h\n" +
 	"\vUnsubscribe\x12\x1b.loom.v1.UnsubscribeRequest\x1a\x1c.loom.v1.UnsubscribeResponse\"\x1e\x82\xd3\xe4\x93\x02\x18:\x01*\"\x13/v1/bus/unsubscribe\x12]\n" +
@@ -11828,7 +11949,7 @@ func file_loom_v1_loom_proto_rawDescGZIP() []byte {
 }
 
 var file_loom_v1_loom_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_loom_v1_loom_proto_msgTypes = make([]protoimpl.MessageInfo, 164)
+var file_loom_v1_loom_proto_msgTypes = make([]protoimpl.MessageInfo, 166)
 var file_loom_v1_loom_proto_goTypes = []any{
 	(ExecutionStage)(0),                        // 0: loom.v1.ExecutionStage
 	(StorageLocation)(0),                       // 1: loom.v1.StorageLocation
@@ -11922,156 +12043,158 @@ var file_loom_v1_loom_proto_goTypes = []any{
 	(*ResumeScheduleRequest)(nil),              // 89: loom.v1.ResumeScheduleRequest
 	(*GetScheduleHistoryRequest)(nil),          // 90: loom.v1.GetScheduleHistoryRequest
 	(*GetScheduleHistoryResponse)(nil),         // 91: loom.v1.GetScheduleHistoryResponse
-	(*ScheduleExecution)(nil),                  // 92: loom.v1.ScheduleExecution
-	(*GetServerConfigRequest)(nil),             // 93: loom.v1.GetServerConfigRequest
-	(*GetTLSStatusRequest)(nil),                // 94: loom.v1.GetTLSStatusRequest
-	(*RenewCertificateRequest)(nil),            // 95: loom.v1.RenewCertificateRequest
-	(*RenewCertificateResponse)(nil),           // 96: loom.v1.RenewCertificateResponse
-	(*SwitchModelRequest)(nil),                 // 97: loom.v1.SwitchModelRequest
-	(*SwitchModelResponse)(nil),                // 98: loom.v1.SwitchModelResponse
-	(*ListAvailableModelsRequest)(nil),         // 99: loom.v1.ListAvailableModelsRequest
-	(*ListAvailableModelsResponse)(nil),        // 100: loom.v1.ListAvailableModelsResponse
-	(*ListProvidersRequest)(nil),               // 101: loom.v1.ListProvidersRequest
-	(*ListProvidersResponse)(nil),              // 102: loom.v1.ListProvidersResponse
-	(*ABTestRequest)(nil),                      // 103: loom.v1.ABTestRequest
-	(*ABTestEvent)(nil),                        // 104: loom.v1.ABTestEvent
-	(*ModelInfo)(nil),                          // 105: loom.v1.ModelInfo
-	(*ToolPermissionRequest)(nil),              // 106: loom.v1.ToolPermissionRequest
-	(*ToolPermissionResponse)(nil),             // 107: loom.v1.ToolPermissionResponse
-	(*ListMCPServersRequest)(nil),              // 108: loom.v1.ListMCPServersRequest
-	(*ListMCPServersResponse)(nil),             // 109: loom.v1.ListMCPServersResponse
-	(*GetMCPServerRequest)(nil),                // 110: loom.v1.GetMCPServerRequest
-	(*MCPServerInfo)(nil),                      // 111: loom.v1.MCPServerInfo
-	(*ToolFilterConfig)(nil),                   // 112: loom.v1.ToolFilterConfig
-	(*AddMCPServerRequest)(nil),                // 113: loom.v1.AddMCPServerRequest
-	(*AddMCPServerResponse)(nil),               // 114: loom.v1.AddMCPServerResponse
-	(*UpdateMCPServerRequest)(nil),             // 115: loom.v1.UpdateMCPServerRequest
-	(*DeleteMCPServerRequest)(nil),             // 116: loom.v1.DeleteMCPServerRequest
-	(*DeleteMCPServerResponse)(nil),            // 117: loom.v1.DeleteMCPServerResponse
-	(*RestartMCPServerRequest)(nil),            // 118: loom.v1.RestartMCPServerRequest
-	(*HealthCheckMCPServersRequest)(nil),       // 119: loom.v1.HealthCheckMCPServersRequest
-	(*HealthCheckMCPServersResponse)(nil),      // 120: loom.v1.HealthCheckMCPServersResponse
-	(*MCPServerHealth)(nil),                    // 121: loom.v1.MCPServerHealth
-	(*TestMCPServerConnectionRequest)(nil),     // 122: loom.v1.TestMCPServerConnectionRequest
-	(*TestMCPServerConnectionResponse)(nil),    // 123: loom.v1.TestMCPServerConnectionResponse
-	(*ListMCPServerToolsRequest)(nil),          // 124: loom.v1.ListMCPServerToolsRequest
-	(*ListMCPServerToolsResponse)(nil),         // 125: loom.v1.ListMCPServerToolsResponse
-	(*Artifact)(nil),                           // 126: loom.v1.Artifact
-	(*ListArtifactsRequest)(nil),               // 127: loom.v1.ListArtifactsRequest
-	(*ListArtifactsResponse)(nil),              // 128: loom.v1.ListArtifactsResponse
-	(*GetArtifactRequest)(nil),                 // 129: loom.v1.GetArtifactRequest
-	(*GetArtifactResponse)(nil),                // 130: loom.v1.GetArtifactResponse
-	(*UploadArtifactRequest)(nil),              // 131: loom.v1.UploadArtifactRequest
-	(*UploadArtifactResponse)(nil),             // 132: loom.v1.UploadArtifactResponse
-	(*DeleteArtifactRequest)(nil),              // 133: loom.v1.DeleteArtifactRequest
-	(*DeleteArtifactResponse)(nil),             // 134: loom.v1.DeleteArtifactResponse
-	(*SearchArtifactsRequest)(nil),             // 135: loom.v1.SearchArtifactsRequest
-	(*SearchArtifactsResponse)(nil),            // 136: loom.v1.SearchArtifactsResponse
-	(*GetArtifactContentRequest)(nil),          // 137: loom.v1.GetArtifactContentRequest
-	(*GetArtifactContentResponse)(nil),         // 138: loom.v1.GetArtifactContentResponse
-	(*GetArtifactStatsRequest)(nil),            // 139: loom.v1.GetArtifactStatsRequest
-	(*GetArtifactStatsResponse)(nil),           // 140: loom.v1.GetArtifactStatsResponse
-	(*ListAllSessionsRequest)(nil),             // 141: loom.v1.ListAllSessionsRequest
-	(*ListAllSessionsResponse)(nil),            // 142: loom.v1.ListAllSessionsResponse
-	(*CountSessionsByUserRequest)(nil),         // 143: loom.v1.CountSessionsByUserRequest
-	(*CountSessionsByUserResponse)(nil),        // 144: loom.v1.CountSessionsByUserResponse
-	(*GetSystemStatsRequest)(nil),              // 145: loom.v1.GetSystemStatsRequest
-	(*GetSystemStatsResponse)(nil),             // 146: loom.v1.GetSystemStatsResponse
-	nil,                                        // 147: loom.v1.WeaveRequest.BackendConfigEntry
-	nil,                                        // 148: loom.v1.WeaveRequest.ContextEntry
-	nil,                                        // 149: loom.v1.ExecutionResult.BackendMetadataEntry
-	nil,                                        // 150: loom.v1.DataReference.MetadataEntry
-	nil,                                        // 151: loom.v1.Pattern.BackendHintsEntry
-	nil,                                        // 152: loom.v1.CreateSessionRequest.ConfigEntry
-	nil,                                        // 153: loom.v1.CreateSessionRequest.MetadataEntry
-	nil,                                        // 154: loom.v1.Session.MetadataEntry
-	nil,                                        // 155: loom.v1.Span.AttributesEntry
-	nil,                                        // 156: loom.v1.SpanEvent.AttributesEntry
-	nil,                                        // 157: loom.v1.HealthStatus.ComponentsEntry
-	nil,                                        // 158: loom.v1.AgentInfo.MetadataEntry
-	nil,                                        // 159: loom.v1.ScheduleWorkflowRequest.MetadataEntry
-	nil,                                        // 160: loom.v1.TriggerScheduledWorkflowRequest.VariablesEntry
-	nil,                                        // 161: loom.v1.MCPServerInfo.EnvEntry
-	nil,                                        // 162: loom.v1.AddMCPServerRequest.EnvEntry
-	nil,                                        // 163: loom.v1.UpdateMCPServerRequest.EnvEntry
-	nil,                                        // 164: loom.v1.HealthCheckMCPServersResponse.ServersEntry
-	nil,                                        // 165: loom.v1.TestMCPServerConnectionRequest.EnvEntry
-	nil,                                        // 166: loom.v1.Artifact.MetadataEntry
-	nil,                                        // 167: loom.v1.CountSessionsByUserResponse.UserCountsEntry
-	(*timestamppb.Timestamp)(nil),              // 168: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                    // 169: google.protobuf.Struct
-	(*structpb.Value)(nil),                     // 170: google.protobuf.Value
-	(*ToolExample)(nil),                        // 171: loom.v1.ToolExample
-	(*RateLimitInfo)(nil),                      // 172: loom.v1.RateLimitInfo
-	(*AgentConfig)(nil),                        // 173: loom.v1.AgentConfig
-	(*WorkflowExecution)(nil),                  // 174: loom.v1.WorkflowExecution
-	(*AgentResult)(nil),                        // 175: loom.v1.AgentResult
-	(*WorkflowPattern)(nil),                    // 176: loom.v1.WorkflowPattern
-	(*ScheduleConfig)(nil),                     // 177: loom.v1.ScheduleConfig
-	(*ScheduledWorkflow)(nil),                  // 178: loom.v1.ScheduledWorkflow
-	(*CertificateInfo)(nil),                    // 179: loom.v1.CertificateInfo
-	(LLMRole)(0),                               // 180: loom.v1.LLMRole
-	(*ProviderEntry)(nil),                      // 181: loom.v1.ProviderEntry
-	(*GetStorageStatusRequest)(nil),            // 182: loom.v1.GetStorageStatusRequest
-	(*RunMigrationRequest)(nil),                // 183: loom.v1.RunMigrationRequest
-	(*ExecuteWorkflowRequest)(nil),             // 184: loom.v1.ExecuteWorkflowRequest
-	(*ListWorkflowsRequest)(nil),               // 185: loom.v1.ListWorkflowsRequest
-	(*PublishRequest)(nil),                     // 186: loom.v1.PublishRequest
-	(*SubscribeRequest)(nil),                   // 187: loom.v1.SubscribeRequest
-	(*UnsubscribeRequest)(nil),                 // 188: loom.v1.UnsubscribeRequest
-	(*ListTopicsRequest)(nil),                  // 189: loom.v1.ListTopicsRequest
-	(*GetTopicStatsRequest)(nil),               // 190: loom.v1.GetTopicStatsRequest
-	(*SendAsyncRequest)(nil),                   // 191: loom.v1.SendAsyncRequest
-	(*SendAndReceiveRequest)(nil),              // 192: loom.v1.SendAndReceiveRequest
-	(*PutSharedMemoryRequest)(nil),             // 193: loom.v1.PutSharedMemoryRequest
-	(*GetSharedMemoryRequest)(nil),             // 194: loom.v1.GetSharedMemoryRequest
-	(*DeleteSharedMemoryRequest)(nil),          // 195: loom.v1.DeleteSharedMemoryRequest
-	(*WatchSharedMemoryRequest)(nil),           // 196: loom.v1.WatchSharedMemoryRequest
-	(*ListSharedMemoryKeysRequest)(nil),        // 197: loom.v1.ListSharedMemoryKeysRequest
-	(*GetSharedMemoryStatsRequest)(nil),        // 198: loom.v1.GetSharedMemoryStatsRequest
-	(*ListUIAppsRequest)(nil),                  // 199: loom.v1.ListUIAppsRequest
-	(*GetUIAppRequest)(nil),                    // 200: loom.v1.GetUIAppRequest
-	(*CreateUIAppRequest)(nil),                 // 201: loom.v1.CreateUIAppRequest
-	(*UpdateUIAppRequest)(nil),                 // 202: loom.v1.UpdateUIAppRequest
-	(*DeleteUIAppRequest)(nil),                 // 203: loom.v1.DeleteUIAppRequest
-	(*ListComponentTypesRequest)(nil),          // 204: loom.v1.ListComponentTypesRequest
-	(*ListAgentPresetsRequest)(nil),            // 205: loom.v1.ListAgentPresetsRequest
-	(*ListWorkflowTemplatesRequest)(nil),       // 206: loom.v1.ListWorkflowTemplatesRequest
-	(*CreateWorkflowFromTemplateRequest)(nil),  // 207: loom.v1.CreateWorkflowFromTemplateRequest
-	(*ServerConfig)(nil),                       // 208: loom.v1.ServerConfig
-	(*TLSStatus)(nil),                          // 209: loom.v1.TLSStatus
-	(*GetStorageStatusResponse)(nil),           // 210: loom.v1.GetStorageStatusResponse
-	(*RunMigrationResponse)(nil),               // 211: loom.v1.RunMigrationResponse
-	(*ExecuteWorkflowResponse)(nil),            // 212: loom.v1.ExecuteWorkflowResponse
-	(*ListWorkflowsResponse)(nil),              // 213: loom.v1.ListWorkflowsResponse
-	(*emptypb.Empty)(nil),                      // 214: google.protobuf.Empty
-	(*PublishResponse)(nil),                    // 215: loom.v1.PublishResponse
-	(*BusMessage)(nil),                         // 216: loom.v1.BusMessage
-	(*UnsubscribeResponse)(nil),                // 217: loom.v1.UnsubscribeResponse
-	(*ListTopicsResponse)(nil),                 // 218: loom.v1.ListTopicsResponse
-	(*TopicStats)(nil),                         // 219: loom.v1.TopicStats
-	(*SendAsyncResponse)(nil),                  // 220: loom.v1.SendAsyncResponse
-	(*SendAndReceiveResponse)(nil),             // 221: loom.v1.SendAndReceiveResponse
-	(*PutSharedMemoryResponse)(nil),            // 222: loom.v1.PutSharedMemoryResponse
-	(*GetSharedMemoryResponse)(nil),            // 223: loom.v1.GetSharedMemoryResponse
-	(*DeleteSharedMemoryResponse)(nil),         // 224: loom.v1.DeleteSharedMemoryResponse
-	(*SharedMemoryValue)(nil),                  // 225: loom.v1.SharedMemoryValue
-	(*ListSharedMemoryKeysResponse)(nil),       // 226: loom.v1.ListSharedMemoryKeysResponse
-	(*SharedMemoryStats)(nil),                  // 227: loom.v1.SharedMemoryStats
-	(*ListUIAppsResponse)(nil),                 // 228: loom.v1.ListUIAppsResponse
-	(*GetUIAppResponse)(nil),                   // 229: loom.v1.GetUIAppResponse
-	(*CreateUIAppResponse)(nil),                // 230: loom.v1.CreateUIAppResponse
-	(*UpdateUIAppResponse)(nil),                // 231: loom.v1.UpdateUIAppResponse
-	(*DeleteUIAppResponse)(nil),                // 232: loom.v1.DeleteUIAppResponse
-	(*ListComponentTypesResponse)(nil),         // 233: loom.v1.ListComponentTypesResponse
-	(*ListAgentPresetsResponse)(nil),           // 234: loom.v1.ListAgentPresetsResponse
-	(*ListWorkflowTemplatesResponse)(nil),      // 235: loom.v1.ListWorkflowTemplatesResponse
-	(*CreateWorkflowFromTemplateResponse)(nil), // 236: loom.v1.CreateWorkflowFromTemplateResponse
+	(*CancelWorkflowExecutionRequest)(nil),     // 92: loom.v1.CancelWorkflowExecutionRequest
+	(*CancelWorkflowExecutionResponse)(nil),    // 93: loom.v1.CancelWorkflowExecutionResponse
+	(*ScheduleExecution)(nil),                  // 94: loom.v1.ScheduleExecution
+	(*GetServerConfigRequest)(nil),             // 95: loom.v1.GetServerConfigRequest
+	(*GetTLSStatusRequest)(nil),                // 96: loom.v1.GetTLSStatusRequest
+	(*RenewCertificateRequest)(nil),            // 97: loom.v1.RenewCertificateRequest
+	(*RenewCertificateResponse)(nil),           // 98: loom.v1.RenewCertificateResponse
+	(*SwitchModelRequest)(nil),                 // 99: loom.v1.SwitchModelRequest
+	(*SwitchModelResponse)(nil),                // 100: loom.v1.SwitchModelResponse
+	(*ListAvailableModelsRequest)(nil),         // 101: loom.v1.ListAvailableModelsRequest
+	(*ListAvailableModelsResponse)(nil),        // 102: loom.v1.ListAvailableModelsResponse
+	(*ListProvidersRequest)(nil),               // 103: loom.v1.ListProvidersRequest
+	(*ListProvidersResponse)(nil),              // 104: loom.v1.ListProvidersResponse
+	(*ABTestRequest)(nil),                      // 105: loom.v1.ABTestRequest
+	(*ABTestEvent)(nil),                        // 106: loom.v1.ABTestEvent
+	(*ModelInfo)(nil),                          // 107: loom.v1.ModelInfo
+	(*ToolPermissionRequest)(nil),              // 108: loom.v1.ToolPermissionRequest
+	(*ToolPermissionResponse)(nil),             // 109: loom.v1.ToolPermissionResponse
+	(*ListMCPServersRequest)(nil),              // 110: loom.v1.ListMCPServersRequest
+	(*ListMCPServersResponse)(nil),             // 111: loom.v1.ListMCPServersResponse
+	(*GetMCPServerRequest)(nil),                // 112: loom.v1.GetMCPServerRequest
+	(*MCPServerInfo)(nil),                      // 113: loom.v1.MCPServerInfo
+	(*ToolFilterConfig)(nil),                   // 114: loom.v1.ToolFilterConfig
+	(*AddMCPServerRequest)(nil),                // 115: loom.v1.AddMCPServerRequest
+	(*AddMCPServerResponse)(nil),               // 116: loom.v1.AddMCPServerResponse
+	(*UpdateMCPServerRequest)(nil),             // 117: loom.v1.UpdateMCPServerRequest
+	(*DeleteMCPServerRequest)(nil),             // 118: loom.v1.DeleteMCPServerRequest
+	(*DeleteMCPServerResponse)(nil),            // 119: loom.v1.DeleteMCPServerResponse
+	(*RestartMCPServerRequest)(nil),            // 120: loom.v1.RestartMCPServerRequest
+	(*HealthCheckMCPServersRequest)(nil),       // 121: loom.v1.HealthCheckMCPServersRequest
+	(*HealthCheckMCPServersResponse)(nil),      // 122: loom.v1.HealthCheckMCPServersResponse
+	(*MCPServerHealth)(nil),                    // 123: loom.v1.MCPServerHealth
+	(*TestMCPServerConnectionRequest)(nil),     // 124: loom.v1.TestMCPServerConnectionRequest
+	(*TestMCPServerConnectionResponse)(nil),    // 125: loom.v1.TestMCPServerConnectionResponse
+	(*ListMCPServerToolsRequest)(nil),          // 126: loom.v1.ListMCPServerToolsRequest
+	(*ListMCPServerToolsResponse)(nil),         // 127: loom.v1.ListMCPServerToolsResponse
+	(*Artifact)(nil),                           // 128: loom.v1.Artifact
+	(*ListArtifactsRequest)(nil),               // 129: loom.v1.ListArtifactsRequest
+	(*ListArtifactsResponse)(nil),              // 130: loom.v1.ListArtifactsResponse
+	(*GetArtifactRequest)(nil),                 // 131: loom.v1.GetArtifactRequest
+	(*GetArtifactResponse)(nil),                // 132: loom.v1.GetArtifactResponse
+	(*UploadArtifactRequest)(nil),              // 133: loom.v1.UploadArtifactRequest
+	(*UploadArtifactResponse)(nil),             // 134: loom.v1.UploadArtifactResponse
+	(*DeleteArtifactRequest)(nil),              // 135: loom.v1.DeleteArtifactRequest
+	(*DeleteArtifactResponse)(nil),             // 136: loom.v1.DeleteArtifactResponse
+	(*SearchArtifactsRequest)(nil),             // 137: loom.v1.SearchArtifactsRequest
+	(*SearchArtifactsResponse)(nil),            // 138: loom.v1.SearchArtifactsResponse
+	(*GetArtifactContentRequest)(nil),          // 139: loom.v1.GetArtifactContentRequest
+	(*GetArtifactContentResponse)(nil),         // 140: loom.v1.GetArtifactContentResponse
+	(*GetArtifactStatsRequest)(nil),            // 141: loom.v1.GetArtifactStatsRequest
+	(*GetArtifactStatsResponse)(nil),           // 142: loom.v1.GetArtifactStatsResponse
+	(*ListAllSessionsRequest)(nil),             // 143: loom.v1.ListAllSessionsRequest
+	(*ListAllSessionsResponse)(nil),            // 144: loom.v1.ListAllSessionsResponse
+	(*CountSessionsByUserRequest)(nil),         // 145: loom.v1.CountSessionsByUserRequest
+	(*CountSessionsByUserResponse)(nil),        // 146: loom.v1.CountSessionsByUserResponse
+	(*GetSystemStatsRequest)(nil),              // 147: loom.v1.GetSystemStatsRequest
+	(*GetSystemStatsResponse)(nil),             // 148: loom.v1.GetSystemStatsResponse
+	nil,                                        // 149: loom.v1.WeaveRequest.BackendConfigEntry
+	nil,                                        // 150: loom.v1.WeaveRequest.ContextEntry
+	nil,                                        // 151: loom.v1.ExecutionResult.BackendMetadataEntry
+	nil,                                        // 152: loom.v1.DataReference.MetadataEntry
+	nil,                                        // 153: loom.v1.Pattern.BackendHintsEntry
+	nil,                                        // 154: loom.v1.CreateSessionRequest.ConfigEntry
+	nil,                                        // 155: loom.v1.CreateSessionRequest.MetadataEntry
+	nil,                                        // 156: loom.v1.Session.MetadataEntry
+	nil,                                        // 157: loom.v1.Span.AttributesEntry
+	nil,                                        // 158: loom.v1.SpanEvent.AttributesEntry
+	nil,                                        // 159: loom.v1.HealthStatus.ComponentsEntry
+	nil,                                        // 160: loom.v1.AgentInfo.MetadataEntry
+	nil,                                        // 161: loom.v1.ScheduleWorkflowRequest.MetadataEntry
+	nil,                                        // 162: loom.v1.TriggerScheduledWorkflowRequest.VariablesEntry
+	nil,                                        // 163: loom.v1.MCPServerInfo.EnvEntry
+	nil,                                        // 164: loom.v1.AddMCPServerRequest.EnvEntry
+	nil,                                        // 165: loom.v1.UpdateMCPServerRequest.EnvEntry
+	nil,                                        // 166: loom.v1.HealthCheckMCPServersResponse.ServersEntry
+	nil,                                        // 167: loom.v1.TestMCPServerConnectionRequest.EnvEntry
+	nil,                                        // 168: loom.v1.Artifact.MetadataEntry
+	nil,                                        // 169: loom.v1.CountSessionsByUserResponse.UserCountsEntry
+	(*timestamppb.Timestamp)(nil),              // 170: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                    // 171: google.protobuf.Struct
+	(*structpb.Value)(nil),                     // 172: google.protobuf.Value
+	(*ToolExample)(nil),                        // 173: loom.v1.ToolExample
+	(*RateLimitInfo)(nil),                      // 174: loom.v1.RateLimitInfo
+	(*AgentConfig)(nil),                        // 175: loom.v1.AgentConfig
+	(*WorkflowExecution)(nil),                  // 176: loom.v1.WorkflowExecution
+	(*AgentResult)(nil),                        // 177: loom.v1.AgentResult
+	(*WorkflowPattern)(nil),                    // 178: loom.v1.WorkflowPattern
+	(*ScheduleConfig)(nil),                     // 179: loom.v1.ScheduleConfig
+	(*ScheduledWorkflow)(nil),                  // 180: loom.v1.ScheduledWorkflow
+	(*CertificateInfo)(nil),                    // 181: loom.v1.CertificateInfo
+	(LLMRole)(0),                               // 182: loom.v1.LLMRole
+	(*ProviderEntry)(nil),                      // 183: loom.v1.ProviderEntry
+	(*GetStorageStatusRequest)(nil),            // 184: loom.v1.GetStorageStatusRequest
+	(*RunMigrationRequest)(nil),                // 185: loom.v1.RunMigrationRequest
+	(*ExecuteWorkflowRequest)(nil),             // 186: loom.v1.ExecuteWorkflowRequest
+	(*ListWorkflowsRequest)(nil),               // 187: loom.v1.ListWorkflowsRequest
+	(*PublishRequest)(nil),                     // 188: loom.v1.PublishRequest
+	(*SubscribeRequest)(nil),                   // 189: loom.v1.SubscribeRequest
+	(*UnsubscribeRequest)(nil),                 // 190: loom.v1.UnsubscribeRequest
+	(*ListTopicsRequest)(nil),                  // 191: loom.v1.ListTopicsRequest
+	(*GetTopicStatsRequest)(nil),               // 192: loom.v1.GetTopicStatsRequest
+	(*SendAsyncRequest)(nil),                   // 193: loom.v1.SendAsyncRequest
+	(*SendAndReceiveRequest)(nil),              // 194: loom.v1.SendAndReceiveRequest
+	(*PutSharedMemoryRequest)(nil),             // 195: loom.v1.PutSharedMemoryRequest
+	(*GetSharedMemoryRequest)(nil),             // 196: loom.v1.GetSharedMemoryRequest
+	(*DeleteSharedMemoryRequest)(nil),          // 197: loom.v1.DeleteSharedMemoryRequest
+	(*WatchSharedMemoryRequest)(nil),           // 198: loom.v1.WatchSharedMemoryRequest
+	(*ListSharedMemoryKeysRequest)(nil),        // 199: loom.v1.ListSharedMemoryKeysRequest
+	(*GetSharedMemoryStatsRequest)(nil),        // 200: loom.v1.GetSharedMemoryStatsRequest
+	(*ListUIAppsRequest)(nil),                  // 201: loom.v1.ListUIAppsRequest
+	(*GetUIAppRequest)(nil),                    // 202: loom.v1.GetUIAppRequest
+	(*CreateUIAppRequest)(nil),                 // 203: loom.v1.CreateUIAppRequest
+	(*UpdateUIAppRequest)(nil),                 // 204: loom.v1.UpdateUIAppRequest
+	(*DeleteUIAppRequest)(nil),                 // 205: loom.v1.DeleteUIAppRequest
+	(*ListComponentTypesRequest)(nil),          // 206: loom.v1.ListComponentTypesRequest
+	(*ListAgentPresetsRequest)(nil),            // 207: loom.v1.ListAgentPresetsRequest
+	(*ListWorkflowTemplatesRequest)(nil),       // 208: loom.v1.ListWorkflowTemplatesRequest
+	(*CreateWorkflowFromTemplateRequest)(nil),  // 209: loom.v1.CreateWorkflowFromTemplateRequest
+	(*ServerConfig)(nil),                       // 210: loom.v1.ServerConfig
+	(*TLSStatus)(nil),                          // 211: loom.v1.TLSStatus
+	(*GetStorageStatusResponse)(nil),           // 212: loom.v1.GetStorageStatusResponse
+	(*RunMigrationResponse)(nil),               // 213: loom.v1.RunMigrationResponse
+	(*ExecuteWorkflowResponse)(nil),            // 214: loom.v1.ExecuteWorkflowResponse
+	(*ListWorkflowsResponse)(nil),              // 215: loom.v1.ListWorkflowsResponse
+	(*emptypb.Empty)(nil),                      // 216: google.protobuf.Empty
+	(*PublishResponse)(nil),                    // 217: loom.v1.PublishResponse
+	(*BusMessage)(nil),                         // 218: loom.v1.BusMessage
+	(*UnsubscribeResponse)(nil),                // 219: loom.v1.UnsubscribeResponse
+	(*ListTopicsResponse)(nil),                 // 220: loom.v1.ListTopicsResponse
+	(*TopicStats)(nil),                         // 221: loom.v1.TopicStats
+	(*SendAsyncResponse)(nil),                  // 222: loom.v1.SendAsyncResponse
+	(*SendAndReceiveResponse)(nil),             // 223: loom.v1.SendAndReceiveResponse
+	(*PutSharedMemoryResponse)(nil),            // 224: loom.v1.PutSharedMemoryResponse
+	(*GetSharedMemoryResponse)(nil),            // 225: loom.v1.GetSharedMemoryResponse
+	(*DeleteSharedMemoryResponse)(nil),         // 226: loom.v1.DeleteSharedMemoryResponse
+	(*SharedMemoryValue)(nil),                  // 227: loom.v1.SharedMemoryValue
+	(*ListSharedMemoryKeysResponse)(nil),       // 228: loom.v1.ListSharedMemoryKeysResponse
+	(*SharedMemoryStats)(nil),                  // 229: loom.v1.SharedMemoryStats
+	(*ListUIAppsResponse)(nil),                 // 230: loom.v1.ListUIAppsResponse
+	(*GetUIAppResponse)(nil),                   // 231: loom.v1.GetUIAppResponse
+	(*CreateUIAppResponse)(nil),                // 232: loom.v1.CreateUIAppResponse
+	(*UpdateUIAppResponse)(nil),                // 233: loom.v1.UpdateUIAppResponse
+	(*DeleteUIAppResponse)(nil),                // 234: loom.v1.DeleteUIAppResponse
+	(*ListComponentTypesResponse)(nil),         // 235: loom.v1.ListComponentTypesResponse
+	(*ListAgentPresetsResponse)(nil),           // 236: loom.v1.ListAgentPresetsResponse
+	(*ListWorkflowTemplatesResponse)(nil),      // 237: loom.v1.ListWorkflowTemplatesResponse
+	(*CreateWorkflowFromTemplateResponse)(nil), // 238: loom.v1.CreateWorkflowFromTemplateResponse
 }
 var file_loom_v1_loom_proto_depIdxs = []int32{
-	147, // 0: loom.v1.WeaveRequest.backend_config:type_name -> loom.v1.WeaveRequest.BackendConfigEntry
-	148, // 1: loom.v1.WeaveRequest.context:type_name -> loom.v1.WeaveRequest.ContextEntry
-	168, // 2: loom.v1.WeaveRequest.occurred_at:type_name -> google.protobuf.Timestamp
+	149, // 0: loom.v1.WeaveRequest.backend_config:type_name -> loom.v1.WeaveRequest.BackendConfigEntry
+	150, // 1: loom.v1.WeaveRequest.context:type_name -> loom.v1.WeaveRequest.ContextEntry
+	170, // 2: loom.v1.WeaveRequest.occurred_at:type_name -> google.protobuf.Timestamp
 	8,   // 3: loom.v1.WeaveResponse.result:type_name -> loom.v1.ExecutionResult
 	14,  // 4: loom.v1.WeaveResponse.cost:type_name -> loom.v1.CostInfo
 	17,  // 5: loom.v1.WeaveResponse.metadata:type_name -> loom.v1.ExecutionMetadata
@@ -12081,13 +12204,13 @@ var file_loom_v1_loom_proto_depIdxs = []int32{
 	8,   // 9: loom.v1.WeaveProgress.partial_result:type_name -> loom.v1.ExecutionResult
 	7,   // 10: loom.v1.WeaveProgress.hitl_request:type_name -> loom.v1.HITLRequestInfo
 	14,  // 11: loom.v1.WeaveProgress.cost:type_name -> loom.v1.CostInfo
-	169, // 12: loom.v1.WeaveProgress.tool_input:type_name -> google.protobuf.Struct
-	170, // 13: loom.v1.WeaveProgress.tool_result:type_name -> google.protobuf.Value
+	171, // 12: loom.v1.WeaveProgress.tool_input:type_name -> google.protobuf.Struct
+	172, // 13: loom.v1.WeaveProgress.tool_result:type_name -> google.protobuf.Value
 	16,  // 14: loom.v1.WeaveProgress.context_state:type_name -> loom.v1.ContextState
-	149, // 15: loom.v1.ExecutionResult.backend_metadata:type_name -> loom.v1.ExecutionResult.BackendMetadataEntry
+	151, // 15: loom.v1.ExecutionResult.backend_metadata:type_name -> loom.v1.ExecutionResult.BackendMetadataEntry
 	9,   // 16: loom.v1.ExecutionResult.data_reference:type_name -> loom.v1.DataReference
 	1,   // 17: loom.v1.DataReference.location:type_name -> loom.v1.StorageLocation
-	150, // 18: loom.v1.DataReference.metadata:type_name -> loom.v1.DataReference.MetadataEntry
+	152, // 18: loom.v1.DataReference.metadata:type_name -> loom.v1.DataReference.MetadataEntry
 	11,  // 19: loom.v1.SharedMemoryConfig.disk_overflow:type_name -> loom.v1.DiskOverflowConfig
 	12,  // 20: loom.v1.SharedMemoryConfig.compression:type_name -> loom.v1.CompressionConfig
 	13,  // 21: loom.v1.SharedMemoryConfig.cleanup:type_name -> loom.v1.CleanupConfig
@@ -12097,10 +12220,10 @@ var file_loom_v1_loom_proto_depIdxs = []int32{
 	2,   // 25: loom.v1.PatternUpdateEvent.type:type_name -> loom.v1.PatternUpdateType
 	31,  // 26: loom.v1.Pattern.parameters:type_name -> loom.v1.PatternParameter
 	32,  // 27: loom.v1.Pattern.examples:type_name -> loom.v1.PatternExample
-	151, // 28: loom.v1.Pattern.backend_hints:type_name -> loom.v1.Pattern.BackendHintsEntry
-	152, // 29: loom.v1.CreateSessionRequest.config:type_name -> loom.v1.CreateSessionRequest.ConfigEntry
-	153, // 30: loom.v1.CreateSessionRequest.metadata:type_name -> loom.v1.CreateSessionRequest.MetadataEntry
-	154, // 31: loom.v1.Session.metadata:type_name -> loom.v1.Session.MetadataEntry
+	153, // 28: loom.v1.Pattern.backend_hints:type_name -> loom.v1.Pattern.BackendHintsEntry
+	154, // 29: loom.v1.CreateSessionRequest.config:type_name -> loom.v1.CreateSessionRequest.ConfigEntry
+	155, // 30: loom.v1.CreateSessionRequest.metadata:type_name -> loom.v1.CreateSessionRequest.MetadataEntry
+	156, // 31: loom.v1.Session.metadata:type_name -> loom.v1.Session.MetadataEntry
 	34,  // 32: loom.v1.ListSessionsResponse.sessions:type_name -> loom.v1.Session
 	42,  // 33: loom.v1.SessionUpdate.new_message:type_name -> loom.v1.NewMessageUpdate
 	43,  // 34: loom.v1.SessionUpdate.status_change:type_name -> loom.v1.SessionStatusUpdate
@@ -12113,61 +12236,61 @@ var file_loom_v1_loom_proto_depIdxs = []int32{
 	53,  // 41: loom.v1.ToolDefinition.use_cases:type_name -> loom.v1.ToolUseCase
 	54,  // 42: loom.v1.ToolDefinition.conflicts:type_name -> loom.v1.ToolConflict
 	55,  // 43: loom.v1.ToolDefinition.alternatives:type_name -> loom.v1.ToolAlternative
-	171, // 44: loom.v1.ToolDefinition.examples:type_name -> loom.v1.ToolExample
+	173, // 44: loom.v1.ToolDefinition.examples:type_name -> loom.v1.ToolExample
 	57,  // 45: loom.v1.ToolDefinition.prerequisites:type_name -> loom.v1.ToolPrerequisite
-	172, // 46: loom.v1.ToolDefinition.rate_limit:type_name -> loom.v1.RateLimitInfo
+	174, // 46: loom.v1.ToolDefinition.rate_limit:type_name -> loom.v1.RateLimitInfo
 	58,  // 47: loom.v1.ToolDefinition.common_errors:type_name -> loom.v1.ToolCommonError
 	56,  // 48: loom.v1.ToolDefinition.complements:type_name -> loom.v1.ToolComplement
 	61,  // 49: loom.v1.Trace.root_span:type_name -> loom.v1.Span
 	61,  // 50: loom.v1.Trace.spans:type_name -> loom.v1.Span
 	14,  // 51: loom.v1.Trace.total_cost:type_name -> loom.v1.CostInfo
-	155, // 52: loom.v1.Span.attributes:type_name -> loom.v1.Span.AttributesEntry
+	157, // 52: loom.v1.Span.attributes:type_name -> loom.v1.Span.AttributesEntry
 	62,  // 53: loom.v1.Span.events:type_name -> loom.v1.SpanEvent
-	156, // 54: loom.v1.SpanEvent.attributes:type_name -> loom.v1.SpanEvent.AttributesEntry
-	157, // 55: loom.v1.HealthStatus.components:type_name -> loom.v1.HealthStatus.ComponentsEntry
-	173, // 56: loom.v1.CreateAgentRequest.config:type_name -> loom.v1.AgentConfig
-	158, // 57: loom.v1.AgentInfo.metadata:type_name -> loom.v1.AgentInfo.MetadataEntry
-	173, // 58: loom.v1.AgentInfo.config:type_name -> loom.v1.AgentConfig
+	158, // 54: loom.v1.SpanEvent.attributes:type_name -> loom.v1.SpanEvent.AttributesEntry
+	159, // 55: loom.v1.HealthStatus.components:type_name -> loom.v1.HealthStatus.ComponentsEntry
+	175, // 56: loom.v1.CreateAgentRequest.config:type_name -> loom.v1.AgentConfig
+	160, // 57: loom.v1.AgentInfo.metadata:type_name -> loom.v1.AgentInfo.MetadataEntry
+	175, // 58: loom.v1.AgentInfo.config:type_name -> loom.v1.AgentConfig
 	67,  // 59: loom.v1.ListAgentsResponse.agents:type_name -> loom.v1.AgentInfo
-	173, // 60: loom.v1.ReloadAgentRequest.config:type_name -> loom.v1.AgentConfig
-	174, // 61: loom.v1.ListWorkflowExecutionsResponse.executions:type_name -> loom.v1.WorkflowExecution
-	175, // 62: loom.v1.WorkflowProgress.partial_results:type_name -> loom.v1.AgentResult
-	176, // 63: loom.v1.ScheduleWorkflowRequest.pattern:type_name -> loom.v1.WorkflowPattern
-	177, // 64: loom.v1.ScheduleWorkflowRequest.schedule:type_name -> loom.v1.ScheduleConfig
-	159, // 65: loom.v1.ScheduleWorkflowRequest.metadata:type_name -> loom.v1.ScheduleWorkflowRequest.MetadataEntry
-	178, // 66: loom.v1.ScheduleWorkflowResponse.schedule:type_name -> loom.v1.ScheduledWorkflow
-	176, // 67: loom.v1.UpdateScheduledWorkflowRequest.pattern:type_name -> loom.v1.WorkflowPattern
-	177, // 68: loom.v1.UpdateScheduledWorkflowRequest.schedule:type_name -> loom.v1.ScheduleConfig
-	178, // 69: loom.v1.ListScheduledWorkflowsResponse.schedules:type_name -> loom.v1.ScheduledWorkflow
-	160, // 70: loom.v1.TriggerScheduledWorkflowRequest.variables:type_name -> loom.v1.TriggerScheduledWorkflowRequest.VariablesEntry
-	92,  // 71: loom.v1.GetScheduleHistoryResponse.executions:type_name -> loom.v1.ScheduleExecution
-	179, // 72: loom.v1.RenewCertificateResponse.certificate:type_name -> loom.v1.CertificateInfo
-	180, // 73: loom.v1.SwitchModelRequest.role:type_name -> loom.v1.LLMRole
-	105, // 74: loom.v1.SwitchModelResponse.previous_model:type_name -> loom.v1.ModelInfo
-	105, // 75: loom.v1.SwitchModelResponse.new_model:type_name -> loom.v1.ModelInfo
-	105, // 76: loom.v1.ListAvailableModelsResponse.models:type_name -> loom.v1.ModelInfo
-	181, // 77: loom.v1.ListProvidersResponse.providers:type_name -> loom.v1.ProviderEntry
+	175, // 60: loom.v1.ReloadAgentRequest.config:type_name -> loom.v1.AgentConfig
+	176, // 61: loom.v1.ListWorkflowExecutionsResponse.executions:type_name -> loom.v1.WorkflowExecution
+	177, // 62: loom.v1.WorkflowProgress.partial_results:type_name -> loom.v1.AgentResult
+	178, // 63: loom.v1.ScheduleWorkflowRequest.pattern:type_name -> loom.v1.WorkflowPattern
+	179, // 64: loom.v1.ScheduleWorkflowRequest.schedule:type_name -> loom.v1.ScheduleConfig
+	161, // 65: loom.v1.ScheduleWorkflowRequest.metadata:type_name -> loom.v1.ScheduleWorkflowRequest.MetadataEntry
+	180, // 66: loom.v1.ScheduleWorkflowResponse.schedule:type_name -> loom.v1.ScheduledWorkflow
+	178, // 67: loom.v1.UpdateScheduledWorkflowRequest.pattern:type_name -> loom.v1.WorkflowPattern
+	179, // 68: loom.v1.UpdateScheduledWorkflowRequest.schedule:type_name -> loom.v1.ScheduleConfig
+	180, // 69: loom.v1.ListScheduledWorkflowsResponse.schedules:type_name -> loom.v1.ScheduledWorkflow
+	162, // 70: loom.v1.TriggerScheduledWorkflowRequest.variables:type_name -> loom.v1.TriggerScheduledWorkflowRequest.VariablesEntry
+	94,  // 71: loom.v1.GetScheduleHistoryResponse.executions:type_name -> loom.v1.ScheduleExecution
+	181, // 72: loom.v1.RenewCertificateResponse.certificate:type_name -> loom.v1.CertificateInfo
+	182, // 73: loom.v1.SwitchModelRequest.role:type_name -> loom.v1.LLMRole
+	107, // 74: loom.v1.SwitchModelResponse.previous_model:type_name -> loom.v1.ModelInfo
+	107, // 75: loom.v1.SwitchModelResponse.new_model:type_name -> loom.v1.ModelInfo
+	107, // 76: loom.v1.ListAvailableModelsResponse.models:type_name -> loom.v1.ModelInfo
+	183, // 77: loom.v1.ListProvidersResponse.providers:type_name -> loom.v1.ProviderEntry
 	3,   // 78: loom.v1.ABTestRequest.mode:type_name -> loom.v1.ABTestMode
-	111, // 79: loom.v1.ListMCPServersResponse.servers:type_name -> loom.v1.MCPServerInfo
-	161, // 80: loom.v1.MCPServerInfo.env:type_name -> loom.v1.MCPServerInfo.EnvEntry
-	162, // 81: loom.v1.AddMCPServerRequest.env:type_name -> loom.v1.AddMCPServerRequest.EnvEntry
-	112, // 82: loom.v1.AddMCPServerRequest.tool_filter:type_name -> loom.v1.ToolFilterConfig
-	111, // 83: loom.v1.AddMCPServerResponse.server:type_name -> loom.v1.MCPServerInfo
-	163, // 84: loom.v1.UpdateMCPServerRequest.env:type_name -> loom.v1.UpdateMCPServerRequest.EnvEntry
-	112, // 85: loom.v1.UpdateMCPServerRequest.tool_filter:type_name -> loom.v1.ToolFilterConfig
-	164, // 86: loom.v1.HealthCheckMCPServersResponse.servers:type_name -> loom.v1.HealthCheckMCPServersResponse.ServersEntry
-	165, // 87: loom.v1.TestMCPServerConnectionRequest.env:type_name -> loom.v1.TestMCPServerConnectionRequest.EnvEntry
-	112, // 88: loom.v1.TestMCPServerConnectionRequest.tool_filter:type_name -> loom.v1.ToolFilterConfig
+	113, // 79: loom.v1.ListMCPServersResponse.servers:type_name -> loom.v1.MCPServerInfo
+	163, // 80: loom.v1.MCPServerInfo.env:type_name -> loom.v1.MCPServerInfo.EnvEntry
+	164, // 81: loom.v1.AddMCPServerRequest.env:type_name -> loom.v1.AddMCPServerRequest.EnvEntry
+	114, // 82: loom.v1.AddMCPServerRequest.tool_filter:type_name -> loom.v1.ToolFilterConfig
+	113, // 83: loom.v1.AddMCPServerResponse.server:type_name -> loom.v1.MCPServerInfo
+	165, // 84: loom.v1.UpdateMCPServerRequest.env:type_name -> loom.v1.UpdateMCPServerRequest.EnvEntry
+	114, // 85: loom.v1.UpdateMCPServerRequest.tool_filter:type_name -> loom.v1.ToolFilterConfig
+	166, // 86: loom.v1.HealthCheckMCPServersResponse.servers:type_name -> loom.v1.HealthCheckMCPServersResponse.ServersEntry
+	167, // 87: loom.v1.TestMCPServerConnectionRequest.env:type_name -> loom.v1.TestMCPServerConnectionRequest.EnvEntry
+	114, // 88: loom.v1.TestMCPServerConnectionRequest.tool_filter:type_name -> loom.v1.ToolFilterConfig
 	52,  // 89: loom.v1.ListMCPServerToolsResponse.tools:type_name -> loom.v1.ToolDefinition
-	166, // 90: loom.v1.Artifact.metadata:type_name -> loom.v1.Artifact.MetadataEntry
-	126, // 91: loom.v1.ListArtifactsResponse.artifacts:type_name -> loom.v1.Artifact
-	126, // 92: loom.v1.GetArtifactResponse.artifact:type_name -> loom.v1.Artifact
-	126, // 93: loom.v1.UploadArtifactResponse.artifact:type_name -> loom.v1.Artifact
-	126, // 94: loom.v1.SearchArtifactsResponse.artifacts:type_name -> loom.v1.Artifact
+	168, // 90: loom.v1.Artifact.metadata:type_name -> loom.v1.Artifact.MetadataEntry
+	128, // 91: loom.v1.ListArtifactsResponse.artifacts:type_name -> loom.v1.Artifact
+	128, // 92: loom.v1.GetArtifactResponse.artifact:type_name -> loom.v1.Artifact
+	128, // 93: loom.v1.UploadArtifactResponse.artifact:type_name -> loom.v1.Artifact
+	128, // 94: loom.v1.SearchArtifactsResponse.artifacts:type_name -> loom.v1.Artifact
 	34,  // 95: loom.v1.ListAllSessionsResponse.sessions:type_name -> loom.v1.Session
-	167, // 96: loom.v1.CountSessionsByUserResponse.user_counts:type_name -> loom.v1.CountSessionsByUserResponse.UserCountsEntry
+	169, // 96: loom.v1.CountSessionsByUserResponse.user_counts:type_name -> loom.v1.CountSessionsByUserResponse.UserCountsEntry
 	65,  // 97: loom.v1.HealthStatus.ComponentsEntry.value:type_name -> loom.v1.ComponentHealth
-	121, // 98: loom.v1.HealthCheckMCPServersResponse.ServersEntry.value:type_name -> loom.v1.MCPServerHealth
+	123, // 98: loom.v1.HealthCheckMCPServersResponse.ServersEntry.value:type_name -> loom.v1.MCPServerHealth
 	4,   // 99: loom.v1.LoomService.Weave:input_type -> loom.v1.WeaveRequest
 	4,   // 100: loom.v1.LoomService.StreamWeave:input_type -> loom.v1.WeaveRequest
 	19,  // 101: loom.v1.LoomService.LoadPatterns:input_type -> loom.v1.LoadPatternsRequest
@@ -12186,11 +12309,11 @@ var file_loom_v1_loom_proto_depIdxs = []int32{
 	50,  // 114: loom.v1.LoomService.ListTools:input_type -> loom.v1.ListToolsRequest
 	59,  // 115: loom.v1.LoomService.GetTrace:input_type -> loom.v1.GetTraceRequest
 	63,  // 116: loom.v1.LoomService.GetHealth:input_type -> loom.v1.GetHealthRequest
-	93,  // 117: loom.v1.LoomService.GetServerConfig:input_type -> loom.v1.GetServerConfigRequest
-	94,  // 118: loom.v1.LoomService.GetTLSStatus:input_type -> loom.v1.GetTLSStatusRequest
-	95,  // 119: loom.v1.LoomService.RenewCertificate:input_type -> loom.v1.RenewCertificateRequest
-	182, // 120: loom.v1.LoomService.GetStorageStatus:input_type -> loom.v1.GetStorageStatusRequest
-	183, // 121: loom.v1.LoomService.RunMigration:input_type -> loom.v1.RunMigrationRequest
+	95,  // 117: loom.v1.LoomService.GetServerConfig:input_type -> loom.v1.GetServerConfigRequest
+	96,  // 118: loom.v1.LoomService.GetTLSStatus:input_type -> loom.v1.GetTLSStatusRequest
+	97,  // 119: loom.v1.LoomService.RenewCertificate:input_type -> loom.v1.RenewCertificateRequest
+	184, // 120: loom.v1.LoomService.GetStorageStatus:input_type -> loom.v1.GetStorageStatusRequest
+	185, // 121: loom.v1.LoomService.RunMigration:input_type -> loom.v1.RunMigrationRequest
 	66,  // 122: loom.v1.LoomService.CreateAgentFromConfig:input_type -> loom.v1.CreateAgentRequest
 	68,  // 123: loom.v1.LoomService.ListAgents:input_type -> loom.v1.ListAgentsRequest
 	70,  // 124: loom.v1.LoomService.GetAgent:input_type -> loom.v1.GetAgentRequest
@@ -12198,25 +12321,25 @@ var file_loom_v1_loom_proto_depIdxs = []int32{
 	72,  // 126: loom.v1.LoomService.StopAgent:input_type -> loom.v1.StopAgentRequest
 	73,  // 127: loom.v1.LoomService.DeleteAgent:input_type -> loom.v1.DeleteAgentRequest
 	75,  // 128: loom.v1.LoomService.ReloadAgent:input_type -> loom.v1.ReloadAgentRequest
-	97,  // 129: loom.v1.LoomService.SwitchModel:input_type -> loom.v1.SwitchModelRequest
-	99,  // 130: loom.v1.LoomService.ListAvailableModels:input_type -> loom.v1.ListAvailableModelsRequest
-	101, // 131: loom.v1.LoomService.ListProviders:input_type -> loom.v1.ListProvidersRequest
-	103, // 132: loom.v1.LoomService.ABTest:input_type -> loom.v1.ABTestRequest
-	106, // 133: loom.v1.LoomService.RequestToolPermission:input_type -> loom.v1.ToolPermissionRequest
-	108, // 134: loom.v1.LoomService.ListMCPServers:input_type -> loom.v1.ListMCPServersRequest
-	110, // 135: loom.v1.LoomService.GetMCPServer:input_type -> loom.v1.GetMCPServerRequest
-	113, // 136: loom.v1.LoomService.AddMCPServer:input_type -> loom.v1.AddMCPServerRequest
-	115, // 137: loom.v1.LoomService.UpdateMCPServer:input_type -> loom.v1.UpdateMCPServerRequest
-	116, // 138: loom.v1.LoomService.DeleteMCPServer:input_type -> loom.v1.DeleteMCPServerRequest
-	118, // 139: loom.v1.LoomService.RestartMCPServer:input_type -> loom.v1.RestartMCPServerRequest
-	119, // 140: loom.v1.LoomService.HealthCheckMCPServers:input_type -> loom.v1.HealthCheckMCPServersRequest
-	122, // 141: loom.v1.LoomService.TestMCPServerConnection:input_type -> loom.v1.TestMCPServerConnectionRequest
-	124, // 142: loom.v1.LoomService.ListMCPServerTools:input_type -> loom.v1.ListMCPServerToolsRequest
-	184, // 143: loom.v1.LoomService.ExecuteWorkflow:input_type -> loom.v1.ExecuteWorkflowRequest
-	184, // 144: loom.v1.LoomService.StreamWorkflow:input_type -> loom.v1.ExecuteWorkflowRequest
+	99,  // 129: loom.v1.LoomService.SwitchModel:input_type -> loom.v1.SwitchModelRequest
+	101, // 130: loom.v1.LoomService.ListAvailableModels:input_type -> loom.v1.ListAvailableModelsRequest
+	103, // 131: loom.v1.LoomService.ListProviders:input_type -> loom.v1.ListProvidersRequest
+	105, // 132: loom.v1.LoomService.ABTest:input_type -> loom.v1.ABTestRequest
+	108, // 133: loom.v1.LoomService.RequestToolPermission:input_type -> loom.v1.ToolPermissionRequest
+	110, // 134: loom.v1.LoomService.ListMCPServers:input_type -> loom.v1.ListMCPServersRequest
+	112, // 135: loom.v1.LoomService.GetMCPServer:input_type -> loom.v1.GetMCPServerRequest
+	115, // 136: loom.v1.LoomService.AddMCPServer:input_type -> loom.v1.AddMCPServerRequest
+	117, // 137: loom.v1.LoomService.UpdateMCPServer:input_type -> loom.v1.UpdateMCPServerRequest
+	118, // 138: loom.v1.LoomService.DeleteMCPServer:input_type -> loom.v1.DeleteMCPServerRequest
+	120, // 139: loom.v1.LoomService.RestartMCPServer:input_type -> loom.v1.RestartMCPServerRequest
+	121, // 140: loom.v1.LoomService.HealthCheckMCPServers:input_type -> loom.v1.HealthCheckMCPServersRequest
+	124, // 141: loom.v1.LoomService.TestMCPServerConnection:input_type -> loom.v1.TestMCPServerConnectionRequest
+	126, // 142: loom.v1.LoomService.ListMCPServerTools:input_type -> loom.v1.ListMCPServerToolsRequest
+	186, // 143: loom.v1.LoomService.ExecuteWorkflow:input_type -> loom.v1.ExecuteWorkflowRequest
+	186, // 144: loom.v1.LoomService.StreamWorkflow:input_type -> loom.v1.ExecuteWorkflowRequest
 	76,  // 145: loom.v1.LoomService.GetWorkflowExecution:input_type -> loom.v1.GetWorkflowExecutionRequest
 	77,  // 146: loom.v1.LoomService.ListWorkflowExecutions:input_type -> loom.v1.ListWorkflowExecutionsRequest
-	185, // 147: loom.v1.LoomService.ListWorkflows:input_type -> loom.v1.ListWorkflowsRequest
+	187, // 147: loom.v1.LoomService.ListWorkflows:input_type -> loom.v1.ListWorkflowsRequest
 	80,  // 148: loom.v1.LoomService.ScheduleWorkflow:input_type -> loom.v1.ScheduleWorkflowRequest
 	82,  // 149: loom.v1.LoomService.UpdateScheduledWorkflow:input_type -> loom.v1.UpdateScheduledWorkflowRequest
 	83,  // 150: loom.v1.LoomService.GetScheduledWorkflow:input_type -> loom.v1.GetScheduledWorkflowRequest
@@ -12226,130 +12349,132 @@ var file_loom_v1_loom_proto_depIdxs = []int32{
 	88,  // 154: loom.v1.LoomService.PauseSchedule:input_type -> loom.v1.PauseScheduleRequest
 	89,  // 155: loom.v1.LoomService.ResumeSchedule:input_type -> loom.v1.ResumeScheduleRequest
 	90,  // 156: loom.v1.LoomService.GetScheduleHistory:input_type -> loom.v1.GetScheduleHistoryRequest
-	186, // 157: loom.v1.LoomService.Publish:input_type -> loom.v1.PublishRequest
-	187, // 158: loom.v1.LoomService.Subscribe:input_type -> loom.v1.SubscribeRequest
-	188, // 159: loom.v1.LoomService.Unsubscribe:input_type -> loom.v1.UnsubscribeRequest
-	189, // 160: loom.v1.LoomService.ListTopics:input_type -> loom.v1.ListTopicsRequest
-	190, // 161: loom.v1.LoomService.GetTopicStats:input_type -> loom.v1.GetTopicStatsRequest
-	191, // 162: loom.v1.LoomService.SendAsync:input_type -> loom.v1.SendAsyncRequest
-	192, // 163: loom.v1.LoomService.SendAndReceive:input_type -> loom.v1.SendAndReceiveRequest
-	193, // 164: loom.v1.LoomService.PutSharedMemory:input_type -> loom.v1.PutSharedMemoryRequest
-	194, // 165: loom.v1.LoomService.GetSharedMemory:input_type -> loom.v1.GetSharedMemoryRequest
-	195, // 166: loom.v1.LoomService.DeleteSharedMemory:input_type -> loom.v1.DeleteSharedMemoryRequest
-	196, // 167: loom.v1.LoomService.WatchSharedMemory:input_type -> loom.v1.WatchSharedMemoryRequest
-	197, // 168: loom.v1.LoomService.ListSharedMemoryKeys:input_type -> loom.v1.ListSharedMemoryKeysRequest
-	198, // 169: loom.v1.LoomService.GetSharedMemoryStats:input_type -> loom.v1.GetSharedMemoryStatsRequest
-	127, // 170: loom.v1.LoomService.ListArtifacts:input_type -> loom.v1.ListArtifactsRequest
-	129, // 171: loom.v1.LoomService.GetArtifact:input_type -> loom.v1.GetArtifactRequest
-	131, // 172: loom.v1.LoomService.UploadArtifact:input_type -> loom.v1.UploadArtifactRequest
-	133, // 173: loom.v1.LoomService.DeleteArtifact:input_type -> loom.v1.DeleteArtifactRequest
-	135, // 174: loom.v1.LoomService.SearchArtifacts:input_type -> loom.v1.SearchArtifactsRequest
-	137, // 175: loom.v1.LoomService.GetArtifactContent:input_type -> loom.v1.GetArtifactContentRequest
-	139, // 176: loom.v1.LoomService.GetArtifactStats:input_type -> loom.v1.GetArtifactStatsRequest
-	199, // 177: loom.v1.LoomService.ListUIApps:input_type -> loom.v1.ListUIAppsRequest
-	200, // 178: loom.v1.LoomService.GetUIApp:input_type -> loom.v1.GetUIAppRequest
-	201, // 179: loom.v1.LoomService.CreateUIApp:input_type -> loom.v1.CreateUIAppRequest
-	202, // 180: loom.v1.LoomService.UpdateUIApp:input_type -> loom.v1.UpdateUIAppRequest
-	203, // 181: loom.v1.LoomService.DeleteUIApp:input_type -> loom.v1.DeleteUIAppRequest
-	204, // 182: loom.v1.LoomService.ListComponentTypes:input_type -> loom.v1.ListComponentTypesRequest
-	205, // 183: loom.v1.LoomService.ListAgentPresets:input_type -> loom.v1.ListAgentPresetsRequest
-	206, // 184: loom.v1.LoomService.ListWorkflowTemplates:input_type -> loom.v1.ListWorkflowTemplatesRequest
-	207, // 185: loom.v1.LoomService.CreateWorkflowFromTemplate:input_type -> loom.v1.CreateWorkflowFromTemplateRequest
-	141, // 186: loom.v1.AdminService.ListAllSessions:input_type -> loom.v1.ListAllSessionsRequest
-	143, // 187: loom.v1.AdminService.CountSessionsByUser:input_type -> loom.v1.CountSessionsByUserRequest
-	145, // 188: loom.v1.AdminService.GetSystemStats:input_type -> loom.v1.GetSystemStatsRequest
-	5,   // 189: loom.v1.LoomService.Weave:output_type -> loom.v1.WeaveResponse
-	6,   // 190: loom.v1.LoomService.StreamWeave:output_type -> loom.v1.WeaveProgress
-	20,  // 191: loom.v1.LoomService.LoadPatterns:output_type -> loom.v1.LoadPatternsResponse
-	22,  // 192: loom.v1.LoomService.ListPatterns:output_type -> loom.v1.ListPatternsResponse
-	30,  // 193: loom.v1.LoomService.GetPattern:output_type -> loom.v1.Pattern
-	25,  // 194: loom.v1.LoomService.CreatePattern:output_type -> loom.v1.CreatePatternResponse
-	27,  // 195: loom.v1.LoomService.StreamPatternUpdates:output_type -> loom.v1.PatternUpdateEvent
-	29,  // 196: loom.v1.LoomService.AnswerClarificationQuestion:output_type -> loom.v1.AnswerClarificationResponse
-	34,  // 197: loom.v1.LoomService.CreateSession:output_type -> loom.v1.Session
-	34,  // 198: loom.v1.LoomService.GetSession:output_type -> loom.v1.Session
-	37,  // 199: loom.v1.LoomService.ListSessions:output_type -> loom.v1.ListSessionsResponse
-	39,  // 200: loom.v1.LoomService.DeleteSession:output_type -> loom.v1.DeleteSessionResponse
-	41,  // 201: loom.v1.LoomService.SubscribeToSession:output_type -> loom.v1.SessionUpdate
-	45,  // 202: loom.v1.LoomService.GetConversationHistory:output_type -> loom.v1.ConversationHistory
-	49,  // 203: loom.v1.LoomService.RegisterTool:output_type -> loom.v1.RegisterToolResponse
-	51,  // 204: loom.v1.LoomService.ListTools:output_type -> loom.v1.ListToolsResponse
-	60,  // 205: loom.v1.LoomService.GetTrace:output_type -> loom.v1.Trace
-	64,  // 206: loom.v1.LoomService.GetHealth:output_type -> loom.v1.HealthStatus
-	208, // 207: loom.v1.LoomService.GetServerConfig:output_type -> loom.v1.ServerConfig
-	209, // 208: loom.v1.LoomService.GetTLSStatus:output_type -> loom.v1.TLSStatus
-	96,  // 209: loom.v1.LoomService.RenewCertificate:output_type -> loom.v1.RenewCertificateResponse
-	210, // 210: loom.v1.LoomService.GetStorageStatus:output_type -> loom.v1.GetStorageStatusResponse
-	211, // 211: loom.v1.LoomService.RunMigration:output_type -> loom.v1.RunMigrationResponse
-	67,  // 212: loom.v1.LoomService.CreateAgentFromConfig:output_type -> loom.v1.AgentInfo
-	69,  // 213: loom.v1.LoomService.ListAgents:output_type -> loom.v1.ListAgentsResponse
-	67,  // 214: loom.v1.LoomService.GetAgent:output_type -> loom.v1.AgentInfo
-	67,  // 215: loom.v1.LoomService.StartAgent:output_type -> loom.v1.AgentInfo
-	67,  // 216: loom.v1.LoomService.StopAgent:output_type -> loom.v1.AgentInfo
-	74,  // 217: loom.v1.LoomService.DeleteAgent:output_type -> loom.v1.DeleteAgentResponse
-	67,  // 218: loom.v1.LoomService.ReloadAgent:output_type -> loom.v1.AgentInfo
-	98,  // 219: loom.v1.LoomService.SwitchModel:output_type -> loom.v1.SwitchModelResponse
-	100, // 220: loom.v1.LoomService.ListAvailableModels:output_type -> loom.v1.ListAvailableModelsResponse
-	102, // 221: loom.v1.LoomService.ListProviders:output_type -> loom.v1.ListProvidersResponse
-	104, // 222: loom.v1.LoomService.ABTest:output_type -> loom.v1.ABTestEvent
-	107, // 223: loom.v1.LoomService.RequestToolPermission:output_type -> loom.v1.ToolPermissionResponse
-	109, // 224: loom.v1.LoomService.ListMCPServers:output_type -> loom.v1.ListMCPServersResponse
-	111, // 225: loom.v1.LoomService.GetMCPServer:output_type -> loom.v1.MCPServerInfo
-	114, // 226: loom.v1.LoomService.AddMCPServer:output_type -> loom.v1.AddMCPServerResponse
-	111, // 227: loom.v1.LoomService.UpdateMCPServer:output_type -> loom.v1.MCPServerInfo
-	117, // 228: loom.v1.LoomService.DeleteMCPServer:output_type -> loom.v1.DeleteMCPServerResponse
-	111, // 229: loom.v1.LoomService.RestartMCPServer:output_type -> loom.v1.MCPServerInfo
-	120, // 230: loom.v1.LoomService.HealthCheckMCPServers:output_type -> loom.v1.HealthCheckMCPServersResponse
-	123, // 231: loom.v1.LoomService.TestMCPServerConnection:output_type -> loom.v1.TestMCPServerConnectionResponse
-	125, // 232: loom.v1.LoomService.ListMCPServerTools:output_type -> loom.v1.ListMCPServerToolsResponse
-	212, // 233: loom.v1.LoomService.ExecuteWorkflow:output_type -> loom.v1.ExecuteWorkflowResponse
-	79,  // 234: loom.v1.LoomService.StreamWorkflow:output_type -> loom.v1.WorkflowProgress
-	174, // 235: loom.v1.LoomService.GetWorkflowExecution:output_type -> loom.v1.WorkflowExecution
-	78,  // 236: loom.v1.LoomService.ListWorkflowExecutions:output_type -> loom.v1.ListWorkflowExecutionsResponse
-	213, // 237: loom.v1.LoomService.ListWorkflows:output_type -> loom.v1.ListWorkflowsResponse
-	81,  // 238: loom.v1.LoomService.ScheduleWorkflow:output_type -> loom.v1.ScheduleWorkflowResponse
-	81,  // 239: loom.v1.LoomService.UpdateScheduledWorkflow:output_type -> loom.v1.ScheduleWorkflowResponse
-	178, // 240: loom.v1.LoomService.GetScheduledWorkflow:output_type -> loom.v1.ScheduledWorkflow
-	85,  // 241: loom.v1.LoomService.ListScheduledWorkflows:output_type -> loom.v1.ListScheduledWorkflowsResponse
-	214, // 242: loom.v1.LoomService.DeleteScheduledWorkflow:output_type -> google.protobuf.Empty
-	212, // 243: loom.v1.LoomService.TriggerScheduledWorkflow:output_type -> loom.v1.ExecuteWorkflowResponse
-	214, // 244: loom.v1.LoomService.PauseSchedule:output_type -> google.protobuf.Empty
-	214, // 245: loom.v1.LoomService.ResumeSchedule:output_type -> google.protobuf.Empty
-	91,  // 246: loom.v1.LoomService.GetScheduleHistory:output_type -> loom.v1.GetScheduleHistoryResponse
-	215, // 247: loom.v1.LoomService.Publish:output_type -> loom.v1.PublishResponse
-	216, // 248: loom.v1.LoomService.Subscribe:output_type -> loom.v1.BusMessage
-	217, // 249: loom.v1.LoomService.Unsubscribe:output_type -> loom.v1.UnsubscribeResponse
-	218, // 250: loom.v1.LoomService.ListTopics:output_type -> loom.v1.ListTopicsResponse
-	219, // 251: loom.v1.LoomService.GetTopicStats:output_type -> loom.v1.TopicStats
-	220, // 252: loom.v1.LoomService.SendAsync:output_type -> loom.v1.SendAsyncResponse
-	221, // 253: loom.v1.LoomService.SendAndReceive:output_type -> loom.v1.SendAndReceiveResponse
-	222, // 254: loom.v1.LoomService.PutSharedMemory:output_type -> loom.v1.PutSharedMemoryResponse
-	223, // 255: loom.v1.LoomService.GetSharedMemory:output_type -> loom.v1.GetSharedMemoryResponse
-	224, // 256: loom.v1.LoomService.DeleteSharedMemory:output_type -> loom.v1.DeleteSharedMemoryResponse
-	225, // 257: loom.v1.LoomService.WatchSharedMemory:output_type -> loom.v1.SharedMemoryValue
-	226, // 258: loom.v1.LoomService.ListSharedMemoryKeys:output_type -> loom.v1.ListSharedMemoryKeysResponse
-	227, // 259: loom.v1.LoomService.GetSharedMemoryStats:output_type -> loom.v1.SharedMemoryStats
-	128, // 260: loom.v1.LoomService.ListArtifacts:output_type -> loom.v1.ListArtifactsResponse
-	130, // 261: loom.v1.LoomService.GetArtifact:output_type -> loom.v1.GetArtifactResponse
-	132, // 262: loom.v1.LoomService.UploadArtifact:output_type -> loom.v1.UploadArtifactResponse
-	134, // 263: loom.v1.LoomService.DeleteArtifact:output_type -> loom.v1.DeleteArtifactResponse
-	136, // 264: loom.v1.LoomService.SearchArtifacts:output_type -> loom.v1.SearchArtifactsResponse
-	138, // 265: loom.v1.LoomService.GetArtifactContent:output_type -> loom.v1.GetArtifactContentResponse
-	140, // 266: loom.v1.LoomService.GetArtifactStats:output_type -> loom.v1.GetArtifactStatsResponse
-	228, // 267: loom.v1.LoomService.ListUIApps:output_type -> loom.v1.ListUIAppsResponse
-	229, // 268: loom.v1.LoomService.GetUIApp:output_type -> loom.v1.GetUIAppResponse
-	230, // 269: loom.v1.LoomService.CreateUIApp:output_type -> loom.v1.CreateUIAppResponse
-	231, // 270: loom.v1.LoomService.UpdateUIApp:output_type -> loom.v1.UpdateUIAppResponse
-	232, // 271: loom.v1.LoomService.DeleteUIApp:output_type -> loom.v1.DeleteUIAppResponse
-	233, // 272: loom.v1.LoomService.ListComponentTypes:output_type -> loom.v1.ListComponentTypesResponse
-	234, // 273: loom.v1.LoomService.ListAgentPresets:output_type -> loom.v1.ListAgentPresetsResponse
-	235, // 274: loom.v1.LoomService.ListWorkflowTemplates:output_type -> loom.v1.ListWorkflowTemplatesResponse
-	236, // 275: loom.v1.LoomService.CreateWorkflowFromTemplate:output_type -> loom.v1.CreateWorkflowFromTemplateResponse
-	142, // 276: loom.v1.AdminService.ListAllSessions:output_type -> loom.v1.ListAllSessionsResponse
-	144, // 277: loom.v1.AdminService.CountSessionsByUser:output_type -> loom.v1.CountSessionsByUserResponse
-	146, // 278: loom.v1.AdminService.GetSystemStats:output_type -> loom.v1.GetSystemStatsResponse
-	189, // [189:279] is the sub-list for method output_type
-	99,  // [99:189] is the sub-list for method input_type
+	92,  // 157: loom.v1.LoomService.CancelWorkflowExecution:input_type -> loom.v1.CancelWorkflowExecutionRequest
+	188, // 158: loom.v1.LoomService.Publish:input_type -> loom.v1.PublishRequest
+	189, // 159: loom.v1.LoomService.Subscribe:input_type -> loom.v1.SubscribeRequest
+	190, // 160: loom.v1.LoomService.Unsubscribe:input_type -> loom.v1.UnsubscribeRequest
+	191, // 161: loom.v1.LoomService.ListTopics:input_type -> loom.v1.ListTopicsRequest
+	192, // 162: loom.v1.LoomService.GetTopicStats:input_type -> loom.v1.GetTopicStatsRequest
+	193, // 163: loom.v1.LoomService.SendAsync:input_type -> loom.v1.SendAsyncRequest
+	194, // 164: loom.v1.LoomService.SendAndReceive:input_type -> loom.v1.SendAndReceiveRequest
+	195, // 165: loom.v1.LoomService.PutSharedMemory:input_type -> loom.v1.PutSharedMemoryRequest
+	196, // 166: loom.v1.LoomService.GetSharedMemory:input_type -> loom.v1.GetSharedMemoryRequest
+	197, // 167: loom.v1.LoomService.DeleteSharedMemory:input_type -> loom.v1.DeleteSharedMemoryRequest
+	198, // 168: loom.v1.LoomService.WatchSharedMemory:input_type -> loom.v1.WatchSharedMemoryRequest
+	199, // 169: loom.v1.LoomService.ListSharedMemoryKeys:input_type -> loom.v1.ListSharedMemoryKeysRequest
+	200, // 170: loom.v1.LoomService.GetSharedMemoryStats:input_type -> loom.v1.GetSharedMemoryStatsRequest
+	129, // 171: loom.v1.LoomService.ListArtifacts:input_type -> loom.v1.ListArtifactsRequest
+	131, // 172: loom.v1.LoomService.GetArtifact:input_type -> loom.v1.GetArtifactRequest
+	133, // 173: loom.v1.LoomService.UploadArtifact:input_type -> loom.v1.UploadArtifactRequest
+	135, // 174: loom.v1.LoomService.DeleteArtifact:input_type -> loom.v1.DeleteArtifactRequest
+	137, // 175: loom.v1.LoomService.SearchArtifacts:input_type -> loom.v1.SearchArtifactsRequest
+	139, // 176: loom.v1.LoomService.GetArtifactContent:input_type -> loom.v1.GetArtifactContentRequest
+	141, // 177: loom.v1.LoomService.GetArtifactStats:input_type -> loom.v1.GetArtifactStatsRequest
+	201, // 178: loom.v1.LoomService.ListUIApps:input_type -> loom.v1.ListUIAppsRequest
+	202, // 179: loom.v1.LoomService.GetUIApp:input_type -> loom.v1.GetUIAppRequest
+	203, // 180: loom.v1.LoomService.CreateUIApp:input_type -> loom.v1.CreateUIAppRequest
+	204, // 181: loom.v1.LoomService.UpdateUIApp:input_type -> loom.v1.UpdateUIAppRequest
+	205, // 182: loom.v1.LoomService.DeleteUIApp:input_type -> loom.v1.DeleteUIAppRequest
+	206, // 183: loom.v1.LoomService.ListComponentTypes:input_type -> loom.v1.ListComponentTypesRequest
+	207, // 184: loom.v1.LoomService.ListAgentPresets:input_type -> loom.v1.ListAgentPresetsRequest
+	208, // 185: loom.v1.LoomService.ListWorkflowTemplates:input_type -> loom.v1.ListWorkflowTemplatesRequest
+	209, // 186: loom.v1.LoomService.CreateWorkflowFromTemplate:input_type -> loom.v1.CreateWorkflowFromTemplateRequest
+	143, // 187: loom.v1.AdminService.ListAllSessions:input_type -> loom.v1.ListAllSessionsRequest
+	145, // 188: loom.v1.AdminService.CountSessionsByUser:input_type -> loom.v1.CountSessionsByUserRequest
+	147, // 189: loom.v1.AdminService.GetSystemStats:input_type -> loom.v1.GetSystemStatsRequest
+	5,   // 190: loom.v1.LoomService.Weave:output_type -> loom.v1.WeaveResponse
+	6,   // 191: loom.v1.LoomService.StreamWeave:output_type -> loom.v1.WeaveProgress
+	20,  // 192: loom.v1.LoomService.LoadPatterns:output_type -> loom.v1.LoadPatternsResponse
+	22,  // 193: loom.v1.LoomService.ListPatterns:output_type -> loom.v1.ListPatternsResponse
+	30,  // 194: loom.v1.LoomService.GetPattern:output_type -> loom.v1.Pattern
+	25,  // 195: loom.v1.LoomService.CreatePattern:output_type -> loom.v1.CreatePatternResponse
+	27,  // 196: loom.v1.LoomService.StreamPatternUpdates:output_type -> loom.v1.PatternUpdateEvent
+	29,  // 197: loom.v1.LoomService.AnswerClarificationQuestion:output_type -> loom.v1.AnswerClarificationResponse
+	34,  // 198: loom.v1.LoomService.CreateSession:output_type -> loom.v1.Session
+	34,  // 199: loom.v1.LoomService.GetSession:output_type -> loom.v1.Session
+	37,  // 200: loom.v1.LoomService.ListSessions:output_type -> loom.v1.ListSessionsResponse
+	39,  // 201: loom.v1.LoomService.DeleteSession:output_type -> loom.v1.DeleteSessionResponse
+	41,  // 202: loom.v1.LoomService.SubscribeToSession:output_type -> loom.v1.SessionUpdate
+	45,  // 203: loom.v1.LoomService.GetConversationHistory:output_type -> loom.v1.ConversationHistory
+	49,  // 204: loom.v1.LoomService.RegisterTool:output_type -> loom.v1.RegisterToolResponse
+	51,  // 205: loom.v1.LoomService.ListTools:output_type -> loom.v1.ListToolsResponse
+	60,  // 206: loom.v1.LoomService.GetTrace:output_type -> loom.v1.Trace
+	64,  // 207: loom.v1.LoomService.GetHealth:output_type -> loom.v1.HealthStatus
+	210, // 208: loom.v1.LoomService.GetServerConfig:output_type -> loom.v1.ServerConfig
+	211, // 209: loom.v1.LoomService.GetTLSStatus:output_type -> loom.v1.TLSStatus
+	98,  // 210: loom.v1.LoomService.RenewCertificate:output_type -> loom.v1.RenewCertificateResponse
+	212, // 211: loom.v1.LoomService.GetStorageStatus:output_type -> loom.v1.GetStorageStatusResponse
+	213, // 212: loom.v1.LoomService.RunMigration:output_type -> loom.v1.RunMigrationResponse
+	67,  // 213: loom.v1.LoomService.CreateAgentFromConfig:output_type -> loom.v1.AgentInfo
+	69,  // 214: loom.v1.LoomService.ListAgents:output_type -> loom.v1.ListAgentsResponse
+	67,  // 215: loom.v1.LoomService.GetAgent:output_type -> loom.v1.AgentInfo
+	67,  // 216: loom.v1.LoomService.StartAgent:output_type -> loom.v1.AgentInfo
+	67,  // 217: loom.v1.LoomService.StopAgent:output_type -> loom.v1.AgentInfo
+	74,  // 218: loom.v1.LoomService.DeleteAgent:output_type -> loom.v1.DeleteAgentResponse
+	67,  // 219: loom.v1.LoomService.ReloadAgent:output_type -> loom.v1.AgentInfo
+	100, // 220: loom.v1.LoomService.SwitchModel:output_type -> loom.v1.SwitchModelResponse
+	102, // 221: loom.v1.LoomService.ListAvailableModels:output_type -> loom.v1.ListAvailableModelsResponse
+	104, // 222: loom.v1.LoomService.ListProviders:output_type -> loom.v1.ListProvidersResponse
+	106, // 223: loom.v1.LoomService.ABTest:output_type -> loom.v1.ABTestEvent
+	109, // 224: loom.v1.LoomService.RequestToolPermission:output_type -> loom.v1.ToolPermissionResponse
+	111, // 225: loom.v1.LoomService.ListMCPServers:output_type -> loom.v1.ListMCPServersResponse
+	113, // 226: loom.v1.LoomService.GetMCPServer:output_type -> loom.v1.MCPServerInfo
+	116, // 227: loom.v1.LoomService.AddMCPServer:output_type -> loom.v1.AddMCPServerResponse
+	113, // 228: loom.v1.LoomService.UpdateMCPServer:output_type -> loom.v1.MCPServerInfo
+	119, // 229: loom.v1.LoomService.DeleteMCPServer:output_type -> loom.v1.DeleteMCPServerResponse
+	113, // 230: loom.v1.LoomService.RestartMCPServer:output_type -> loom.v1.MCPServerInfo
+	122, // 231: loom.v1.LoomService.HealthCheckMCPServers:output_type -> loom.v1.HealthCheckMCPServersResponse
+	125, // 232: loom.v1.LoomService.TestMCPServerConnection:output_type -> loom.v1.TestMCPServerConnectionResponse
+	127, // 233: loom.v1.LoomService.ListMCPServerTools:output_type -> loom.v1.ListMCPServerToolsResponse
+	214, // 234: loom.v1.LoomService.ExecuteWorkflow:output_type -> loom.v1.ExecuteWorkflowResponse
+	79,  // 235: loom.v1.LoomService.StreamWorkflow:output_type -> loom.v1.WorkflowProgress
+	176, // 236: loom.v1.LoomService.GetWorkflowExecution:output_type -> loom.v1.WorkflowExecution
+	78,  // 237: loom.v1.LoomService.ListWorkflowExecutions:output_type -> loom.v1.ListWorkflowExecutionsResponse
+	215, // 238: loom.v1.LoomService.ListWorkflows:output_type -> loom.v1.ListWorkflowsResponse
+	81,  // 239: loom.v1.LoomService.ScheduleWorkflow:output_type -> loom.v1.ScheduleWorkflowResponse
+	81,  // 240: loom.v1.LoomService.UpdateScheduledWorkflow:output_type -> loom.v1.ScheduleWorkflowResponse
+	180, // 241: loom.v1.LoomService.GetScheduledWorkflow:output_type -> loom.v1.ScheduledWorkflow
+	85,  // 242: loom.v1.LoomService.ListScheduledWorkflows:output_type -> loom.v1.ListScheduledWorkflowsResponse
+	216, // 243: loom.v1.LoomService.DeleteScheduledWorkflow:output_type -> google.protobuf.Empty
+	214, // 244: loom.v1.LoomService.TriggerScheduledWorkflow:output_type -> loom.v1.ExecuteWorkflowResponse
+	216, // 245: loom.v1.LoomService.PauseSchedule:output_type -> google.protobuf.Empty
+	216, // 246: loom.v1.LoomService.ResumeSchedule:output_type -> google.protobuf.Empty
+	91,  // 247: loom.v1.LoomService.GetScheduleHistory:output_type -> loom.v1.GetScheduleHistoryResponse
+	93,  // 248: loom.v1.LoomService.CancelWorkflowExecution:output_type -> loom.v1.CancelWorkflowExecutionResponse
+	217, // 249: loom.v1.LoomService.Publish:output_type -> loom.v1.PublishResponse
+	218, // 250: loom.v1.LoomService.Subscribe:output_type -> loom.v1.BusMessage
+	219, // 251: loom.v1.LoomService.Unsubscribe:output_type -> loom.v1.UnsubscribeResponse
+	220, // 252: loom.v1.LoomService.ListTopics:output_type -> loom.v1.ListTopicsResponse
+	221, // 253: loom.v1.LoomService.GetTopicStats:output_type -> loom.v1.TopicStats
+	222, // 254: loom.v1.LoomService.SendAsync:output_type -> loom.v1.SendAsyncResponse
+	223, // 255: loom.v1.LoomService.SendAndReceive:output_type -> loom.v1.SendAndReceiveResponse
+	224, // 256: loom.v1.LoomService.PutSharedMemory:output_type -> loom.v1.PutSharedMemoryResponse
+	225, // 257: loom.v1.LoomService.GetSharedMemory:output_type -> loom.v1.GetSharedMemoryResponse
+	226, // 258: loom.v1.LoomService.DeleteSharedMemory:output_type -> loom.v1.DeleteSharedMemoryResponse
+	227, // 259: loom.v1.LoomService.WatchSharedMemory:output_type -> loom.v1.SharedMemoryValue
+	228, // 260: loom.v1.LoomService.ListSharedMemoryKeys:output_type -> loom.v1.ListSharedMemoryKeysResponse
+	229, // 261: loom.v1.LoomService.GetSharedMemoryStats:output_type -> loom.v1.SharedMemoryStats
+	130, // 262: loom.v1.LoomService.ListArtifacts:output_type -> loom.v1.ListArtifactsResponse
+	132, // 263: loom.v1.LoomService.GetArtifact:output_type -> loom.v1.GetArtifactResponse
+	134, // 264: loom.v1.LoomService.UploadArtifact:output_type -> loom.v1.UploadArtifactResponse
+	136, // 265: loom.v1.LoomService.DeleteArtifact:output_type -> loom.v1.DeleteArtifactResponse
+	138, // 266: loom.v1.LoomService.SearchArtifacts:output_type -> loom.v1.SearchArtifactsResponse
+	140, // 267: loom.v1.LoomService.GetArtifactContent:output_type -> loom.v1.GetArtifactContentResponse
+	142, // 268: loom.v1.LoomService.GetArtifactStats:output_type -> loom.v1.GetArtifactStatsResponse
+	230, // 269: loom.v1.LoomService.ListUIApps:output_type -> loom.v1.ListUIAppsResponse
+	231, // 270: loom.v1.LoomService.GetUIApp:output_type -> loom.v1.GetUIAppResponse
+	232, // 271: loom.v1.LoomService.CreateUIApp:output_type -> loom.v1.CreateUIAppResponse
+	233, // 272: loom.v1.LoomService.UpdateUIApp:output_type -> loom.v1.UpdateUIAppResponse
+	234, // 273: loom.v1.LoomService.DeleteUIApp:output_type -> loom.v1.DeleteUIAppResponse
+	235, // 274: loom.v1.LoomService.ListComponentTypes:output_type -> loom.v1.ListComponentTypesResponse
+	236, // 275: loom.v1.LoomService.ListAgentPresets:output_type -> loom.v1.ListAgentPresetsResponse
+	237, // 276: loom.v1.LoomService.ListWorkflowTemplates:output_type -> loom.v1.ListWorkflowTemplatesResponse
+	238, // 277: loom.v1.LoomService.CreateWorkflowFromTemplate:output_type -> loom.v1.CreateWorkflowFromTemplateResponse
+	144, // 278: loom.v1.AdminService.ListAllSessions:output_type -> loom.v1.ListAllSessionsResponse
+	146, // 279: loom.v1.AdminService.CountSessionsByUser:output_type -> loom.v1.CountSessionsByUserResponse
+	148, // 280: loom.v1.AdminService.GetSystemStats:output_type -> loom.v1.GetSystemStatsResponse
+	190, // [190:281] is the sub-list for method output_type
+	99,  // [99:190] is the sub-list for method input_type
 	99,  // [99:99] is the sub-list for extension type_name
 	99,  // [99:99] is the sub-list for extension extendee
 	0,   // [0:99] is the sub-list for field type_name
@@ -12380,7 +12505,7 @@ func file_loom_v1_loom_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_loom_v1_loom_proto_rawDesc), len(file_loom_v1_loom_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   164,
+			NumMessages:   166,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/gen/go/loom/v1/loom.pb.gw.go
+++ b/gen/go/loom/v1/loom.pb.gw.go
@@ -2044,6 +2044,51 @@ func local_request_LoomService_GetScheduleHistory_0(ctx context.Context, marshal
 	return msg, metadata, err
 }
 
+func request_LoomService_CancelWorkflowExecution_0(ctx context.Context, marshaler runtime.Marshaler, client LoomServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CancelWorkflowExecutionRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["execution_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "execution_id")
+	}
+	protoReq.ExecutionId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "execution_id", err)
+	}
+	msg, err := client.CancelWorkflowExecution(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_LoomService_CancelWorkflowExecution_0(ctx context.Context, marshaler runtime.Marshaler, server LoomServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CancelWorkflowExecutionRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["execution_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "execution_id")
+	}
+	protoReq.ExecutionId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "execution_id", err)
+	}
+	msg, err := server.CancelWorkflowExecution(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_LoomService_Publish_0(ctx context.Context, marshaler runtime.Marshaler, client LoomServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq PublishRequest
@@ -4299,6 +4344,26 @@ func RegisterLoomServiceHandlerServer(ctx context.Context, mux *runtime.ServeMux
 		}
 		forward_LoomService_GetScheduleHistory_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_LoomService_CancelWorkflowExecution_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/loom.v1.LoomService/CancelWorkflowExecution", runtime.WithHTTPPathPattern("/v1/workflows/executions/{execution_id}:cancel"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_LoomService_CancelWorkflowExecution_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_LoomService_CancelWorkflowExecution_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_LoomService_Publish_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -5949,6 +6014,23 @@ func RegisterLoomServiceHandlerClient(ctx context.Context, mux *runtime.ServeMux
 		}
 		forward_LoomService_GetScheduleHistory_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_LoomService_CancelWorkflowExecution_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/loom.v1.LoomService/CancelWorkflowExecution", runtime.WithHTTPPathPattern("/v1/workflows/executions/{execution_id}:cancel"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_LoomService_CancelWorkflowExecution_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_LoomService_CancelWorkflowExecution_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_LoomService_Publish_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -6504,6 +6586,7 @@ var (
 	pattern_LoomService_PauseSchedule_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "workflows", "schedules", "schedule_id"}, "pause"))
 	pattern_LoomService_ResumeSchedule_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "workflows", "schedules", "schedule_id"}, "resume"))
 	pattern_LoomService_GetScheduleHistory_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"v1", "workflows", "schedules", "schedule_id", "history"}, ""))
+	pattern_LoomService_CancelWorkflowExecution_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "workflows", "executions", "execution_id"}, "cancel"))
 	pattern_LoomService_Publish_0                     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "bus", "publish"}, ""))
 	pattern_LoomService_Subscribe_0                   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "bus", "subscribe"}, ""))
 	pattern_LoomService_Unsubscribe_0                 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "bus", "unsubscribe"}, ""))
@@ -6594,6 +6677,7 @@ var (
 	forward_LoomService_PauseSchedule_0               = runtime.ForwardResponseMessage
 	forward_LoomService_ResumeSchedule_0              = runtime.ForwardResponseMessage
 	forward_LoomService_GetScheduleHistory_0          = runtime.ForwardResponseMessage
+	forward_LoomService_CancelWorkflowExecution_0     = runtime.ForwardResponseMessage
 	forward_LoomService_Publish_0                     = runtime.ForwardResponseMessage
 	forward_LoomService_Subscribe_0                   = runtime.ForwardResponseStream
 	forward_LoomService_Unsubscribe_0                 = runtime.ForwardResponseMessage

--- a/gen/go/loom/v1/loom.pb.gw.go
+++ b/gen/go/loom/v1/loom.pb.gw.go
@@ -2044,9 +2044,9 @@ func local_request_LoomService_GetScheduleHistory_0(ctx context.Context, marshal
 	return msg, metadata, err
 }
 
-func request_LoomService_CancelWorkflowExecution_0(ctx context.Context, marshaler runtime.Marshaler, client LoomServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func request_LoomService_CancelScheduledExecution_0(ctx context.Context, marshaler runtime.Marshaler, client LoomServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq CancelWorkflowExecutionRequest
+		protoReq CancelScheduledExecutionRequest
 		metadata runtime.ServerMetadata
 		err      error
 	)
@@ -2064,13 +2064,13 @@ func request_LoomService_CancelWorkflowExecution_0(ctx context.Context, marshale
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "execution_id", err)
 	}
-	msg, err := client.CancelWorkflowExecution(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	msg, err := client.CancelScheduledExecution(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
 
-func local_request_LoomService_CancelWorkflowExecution_0(ctx context.Context, marshaler runtime.Marshaler, server LoomServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func local_request_LoomService_CancelScheduledExecution_0(ctx context.Context, marshaler runtime.Marshaler, server LoomServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq CancelWorkflowExecutionRequest
+		protoReq CancelScheduledExecutionRequest
 		metadata runtime.ServerMetadata
 		err      error
 	)
@@ -2085,7 +2085,7 @@ func local_request_LoomService_CancelWorkflowExecution_0(ctx context.Context, ma
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "execution_id", err)
 	}
-	msg, err := server.CancelWorkflowExecution(ctx, &protoReq)
+	msg, err := server.CancelScheduledExecution(ctx, &protoReq)
 	return msg, metadata, err
 }
 
@@ -4344,25 +4344,25 @@ func RegisterLoomServiceHandlerServer(ctx context.Context, mux *runtime.ServeMux
 		}
 		forward_LoomService_GetScheduleHistory_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodPost, pattern_LoomService_CancelWorkflowExecution_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodPost, pattern_LoomService_CancelScheduledExecution_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/loom.v1.LoomService/CancelWorkflowExecution", runtime.WithHTTPPathPattern("/v1/workflows/executions/{execution_id}:cancel"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/loom.v1.LoomService/CancelScheduledExecution", runtime.WithHTTPPathPattern("/v1/workflows/schedules/executions/{execution_id}:cancel"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := local_request_LoomService_CancelWorkflowExecution_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		resp, md, err := local_request_LoomService_CancelScheduledExecution_0(annotatedContext, inboundMarshaler, server, req, pathParams)
 		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_LoomService_CancelWorkflowExecution_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_LoomService_CancelScheduledExecution_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	mux.Handle(http.MethodPost, pattern_LoomService_Publish_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
@@ -6014,22 +6014,22 @@ func RegisterLoomServiceHandlerClient(ctx context.Context, mux *runtime.ServeMux
 		}
 		forward_LoomService_GetScheduleHistory_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodPost, pattern_LoomService_CancelWorkflowExecution_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodPost, pattern_LoomService_CancelScheduledExecution_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/loom.v1.LoomService/CancelWorkflowExecution", runtime.WithHTTPPathPattern("/v1/workflows/executions/{execution_id}:cancel"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/loom.v1.LoomService/CancelScheduledExecution", runtime.WithHTTPPathPattern("/v1/workflows/schedules/executions/{execution_id}:cancel"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := request_LoomService_CancelWorkflowExecution_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		resp, md, err := request_LoomService_CancelScheduledExecution_0(annotatedContext, inboundMarshaler, client, req, pathParams)
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_LoomService_CancelWorkflowExecution_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_LoomService_CancelScheduledExecution_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	mux.Handle(http.MethodPost, pattern_LoomService_Publish_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
@@ -6586,7 +6586,7 @@ var (
 	pattern_LoomService_PauseSchedule_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "workflows", "schedules", "schedule_id"}, "pause"))
 	pattern_LoomService_ResumeSchedule_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "workflows", "schedules", "schedule_id"}, "resume"))
 	pattern_LoomService_GetScheduleHistory_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"v1", "workflows", "schedules", "schedule_id", "history"}, ""))
-	pattern_LoomService_CancelWorkflowExecution_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "workflows", "executions", "execution_id"}, "cancel"))
+	pattern_LoomService_CancelScheduledExecution_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"v1", "workflows", "schedules", "executions", "execution_id"}, "cancel"))
 	pattern_LoomService_Publish_0                     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "bus", "publish"}, ""))
 	pattern_LoomService_Subscribe_0                   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "bus", "subscribe"}, ""))
 	pattern_LoomService_Unsubscribe_0                 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "bus", "unsubscribe"}, ""))
@@ -6677,7 +6677,7 @@ var (
 	forward_LoomService_PauseSchedule_0               = runtime.ForwardResponseMessage
 	forward_LoomService_ResumeSchedule_0              = runtime.ForwardResponseMessage
 	forward_LoomService_GetScheduleHistory_0          = runtime.ForwardResponseMessage
-	forward_LoomService_CancelWorkflowExecution_0     = runtime.ForwardResponseMessage
+	forward_LoomService_CancelScheduledExecution_0    = runtime.ForwardResponseMessage
 	forward_LoomService_Publish_0                     = runtime.ForwardResponseMessage
 	forward_LoomService_Subscribe_0                   = runtime.ForwardResponseStream
 	forward_LoomService_Unsubscribe_0                 = runtime.ForwardResponseMessage

--- a/gen/go/loom/v1/loom_grpc.pb.go
+++ b/gen/go/loom/v1/loom_grpc.pb.go
@@ -92,6 +92,7 @@ const (
 	LoomService_PauseSchedule_FullMethodName               = "/loom.v1.LoomService/PauseSchedule"
 	LoomService_ResumeSchedule_FullMethodName              = "/loom.v1.LoomService/ResumeSchedule"
 	LoomService_GetScheduleHistory_FullMethodName          = "/loom.v1.LoomService/GetScheduleHistory"
+	LoomService_CancelWorkflowExecution_FullMethodName     = "/loom.v1.LoomService/CancelWorkflowExecution"
 	LoomService_Publish_FullMethodName                     = "/loom.v1.LoomService/Publish"
 	LoomService_Subscribe_FullMethodName                   = "/loom.v1.LoomService/Subscribe"
 	LoomService_Unsubscribe_FullMethodName                 = "/loom.v1.LoomService/Unsubscribe"
@@ -256,6 +257,18 @@ type LoomServiceClient interface {
 	ResumeSchedule(ctx context.Context, in *ResumeScheduleRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// GetScheduleHistory retrieves execution history for a schedule.
 	GetScheduleHistory(ctx context.Context, in *GetScheduleHistoryRequest, opts ...grpc.CallOption) (*GetScheduleHistoryResponse, error)
+	// CancelWorkflowExecution stops an execution that is currently running.
+	//
+	// Pausing a schedule prevents future runs but does nothing about one already
+	// in flight, and max_execution_seconds only detects a stuck run after the
+	// fact. This is the operator's stop button: without it a workflow that hangs
+	// holds its schedule's slot until the timeout expires, and skip_if_running
+	// silently skips every run in the meantime.
+	//
+	// Cancellation is cooperative — the execution's context is cancelled and the
+	// run is recorded as cancelled. Work already committed by earlier stages is
+	// not rolled back.
+	CancelWorkflowExecution(ctx context.Context, in *CancelWorkflowExecutionRequest, opts ...grpc.CallOption) (*CancelWorkflowExecutionResponse, error)
 	// Publish publishes a message to a topic (one-to-many broadcast).
 	Publish(ctx context.Context, in *PublishRequest, opts ...grpc.CallOption) (*PublishResponse, error)
 	// Subscribe subscribes to a topic and receives messages via stream.
@@ -952,6 +965,16 @@ func (c *loomServiceClient) GetScheduleHistory(ctx context.Context, in *GetSched
 	return out, nil
 }
 
+func (c *loomServiceClient) CancelWorkflowExecution(ctx context.Context, in *CancelWorkflowExecutionRequest, opts ...grpc.CallOption) (*CancelWorkflowExecutionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CancelWorkflowExecutionResponse)
+	err := c.cc.Invoke(ctx, LoomService_CancelWorkflowExecution_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *loomServiceClient) Publish(ctx context.Context, in *PublishRequest, opts ...grpc.CallOption) (*PublishResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(PublishResponse)
@@ -1393,6 +1416,18 @@ type LoomServiceServer interface {
 	ResumeSchedule(context.Context, *ResumeScheduleRequest) (*emptypb.Empty, error)
 	// GetScheduleHistory retrieves execution history for a schedule.
 	GetScheduleHistory(context.Context, *GetScheduleHistoryRequest) (*GetScheduleHistoryResponse, error)
+	// CancelWorkflowExecution stops an execution that is currently running.
+	//
+	// Pausing a schedule prevents future runs but does nothing about one already
+	// in flight, and max_execution_seconds only detects a stuck run after the
+	// fact. This is the operator's stop button: without it a workflow that hangs
+	// holds its schedule's slot until the timeout expires, and skip_if_running
+	// silently skips every run in the meantime.
+	//
+	// Cancellation is cooperative — the execution's context is cancelled and the
+	// run is recorded as cancelled. Work already committed by earlier stages is
+	// not rolled back.
+	CancelWorkflowExecution(context.Context, *CancelWorkflowExecutionRequest) (*CancelWorkflowExecutionResponse, error)
 	// Publish publishes a message to a topic (one-to-many broadcast).
 	Publish(context.Context, *PublishRequest) (*PublishResponse, error)
 	// Subscribe subscribes to a topic and receives messages via stream.
@@ -1637,6 +1672,9 @@ func (UnimplementedLoomServiceServer) ResumeSchedule(context.Context, *ResumeSch
 }
 func (UnimplementedLoomServiceServer) GetScheduleHistory(context.Context, *GetScheduleHistoryRequest) (*GetScheduleHistoryResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetScheduleHistory not implemented")
+}
+func (UnimplementedLoomServiceServer) CancelWorkflowExecution(context.Context, *CancelWorkflowExecutionRequest) (*CancelWorkflowExecutionResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CancelWorkflowExecution not implemented")
 }
 func (UnimplementedLoomServiceServer) Publish(context.Context, *PublishRequest) (*PublishResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Publish not implemented")
@@ -2755,6 +2793,24 @@ func _LoomService_GetScheduleHistory_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _LoomService_CancelWorkflowExecution_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CancelWorkflowExecutionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LoomServiceServer).CancelWorkflowExecution(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: LoomService_CancelWorkflowExecution_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LoomServiceServer).CancelWorkflowExecution(ctx, req.(*CancelWorkflowExecutionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _LoomService_Publish_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(PublishRequest)
 	if err := dec(in); err != nil {
@@ -3481,6 +3537,10 @@ var LoomService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetScheduleHistory",
 			Handler:    _LoomService_GetScheduleHistory_Handler,
+		},
+		{
+			MethodName: "CancelWorkflowExecution",
+			Handler:    _LoomService_CancelWorkflowExecution_Handler,
 		},
 		{
 			MethodName: "Publish",

--- a/gen/go/loom/v1/loom_grpc.pb.go
+++ b/gen/go/loom/v1/loom_grpc.pb.go
@@ -92,7 +92,7 @@ const (
 	LoomService_PauseSchedule_FullMethodName               = "/loom.v1.LoomService/PauseSchedule"
 	LoomService_ResumeSchedule_FullMethodName              = "/loom.v1.LoomService/ResumeSchedule"
 	LoomService_GetScheduleHistory_FullMethodName          = "/loom.v1.LoomService/GetScheduleHistory"
-	LoomService_CancelWorkflowExecution_FullMethodName     = "/loom.v1.LoomService/CancelWorkflowExecution"
+	LoomService_CancelScheduledExecution_FullMethodName    = "/loom.v1.LoomService/CancelScheduledExecution"
 	LoomService_Publish_FullMethodName                     = "/loom.v1.LoomService/Publish"
 	LoomService_Subscribe_FullMethodName                   = "/loom.v1.LoomService/Subscribe"
 	LoomService_Unsubscribe_FullMethodName                 = "/loom.v1.LoomService/Unsubscribe"
@@ -257,7 +257,7 @@ type LoomServiceClient interface {
 	ResumeSchedule(ctx context.Context, in *ResumeScheduleRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// GetScheduleHistory retrieves execution history for a schedule.
 	GetScheduleHistory(ctx context.Context, in *GetScheduleHistoryRequest, opts ...grpc.CallOption) (*GetScheduleHistoryResponse, error)
-	// CancelWorkflowExecution stops an execution that is currently running.
+	// CancelScheduledExecution stops a scheduled execution that is in flight.
 	//
 	// Pausing a schedule prevents future runs but does nothing about one already
 	// in flight, and max_execution_seconds only detects a stuck run after the
@@ -265,10 +265,31 @@ type LoomServiceClient interface {
 	// holds its schedule's slot until the timeout expires, and skip_if_running
 	// silently skips every run in the meantime.
 	//
-	// Cancellation is cooperative — the execution's context is cancelled and the
-	// run is recorded as cancelled. Work already committed by earlier stages is
-	// not rolled back.
-	CancelWorkflowExecution(ctx context.Context, in *CancelWorkflowExecutionRequest, opts ...grpc.CallOption) (*CancelWorkflowExecutionResponse, error)
+	// Scope: this cancels executions minted by the scheduler — the IDs reported
+	// in ScheduledWorkflow.current_execution_id and in the response to
+	// TriggerScheduledWorkflow. Execution IDs from ExecuteWorkflow and
+	// StreamWorkflow live in a different namespace (the one GetWorkflowExecution
+	// and ListWorkflowExecutions read) and cannot be canceled here; passing one
+	// returns NOT_FOUND.
+	//
+	// NOT_FOUND means no scheduled execution with that ID exists, neither in
+	// flight nor in the schedule's history. A response with canceled = false and
+	// a message means the execution was found but had already reached its verdict
+	// before the request arrived; that is deliberately not an error, because a
+	// caller stopping a run that just finished got the state it asked for.
+	//
+	// Cancellation is cooperative — the execution's context is canceled and the
+	// run is recorded as canceled once it unwinds. Work already committed by
+	// earlier stages is not rolled back.
+	//
+	// Authorization: like the sibling schedule RPCs (PauseSchedule,
+	// ResumeSchedule, DeleteScheduledWorkflow, TriggerScheduledWorkflow), this
+	// performs no ownership check — the scheduled_workflows table has no owner
+	// column, so there is nothing to check against. Any caller that reaches the
+	// service can stop any scheduled execution. Adding ownership is a follow-up
+	// for the whole schedule surface rather than something this one RPC can
+	// solve; it is recorded here so the gap is not mistaken for an oversight.
+	CancelScheduledExecution(ctx context.Context, in *CancelScheduledExecutionRequest, opts ...grpc.CallOption) (*CancelScheduledExecutionResponse, error)
 	// Publish publishes a message to a topic (one-to-many broadcast).
 	Publish(ctx context.Context, in *PublishRequest, opts ...grpc.CallOption) (*PublishResponse, error)
 	// Subscribe subscribes to a topic and receives messages via stream.
@@ -965,10 +986,10 @@ func (c *loomServiceClient) GetScheduleHistory(ctx context.Context, in *GetSched
 	return out, nil
 }
 
-func (c *loomServiceClient) CancelWorkflowExecution(ctx context.Context, in *CancelWorkflowExecutionRequest, opts ...grpc.CallOption) (*CancelWorkflowExecutionResponse, error) {
+func (c *loomServiceClient) CancelScheduledExecution(ctx context.Context, in *CancelScheduledExecutionRequest, opts ...grpc.CallOption) (*CancelScheduledExecutionResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(CancelWorkflowExecutionResponse)
-	err := c.cc.Invoke(ctx, LoomService_CancelWorkflowExecution_FullMethodName, in, out, cOpts...)
+	out := new(CancelScheduledExecutionResponse)
+	err := c.cc.Invoke(ctx, LoomService_CancelScheduledExecution_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1416,7 +1437,7 @@ type LoomServiceServer interface {
 	ResumeSchedule(context.Context, *ResumeScheduleRequest) (*emptypb.Empty, error)
 	// GetScheduleHistory retrieves execution history for a schedule.
 	GetScheduleHistory(context.Context, *GetScheduleHistoryRequest) (*GetScheduleHistoryResponse, error)
-	// CancelWorkflowExecution stops an execution that is currently running.
+	// CancelScheduledExecution stops a scheduled execution that is in flight.
 	//
 	// Pausing a schedule prevents future runs but does nothing about one already
 	// in flight, and max_execution_seconds only detects a stuck run after the
@@ -1424,10 +1445,31 @@ type LoomServiceServer interface {
 	// holds its schedule's slot until the timeout expires, and skip_if_running
 	// silently skips every run in the meantime.
 	//
-	// Cancellation is cooperative — the execution's context is cancelled and the
-	// run is recorded as cancelled. Work already committed by earlier stages is
-	// not rolled back.
-	CancelWorkflowExecution(context.Context, *CancelWorkflowExecutionRequest) (*CancelWorkflowExecutionResponse, error)
+	// Scope: this cancels executions minted by the scheduler — the IDs reported
+	// in ScheduledWorkflow.current_execution_id and in the response to
+	// TriggerScheduledWorkflow. Execution IDs from ExecuteWorkflow and
+	// StreamWorkflow live in a different namespace (the one GetWorkflowExecution
+	// and ListWorkflowExecutions read) and cannot be canceled here; passing one
+	// returns NOT_FOUND.
+	//
+	// NOT_FOUND means no scheduled execution with that ID exists, neither in
+	// flight nor in the schedule's history. A response with canceled = false and
+	// a message means the execution was found but had already reached its verdict
+	// before the request arrived; that is deliberately not an error, because a
+	// caller stopping a run that just finished got the state it asked for.
+	//
+	// Cancellation is cooperative — the execution's context is canceled and the
+	// run is recorded as canceled once it unwinds. Work already committed by
+	// earlier stages is not rolled back.
+	//
+	// Authorization: like the sibling schedule RPCs (PauseSchedule,
+	// ResumeSchedule, DeleteScheduledWorkflow, TriggerScheduledWorkflow), this
+	// performs no ownership check — the scheduled_workflows table has no owner
+	// column, so there is nothing to check against. Any caller that reaches the
+	// service can stop any scheduled execution. Adding ownership is a follow-up
+	// for the whole schedule surface rather than something this one RPC can
+	// solve; it is recorded here so the gap is not mistaken for an oversight.
+	CancelScheduledExecution(context.Context, *CancelScheduledExecutionRequest) (*CancelScheduledExecutionResponse, error)
 	// Publish publishes a message to a topic (one-to-many broadcast).
 	Publish(context.Context, *PublishRequest) (*PublishResponse, error)
 	// Subscribe subscribes to a topic and receives messages via stream.
@@ -1673,8 +1715,8 @@ func (UnimplementedLoomServiceServer) ResumeSchedule(context.Context, *ResumeSch
 func (UnimplementedLoomServiceServer) GetScheduleHistory(context.Context, *GetScheduleHistoryRequest) (*GetScheduleHistoryResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetScheduleHistory not implemented")
 }
-func (UnimplementedLoomServiceServer) CancelWorkflowExecution(context.Context, *CancelWorkflowExecutionRequest) (*CancelWorkflowExecutionResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method CancelWorkflowExecution not implemented")
+func (UnimplementedLoomServiceServer) CancelScheduledExecution(context.Context, *CancelScheduledExecutionRequest) (*CancelScheduledExecutionResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CancelScheduledExecution not implemented")
 }
 func (UnimplementedLoomServiceServer) Publish(context.Context, *PublishRequest) (*PublishResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Publish not implemented")
@@ -2793,20 +2835,20 @@ func _LoomService_GetScheduleHistory_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
-func _LoomService_CancelWorkflowExecution_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CancelWorkflowExecutionRequest)
+func _LoomService_CancelScheduledExecution_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CancelScheduledExecutionRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(LoomServiceServer).CancelWorkflowExecution(ctx, in)
+		return srv.(LoomServiceServer).CancelScheduledExecution(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: LoomService_CancelWorkflowExecution_FullMethodName,
+		FullMethod: LoomService_CancelScheduledExecution_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(LoomServiceServer).CancelWorkflowExecution(ctx, req.(*CancelWorkflowExecutionRequest))
+		return srv.(LoomServiceServer).CancelScheduledExecution(ctx, req.(*CancelScheduledExecutionRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -3539,8 +3581,8 @@ var LoomService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _LoomService_GetScheduleHistory_Handler,
 		},
 		{
-			MethodName: "CancelWorkflowExecution",
-			Handler:    _LoomService_CancelWorkflowExecution_Handler,
+			MethodName: "CancelScheduledExecution",
+			Handler:    _LoomService_CancelScheduledExecution_Handler,
 		},
 		{
 			MethodName: "Publish",

--- a/gen/go/loom/v1/orchestration.pb.go
+++ b/gen/go/loom/v1/orchestration.pb.go
@@ -3490,7 +3490,7 @@ type ScheduleStats struct {
 	FailedExecutions int32 `protobuf:"varint,3,opt,name=failed_executions,json=failedExecutions,proto3" json:"failed_executions,omitempty"`
 	// Number of skipped executions (due to previous run still active)
 	SkippedExecutions int32 `protobuf:"varint,4,opt,name=skipped_executions,json=skippedExecutions,proto3" json:"skipped_executions,omitempty"`
-	// Last execution status: "success", "failed", "skipped"
+	// Last execution status: "success", "failed", "skipped", "canceled"
 	LastStatus string `protobuf:"bytes,5,opt,name=last_status,json=lastStatus,proto3" json:"last_status,omitempty"`
 	// Last error message (if failed)
 	LastError     string `protobuf:"bytes,6,opt,name=last_error,json=lastError,proto3" json:"last_error,omitempty"`

--- a/gen/openapiv2/loom/v1/loom.swagger.json
+++ b/gen/openapiv2/loom/v1/loom.swagger.json
@@ -2927,47 +2927,6 @@
         ]
       }
     },
-    "/v1/workflows/executions/{executionId}:cancel": {
-      "post": {
-        "summary": "CancelWorkflowExecution stops an execution that is currently running.",
-        "description": "Pausing a schedule prevents future runs but does nothing about one already\nin flight, and max_execution_seconds only detects a stuck run after the\nfact. This is the operator's stop button: without it a workflow that hangs\nholds its schedule's slot until the timeout expires, and skip_if_running\nsilently skips every run in the meantime.\n\nCancellation is cooperative — the execution's context is cancelled and the\nrun is recorded as cancelled. Work already committed by earlier stages is\nnot rolled back.",
-        "operationId": "LoomService_CancelWorkflowExecution",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1CancelWorkflowExecutionResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "executionId",
-            "description": "Execution ID to cancel, as reported by ScheduledWorkflow.current_execution_id\nor by the response to TriggerScheduledWorkflow.",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/LoomServiceCancelWorkflowExecutionBody"
-            }
-          }
-        ],
-        "tags": [
-          "LoomService"
-        ]
-      }
-    },
     "/v1/workflows/schedules": {
       "get": {
         "summary": "ListScheduledWorkflows lists all scheduled workflows.",
@@ -3039,6 +2998,47 @@
             "required": true,
             "schema": {
               "$ref": "#/definitions/v1ScheduleWorkflowRequest"
+            }
+          }
+        ],
+        "tags": [
+          "LoomService"
+        ]
+      }
+    },
+    "/v1/workflows/schedules/executions/{executionId}:cancel": {
+      "post": {
+        "summary": "CancelScheduledExecution stops a scheduled execution that is in flight.",
+        "description": "Pausing a schedule prevents future runs but does nothing about one already\nin flight, and max_execution_seconds only detects a stuck run after the\nfact. This is the operator's stop button: without it a workflow that hangs\nholds its schedule's slot until the timeout expires, and skip_if_running\nsilently skips every run in the meantime.\n\nScope: this cancels executions minted by the scheduler — the IDs reported\nin ScheduledWorkflow.current_execution_id and in the response to\nTriggerScheduledWorkflow. Execution IDs from ExecuteWorkflow and\nStreamWorkflow live in a different namespace (the one GetWorkflowExecution\nand ListWorkflowExecutions read) and cannot be canceled here; passing one\nreturns NOT_FOUND.\n\nNOT_FOUND means no scheduled execution with that ID exists, neither in\nflight nor in the schedule's history. A response with canceled = false and\na message means the execution was found but had already reached its verdict\nbefore the request arrived; that is deliberately not an error, because a\ncaller stopping a run that just finished got the state it asked for.\n\nCancellation is cooperative — the execution's context is canceled and the\nrun is recorded as canceled once it unwinds. Work already committed by\nearlier stages is not rolled back.\n\nAuthorization: like the sibling schedule RPCs (PauseSchedule,\nResumeSchedule, DeleteScheduledWorkflow, TriggerScheduledWorkflow), this\nperforms no ownership check — the scheduled_workflows table has no owner\ncolumn, so there is nothing to check against. Any caller that reaches the\nservice can stop any scheduled execution. Adding ownership is a follow-up\nfor the whole schedule surface rather than something this one RPC can\nsolve; it is recorded here so the gap is not mistaken for an oversight.",
+        "operationId": "LoomService_CancelScheduledExecution",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1CancelScheduledExecutionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "executionId",
+            "description": "Execution ID to cancel, as reported by ScheduledWorkflow.current_execution_id\nor by the response to TriggerScheduledWorkflow. An ID that names no\nscheduled execution — in flight or in history — returns NOT_FOUND.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LoomServiceCancelScheduledExecutionBody"
             }
           }
         ],
@@ -3407,7 +3407,7 @@
       },
       "description": "AnswerClarificationRequest provides an answer to a clarification question."
     },
-    "LoomServiceCancelWorkflowExecutionBody": {
+    "LoomServiceCancelScheduledExecutionBody": {
       "type": "object",
       "properties": {
         "reason": {
@@ -3415,7 +3415,7 @@
           "description": "Optional human-readable reason, recorded in the execution history so the\nrecord distinguishes an operator stop from a crash."
         }
       },
-      "description": "CancelWorkflowExecutionRequest stops a running execution."
+      "description": "CancelScheduledExecutionRequest stops a scheduled execution that is in\nflight.\n\nThe ID must be one the scheduler minted. IDs returned by ExecuteWorkflow and\nStreamWorkflow belong to a different namespace and yield NOT_FOUND."
     },
     "LoomServicePauseScheduleBody": {
       "type": "object",
@@ -4401,19 +4401,19 @@
       },
       "description": "BusMessage is the envelope for pub/sub messages broadcast to topic subscribers.\nUnlike point-to-point CommunicationMessage, BusMessage is one-to-many."
     },
-    "v1CancelWorkflowExecutionResponse": {
+    "v1CancelScheduledExecutionResponse": {
       "type": "object",
       "properties": {
-        "cancelled": {
+        "canceled": {
           "type": "boolean",
-          "description": "True when a running execution was found and signalled. False means the\nexecution was already finished or was never running — not an error, since\na user cancelling a run that just completed has got what they wanted."
+          "description": "True when the execution was in flight and its context was canceled; the\nrun is recorded as canceled once it unwinds. False means the execution had\nalready reached its verdict before the request arrived, so nothing was\nsignaled and the recorded outcome stands — not an error, since a caller\nstopping a run that just completed got the state it asked for.\n\nCancellation is cooperative: true says the signal was delivered, not that\nthe run has stopped yet, and work already committed is not rolled back."
         },
         "message": {
           "type": "string",
-          "description": "Human-readable outcome, suitable for showing directly."
+          "description": "Human-readable outcome, suitable for showing directly. It is the only thing\nthat distinguishes \"signaled\" from \"already finished\" beyond the boolean."
         }
       },
-      "description": "CancelWorkflowExecutionResponse reports what the cancellation did."
+      "description": "CancelScheduledExecutionResponse reports what the cancellation did.\n\nReaching this message at all means the execution exists in the scheduler's\nnamespace; an unknown ID is a NOT_FOUND error instead."
     },
     "v1CertificateInfo": {
       "type": "object",
@@ -7953,7 +7953,7 @@
         },
         "status": {
           "type": "string",
-          "title": "Status: \"success\", \"failed\", \"skipped\""
+          "description": "Status: \"success\", \"failed\", \"skipped\", \"canceled\"\nThe US spelling matches WorkflowStatus \"canceled\" in the workflow-execution\nnamespace, so both surfaces report the same word for the same outcome."
         },
         "error": {
           "type": "string",
@@ -7996,7 +7996,7 @@
         },
         "lastStatus": {
           "type": "string",
-          "title": "Last execution status: \"success\", \"failed\", \"skipped\""
+          "title": "Last execution status: \"success\", \"failed\", \"skipped\", \"canceled\""
         },
         "lastError": {
           "type": "string",

--- a/gen/openapiv2/loom/v1/loom.swagger.json
+++ b/gen/openapiv2/loom/v1/loom.swagger.json
@@ -2927,6 +2927,47 @@
         ]
       }
     },
+    "/v1/workflows/executions/{executionId}:cancel": {
+      "post": {
+        "summary": "CancelWorkflowExecution stops an execution that is currently running.",
+        "description": "Pausing a schedule prevents future runs but does nothing about one already\nin flight, and max_execution_seconds only detects a stuck run after the\nfact. This is the operator's stop button: without it a workflow that hangs\nholds its schedule's slot until the timeout expires, and skip_if_running\nsilently skips every run in the meantime.\n\nCancellation is cooperative — the execution's context is cancelled and the\nrun is recorded as cancelled. Work already committed by earlier stages is\nnot rolled back.",
+        "operationId": "LoomService_CancelWorkflowExecution",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1CancelWorkflowExecutionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "executionId",
+            "description": "Execution ID to cancel, as reported by ScheduledWorkflow.current_execution_id\nor by the response to TriggerScheduledWorkflow.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LoomServiceCancelWorkflowExecutionBody"
+            }
+          }
+        ],
+        "tags": [
+          "LoomService"
+        ]
+      }
+    },
     "/v1/workflows/schedules": {
       "get": {
         "summary": "ListScheduledWorkflows lists all scheduled workflows.",
@@ -3365,6 +3406,16 @@
         }
       },
       "description": "AnswerClarificationRequest provides an answer to a clarification question."
+    },
+    "LoomServiceCancelWorkflowExecutionBody": {
+      "type": "object",
+      "properties": {
+        "reason": {
+          "type": "string",
+          "description": "Optional human-readable reason, recorded in the execution history so the\nrecord distinguishes an operator stop from a crash."
+        }
+      },
+      "description": "CancelWorkflowExecutionRequest stops a running execution."
     },
     "LoomServicePauseScheduleBody": {
       "type": "object",
@@ -4349,6 +4400,20 @@
         }
       },
       "description": "BusMessage is the envelope for pub/sub messages broadcast to topic subscribers.\nUnlike point-to-point CommunicationMessage, BusMessage is one-to-many."
+    },
+    "v1CancelWorkflowExecutionResponse": {
+      "type": "object",
+      "properties": {
+        "cancelled": {
+          "type": "boolean",
+          "description": "True when a running execution was found and signalled. False means the\nexecution was already finished or was never running — not an error, since\na user cancelling a run that just completed has got what they wanted."
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable outcome, suitable for showing directly."
+        }
+      },
+      "description": "CancelWorkflowExecutionResponse reports what the cancellation did."
     },
     "v1CertificateInfo": {
       "type": "object",

--- a/pkg/orchestration/fork_join_executor.go
+++ b/pkg/orchestration/fork_join_executor.go
@@ -7,6 +7,7 @@ package orchestration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -199,20 +200,20 @@ func (e *ForkJoinExecutor) executeFork(ctx context.Context, workflowID string) (
 	}
 
 	// Check for errors
-	errors := make([]error, 0)
+	errs := make([]error, 0)
 	for err := range errorsChan {
-		errors = append(errors, err)
+		errs = append(errs, err)
 	}
 
 	// If all agents failed, return error
-	if len(errors) == len(e.pattern.AgentIds) {
-		return nil, nil, fmt.Errorf("all agents failed: %v", errors)
+	if len(errs) == len(e.pattern.AgentIds) {
+		return nil, nil, fmt.Errorf("all agents failed: %w", errors.Join(errs...))
 	}
 
 	// Log partial failures
-	if len(errors) > 0 {
+	if len(errs) > 0 {
 		e.orchestrator.logger.Warn("Some agents failed in fork-join",
-			zap.Int("failed_count", len(errors)),
+			zap.Int("failed_count", len(errs)),
 			zap.Int("total_count", len(e.pattern.AgentIds)))
 	}
 

--- a/pkg/orchestration/fork_join_executor.go
+++ b/pkg/orchestration/fork_join_executor.go
@@ -58,6 +58,10 @@ func (e *ForkJoinExecutor) Execute(ctx context.Context) (*loomv1.WorkflowResult,
 		zap.String("prompt", truncateForLog(e.pattern.Prompt, 100)),
 		zap.Int("agents", len(e.pattern.AgentIds)))
 
+	if len(e.pattern.AgentIds) == 0 {
+		return nil, fmt.Errorf("fork-join has no agents")
+	}
+
 	// Validate agents exist
 	for _, agentID := range e.pattern.AgentIds {
 		if _, err := e.orchestrator.GetAgent(ctx, agentID); err != nil {

--- a/pkg/orchestration/orchestration_test.go
+++ b/pkg/orchestration/orchestration_test.go
@@ -257,6 +257,19 @@ func TestForkJoinPattern(t *testing.T) {
 			timeout:       30,
 			wantErr:       false,
 		},
+		{
+			// A schedule can be created with agent_ids: [] (validateSchedule
+			// doesn't reject it), and executeFork's own "all agents failed"
+			// guard is len(errs) == len(AgentIds), which is 0 == 0 for this
+			// case — errors.Join() with zero args returns nil, producing a
+			// literal "%!w(<nil>)" in the recorded error instead of a real
+			// message. This must be rejected before executeFork ever runs.
+			name:          "no agents is rejected up front",
+			prompt:        "Analyze this code",
+			numAgents:     0,
+			mergeStrategy: loomv1.MergeStrategy_CONCATENATE,
+			wantErr:       true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -386,6 +399,28 @@ func TestParallelPattern(t *testing.T) {
 	for _, agentResult := range result.AgentResults {
 		assert.Contains(t, agentResult.Metadata, "task_index")
 	}
+}
+
+// TestParallelPatternNoTasksIsRejectedUpFront is the parallel twin of the
+// fork-join "no agents" case: a schedule can be created with tasks: []
+// (validateSchedule doesn't reject it), and executeParallel's own "all tasks
+// failed" guard is len(errs) == len(Tasks), which is 0 == 0 here —
+// errors.Join() with zero args returns nil, producing a literal
+// "%!w(<nil>)" in the recorded error instead of a real message. This must be
+// rejected before executeParallel ever runs.
+func TestParallelPatternNoTasksIsRejectedUpFront(t *testing.T) {
+	orchestrator := NewOrchestrator(Config{
+		Logger:      zaptest.NewLogger(t),
+		Tracer:      observability.NewNoOpTracer(),
+		LLMProvider: newMockLLMProvider("Combined summary"),
+	})
+
+	_, err := orchestrator.
+		Parallel().
+		WithMergeStrategy(loomv1.MergeStrategy_SUMMARY).
+		Execute(context.Background())
+
+	require.Error(t, err)
 }
 
 // TestConditionalPattern tests the conditional orchestration pattern.

--- a/pkg/orchestration/orchestration_test.go
+++ b/pkg/orchestration/orchestration_test.go
@@ -423,6 +423,63 @@ func TestParallelPatternNoTasksIsRejectedUpFront(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestEmptyPatternsAreRejectedByTheExecutor pins the guard the two cases above
+// only look like they pin.
+//
+// Both of those go through ForkJoinBuilder.Execute / ParallelBuilder.Execute,
+// which carry their own pre-existing "at least 1 agent/task" check; that check
+// fires first, so both tests keep passing with the executor-level guard
+// removed. A schedule never touches those builders — it hands a pattern
+// straight to ExecutePattern, which is the path exercised here, and the
+// assertion is on the executor's own message rather than on some error having
+// come back.
+func TestEmptyPatternsAreRejectedByTheExecutor(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern *loomv1.WorkflowPattern
+		wantErr string
+	}{
+		{
+			name: "fork-join with no agents",
+			pattern: &loomv1.WorkflowPattern{
+				Pattern: &loomv1.WorkflowPattern_ForkJoin{
+					ForkJoin: &loomv1.ForkJoinPattern{Prompt: "Analyze this code"},
+				},
+			},
+			wantErr: "fork-join has no agents",
+		},
+		{
+			name: "parallel with no tasks",
+			pattern: &loomv1.WorkflowPattern{
+				Pattern: &loomv1.WorkflowPattern_Parallel{
+					Parallel: &loomv1.ParallelPattern{},
+				},
+			},
+			wantErr: "parallel pattern has no tasks",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orchestrator := NewOrchestrator(Config{
+				Logger:      zaptest.NewLogger(t),
+				Tracer:      observability.NewNoOpTracer(),
+				LLMProvider: newMockLLMProvider("never asked"),
+			})
+
+			_, err := orchestrator.ExecutePattern(context.Background(), tt.pattern)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			// The failure mode being guarded against: errors.Join() over zero
+			// branch errors is nil, and fmt.Errorf("...: %w", nil) renders that
+			// literally, so an operator's history entry read "%!w(<nil>)".
+			assert.NotContains(t, err.Error(), "%!w(<nil>)",
+				"the degenerate pattern reached the error-joining path instead of being rejected up front")
+		})
+	}
+}
+
 // TestConditionalPattern tests the conditional orchestration pattern.
 func TestConditionalPattern(t *testing.T) {
 	tests := []struct {

--- a/pkg/orchestration/parallel_executor.go
+++ b/pkg/orchestration/parallel_executor.go
@@ -52,6 +52,10 @@ func (e *ParallelExecutor) Execute(ctx context.Context) (*loomv1.WorkflowResult,
 	e.orchestrator.logger.Info("Starting parallel execution",
 		zap.Int("tasks", len(e.pattern.Tasks)))
 
+	if len(e.pattern.Tasks) == 0 {
+		return nil, fmt.Errorf("parallel pattern has no tasks")
+	}
+
 	// Validate all agents exist
 	for i, task := range e.pattern.Tasks {
 		if _, err := e.orchestrator.GetAgent(ctx, task.AgentId); err != nil {

--- a/pkg/orchestration/parallel_executor.go
+++ b/pkg/orchestration/parallel_executor.go
@@ -7,6 +7,7 @@ package orchestration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -195,20 +196,20 @@ func (e *ParallelExecutor) executeParallel(ctx context.Context) ([]*loomv1.Agent
 	}
 
 	// Check for errors
-	errors := make([]error, 0)
+	errs := make([]error, 0)
 	for err := range errorsChan {
-		errors = append(errors, err)
+		errs = append(errs, err)
 	}
 
 	// If all tasks failed, return error
-	if len(errors) == len(e.pattern.Tasks) {
-		return nil, nil, fmt.Errorf("all tasks failed: %v", errors)
+	if len(errs) == len(e.pattern.Tasks) {
+		return nil, nil, fmt.Errorf("all tasks failed: %w", errors.Join(errs...))
 	}
 
 	// Log partial failures
-	if len(errors) > 0 {
+	if len(errs) > 0 {
 		e.orchestrator.logger.Warn("Some tasks failed in parallel execution",
-			zap.Int("failed_count", len(errors)),
+			zap.Int("failed_count", len(errs)),
 			zap.Int("total_count", len(e.pattern.Tasks)))
 	}
 

--- a/pkg/scheduler/admission_test.go
+++ b/pkg/scheduler/admission_test.go
@@ -1,0 +1,235 @@
+// Copyright © 2026 Teradata Corporation - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package scheduler
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestShutdownSignalReachesRunAdmittedBeforeItStarts covers the gap between
+// reserving a drain slot and becoming cancellable.
+//
+// Reserving and registering used to be separate steps: the cron path counted a
+// run in inFlight and only registered it several instructions later, inside
+// executeWorkflow. Stop's grace expiry signals exactly once, so a run sitting
+// in that gap was never signaled — and the final drain, which has no deadline
+// on purpose, then waited for it anyway. Shutdown stopped being bounded by the
+// operator's 30s shutdown context and became bounded by max_execution_seconds,
+// an hour by default, with a hung agent call at the other end.
+//
+// The handoff is parked deliberately rather than raced: the run is admitted,
+// then held outside executeWorkflow for the whole of Stop's signal, which is
+// the interleaving the bug needed and which no amount of -race can surface on
+// its own.
+func TestShutdownSignalReachesRunAdmittedBeforeItStarts(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	h := newDrainTestScheduler(t)
+	s := h.scheduler
+
+	sched := agentWorkflow("sched-admitted-early")
+	require.NoError(t, s.AddSchedule(ctx, sched))
+
+	const execID = "exec-admitted-early"
+	admission, _ := s.admitRun(sched.Id, execID, false)
+	require.Equal(t, runAdmitted, admission)
+
+	// Admission alone makes the run cancellable. This is the assertion that
+	// fails outright if reservation and registration are ever split again.
+	require.Equal(t, execID, s.RunningExecutions()[sched.Id],
+		"a run holding its schedule's slot must be cancellable before the goroutine that executes it exists")
+
+	// Park the handoff: the run stays between admission and executeWorkflow for
+	// the whole of Stop's grace expiry and signal.
+	release := make(chan struct{})
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		defer s.inFlight.Done()
+		<-release
+		s.executeWorkflow(ctx, sched, execID, nil)
+	}()
+
+	// A deadline already in the past, so Stop takes its expired-grace branch
+	// without this test depending on how fast anything runs.
+	stopCtx, cancelStop := context.WithDeadline(ctx, time.Now().Add(-time.Second))
+	defer cancelStop()
+
+	stopped := make(chan error, 1)
+	go func() { stopped <- h.stop(stopCtx) }()
+
+	awaitDrainCond(t, "the shutdown signal should reach a run that has only just been admitted", func() bool {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		run, ok := s.runs[execID]
+		return ok && run.canceled
+	})
+
+	// Only now does the run reach executeWorkflow, which must deliver the
+	// signal that landed while it was parked instead of blocking in the agent
+	// until its execution timeout.
+	close(release)
+
+	select {
+	case err := <-stopped:
+		require.NoError(t, err)
+	case <-time.After(hangGuard):
+		t.Fatal("Stop never returned: the shutdown signal missed a run that was admitted but had not yet started, so the deadline-free drain waited out its execution timeout")
+	}
+	<-runDone
+
+	// Read the outcome back through a fresh store: Stop closed the one the
+	// scheduler held, so anything visible here was written before it went away.
+	reopened, err := NewStore(ctx, h.dbPath, zap.NewNop())
+	require.NoError(t, err)
+	defer func() { _ = reopened.Close() }()
+
+	history, err := reopened.GetExecutionHistory(ctx, sched.Id, 10)
+	require.NoError(t, err)
+	require.Len(t, history, 1,
+		"the run recorded no history; it was never signaled, or the store closed while it was still writing")
+	assert.Equal(t, execID, history[0].ExecutionId)
+	assert.Equal(t, "canceled", history[0].Status)
+	assert.Equal(t, shutdownCancelReason, history[0].Error)
+}
+
+// TestConcurrentTriggersHonorSkipIfRunning covers two-phase admission.
+//
+// The skip_if_running check and the registration that answers it used to be
+// separate critical sections, so triggers arriving together could all observe
+// an idle schedule and all start. That is not a cosmetic race: skip_if_running
+// is the guarantee RESUME-mode schedules rely on to keep two runs out of the
+// same agent sessions, and the manual-trigger path has no second line of
+// defence — executeWorkflow deliberately does not recheck the schedule's own
+// setting for a manual run.
+//
+// All the triggers are released from one barrier so they hit the admission
+// window together. The verdict does not depend on who wins: whoever is
+// admitted first holds the slot for the rest of the test, because the agent
+// blocks, so exactly one admission is the only correct outcome under every
+// interleaving.
+func TestConcurrentTriggersHonorSkipIfRunning(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	h := newDrainTestScheduler(t)
+	s := h.scheduler
+
+	sched := agentWorkflow("sched-concurrent-trigger")
+	require.NoError(t, s.AddSchedule(ctx, sched))
+
+	const triggers = 8
+
+	var (
+		release  = make(chan struct{})
+		wg       sync.WaitGroup
+		mu       sync.Mutex
+		admitted []string
+		refused  []string
+	)
+
+	for range triggers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-release
+			execID, err := s.TriggerNow(ctx, sched.Id, true, nil)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				refused = append(refused, err.Error())
+				return
+			}
+			admitted = append(admitted, execID)
+		}()
+	}
+	close(release)
+	wg.Wait()
+
+	require.Len(t, admitted, 1,
+		"skip_if_running admitted %d concurrent runs of one schedule; it promises at most one", len(admitted))
+	require.Len(t, refused, triggers-1)
+	for _, msg := range refused {
+		assert.Contains(t, msg, "previous execution still running")
+		assert.Contains(t, msg, admitted[0],
+			"a refusal must name the run that actually holds the slot, since that is the one an operator waits on or cancels")
+	}
+	assert.Equal(t, admitted[0], s.RunningExecutions()[sched.Id],
+		"the admitted run is the one occupying the schedule")
+
+	// Stop with no grace left, so the blocked run is signaled at once rather
+	// than leaving the cleanup to sit out its whole grace period.
+	expired, cancelStop := context.WithDeadline(ctx, time.Now().Add(-time.Second))
+	defer cancelStop()
+	require.NoError(t, h.stop(expired))
+}
+
+// TestSkipIfRunningIsDecidedUnderOneLockHold is the deterministic pin for the
+// same bug, and the reason it is a separate test: the concurrent-trigger case
+// above asserts the promise an operator relies on, but it cannot force the
+// interleaving that broke it — two-phase admission still admits one run most
+// of the time, so that test passes against the bug often enough to be useless
+// as a regression pin.
+//
+// This one asserts the structural property instead, with no race to lose. A
+// reader holds s.mu for the whole call: under single-critical-section
+// admission, admitRun cannot reach any verdict until that reader lets go,
+// because deciding and recording the answer are the same lock hold. A verdict
+// that arrives while the read lock is still held can only have been computed
+// from a snapshot somebody else was free to invalidate — which is exactly how
+// two concurrent triggers both passed skip_if_running.
+func TestSkipIfRunningIsDecidedUnderOneLockHold(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := setupTestScheduler(t)
+
+	sched := failingSchedule("sched-admission-lock")
+	sched.Schedule.SkipIfRunning = true
+	require.NoError(t, s.AddSchedule(ctx, sched))
+
+	// The schedule is already occupied, so admitRun has a verdict available to
+	// it — refuse — without anything having to execute.
+	seedRun(s, sched.Id, "exec-holding-the-slot", nil, false)
+
+	s.mu.RLock()
+
+	verdict := make(chan runAdmission, 1)
+	go func() {
+		admission, _ := s.admitRun(sched.Id, "exec-racing", true)
+		verdict <- admission
+	}()
+
+	// Generous on purpose: with admission in one critical section the call is
+	// blocked on a lock this test holds, so no runner is slow enough to make
+	// this wait flaky. It is only sensitivity to the bug that it buys.
+	select {
+	case got := <-verdict:
+		s.mu.RUnlock()
+		t.Fatalf("admitRun reached the verdict %v while another reader held s.mu: "+
+			"skip_if_running is being decided outside the critical section that registers the answer, "+
+			"so two triggers can both be admitted", got)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	s.mu.RUnlock()
+
+	select {
+	case got := <-verdict:
+		require.Equal(t, runRefusedRunning, got)
+	case <-time.After(hangGuard):
+		t.Fatal("admitRun never returned after the read lock was released")
+	}
+}

--- a/pkg/scheduler/cancel_test.go
+++ b/pkg/scheduler/cancel_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package scheduler
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// newCancelTestScheduler builds only the state CancelExecution touches. The
+// full scheduler needs an orchestrator, a registry, and a database; none of
+// that is involved in signalling a cancel.
+func newCancelTestScheduler() *Scheduler {
+	return &Scheduler{
+		runningWorkflows: make(map[string]string),
+		runningCancels:   make(map[string]context.CancelFunc),
+		cancelReasons:    make(map[string]string),
+		logger:           zap.NewNop(),
+	}
+}
+
+// Cancelling a live execution must actually cancel its context and record the
+// reason, so executeWorkflow can classify the run as cancelled rather than
+// failed.
+func TestCancelExecutionSignalsTheRun(t *testing.T) {
+	s := newCancelTestScheduler()
+
+	execCtx, cancel := context.WithCancel(context.Background())
+	s.mu.Lock()
+	s.runningWorkflows["sched-1"] = "exec-1"
+	s.runningCancels["exec-1"] = cancel
+	s.mu.Unlock()
+
+	cancelled, err := s.CancelExecution(context.Background(), "exec-1", "stopped by test")
+	if err != nil {
+		t.Fatalf("CancelExecution: %v", err)
+	}
+	if !cancelled {
+		t.Fatal("cancelled = false for a running execution")
+	}
+
+	select {
+	case <-execCtx.Done():
+	default:
+		t.Error("the execution context was not cancelled")
+	}
+
+	s.mu.RLock()
+	reason := s.cancelReasons["exec-1"]
+	s.mu.RUnlock()
+	if reason != "stopped by test" {
+		t.Errorf("recorded reason = %q, want %q", reason, "stopped by test")
+	}
+}
+
+// An execution that already finished is not an error: the caller wanted it
+// stopped and it is stopped. Reporting NotFound would make the UI apologise for
+// winning a race.
+func TestCancelExecutionUnknownIDIsNotAnError(t *testing.T) {
+	s := newCancelTestScheduler()
+
+	cancelled, err := s.CancelExecution(context.Background(), "exec-gone", "")
+	if err != nil {
+		t.Fatalf("unknown execution returned an error: %v", err)
+	}
+	if cancelled {
+		t.Error("cancelled = true for an execution that was never running")
+	}
+
+	// Nothing should be left behind for a run that does not exist, or the
+	// reason would be misapplied if that ID were later reused.
+	s.mu.RLock()
+	_, leaked := s.cancelReasons["exec-gone"]
+	s.mu.RUnlock()
+	if leaked {
+		t.Error("a reason was recorded for a non-running execution")
+	}
+}
+
+func TestCancelExecutionRequiresID(t *testing.T) {
+	s := newCancelTestScheduler()
+
+	if _, err := s.CancelExecution(context.Background(), "", "why"); err == nil {
+		t.Error("empty execution_id returned nil error")
+	}
+}
+
+// The reason must be recorded before the context is cancelled. If it were the
+// other way round, executeWorkflow could observe a cancelled context, classify
+// the run as failed, and miss the reason entirely.
+func TestCancelRecordsReasonBeforeCancelling(t *testing.T) {
+	s := newCancelTestScheduler()
+
+	var (
+		mu             sync.Mutex
+		reasonAtCancel string
+		sawReason      bool
+	)
+
+	s.mu.Lock()
+	s.runningCancels["exec-1"] = func() {
+		s.mu.RLock()
+		r, ok := s.cancelReasons["exec-1"]
+		s.mu.RUnlock()
+		mu.Lock()
+		reasonAtCancel, sawReason = r, ok
+		mu.Unlock()
+	}
+	s.mu.Unlock()
+
+	if _, err := s.CancelExecution(context.Background(), "exec-1", "operator stop"); err != nil {
+		t.Fatalf("CancelExecution: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !sawReason {
+		t.Fatal("the reason was not visible when cancel fired")
+	}
+	if reasonAtCancel != "operator stop" {
+		t.Errorf("reason at cancel = %q, want %q", reasonAtCancel, "operator stop")
+	}
+}
+
+func TestRunningExecutionsSnapshot(t *testing.T) {
+	s := newCancelTestScheduler()
+
+	s.mu.Lock()
+	s.runningWorkflows["sched-1"] = "exec-1"
+	s.runningWorkflows["sched-2"] = "exec-2"
+	s.mu.Unlock()
+
+	got := s.RunningExecutions()
+	if len(got) != 2 || got["sched-1"] != "exec-1" || got["sched-2"] != "exec-2" {
+		t.Fatalf("RunningExecutions() = %v", got)
+	}
+
+	// The result must be a copy — handing out the live map would let a caller
+	// mutate scheduler state without the lock.
+	got["sched-1"] = "tampered"
+	s.mu.RLock()
+	live := s.runningWorkflows["sched-1"]
+	s.mu.RUnlock()
+	if live != "exec-1" {
+		t.Error("RunningExecutions returned the live map, not a copy")
+	}
+}

--- a/pkg/scheduler/cancel_test.go
+++ b/pkg/scheduler/cancel_test.go
@@ -105,7 +105,7 @@ func launchParkedAfterVerdict(t *testing.T, s *Scheduler, sched *loomv1.Schedule
 	s.store.mu.Lock() // park 1: UpdateCurrentExecution
 	go func() {
 		defer close(done)
-		s.executeWorkflow(ctx, sched, execID, nil, true)
+		s.executeWorkflow(ctx, sched, execID, nil)
 	}()
 	waitFor(t, "the run to register", func() bool {
 		s.mu.RLock()
@@ -343,7 +343,7 @@ func TestExecuteWorkflowRegistersBeforeAdvertising(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		s.executeWorkflow(ctx, sched, "exec-advertise", nil, true)
+		s.executeWorkflow(ctx, sched, "exec-advertise", nil)
 	}()
 
 	waitFor(t, "the run to be advertised", func() bool {
@@ -489,7 +489,7 @@ func TestExecuteWorkflowRecordsGenuineCancellation(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		s.executeWorkflow(ctx, sched, "exec-genuine", nil, true)
+		s.executeWorkflow(ctx, sched, "exec-genuine", nil)
 	}()
 
 	select {
@@ -541,7 +541,7 @@ func TestExecuteWorkflowRecordsGenuineCancellationForForkJoin(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		s.executeWorkflow(ctx, sched, "exec-genuine-forkjoin", nil, true)
+		s.executeWorkflow(ctx, sched, "exec-genuine-forkjoin", nil)
 	}()
 
 	select {
@@ -590,7 +590,7 @@ func TestExecuteWorkflowRecordsGenuineCancellationForParallel(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		s.executeWorkflow(ctx, sched, "exec-genuine-parallel", nil, true)
+		s.executeWorkflow(ctx, sched, "exec-genuine-parallel", nil)
 	}()
 
 	select {
@@ -643,7 +643,7 @@ func TestCancelBeforeOrchestratorWithUnrelatedFailureIsNotMislabeledCanceled(t *
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		s.executeWorkflow(ctx, sched, "exec-unrelated", nil, true)
+		s.executeWorkflow(ctx, sched, "exec-unrelated", nil)
 	}()
 
 	waitFor(t, "the run to register", func() bool {
@@ -756,7 +756,7 @@ func TestCancelRacingCompletionKeepsRecordAndCountersConsistent(t *testing.T) {
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
-			s.executeWorkflow(ctx, sched, execID, nil, true)
+			s.executeWorkflow(ctx, sched, execID, nil)
 		}()
 
 		select {
@@ -851,7 +851,8 @@ func TestTriggerNowRegistersBeforeReturningTheID(t *testing.T) {
 // anyway" (skipIfRunning=false) against a SkipIfRunning:true schedule with a
 // run already in flight minted a second ID, returned it, and then silently
 // skipped without ever registering it — an ID that would answer NOT_FOUND
-// forever, because nothing this scheduler ever recorded used it.
+// forever, because nothing this scheduler ever recorded used it. The decision
+// is now made exactly once, in admitRun, against the request's own flag.
 func TestTriggerNowOverridesScheduleSkipIfRunning(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/scheduler/cancel_test.go
+++ b/pkg/scheduler/cancel_test.go
@@ -520,6 +520,57 @@ func TestExecuteWorkflowRecordsGenuineCancellation(t *testing.T) {
 		"an operator's stop is not a failure; counting it would distort the success rate")
 }
 
+// TestExecuteWorkflowRecordsGenuineCancellationForForkJoin covers N8: a
+// genuine cancel of a fork-join schedule must still be classified as
+// "canceled", not "failed". Fork-join and parallel patterns collect every
+// branch's error into a local slice before this PR's fix and joined them with
+// fmt.Errorf("...: %v", errors) — %v, not %w, so context.Canceled never
+// reached errors.Is and the classification switch's canceled branch was
+// unreachable for these two pattern types no matter how a run was stopped.
+func TestExecuteWorkflowRecordsGenuineCancellationForForkJoin(t *testing.T) {
+	t.Parallel()
+
+	llm := newDrainBlockingLLM()
+	h := newAgentTestScheduler(t, llm)
+	s := h.scheduler
+	ctx := context.Background()
+
+	sched := forkJoinWorkflow("sched-genuine-forkjoin")
+	require.NoError(t, s.store.Create(ctx, sched))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.executeWorkflow(ctx, sched, "exec-genuine-forkjoin", nil, true)
+	}()
+
+	select {
+	case <-llm.started:
+	case <-time.After(hangGuard):
+		t.Fatal("the workflow never reached the agent, so nothing was in flight to cancel")
+	}
+
+	outcome, err := s.CancelExecution(ctx, "exec-genuine-forkjoin", "stopped by operator")
+	require.NoError(t, err)
+	require.Equal(t, CancelOutcomeSignaled, outcome)
+
+	<-done
+
+	history, err := s.store.GetExecutionHistory(ctx, sched.Id, 10)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	assert.Equal(t, "canceled", history[0].Status,
+		"a genuine cancel of a fork-join run was recorded as failed because the joined branch errors lost context.Canceled through %v instead of %w")
+	assert.Equal(t, "stopped by operator", history[0].Error)
+
+	got, err := s.store.Get(ctx, sched.Id)
+	require.NoError(t, err)
+	assert.Equal(t, "canceled", got.Stats.LastStatus)
+	assert.Equal(t, int32(0), got.Stats.TotalExecutions)
+	assert.Equal(t, int32(0), got.Stats.FailedExecutions,
+		"an operator's stop of a fork-join run was counted as a failure, corrupting the success rate")
+}
+
 // TestCancelBeforeOrchestratorWithUnrelatedFailureIsNotMislabeledCanceled
 // covers N1: a cancel signal that arrives before the orchestrator ever runs
 // does not, by itself, mean the orchestrator's error was caused by it. A

--- a/pkg/scheduler/cancel_test.go
+++ b/pkg/scheduler/cancel_test.go
@@ -44,20 +44,30 @@ func failingSchedule(id string) *loomv1.ScheduledWorkflow {
 	}
 }
 
-// waitFor spins until cond holds, failing the test rather than hanging forever.
+// hangGuard bounds every wait in the scheduler tests.
 //
-// Every wait in this file goes through here on purpose: a lock-ordering
-// regression in the cancel path deadlocks, and a bare channel receive would
-// turn that into a CI timeout with no indication of which invariant broke.
+// It is a hang guard, not a performance bound. Its only job is to turn a
+// deadlock — a lock-ordering regression in the cancel path, say — into a
+// failure that names the invariant, instead of the bare CI timeout a channel
+// receive would produce. It is therefore generous: on a CI runner under -race
+// and atomic coverage, with the parallel tests in this package competing for
+// CPU, a real agent run has been observed to take over four seconds to settle,
+// and a guard sized to local timings failed there.
+const hangGuard = 30 * time.Second
+
+// waitFor spins until cond holds, failing the test rather than hanging forever.
+// Every wait in this file goes through here on purpose; see hangGuard.
 func waitFor(t *testing.T, what string, cond func() bool) {
 	t.Helper()
 
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(hangGuard)
 	for !cond() {
 		if time.Now().After(deadline) {
 			t.Fatalf("timed out waiting for %s", what)
 		}
-		time.Sleep(200 * time.Microsecond)
+		// Long enough not to contend with the run being waited on for the
+		// scheduler lock; short enough that the wait adds nothing measurable.
+		time.Sleep(2 * time.Millisecond)
 	}
 }
 
@@ -67,6 +77,60 @@ func seedRun(s *Scheduler, scheduleID, execID string, cancel context.CancelFunc,
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.runs[execID] = &runState{scheduleID: scheduleID, cancel: cancel, settled: settled}
+}
+
+// launchParkedAfterVerdict starts executeWorkflow for sched/execID and returns
+// once the run is parked at its first post-verdict store write, with the store
+// lock held by the caller. The caller releases s.store.mu to let the run finish
+// and then receives from done.
+//
+// This is deterministic rather than timing-based, which matters: a poll for
+// "settled" can miss a fast run entirely — it settles and tears down between
+// two polls, and an absent entry is indistinguishable from one not yet
+// registered — so the poll spins until the hang guard fires. Every wait below
+// is on a state the run cannot leave while it is parked.
+//
+// Sequence: the store lock is taken before launch, so the run registers and
+// parks at UpdateCurrentExecution. The scheduler lock is then taken and the
+// store lock released; the run performs that write, runs the orchestrator, and
+// blocks at its linearization point. Once current_execution_id is visible in
+// the store — proof the run is past that write and will not touch the store
+// again before settling — the store lock is retaken and the scheduler lock
+// released: the run settles and parks at UpdateLastWorkflowID, provably after
+// the verdict, before any bookkeeping write, still in the run map.
+func launchParkedAfterVerdict(t *testing.T, s *Scheduler, sched *loomv1.ScheduledWorkflow, execID string) <-chan struct{} {
+	t.Helper()
+	ctx := context.Background()
+	done := make(chan struct{})
+
+	s.store.mu.Lock() // park 1: UpdateCurrentExecution
+	go func() {
+		defer close(done)
+		s.executeWorkflow(ctx, sched, execID, nil)
+	}()
+	waitFor(t, "the run to register", func() bool {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		_, ok := s.runs[execID]
+		return ok
+	})
+
+	s.mu.Lock()         // the run will block here at its linearization point
+	s.store.mu.Unlock() // release park 1
+	waitFor(t, "current_execution_id to be persisted", func() bool {
+		got, err := s.store.Get(ctx, sched.Id)
+		return err == nil && got.CurrentExecutionId == execID
+	})
+
+	s.store.mu.Lock() // park 2: UpdateLastWorkflowID
+	s.mu.Unlock()     // the run settles, then parks at park 2
+	waitFor(t, "the run to read its verdict", func() bool {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		run, ok := s.runs[execID]
+		return ok && run.settled
+	})
+	return done
 }
 
 func TestCancelExecutionOutcomes(t *testing.T) {
@@ -316,22 +380,11 @@ func TestCancelAfterVerdictReportsAlreadyFinished(t *testing.T) {
 	sched := failingSchedule("sched-late-cancel")
 	require.NoError(t, s.store.Create(ctx, sched))
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		s.executeWorkflow(ctx, sched, "exec-late", nil)
-	}()
-
-	// settled is set in the same critical section that reads the verdict, so
-	// observing it is proof the orchestrator has already returned.
-	waitFor(t, "the run to read its verdict", func() bool {
-		s.mu.RLock()
-		defer s.mu.RUnlock()
-		run, ok := s.runs["exec-late"]
-		return ok && run.settled
-	})
+	// Parked after the verdict, before any bookkeeping write, still in the map.
+	done := launchParkedAfterVerdict(t, s, sched, "exec-late")
 
 	outcome, err := s.CancelExecution(ctx, "exec-late", "operator stop")
+	s.store.mu.Unlock()
 	require.NoError(t, err)
 	assert.Equal(t, CancelOutcomeAlreadyFinished, outcome,
 		"the run had already reached its verdict; reporting it as signaled tells the operator a run was stopped when it was not")
@@ -387,21 +440,12 @@ func TestCancelAfterSuccessKeepsTheSuccess(t *testing.T) {
 	sched := agentWorkflow("sched-late-success")
 	require.NoError(t, s.store.Create(ctx, sched))
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		s.executeWorkflow(ctx, sched, "exec-late-success", nil)
-	}()
-
-	waitFor(t, "the run to read its verdict", func() bool {
-		s.mu.RLock()
-		defer s.mu.RUnlock()
-		run, ok := s.runs["exec-late-success"]
-		return ok && run.settled
-	})
+	// Parked after the verdict, before any bookkeeping write, still in the map.
+	done := launchParkedAfterVerdict(t, s, sched, "exec-late-success")
 	require.Positive(t, llm.calls.Load(), "the agent was never asked; the run did not actually complete")
 
 	outcome, err := s.CancelExecution(ctx, "exec-late-success", "operator stop")
+	s.store.mu.Unlock()
 	require.NoError(t, err)
 	assert.Equal(t, CancelOutcomeAlreadyFinished, outcome)
 
@@ -485,7 +529,10 @@ func TestExecuteWorkflowRecordsGenuineCancellation(t *testing.T) {
 func TestCancelRacingCompletionKeepsRecordAndCountersConsistent(t *testing.T) {
 	t.Parallel()
 
-	const iterations = 200
+	// Enough that both interleavings — cancel before and after the verdict —
+	// occur every run (dozens of each observed), while keeping this parallel
+	// test from starving its siblings on a slow runner.
+	const iterations = 100
 
 	s := setupTestScheduler(t)
 	ctx := context.Background()

--- a/pkg/scheduler/cancel_test.go
+++ b/pkg/scheduler/cancel_test.go
@@ -8,7 +8,6 @@ package scheduler
 import (
 	"context"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -106,7 +105,7 @@ func launchParkedAfterVerdict(t *testing.T, s *Scheduler, sched *loomv1.Schedule
 	s.store.mu.Lock() // park 1: UpdateCurrentExecution
 	go func() {
 		defer close(done)
-		s.executeWorkflow(ctx, sched, execID, nil)
+		s.executeWorkflow(ctx, sched, execID, nil, true)
 	}()
 	waitFor(t, "the run to register", func() bool {
 		s.mu.RLock()
@@ -344,7 +343,7 @@ func TestExecuteWorkflowRegistersBeforeAdvertising(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		s.executeWorkflow(ctx, sched, "exec-advertise", nil)
+		s.executeWorkflow(ctx, sched, "exec-advertise", nil, true)
 	}()
 
 	waitFor(t, "the run to be advertised", func() bool {
@@ -469,33 +468,37 @@ func TestCancelAfterSuccessKeepsTheSuccess(t *testing.T) {
 // TestExecuteWorkflowRecordsGenuineCancellation is the positive case: a cancel
 // that really does stop the run is recorded as canceled and leaves the
 // success-rate counters alone.
+//
+// The run has to be genuinely interrupted mid-flight, not merely signaled
+// before an orchestrator call that would have failed on its own regardless —
+// see TestCancelBeforeOrchestratorWithUnrelatedFailureIsNotMislabeledCanceled
+// for that distinction. A blocking agent call is what makes the interruption
+// real: the cancel unwinds context.WithTimeout's context inside Chat, which
+// returns ctx.Err() and wraps up through the pipeline as context.Canceled.
 func TestExecuteWorkflowRecordsGenuineCancellation(t *testing.T) {
 	t.Parallel()
 
-	s := setupTestScheduler(t)
+	llm := newDrainBlockingLLM()
+	h := newAgentTestScheduler(t, llm)
+	s := h.scheduler
 	ctx := context.Background()
-	sched := failingSchedule("sched-genuine")
-	require.NoError(t, s.store.Create(ctx, sched))
 
-	// Park the run before the orchestrator runs, so the cancel provably lands
-	// while it is still cancellable.
-	s.store.mu.Lock()
+	sched := agentWorkflow("sched-genuine")
+	require.NoError(t, s.store.Create(ctx, sched))
 
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		s.executeWorkflow(ctx, sched, "exec-genuine", nil)
+		s.executeWorkflow(ctx, sched, "exec-genuine", nil, true)
 	}()
 
-	waitFor(t, "the run to register", func() bool {
-		s.mu.RLock()
-		defer s.mu.RUnlock()
-		_, ok := s.runs["exec-genuine"]
-		return ok
-	})
+	select {
+	case <-llm.started:
+	case <-time.After(hangGuard):
+		t.Fatal("the workflow never reached the agent, so nothing was in flight to cancel")
+	}
 
 	outcome, err := s.CancelExecution(ctx, "exec-genuine", "stopped by operator")
-	s.store.mu.Unlock()
 	require.NoError(t, err)
 	require.Equal(t, CancelOutcomeSignaled, outcome)
 
@@ -517,65 +520,160 @@ func TestExecuteWorkflowRecordsGenuineCancellation(t *testing.T) {
 		"an operator's stop is not a failure; counting it would distort the success rate")
 }
 
-// TestCancelRacingCompletionKeepsRecordAndCountersConsistent fires a cancel at
-// an unsynchronised point around completion, many times, and asserts that the
-// history record and the counters agree on every interleaving.
+// TestCancelBeforeOrchestratorWithUnrelatedFailureIsNotMislabeledCanceled
+// covers N1: a cancel signal that arrives before the orchestrator ever runs
+// does not, by itself, mean the orchestrator's error was caused by it. A
+// misconfigured pipeline fails the same way whether or not anyone canceled it,
+// and that real error must not be discarded and relabeled "canceled" just
+// because a signal happened to land first.
+func TestCancelBeforeOrchestratorWithUnrelatedFailureIsNotMislabeledCanceled(t *testing.T) {
+	t.Parallel()
+
+	s := setupTestScheduler(t)
+	ctx := context.Background()
+	sched := failingSchedule("sched-unrelated-failure")
+	require.NoError(t, s.store.Create(ctx, sched))
+
+	// Park the run before the orchestrator runs, so the cancel provably lands
+	// first, then release it to run ExecutePattern against an already-canceled
+	// context. The pattern has no stages, so it fails immediately for a reason
+	// that has nothing to do with context cancellation.
+	s.store.mu.Lock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.executeWorkflow(ctx, sched, "exec-unrelated", nil, true)
+	}()
+
+	waitFor(t, "the run to register", func() bool {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		_, ok := s.runs["exec-unrelated"]
+		return ok
+	})
+
+	outcome, err := s.CancelExecution(ctx, "exec-unrelated", "stopped by operator")
+	s.store.mu.Unlock()
+	require.NoError(t, err)
+	require.Equal(t, CancelOutcomeSignaled, outcome)
+
+	<-done
+
+	history, err := s.store.GetExecutionHistory(ctx, sched.Id, 10)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	assert.Equal(t, "failed", history[0].Status,
+		"a configuration error unrelated to the cancel signal was relabeled as an operator stop")
+	assert.Contains(t, history[0].Error, "stages",
+		"the real error was discarded in favor of the cancel reason")
+
+	got, err := s.store.Get(ctx, sched.Id)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), got.Stats.FailedExecutions,
+		"the failure was dropped from the counters the success rate is derived from")
+	assert.Equal(t, "failed", got.Stats.LastStatus)
+}
+
+// controllableLLM parks inside Chat until the test releases it, and reports
+// entry so the test never has to guess whether the call has started.
 //
-// This is the shape of test the race detector cannot substitute for: the bug
-// class is a logical interleaving, not a data race, so -race stays green while
-// the two disagree. It checks consistency, not which verdict was right — the
-// two deterministic tests above pin the verdict for a cancel that lands after
-// completion.
+// A timing-based race between "cancel" and "let it complete" was tried here
+// first and discarded: the run's settle time is dominated by real agent
+// dispatch overhead (registry lookup, message assembly, SQLite writes) that
+// varies by an order of magnitude between the first call and later ones, so
+// no fixed jitter window reliably straddles it — the boundary this test
+// exists to exercise cannot be hit by chance without becoming flaky under
+// -race on a loaded runner. Parking on a channel makes both interleavings
+// exact instead of probable.
+type controllableLLM struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func newControllableLLM() *controllableLLM {
+	return &controllableLLM{entered: make(chan struct{}, 1), release: make(chan struct{})}
+}
+
+func (l *controllableLLM) Chat(ctx context.Context, _ []llmtypes.Message, _ []shuttle.Tool) (*llmtypes.LLMResponse, error) {
+	l.entered <- struct{}{}
+	select {
+	case <-l.release:
+		return &llmtypes.LLMResponse{Content: "done", StopReason: "stop"}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (l *controllableLLM) Name() string  { return "controllable" }
+func (l *controllableLLM) Model() string { return "controllable" }
+
+// TestCancelRacingCompletionKeepsRecordAndCountersConsistent pins a cancel
+// against a completion at the same point — while the run is genuinely
+// in-flight inside the agent call — many times, alternating which one the
+// test lets win, and asserts the history record and the counters agree on
+// every outcome.
+//
+// This is the shape of bug the race detector cannot substitute for: the bug
+// class is a logical interleaving (does the recorded status match what
+// actually happened at the boundary), not a data race, so -race stays green
+// while the two disagree. The two deterministic tests above already pin the
+// verdict for a cancel landing after the verdict; this one pins it for a
+// cancel and a completion contending for the same still-in-flight run, many
+// times, to catch a lock-ordering regression a single case could miss. The
+// LLM must genuinely honor context cancellation (unlike failingSchedule's
+// config-validation error, which never touches ctx and so can never
+// legitimately race a cancel — see the N1 regression test above): a signal
+// racing an error unrelated to it must never be relabeled canceled.
 func TestCancelRacingCompletionKeepsRecordAndCountersConsistent(t *testing.T) {
 	t.Parallel()
 
-	// Enough that both interleavings — cancel before and after the verdict —
-	// occur every run (dozens of each observed), while keeping this parallel
-	// test from starving its siblings on a slow runner.
+	// Enough to run the lock-ordering path many times over without starving
+	// this parallel test's siblings on a slow runner.
 	const iterations = 100
 
-	s := setupTestScheduler(t)
+	llm := newControllableLLM()
+	h := newAgentTestScheduler(t, llm)
+	s := h.scheduler
 	ctx := context.Background()
 
 	var (
 		canceledRuns int
-		failedRuns   int
+		successRuns  int
 	)
 
 	for i := 0; i < iterations; i++ {
 		// A fresh schedule per iteration, so each one's counters and history
 		// are judged on their own rather than needing a reset.
-		sched := failingSchedule(fmt.Sprintf("sched-race-%d", i))
+		sched := agentWorkflow(fmt.Sprintf("sched-race-%d", i))
 		require.NoError(t, s.store.Create(ctx, sched))
 
 		execID := fmt.Sprintf("exec-race-%d", i)
-		var wg sync.WaitGroup
-		wg.Add(2)
+		llm.entered = make(chan struct{}, 1)
+		llm.release = make(chan struct{})
+		wantCancel := i%2 == 0
 
+		done := make(chan struct{})
 		go func() {
-			defer wg.Done()
-			s.executeWorkflow(ctx, sched, execID, nil)
+			defer close(done)
+			s.executeWorkflow(ctx, sched, execID, nil, true)
 		}()
 
-		go func() {
-			defer wg.Done()
-			// Unsynchronised on purpose: across iterations this lands before,
-			// during and after the verdict. The run may register and tear down
-			// before this goroutine ever observes it, so the spin is bounded —
-			// a missed run is a legitimate interleaving, not a failure.
-			deadline := time.Now().Add(2 * time.Second)
-			for {
-				s.mu.RLock()
-				_, tracked := s.runs[execID]
-				s.mu.RUnlock()
-				if tracked || time.Now().After(deadline) {
-					break
-				}
-			}
-			_, _ = s.CancelExecution(ctx, execID, "operator stop")
-		}()
+		select {
+		case <-llm.entered:
+		case <-time.After(hangGuard):
+			t.Fatalf("iteration %d: the run never reached the agent call", i)
+		}
 
-		wg.Wait()
+		if wantCancel {
+			outcome, err := s.CancelExecution(ctx, execID, "operator stop")
+			require.NoError(t, err)
+			require.Equal(t, CancelOutcomeSignaled, outcome, "iteration %d", i)
+		} else {
+			close(llm.release)
+		}
+
+		<-done
 
 		history, err := s.store.GetExecutionHistory(ctx, sched.Id, 1)
 		require.NoError(t, err)
@@ -584,36 +682,110 @@ func TestCancelRacingCompletionKeepsRecordAndCountersConsistent(t *testing.T) {
 		got, err := s.store.Get(ctx, sched.Id)
 		require.NoError(t, err)
 
-		switch history[0].Status {
-		case "canceled":
+		if wantCancel {
 			canceledRuns++
 			// A canceled run reached no verdict: no counters, and the reason
 			// rather than an orchestrator error.
-			require.Equal(t, int32(0), got.Stats.FailedExecutions,
-				"iteration %d: canceled run counted as a failure", i)
+			require.Equal(t, "canceled", history[0].Status,
+				"iteration %d: a run parked inside the agent call, then canceled, must be recorded as canceled", i)
+			require.Equal(t, "operator stop", history[0].Error,
+				"iteration %d: real error replaced the cancel reason, or vice versa", i)
+			require.Equal(t, int32(0), got.Stats.SuccessfulExecutions,
+				"iteration %d: canceled run counted as a success", i)
 			require.Equal(t, int32(0), got.Stats.TotalExecutions,
 				"iteration %d: canceled run counted as an execution", i)
-
-		case "failed":
-			failedRuns++
-			// The cancel did not stop this run, so its real failure must be
-			// recorded in full — this is the assertion that fails when the run
-			// stays cancellable through its bookkeeping tail.
-			require.Contains(t, history[0].Error, "stages",
-				"iteration %d: real error replaced by the cancel reason", i)
-			require.Equal(t, int32(1), got.Stats.FailedExecutions,
-				"iteration %d: failure dropped from the counters", i)
-			require.Equal(t, "failed", got.Stats.LastStatus,
+		} else {
+			successRuns++
+			// The run was let through to completion, so its real success must
+			// be recorded in full — this is the assertion that fails when the
+			// run stays cancellable through its bookkeeping tail.
+			require.Equal(t, "success", history[0].Status,
+				"iteration %d: a run released to complete normally must be recorded as a success", i)
+			require.Equal(t, int32(1), got.Stats.SuccessfulExecutions,
+				"iteration %d: success dropped from the counters", i)
+			require.Equal(t, "success", got.Stats.LastStatus,
 				"iteration %d: last_status does not match the recorded outcome", i)
-
-		default:
-			t.Fatalf("iteration %d: unexpected status %q", i, history[0].Status)
 		}
 	}
 
-	// Both interleavings must actually have occurred, or the test proved nothing.
-	t.Logf("canceled=%d failed=%d of %d iterations", canceledRuns, failedRuns, iterations)
-	assert.Positive(t, canceledRuns+failedRuns)
+	t.Logf("canceled=%d success=%d of %d iterations", canceledRuns, successRuns, iterations)
+	assert.Positive(t, canceledRuns)
+	assert.Positive(t, successRuns)
+}
+
+// TestTriggerNowRegistersBeforeReturningTheID covers N2's transient half: an ID
+// TriggerNow just handed back must already be tracked, with no window in which
+// canceling it reports NOT_FOUND for an execution this scheduler, in fact,
+// just minted.
+//
+// No synchronization with the spawned goroutine is used on purpose: before the
+// fix, the goroutine registered the run itself, so a cancel arriving before it
+// was even scheduled to run found nothing tracked. Registration now happens in
+// TriggerNow itself, before the ID is returned, so there is nothing to race.
+func TestTriggerNowRegistersBeforeReturningTheID(t *testing.T) {
+	t.Parallel()
+
+	llm := newDrainBlockingLLM()
+	h := newAgentTestScheduler(t, llm)
+	s := h.scheduler
+	ctx := context.Background()
+
+	sched := agentWorkflow("sched-trigger-race")
+	require.NoError(t, s.AddSchedule(ctx, sched))
+
+	executionID, err := s.TriggerNow(ctx, sched.Id, false, nil)
+	require.NoError(t, err)
+
+	outcome, err := s.CancelExecution(ctx, executionID, "operator stop")
+	require.NoError(t, err)
+	assert.Equal(t, CancelOutcomeSignaled, outcome,
+		"an ID TriggerNow just returned must already be tracked, not NOT_FOUND")
+}
+
+// TestTriggerNowOverridesScheduleSkipIfRunning covers N2's permanent half: the
+// skip-if-running decision for a manual trigger is the request's own
+// skipIfRunning, not the schedule's persisted config.
+//
+// Before the fix, executeWorkflow re-checked schedule.Schedule.SkipIfRunning
+// regardless of what TriggerNow's caller asked for. An explicit "run it
+// anyway" (skipIfRunning=false) against a SkipIfRunning:true schedule with a
+// run already in flight minted a second ID, returned it, and then silently
+// skipped without ever registering it — an ID that would answer NOT_FOUND
+// forever, because nothing this scheduler ever recorded used it.
+func TestTriggerNowOverridesScheduleSkipIfRunning(t *testing.T) {
+	t.Parallel()
+
+	llm := newDrainBlockingLLM()
+	h := newAgentTestScheduler(t, llm)
+	s := h.scheduler
+	ctx := context.Background()
+
+	sched := agentWorkflow("sched-trigger-override")
+	sched.Schedule.SkipIfRunning = true
+	require.NoError(t, s.AddSchedule(ctx, sched))
+
+	first, err := s.TriggerNow(ctx, sched.Id, false, nil)
+	require.NoError(t, err)
+
+	select {
+	case <-llm.started:
+	case <-time.After(hangGuard):
+		t.Fatal("the first triggered run never reached the agent")
+	}
+
+	second, err := s.TriggerNow(ctx, sched.Id, false, nil)
+	require.NoError(t, err, `an explicit "run it anyway" trigger must not be rejected because the schedule's own skip_if_running is set`)
+	require.NotEqual(t, first, second)
+
+	outcome, err := s.CancelExecution(ctx, second, "operator stop")
+	require.NoError(t, err)
+	assert.Equal(t, CancelOutcomeSignaled, outcome,
+		"the second trigger was silently skipped instead of running, so its ID was never registered")
+
+	// Also stop the first run, so teardown does not have to sit out Stop's
+	// grace period waiting for a blocked agent call nothing here still needs.
+	_, err = s.CancelExecution(ctx, first, "test cleanup")
+	require.NoError(t, err)
 }
 
 // TestStopCancelsInFlightRunsOnDeadline covers F6: Stop must not close the store

--- a/pkg/scheduler/cancel_test.go
+++ b/pkg/scheduler/cancel_test.go
@@ -571,6 +571,55 @@ func TestExecuteWorkflowRecordsGenuineCancellationForForkJoin(t *testing.T) {
 		"an operator's stop of a fork-join run was counted as a failure, corrupting the success rate")
 }
 
+// TestExecuteWorkflowRecordsGenuineCancellationForParallel is the parallel
+// twin of TestExecuteWorkflowRecordsGenuineCancellationForForkJoin: the same
+// %v-vs-%w bug lived independently in parallel_executor.go, so fixing
+// fork-join alone would have left this pattern type still misclassifying a
+// genuine cancel as "failed".
+func TestExecuteWorkflowRecordsGenuineCancellationForParallel(t *testing.T) {
+	t.Parallel()
+
+	llm := newDrainBlockingLLM()
+	h := newAgentTestScheduler(t, llm)
+	s := h.scheduler
+	ctx := context.Background()
+
+	sched := parallelWorkflow("sched-genuine-parallel")
+	require.NoError(t, s.store.Create(ctx, sched))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.executeWorkflow(ctx, sched, "exec-genuine-parallel", nil, true)
+	}()
+
+	select {
+	case <-llm.started:
+	case <-time.After(hangGuard):
+		t.Fatal("the workflow never reached the agent, so nothing was in flight to cancel")
+	}
+
+	outcome, err := s.CancelExecution(ctx, "exec-genuine-parallel", "stopped by operator")
+	require.NoError(t, err)
+	require.Equal(t, CancelOutcomeSignaled, outcome)
+
+	<-done
+
+	history, err := s.store.GetExecutionHistory(ctx, sched.Id, 10)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	assert.Equal(t, "canceled", history[0].Status,
+		"a genuine cancel of a parallel run was recorded as failed because the joined task errors lost context.Canceled through %v instead of %w")
+	assert.Equal(t, "stopped by operator", history[0].Error)
+
+	got, err := s.store.Get(ctx, sched.Id)
+	require.NoError(t, err)
+	assert.Equal(t, "canceled", got.Stats.LastStatus)
+	assert.Equal(t, int32(0), got.Stats.TotalExecutions)
+	assert.Equal(t, int32(0), got.Stats.FailedExecutions,
+		"an operator's stop of a parallel run was counted as a failure, corrupting the success rate")
+}
+
 // TestCancelBeforeOrchestratorWithUnrelatedFailureIsNotMislabeledCanceled
 // covers N1: a cancel signal that arrives before the orchestrator ever runs
 // does not, by itself, mean the orchestrator's error was caused by it. A

--- a/pkg/scheduler/cancel_test.go
+++ b/pkg/scheduler/cancel_test.go
@@ -1,161 +1,597 @@
-// Copyright 2026 Teradata
+// Copyright © 2026 Teradata Corporation - All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+
 package scheduler
 
 import (
 	"context"
+	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
-	"go.uber.org/zap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+	"github.com/teradata-labs/loom/pkg/shuttle"
 )
 
-// newCancelTestScheduler builds only the state CancelExecution touches. The
-// full scheduler needs an orchestrator, a registry, and a database; none of
-// that is involved in signalling a cancel.
-func newCancelTestScheduler() *Scheduler {
-	return &Scheduler{
-		runningWorkflows: make(map[string]string),
-		runningCancels:   make(map[string]context.CancelFunc),
-		cancelReasons:    make(map[string]string),
-		logger:           zap.NewNop(),
+// failingSchedule returns a schedule whose pattern is rejected by the
+// orchestrator before it runs anything.
+//
+// The verdict is a deterministic configuration error ("pipeline has no
+// stages") with nothing to do with cancellation, which is what makes it useful:
+// any run recorded as canceled that this schedule produced is a run whose real
+// verdict was thrown away.
+func failingSchedule(id string) *loomv1.ScheduledWorkflow {
+	return &loomv1.ScheduledWorkflow{
+		Id:           id,
+		WorkflowName: id,
+		Pattern: &loomv1.WorkflowPattern{
+			Pattern: &loomv1.WorkflowPattern_Pipeline{
+				Pipeline: &loomv1.PipelinePattern{},
+			},
+		},
+		Schedule: &loomv1.ScheduleConfig{
+			Cron:    "0 0 * * *",
+			Enabled: true,
+		},
 	}
 }
 
-// Cancelling a live execution must actually cancel its context and record the
-// reason, so executeWorkflow can classify the run as cancelled rather than
-// failed.
-func TestCancelExecutionSignalsTheRun(t *testing.T) {
-	s := newCancelTestScheduler()
+// waitFor spins until cond holds, failing the test rather than hanging forever.
+//
+// Every wait in this file goes through here on purpose: a lock-ordering
+// regression in the cancel path deadlocks, and a bare channel receive would
+// turn that into a CI timeout with no indication of which invariant broke.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
 
-	execCtx, cancel := context.WithCancel(context.Background())
+	deadline := time.Now().Add(5 * time.Second)
+	for !cond() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", what)
+		}
+		time.Sleep(200 * time.Microsecond)
+	}
+}
+
+// seedRun registers an in-flight run directly, for the cases that are about
+// CancelExecution's own bookkeeping rather than about a real execution.
+func seedRun(s *Scheduler, scheduleID, execID string, cancel context.CancelFunc, settled bool) {
 	s.mu.Lock()
-	s.runningWorkflows["sched-1"] = "exec-1"
-	s.runningCancels["exec-1"] = cancel
+	defer s.mu.Unlock()
+	s.runs[execID] = &runState{scheduleID: scheduleID, cancel: cancel, settled: settled}
+}
+
+func TestCancelExecutionOutcomes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// seed prepares scheduler state and returns the ID to cancel.
+		seed        func(t *testing.T, s *Scheduler) string
+		wantOutcome CancelOutcome
+		wantErr     bool
+		// wantSignaled asserts whether the run's context was actually canceled.
+		wantSignaled bool
+	}{
+		{
+			name: "in flight run is signaled",
+			seed: func(t *testing.T, s *Scheduler) string {
+				_, cancel := context.WithCancel(context.Background())
+				seedRun(s, "sched-1", "exec-1", cancel, false)
+				return "exec-1"
+			},
+			wantOutcome:  CancelOutcomeSignaled,
+			wantSignaled: true,
+		},
+		{
+			name: "settled run reports already finished",
+			seed: func(t *testing.T, s *Scheduler) string {
+				_, cancel := context.WithCancel(context.Background())
+				seedRun(s, "sched-1", "exec-1", cancel, true)
+				return "exec-1"
+			},
+			// The run has read its verdict; signaling now would corrupt it.
+			wantOutcome:  CancelOutcomeAlreadyFinished,
+			wantSignaled: false,
+		},
+		{
+			name: "execution in history reports already finished",
+			seed: func(t *testing.T, s *Scheduler) string {
+				ctx := context.Background()
+				sched := failingSchedule("sched-history")
+				require.NoError(t, s.store.Create(ctx, sched))
+				require.NoError(t, s.store.RecordExecution(ctx, &loomv1.ScheduleExecution{
+					ExecutionId: "exec-done",
+					Status:      "success",
+				}, sched.Id))
+				return "exec-done"
+			},
+			wantOutcome: CancelOutcomeAlreadyFinished,
+		},
+		{
+			name: "unknown id reports not found rather than already finished",
+			// The failure mode this guards: an execution ID from
+			// ExecuteWorkflow/StreamWorkflow is a different namespace, and
+			// telling an operator their live workflow "already finished" is a
+			// lie they would act on.
+			seed: func(t *testing.T, s *Scheduler) string {
+				return "exec-from-another-namespace"
+			},
+			wantOutcome: CancelOutcomeNotFound,
+		},
+		{
+			name: "empty id is rejected",
+			seed: func(t *testing.T, s *Scheduler) string {
+				return ""
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := setupTestScheduler(t)
+			execID := tt.seed(t, s)
+
+			// Track whether the run's context actually got canceled.
+			signaled := false
+			if run, ok := s.runs[execID]; ok {
+				inner := run.cancel
+				run.cancel = func() { signaled = true; inner() }
+			}
+
+			outcome, err := s.CancelExecution(context.Background(), execID, "operator stop")
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOutcome, outcome,
+				"outcome should be %s, got %s", tt.wantOutcome, outcome)
+			assert.Equal(t, tt.wantSignaled, signaled,
+				"whether the run's context was canceled")
+		})
+	}
+}
+
+func TestCancelExecutionRecordsReasonBeforeSignaling(t *testing.T) {
+	t.Parallel()
+
+	s := setupTestScheduler(t)
+
+	// Read the reason from inside the cancel func, which is what executeWorkflow
+	// effectively does when its context unwinds. If the reason were written
+	// after the signal, the classification could see a canceled context with no
+	// explanation and record the stop as a crash.
+	var (
+		seenReason string
+		seenOK     bool
+	)
+	seedRun(s, "sched-1", "exec-1", nil, false)
+	s.mu.Lock()
+	s.runs["exec-1"].cancel = func() {
+		// RLock here also proves cancel() runs outside s.mu: were it called
+		// under the write lock, this would deadlock rather than fail.
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		run := s.runs["exec-1"]
+		seenReason, seenOK = run.reason, run.canceled
+	}
 	s.mu.Unlock()
 
-	cancelled, err := s.CancelExecution(context.Background(), "exec-1", "stopped by test")
-	if err != nil {
-		t.Fatalf("CancelExecution: %v", err)
-	}
-	if !cancelled {
-		t.Fatal("cancelled = false for a running execution")
-	}
+	outcome, err := s.CancelExecution(context.Background(), "exec-1", "operator stop")
+	require.NoError(t, err)
+	require.Equal(t, CancelOutcomeSignaled, outcome)
 
-	select {
-	case <-execCtx.Done():
-	default:
-		t.Error("the execution context was not cancelled")
-	}
+	assert.True(t, seenOK, "cancel flag must be set before the context is canceled")
+	assert.Equal(t, "operator stop", seenReason,
+		"reason must be readable before the context is canceled")
+}
+
+func TestCancelExecutionFirstReasonWins(t *testing.T) {
+	t.Parallel()
+
+	s := setupTestScheduler(t)
+	_, cancel := context.WithCancel(context.Background())
+	seedRun(s, "sched-1", "exec-1", cancel, false)
+
+	ctx := context.Background()
+	first, err := s.CancelExecution(ctx, "exec-1", "stopped by alice")
+	require.NoError(t, err)
+	require.Equal(t, CancelOutcomeSignaled, first)
+
+	second, err := s.CancelExecution(ctx, "exec-1", "stopped by bob")
+	require.NoError(t, err)
+	assert.Equal(t, CancelOutcomeSignaled, second,
+		"a second cancel is idempotent for the caller")
 
 	s.mu.RLock()
-	reason := s.cancelReasons["exec-1"]
-	s.mu.RUnlock()
-	if reason != "stopped by test" {
-		t.Errorf("recorded reason = %q, want %q", reason, "stopped by test")
-	}
+	defer s.mu.RUnlock()
+	assert.Equal(t, "stopped by alice", s.runs["exec-1"].reason,
+		"the history should name the operator whose signal stopped the run, not whoever asked last")
 }
 
-// An execution that already finished is not an error: the caller wanted it
-// stopped and it is stopped. Reporting NotFound would make the UI apologise for
-// winning a race.
-func TestCancelExecutionUnknownIDIsNotAnError(t *testing.T) {
-	s := newCancelTestScheduler()
+func TestRunningExecutions(t *testing.T) {
+	t.Parallel()
 
-	cancelled, err := s.CancelExecution(context.Background(), "exec-gone", "")
-	if err != nil {
-		t.Fatalf("unknown execution returned an error: %v", err)
-	}
-	if cancelled {
-		t.Error("cancelled = true for an execution that was never running")
-	}
+	t.Run("excludes settled runs so every entry is still cancellable", func(t *testing.T) {
+		t.Parallel()
 
-	// Nothing should be left behind for a run that does not exist, or the
-	// reason would be misapplied if that ID were later reused.
-	s.mu.RLock()
-	_, leaked := s.cancelReasons["exec-gone"]
-	s.mu.RUnlock()
-	if leaked {
-		t.Error("a reason was recorded for a non-running execution")
-	}
+		s := setupTestScheduler(t)
+		seedRun(s, "sched-live", "exec-live", func() {}, false)
+		seedRun(s, "sched-settled", "exec-settled", func() {}, true)
+
+		got := s.RunningExecutions()
+
+		assert.Equal(t, map[string]string{"sched-live": "exec-live"}, got,
+			"a settled run would answer a stop button with \"already finished\"")
+
+		// Everything advertised must actually be cancellable.
+		for _, execID := range got {
+			outcome, err := s.CancelExecution(context.Background(), execID, "check")
+			require.NoError(t, err)
+			assert.Equal(t, CancelOutcomeSignaled, outcome,
+				"execution %s was advertised as running but is not cancellable", execID)
+		}
+	})
+
+	t.Run("returns a copy", func(t *testing.T) {
+		t.Parallel()
+
+		s := setupTestScheduler(t)
+		seedRun(s, "sched-1", "exec-1", func() {}, false)
+
+		got := s.RunningExecutions()
+		got["sched-1"] = "mutated"
+
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		assert.Equal(t, "sched-1", s.runs["exec-1"].scheduleID,
+			"RunningExecutions returned the live state, not a copy")
+	})
 }
 
-func TestCancelExecutionRequiresID(t *testing.T) {
-	s := newCancelTestScheduler()
+// TestExecuteWorkflowRegistersBeforeAdvertising covers F3: there must be no
+// window in which a run is advertised as running but answers a cancel with
+// "not running".
+func TestExecuteWorkflowRegistersBeforeAdvertising(t *testing.T) {
+	t.Parallel()
 
-	if _, err := s.CancelExecution(context.Background(), "", "why"); err == nil {
-		t.Error("empty execution_id returned nil error")
-	}
+	s := setupTestScheduler(t)
+	ctx := context.Background()
+	sched := failingSchedule("sched-advertise")
+	require.NoError(t, s.store.Create(ctx, sched))
+
+	// Hold the store lock so the run parks at UpdateCurrentExecution, i.e. in
+	// the window between being marked running and reaching the orchestrator.
+	s.store.mu.Lock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.executeWorkflow(ctx, sched, "exec-advertise", nil)
+	}()
+
+	waitFor(t, "the run to be advertised", func() bool {
+		return len(s.RunningExecutions()) == 1
+	})
+
+	// Advertised. It must therefore be cancellable, while still parked.
+	outcome, err := s.CancelExecution(ctx, "exec-advertise", "operator stop")
+	s.store.mu.Unlock()
+
+	require.NoError(t, err)
+	assert.Equal(t, CancelOutcomeSignaled, outcome,
+		"the scheduler advertised this execution, so a stop button offered for it must work")
+
+	waitFor(t, "the run to finish", func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	})
 }
 
-// The reason must be recorded before the context is cancelled. If it were the
-// other way round, executeWorkflow could observe a cancelled context, classify
-// the run as failed, and miss the reason entirely.
-func TestCancelRecordsReasonBeforeCancelling(t *testing.T) {
-	s := newCancelTestScheduler()
+// TestCancelAfterVerdictReportsAlreadyFinished covers the "false signaled"
+// half of F1: once a run has read its verdict, a cancel must not claim to have
+// signaled it, and must not disturb what was recorded.
+func TestCancelAfterVerdictReportsAlreadyFinished(t *testing.T) {
+	t.Parallel()
+
+	s := setupTestScheduler(t)
+	ctx := context.Background()
+	sched := failingSchedule("sched-late-cancel")
+	require.NoError(t, s.store.Create(ctx, sched))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.executeWorkflow(ctx, sched, "exec-late", nil)
+	}()
+
+	// settled is set in the same critical section that reads the verdict, so
+	// observing it is proof the orchestrator has already returned.
+	waitFor(t, "the run to read its verdict", func() bool {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		run, ok := s.runs["exec-late"]
+		return ok && run.settled
+	})
+
+	outcome, err := s.CancelExecution(ctx, "exec-late", "operator stop")
+	require.NoError(t, err)
+	assert.Equal(t, CancelOutcomeAlreadyFinished, outcome,
+		"the run had already reached its verdict; reporting it as signaled tells the operator a run was stopped when it was not")
+
+	<-done
+
+	// The run's own verdict must be intact.
+	history, err := s.store.GetExecutionHistory(ctx, sched.Id, 10)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	assert.Equal(t, "failed", history[0].Status,
+		"a configuration failure was relabelled as an operator stop")
+	assert.Contains(t, history[0].Error, "stages",
+		"the real error was replaced by the cancel reason")
+
+	got, err := s.store.Get(ctx, sched.Id)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), got.Stats.FailedExecutions,
+		"the failure was dropped from the counters the success rate is derived from")
+	assert.Equal(t, "failed", got.Stats.LastStatus)
+}
+
+// answeringLLM answers at once and counts how often it was asked, so a test can
+// tell whether the workflow actually completed.
+type answeringLLM struct {
+	calls atomic.Int32
+}
+
+func (l *answeringLLM) Chat(_ context.Context, _ []llmtypes.Message, _ []shuttle.Tool) (*llmtypes.LLMResponse, error) {
+	l.calls.Add(1)
+	return &llmtypes.LLMResponse{Content: "done", StopReason: "stop"}, nil
+}
+
+func (l *answeringLLM) Name() string  { return "answering" }
+func (l *answeringLLM) Model() string { return "answering" }
+
+// TestCancelAfterSuccessKeepsTheSuccess covers the verdict-erasure half of F1
+// with a run that genuinely succeeds.
+//
+// The failing-pattern sibling above proves a late cancel cannot relabel a
+// failure. This one proves it cannot relabel a success, which is the worse
+// outcome: a routine that just did its job would show up as stopped by an
+// operator, with successful_executions never moving. The agent answers and the
+// pipeline completes; only then does the cancel arrive.
+func TestCancelAfterSuccessKeepsTheSuccess(t *testing.T) {
+	t.Parallel()
+
+	llm := &answeringLLM{}
+	h := newAgentTestScheduler(t, llm)
+	s := h.scheduler
+	ctx := context.Background()
+
+	sched := agentWorkflow("sched-late-success")
+	require.NoError(t, s.store.Create(ctx, sched))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.executeWorkflow(ctx, sched, "exec-late-success", nil)
+	}()
+
+	waitFor(t, "the run to read its verdict", func() bool {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		run, ok := s.runs["exec-late-success"]
+		return ok && run.settled
+	})
+	require.Positive(t, llm.calls.Load(), "the agent was never asked; the run did not actually complete")
+
+	outcome, err := s.CancelExecution(ctx, "exec-late-success", "operator stop")
+	require.NoError(t, err)
+	assert.Equal(t, CancelOutcomeAlreadyFinished, outcome)
+
+	<-done
+
+	history, err := s.store.GetExecutionHistory(ctx, sched.Id, 10)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	assert.Equal(t, "success", history[0].Status,
+		"a run that completed was relabelled as an operator stop")
+	assert.Empty(t, history[0].Error)
+
+	got, err := s.store.Get(ctx, sched.Id)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), got.Stats.SuccessfulExecutions,
+		"the success was dropped from the counters the success rate is derived from")
+	assert.Equal(t, int32(1), got.Stats.TotalExecutions)
+	assert.Equal(t, "success", got.Stats.LastStatus)
+}
+
+// TestExecuteWorkflowRecordsGenuineCancellation is the positive case: a cancel
+// that really does stop the run is recorded as canceled and leaves the
+// success-rate counters alone.
+func TestExecuteWorkflowRecordsGenuineCancellation(t *testing.T) {
+	t.Parallel()
+
+	s := setupTestScheduler(t)
+	ctx := context.Background()
+	sched := failingSchedule("sched-genuine")
+	require.NoError(t, s.store.Create(ctx, sched))
+
+	// Park the run before the orchestrator runs, so the cancel provably lands
+	// while it is still cancellable.
+	s.store.mu.Lock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.executeWorkflow(ctx, sched, "exec-genuine", nil)
+	}()
+
+	waitFor(t, "the run to register", func() bool {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		_, ok := s.runs["exec-genuine"]
+		return ok
+	})
+
+	outcome, err := s.CancelExecution(ctx, "exec-genuine", "stopped by operator")
+	s.store.mu.Unlock()
+	require.NoError(t, err)
+	require.Equal(t, CancelOutcomeSignaled, outcome)
+
+	<-done
+
+	history, err := s.store.GetExecutionHistory(ctx, sched.Id, 10)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	assert.Equal(t, "canceled", history[0].Status)
+	assert.Equal(t, "stopped by operator", history[0].Error)
+
+	got, err := s.store.Get(ctx, sched.Id)
+	require.NoError(t, err)
+	assert.Equal(t, "canceled", got.Stats.LastStatus,
+		"last_status must move off the previous run, or a stopped routine reports itself as having last succeeded")
+	assert.Equal(t, int32(0), got.Stats.TotalExecutions,
+		"a canceled run reached no verdict and must not count as an execution")
+	assert.Equal(t, int32(0), got.Stats.FailedExecutions,
+		"an operator's stop is not a failure; counting it would distort the success rate")
+}
+
+// TestCancelRacingCompletionKeepsRecordAndCountersConsistent fires a cancel at
+// an unsynchronised point around completion, many times, and asserts that the
+// history record and the counters agree on every interleaving.
+//
+// This is the shape of test the race detector cannot substitute for: the bug
+// class is a logical interleaving, not a data race, so -race stays green while
+// the two disagree. It checks consistency, not which verdict was right — the
+// two deterministic tests above pin the verdict for a cancel that lands after
+// completion.
+func TestCancelRacingCompletionKeepsRecordAndCountersConsistent(t *testing.T) {
+	t.Parallel()
+
+	const iterations = 200
+
+	s := setupTestScheduler(t)
+	ctx := context.Background()
 
 	var (
-		mu             sync.Mutex
-		reasonAtCancel string
-		sawReason      bool
+		canceledRuns int
+		failedRuns   int
 	)
 
-	s.mu.Lock()
-	s.runningCancels["exec-1"] = func() {
-		s.mu.RLock()
-		r, ok := s.cancelReasons["exec-1"]
-		s.mu.RUnlock()
-		mu.Lock()
-		reasonAtCancel, sawReason = r, ok
-		mu.Unlock()
-	}
-	s.mu.Unlock()
+	for i := 0; i < iterations; i++ {
+		// A fresh schedule per iteration, so each one's counters and history
+		// are judged on their own rather than needing a reset.
+		sched := failingSchedule(fmt.Sprintf("sched-race-%d", i))
+		require.NoError(t, s.store.Create(ctx, sched))
 
-	if _, err := s.CancelExecution(context.Background(), "exec-1", "operator stop"); err != nil {
-		t.Fatalf("CancelExecution: %v", err)
+		execID := fmt.Sprintf("exec-race-%d", i)
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			s.executeWorkflow(ctx, sched, execID, nil)
+		}()
+
+		go func() {
+			defer wg.Done()
+			// Unsynchronised on purpose: across iterations this lands before,
+			// during and after the verdict. The run may register and tear down
+			// before this goroutine ever observes it, so the spin is bounded —
+			// a missed run is a legitimate interleaving, not a failure.
+			deadline := time.Now().Add(2 * time.Second)
+			for {
+				s.mu.RLock()
+				_, tracked := s.runs[execID]
+				s.mu.RUnlock()
+				if tracked || time.Now().After(deadline) {
+					break
+				}
+			}
+			_, _ = s.CancelExecution(ctx, execID, "operator stop")
+		}()
+
+		wg.Wait()
+
+		history, err := s.store.GetExecutionHistory(ctx, sched.Id, 1)
+		require.NoError(t, err)
+		require.Len(t, history, 1, "iteration %d recorded no history", i)
+
+		got, err := s.store.Get(ctx, sched.Id)
+		require.NoError(t, err)
+
+		switch history[0].Status {
+		case "canceled":
+			canceledRuns++
+			// A canceled run reached no verdict: no counters, and the reason
+			// rather than an orchestrator error.
+			require.Equal(t, int32(0), got.Stats.FailedExecutions,
+				"iteration %d: canceled run counted as a failure", i)
+			require.Equal(t, int32(0), got.Stats.TotalExecutions,
+				"iteration %d: canceled run counted as an execution", i)
+
+		case "failed":
+			failedRuns++
+			// The cancel did not stop this run, so its real failure must be
+			// recorded in full — this is the assertion that fails when the run
+			// stays cancellable through its bookkeeping tail.
+			require.Contains(t, history[0].Error, "stages",
+				"iteration %d: real error replaced by the cancel reason", i)
+			require.Equal(t, int32(1), got.Stats.FailedExecutions,
+				"iteration %d: failure dropped from the counters", i)
+			require.Equal(t, "failed", got.Stats.LastStatus,
+				"iteration %d: last_status does not match the recorded outcome", i)
+
+		default:
+			t.Fatalf("iteration %d: unexpected status %q", i, history[0].Status)
+		}
 	}
 
-	mu.Lock()
-	defer mu.Unlock()
-	if !sawReason {
-		t.Fatal("the reason was not visible when cancel fired")
-	}
-	if reasonAtCancel != "operator stop" {
-		t.Errorf("reason at cancel = %q, want %q", reasonAtCancel, "operator stop")
-	}
+	// Both interleavings must actually have occurred, or the test proved nothing.
+	t.Logf("canceled=%d failed=%d of %d iterations", canceledRuns, failedRuns, iterations)
+	assert.Positive(t, canceledRuns+failedRuns)
 }
 
-func TestRunningExecutionsSnapshot(t *testing.T) {
-	s := newCancelTestScheduler()
+// TestStopCancelsInFlightRunsOnDeadline covers F6: Stop must not close the store
+// out from under runs that are still writing to it.
+func TestStopCancelsInFlightRunsOnDeadline(t *testing.T) {
+	t.Parallel()
 
-	s.mu.Lock()
-	s.runningWorkflows["sched-1"] = "exec-1"
-	s.runningWorkflows["sched-2"] = "exec-2"
-	s.mu.Unlock()
+	s := setupTestScheduler(t)
+	_, cancel := context.WithCancel(context.Background())
 
-	got := s.RunningExecutions()
-	if len(got) != 2 || got["sched-1"] != "exec-1" || got["sched-2"] != "exec-2" {
-		t.Fatalf("RunningExecutions() = %v", got)
-	}
+	signaled := make(chan struct{})
+	seedRun(s, "sched-1", "exec-1", func() { close(signaled); cancel() }, false)
+	// A settled run is past cancelling; draining must skip it rather than
+	// signaling a context whose run has already recorded its verdict.
+	seedRun(s, "sched-2", "exec-2", func() { t.Error("settled run was canceled during drain") }, true)
 
-	// The result must be a copy — handing out the live map would let a caller
-	// mutate scheduler state without the lock.
-	got["sched-1"] = "tampered"
-	s.mu.RLock()
-	live := s.runningWorkflows["sched-1"]
-	s.mu.RUnlock()
-	if live != "exec-1" {
-		t.Error("RunningExecutions returned the live map, not a copy")
+	// An already-expired context puts Stop straight onto its deadline branch.
+	expired, expiredCancel := context.WithCancel(context.Background())
+	expiredCancel()
+
+	require.NoError(t, s.Stop(expired))
+
+	select {
+	case <-signaled:
+	default:
+		t.Error("Stop hit its deadline without cancelling the in-flight run")
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -37,17 +37,25 @@ type Scheduler struct {
 	mu               sync.RWMutex
 	schedules        map[string]*loomv1.ScheduledWorkflow
 	runningWorkflows map[string]string // schedule_id -> execution_id
-	cronEngine       *cron.Cron
-	cronEntries      map[string]cron.EntryID
-	store            *Store
-	orchestrator     *orchestration.Orchestrator
-	registry         *agent.Registry
-	tracer           observability.Tracer
-	logger           *zap.Logger
-	loader           *Loader
-	stopCh           chan struct{}
-	wg               sync.WaitGroup
-	config           Config
+	// runningCancels holds each in-flight execution's cancel func, keyed by
+	// execution ID. Without it the only way to stop a hung workflow is to wait
+	// out max_execution_seconds, during which skip_if_running silently skips
+	// every scheduled run.
+	runningCancels map[string]context.CancelFunc
+	// cancelReasons records why an execution was cancelled, so the history entry
+	// can distinguish an operator stop from a timeout or a crash.
+	cancelReasons map[string]string
+	cronEngine    *cron.Cron
+	cronEntries   map[string]cron.EntryID
+	store         *Store
+	orchestrator  *orchestration.Orchestrator
+	registry      *agent.Registry
+	tracer        observability.Tracer
+	logger        *zap.Logger
+	loader        *Loader
+	stopCh        chan struct{}
+	wg            sync.WaitGroup
+	config        Config
 }
 
 // NewScheduler creates a new workflow scheduler.
@@ -78,6 +86,8 @@ func NewScheduler(ctx context.Context, config Config) (*Scheduler, error) {
 	s := &Scheduler{
 		schedules:        make(map[string]*loomv1.ScheduledWorkflow),
 		runningWorkflows: make(map[string]string),
+		runningCancels:   make(map[string]context.CancelFunc),
+		cancelReasons:    make(map[string]string),
 		cronEngine:       cronEngine,
 		cronEntries:      make(map[string]cron.EntryID),
 		store:            store,
@@ -380,6 +390,57 @@ func (s *Scheduler) TriggerNow(ctx context.Context, scheduleID string, skipIfRun
 	return executionID, nil
 }
 
+// CancelExecution stops a running execution.
+//
+// Returns false when no execution with that ID is in flight — already finished,
+// or never started. That is deliberately not an error: someone cancelling a run
+// that just completed has got the outcome they wanted, and turning the race into
+// a failure would only make the UI apologise for succeeding.
+//
+// Cancellation is cooperative. The execution's context is cancelled, which
+// unwinds the orchestrator at its next context check; work already committed by
+// earlier stages is not rolled back. The reason is recorded so the history entry
+// reads as an operator stop rather than a crash.
+func (s *Scheduler) CancelExecution(ctx context.Context, executionID, reason string) (bool, error) {
+	if executionID == "" {
+		return false, fmt.Errorf("execution_id is required")
+	}
+
+	s.mu.Lock()
+	cancel, running := s.runningCancels[executionID]
+	if running {
+		// Recorded before cancelling so executeWorkflow's classification cannot
+		// observe the cancelled context before it can see the reason.
+		s.cancelReasons[executionID] = reason
+	}
+	s.mu.Unlock()
+
+	if !running {
+		return false, nil
+	}
+
+	s.logger.Info("Cancelling workflow execution",
+		zap.String("execution_id", executionID),
+		zap.String("reason", reason))
+
+	cancel()
+	return true, nil
+}
+
+// RunningExecutions returns the execution IDs currently in flight, keyed by
+// schedule ID. Useful for an operations view that needs to offer a stop button
+// only where there is something to stop.
+func (s *Scheduler) RunningExecutions() map[string]string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make(map[string]string, len(s.runningWorkflows))
+	for scheduleID, execID := range s.runningWorkflows {
+		out[scheduleID] = execID
+	}
+	return out
+}
+
 // GetSchedule retrieves a schedule by ID.
 func (s *Scheduler) GetSchedule(ctx context.Context, scheduleID string) (*loomv1.ScheduledWorkflow, error) {
 	return s.store.Get(ctx, scheduleID)
@@ -488,6 +549,18 @@ func (s *Scheduler) executeWorkflow(ctx context.Context, schedule *loomv1.Schedu
 	execCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	// Publish the cancel func so CancelExecution can reach this run. Registered
+	// after the running-marker above and torn down alongside it.
+	s.mu.Lock()
+	s.runningCancels[executionID] = cancel
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		delete(s.runningCancels, executionID)
+		delete(s.cancelReasons, executionID)
+		s.mu.Unlock()
+	}()
+
 	// Set workflow_id for session continuity in RESUME mode
 	if schedule.Schedule.SessionMode == loomv1.ScheduledSessionMode_SCHEDULED_SESSION_MODE_RESUME {
 		// Use schedule ID as stable workflow_id so agent sessions are deterministic
@@ -524,7 +597,35 @@ func (s *Scheduler) executeWorkflow(ctx context.Context, schedule *loomv1.Schedu
 		WorkflowId:  workflowID,
 	}
 
-	if err != nil {
+	// A cancelled run is not a failed run. Counting an operator's stop as a
+	// failure would corrupt the success rate the UI uses to convey trust, and
+	// would make a deliberately stopped routine look broken.
+	s.mu.RLock()
+	cancelReason, wasCancelled := s.cancelReasons[executionID]
+	s.mu.RUnlock()
+
+	switch {
+	case wasCancelled:
+		execution.Status = "cancelled"
+		if cancelReason != "" {
+			execution.Error = cancelReason
+		} else {
+			execution.Error = "cancelled by operator"
+		}
+
+		s.logger.Info("Workflow execution cancelled",
+			zap.String("schedule_id", schedule.Id),
+			zap.String("execution_id", executionID),
+			zap.String("reason", cancelReason),
+			zap.Int64("duration_ms", duration.Milliseconds()))
+
+		// Move last_status off the previous run's outcome. Without this a
+		// stopped routine reports itself as having last succeeded.
+		if storeErr := s.store.RecordCancelled(ctx, schedule.Id, execution.Error); storeErr != nil {
+			s.logger.Error("Failed to record cancellation", zap.Error(storeErr))
+		}
+
+	case err != nil:
 		execution.Status = "failed"
 		execution.Error = err.Error()
 
@@ -537,7 +638,8 @@ func (s *Scheduler) executeWorkflow(ctx context.Context, schedule *loomv1.Schedu
 		if err := s.store.RecordFailure(ctx, schedule.Id, err.Error()); err != nil {
 			s.logger.Error("Failed to record failure", zap.Error(err))
 		}
-	} else {
+
+	default:
 		execution.Status = "success"
 
 		s.logger.Info("Workflow execution succeeded",

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -66,7 +66,7 @@ type Scheduler struct {
 	// canceled or does it still occupy its schedule's slot", inFlight answers
 	// "is the store still in use". A run leaves runs before its last write.
 	inFlight sync.WaitGroup
-	// stopped is set once by Stop, under mu. beginRun refuses to launch further
+	// stopped is set once by Stop, under mu. admitRun refuses to launch further
 	// runs after that, which is what makes inFlight.Wait sound: every Add
 	// happens under the same lock that sets this flag, so no Add can race the
 	// Wait that follows it.
@@ -168,49 +168,67 @@ func (s *Scheduler) Start(ctx context.Context) error {
 // reason at all.
 const shutdownCancelReason = "scheduler shutting down"
 
-// beginRun reserves a slot for one execution and reports whether the caller may
-// launch it. Every launch site must go through it, and must call
-// s.inFlight.Done() once the execution's last store write has happened.
+// runAdmission is the verdict admitRun reached for one prospective run.
+type runAdmission int
+
+const (
+	// runAdmitted means the slot is reserved, the execution is registered under
+	// its schedule and already cancellable, and the caller owes exactly one
+	// s.inFlight.Done() once that execution's last store write has happened.
+	runAdmitted runAdmission = iota
+
+	// runRefusedStopped means the scheduler is shutting down. Refusing matters
+	// as much as counting: after Stop the store is closed, and a run that
+	// started anyway would spend its whole life writing to a closed database.
+	runRefusedStopped
+
+	// runRefusedRunning means skip_if_running was asked for and the schedule is
+	// still occupied. admitRun returns the occupying execution ID alongside it,
+	// so the caller can name the run the operator is actually waiting on.
+	runRefusedRunning
+)
+
+// admitRun decides whether one execution may start and, if it may, makes it
+// real: it reserves the drain slot, registers the execution under its schedule,
+// and leaves it cancellable — all in one critical section. Every launch site
+// goes through it, and every admitted run owes one s.inFlight.Done().
 //
-// The Add is done under the same lock Stop uses to set stopped, so a run can
-// never join after Stop has decided what it is waiting for — the happens-before
-// that makes the subsequent inFlight.Wait sound. Refusing the launch matters as
-// much as counting it: after Stop the store is closed, and a run that started
-// anyway would spend its whole life writing to a closed database.
-func (s *Scheduler) beginRun() bool {
+// The three questions are one question, and splitting them cost two bugs:
+//
+//   - Asking "is this schedule busy?" separately from recording the answer let
+//     two triggers arriving together both observe an idle schedule and both
+//     start, so skip_if_running admitted the overlapping run it exists to
+//     prevent.
+//   - Reserving the slot separately from registering the execution left a
+//     window in which a run was already counted by the drain but was not yet
+//     cancellable. Stop's grace expiry signals once; a run inside that window
+//     was missed, and the deadline-free final drain then waited for it anyway —
+//     so shutdown stopped being bounded by the operator's shutdown context and
+//     started being bounded by max_execution_seconds, an hour by default.
+//
+// The Add happens under the same lock Stop uses to set stopped, which is what
+// makes the subsequent inFlight.Wait sound: no run can join after Stop has
+// fixed the set it is waiting for.
+//
+// The registered entry's cancel func is nil until executeWorkflow builds the
+// real context and attaches it. A cancel arriving before then can only set the
+// canceled flag, which executeWorkflow honors the instant the real func exists.
+func (s *Scheduler) admitRun(scheduleID, executionID string, skipIfRunning bool) (runAdmission, string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if s.stopped {
-		return false
+		return runRefusedStopped, ""
 	}
-	s.inFlight.Add(1)
-	return true
-}
-
-// beginTriggeredRun reserves a slot the same way beginRun does, and also
-// pre-registers executionID under scheduleID before returning — in the same
-// critical section, so there is no gap between the caller handing this ID out
-// and the scheduler considering it tracked.
-//
-// TriggerNow needs this and the cron path does not: TriggerNow returns
-// executionID to its caller before the goroutine that will run it even starts,
-// so a cancel arriving in that window has to find something. Without
-// pre-registration it would see nothing tracked and report NOT_FOUND for an ID
-// this scheduler had, in fact, already minted. The entry's cancel func is nil
-// until executeWorkflow builds the real context and attaches it; a cancel
-// arriving before then can only set the canceled flag, which executeWorkflow
-// checks and honors immediately once the real cancel func exists.
-func (s *Scheduler) beginTriggeredRun(scheduleID, executionID string) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.stopped {
-		return false
+	if skipIfRunning {
+		if current := s.runningExecutionForLocked(scheduleID); current != "" {
+			return runRefusedRunning, current
+		}
 	}
+
 	s.inFlight.Add(1)
 	s.runs[executionID] = &runState{scheduleID: scheduleID}
-	return true
+	return runAdmitted, ""
 }
 
 // cancelAllRunning signals every cancellable execution and reports how many it
@@ -260,7 +278,7 @@ func (s *Scheduler) signalShutdown() {
 func (s *Scheduler) Stop(ctx context.Context) error {
 	s.logger.Info("Stopping workflow scheduler")
 
-	// Refuse new runs first. Paired with beginRun's Add under the same lock,
+	// Refuse new runs first. Paired with admitRun's Add under the same lock,
 	// this fixes the set of executions the wait below has to cover. The
 	// stopped check also makes Stop idempotent: without it, a second call
 	// would close(s.stopCh) again and panic.
@@ -517,15 +535,6 @@ func (s *Scheduler) TriggerNow(ctx context.Context, scheduleID string, skipIfRun
 		return "", fmt.Errorf("schedule not found: %s", scheduleID)
 	}
 
-	// Check skip-if-running
-	if skipIfRunning {
-		executionID := s.runningExecutionFor(scheduleID)
-
-		if executionID != "" {
-			return "", fmt.Errorf("previous execution still running: %s", executionID)
-		}
-	}
-
 	// Merge variables
 	mergedVars := make(map[string]string)
 	if schedule.Schedule.Variables != nil {
@@ -537,29 +546,37 @@ func (s *Scheduler) TriggerNow(ctx context.Context, scheduleID string, skipIfRun
 		mergedVars[k] = v
 	}
 
-	// Reserve the run and pre-register it under the ID before spawning the
-	// goroutine, both in one critical section. This ID is handed back to the
-	// caller below, before the goroutine even starts; without pre-registration
-	// a cancel arriving in that window finds nothing tracked and reports
-	// NOT_FOUND for an execution this scheduler already minted. A trigger that
-	// arrives during shutdown is refused rather than started, because the
-	// store it would write to is about to close.
+	// One critical section settles everything about this run: that the
+	// scheduler is still accepting work, that the request's own skip_if_running
+	// is satisfied, and that this execution now holds the schedule's slot and
+	// is cancellable.
+	//
+	// All three have to be one decision. The ID is handed back to the caller
+	// below, before the goroutine even starts; without registration in the same
+	// section, a cancel arriving in that window finds nothing tracked and
+	// reports NOT_FOUND for an execution this scheduler already minted, and two
+	// triggers arriving together both see an idle schedule and both start.
 	executionID := uuid.New().String()
-	if !s.beginTriggeredRun(scheduleID, executionID) {
+	admission, current := s.admitRun(scheduleID, executionID, skipIfRunning)
+	switch admission {
+	case runRefusedStopped:
 		return "", fmt.Errorf("scheduler is stopped")
+	case runRefusedRunning:
+		return "", fmt.Errorf("previous execution still running: %s", current)
+	case runAdmitted:
+		// Launch below. The Done for this Add is deferred in the goroutine.
 	}
 
 	go func() { // #nosec G118 -- intentional: background worker goroutine that must outlive the request context
 		// Done only once executeWorkflow has returned, so it covers the
 		// bookkeeping tail as well as the workflow itself.
 		defer s.inFlight.Done()
-		// checkScheduleSkipIfRunning is false: the skip-if-running decision for
-		// a manual trigger is the request's own skipIfRunning above, already
-		// applied. Re-checking the schedule's persisted setting here would let
-		// stale config silently override an explicit "run it anyway" from the
-		// caller — and would find this run's own pre-registered entry and
-		// report itself as "previous execution still running".
-		s.executeWorkflow(context.Background(), schedule, executionID, mergedVars, false)
+		// The skip_if_running decision for a manual trigger is the request's
+		// own skipIfRunning, already applied by admitRun above. The schedule's
+		// persisted setting is deliberately not consulted for a manual run:
+		// letting stale config override an explicit "run it anyway" from the
+		// caller would be the opposite of what was asked for.
+		s.executeWorkflow(context.Background(), schedule, executionID, mergedVars)
 	}()
 
 	return executionID, nil
@@ -725,17 +742,19 @@ func (s *Scheduler) RunningExecutions() map[string]string {
 	return out
 }
 
-// runningExecutionFor returns the execution currently occupying a schedule's
-// slot, or "" if the schedule is idle.
+// runningExecutionForLocked returns the execution currently occupying a
+// schedule's slot, or "" if the schedule is idle. The caller must hold s.mu.
+//
+// It takes no lock of its own because its only caller is admitRun, which has to
+// read this and register the new run in the same critical section — reading it
+// under its own lock is exactly the two-phase admission that let concurrent
+// triggers both pass skip_if_running.
 //
 // This deliberately counts settled runs too. skip_if_running has to keep
 // blocking until the previous run's bookkeeping tail has finished writing:
 // letting a new run start mid-tail would have the old run's teardown clear the
 // new run's current_execution_id and drop its entry.
-func (s *Scheduler) runningExecutionFor(scheduleID string) string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
+func (s *Scheduler) runningExecutionForLocked(scheduleID string) string {
 	for execID, run := range s.runs {
 		if run.scheduleID == scheduleID {
 			return execID
@@ -773,15 +792,39 @@ func (s *Scheduler) addScheduleToCron(ctx context.Context, schedule *loomv1.Sche
 
 	// Create job function
 	jobFunc := func() {
-		// Same reservation as TriggerNow: a tick that fires while Stop is
-		// draining must not open a new run against a closing store.
-		if !s.beginRun() {
-			return
-		}
-		defer s.inFlight.Done()
-
-		execCtx := context.Background()
+		// The ID is minted before admission because admission is what registers
+		// it. A run has to be cancellable from the instant it occupies its
+		// schedule's slot: Stop's grace expiry signals once, so a run still in
+		// the gap between reserving a slot and becoming cancellable was missed
+		// by that signal and then waited for by the deadline-free final drain.
 		executionID := uuid.New().String()
+
+		// A cron tick has no request-level override to defer to, so it honors
+		// the schedule's own persisted skip_if_running. The same critical
+		// section that applies it also refuses a tick that fires while Stop is
+		// draining, which must not open a new run against a closing store.
+		admission, current := s.admitRun(schedule.Id, executionID, schedule.Schedule.SkipIfRunning)
+		switch admission {
+		case runRefusedStopped:
+			return
+		case runRefusedRunning:
+			s.logger.Info("Skipping execution, previous still running",
+				zap.String("schedule_id", schedule.Id),
+				zap.String("current_execution_id", current))
+
+			// context.Background, not the ctx this schedule was registered
+			// with: that one belongs to the call that installed the cron entry
+			// and may be long gone by the time a tick fires.
+			if err := s.store.IncrementSkipped(context.Background(), schedule.Id); err != nil {
+				s.logger.Error("Failed to increment skipped count", zap.Error(err))
+			}
+			return
+		case runAdmitted:
+			// Run below.
+		}
+		// Done only once executeWorkflow has returned, so it covers the
+		// bookkeeping tail as well as the workflow itself.
+		defer s.inFlight.Done()
 
 		// Use schedule variables
 		variables := schedule.Schedule.Variables
@@ -789,9 +832,7 @@ func (s *Scheduler) addScheduleToCron(ctx context.Context, schedule *loomv1.Sche
 			variables = make(map[string]string)
 		}
 
-		// true: a cron tick has no request-level override to defer to, so it
-		// must honor the schedule's own persisted skip_if_running.
-		s.executeWorkflow(execCtx, schedule, executionID, variables, true)
+		s.executeWorkflow(context.Background(), schedule, executionID, variables)
 	}
 
 	// Add to cron engine
@@ -806,39 +847,19 @@ func (s *Scheduler) addScheduleToCron(ctx context.Context, schedule *loomv1.Sche
 	return nil
 }
 
-// executeWorkflow executes a scheduled workflow.
+// executeWorkflow executes a scheduled workflow that has already been admitted.
 //
-// checkScheduleSkipIfRunning gates the schedule's own persisted
-// skip_if_running setting. A cron tick has no other opinion on the matter and
-// must pass true. A manually triggered run must pass false: TriggerNow already
-// applied the request's own skip_if_running override — using it, not the
-// schedule's config — before this executionID existed anywhere, and by the
-// time control reaches here that ID is already registered in s.runs, so
-// re-checking here would find that entry and report the run as colliding with
-// itself.
-func (s *Scheduler) executeWorkflow(ctx context.Context, schedule *loomv1.ScheduledWorkflow, executionID string, variables map[string]string, checkScheduleSkipIfRunning bool) {
+// skip_if_running is not rechecked here, and deliberately so: admitRun applied
+// it in the same critical section that registered this executionID, so by the
+// time control reaches here the ID is in s.runs and a recheck would find that
+// entry and report the run as colliding with itself.
+func (s *Scheduler) executeWorkflow(ctx context.Context, schedule *loomv1.ScheduledWorkflow, executionID string, variables map[string]string) {
 	startTime := time.Now()
 
 	s.logger.Info("Executing scheduled workflow",
 		zap.String("schedule_id", schedule.Id),
 		zap.String("execution_id", executionID),
 		zap.String("workflow_name", schedule.WorkflowName))
-
-	// Check skip-if-running
-	if checkScheduleSkipIfRunning && schedule.Schedule.SkipIfRunning {
-		currentExecID := s.runningExecutionFor(schedule.Id)
-
-		if currentExecID != "" {
-			s.logger.Info("Skipping execution, previous still running",
-				zap.String("schedule_id", schedule.Id),
-				zap.String("current_execution_id", currentExecID))
-
-			if err := s.store.IncrementSkipped(ctx, schedule.Id); err != nil {
-				s.logger.Error("Failed to increment skipped count", zap.Error(err))
-			}
-			return
-		}
-	}
 
 	// Set execution timeout. Built before the run is advertised so that the
 	// cancel func exists to register in the same breath.
@@ -849,16 +870,21 @@ func (s *Scheduler) executeWorkflow(ctx context.Context, schedule *loomv1.Schedu
 	execCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// Mark as running and publish the cancel func in one critical section, so
-	// there is no window in which the run is advertised as running — including
-	// via current_execution_id, the field callers are told to pass to
-	// CancelScheduledExecution — but a cancel would come back "not running".
+	// Attach the cancel func and read whether a cancel already landed in one
+	// critical section, so there is no window in which the run is advertised as
+	// running — including via current_execution_id, the field callers are told
+	// to pass to CancelScheduledExecution — but a cancel would come back "not
+	// running".
 	//
-	// A triggered run already has an entry here, pre-registered by
-	// beginTriggeredRun before this executionID was ever handed to a caller;
-	// attach the real cancel func to it rather than replacing it. If a cancel
-	// landed in the window before this func existed, deliver it now — the flag
-	// is the only thing a caller with a nil cancel func could set.
+	// Every admitted run already has an entry here, registered by admitRun
+	// before this executionID was handed to anyone; attach the real cancel func
+	// to it rather than replacing it. If a cancel landed in the window before
+	// this func existed, deliver it now — the flag is the only thing a caller
+	// with a nil cancel func could set.
+	//
+	// The fallback registration covers a direct call that bypassed admission,
+	// as this package's own tests do, so this function never executes a run
+	// that nothing can cancel.
 	var deliverPendingCancel bool
 	s.mu.Lock()
 	if run, exists := s.runs[executionID]; exists {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -34,28 +34,43 @@ type Config struct {
 
 // Scheduler manages cron-based workflow execution.
 type Scheduler struct {
-	mu               sync.RWMutex
-	schedules        map[string]*loomv1.ScheduledWorkflow
-	runningWorkflows map[string]string // schedule_id -> execution_id
-	// runningCancels holds each in-flight execution's cancel func, keyed by
-	// execution ID. Without it the only way to stop a hung workflow is to wait
-	// out max_execution_seconds, during which skip_if_running silently skips
-	// every scheduled run.
-	runningCancels map[string]context.CancelFunc
-	// cancelReasons records why an execution was cancelled, so the history entry
-	// can distinguish an operator stop from a timeout or a crash.
-	cancelReasons map[string]string
-	cronEngine    *cron.Cron
-	cronEntries   map[string]cron.EntryID
-	store         *Store
-	orchestrator  *orchestration.Orchestrator
-	registry      *agent.Registry
-	tracer        observability.Tracer
-	logger        *zap.Logger
-	loader        *Loader
-	stopCh        chan struct{}
-	wg            sync.WaitGroup
-	config        Config
+	mu        sync.RWMutex
+	schedules map[string]*loomv1.ScheduledWorkflow
+	// runs holds every in-flight execution, keyed by execution ID.
+	//
+	// This is deliberately one map rather than parallel maps for the cancel
+	// func, the reason and the running marker. Those three facts have to change
+	// together — an execution must become cancellable at the same instant it is
+	// advertised as running, and stop being cancellable at the same instant it
+	// reads its verdict — and keeping them in one value makes that invariant
+	// structural instead of something every future edit has to remember.
+	runs         map[string]*runState
+	cronEngine   *cron.Cron
+	cronEntries  map[string]cron.EntryID
+	store        *Store
+	orchestrator *orchestration.Orchestrator
+	registry     *agent.Registry
+	tracer       observability.Tracer
+	logger       *zap.Logger
+	loader       *Loader
+	stopCh       chan struct{}
+	wg           sync.WaitGroup
+	// inFlight counts executeWorkflow bodies that have been launched and have
+	// not yet finished writing. Stop waits on it so the store is never closed
+	// underneath a run's bookkeeping tail, which would turn four SQLite writes
+	// — including the history entry an operator is waiting to see — into errors
+	// on a goroutine nobody is watching.
+	//
+	// It is distinct from runs: runs answers "can this execution still be
+	// canceled or does it still occupy its schedule's slot", inFlight answers
+	// "is the store still in use". A run leaves runs before its last write.
+	inFlight sync.WaitGroup
+	// stopped is set once by Stop, under mu. beginRun refuses to launch further
+	// runs after that, which is what makes inFlight.Wait sound: every Add
+	// happens under the same lock that sets this flag, so no Add can race the
+	// Wait that follows it.
+	stopped bool
+	config  Config
 }
 
 // NewScheduler creates a new workflow scheduler.
@@ -84,19 +99,17 @@ func NewScheduler(ctx context.Context, config Config) (*Scheduler, error) {
 	cronEngine := cron.New()
 
 	s := &Scheduler{
-		schedules:        make(map[string]*loomv1.ScheduledWorkflow),
-		runningWorkflows: make(map[string]string),
-		runningCancels:   make(map[string]context.CancelFunc),
-		cancelReasons:    make(map[string]string),
-		cronEngine:       cronEngine,
-		cronEntries:      make(map[string]cron.EntryID),
-		store:            store,
-		orchestrator:     config.Orchestrator,
-		registry:         config.Registry,
-		tracer:           config.Tracer,
-		logger:           config.Logger,
-		stopCh:           make(chan struct{}),
-		config:           config,
+		schedules:    make(map[string]*loomv1.ScheduledWorkflow),
+		runs:         make(map[string]*runState),
+		cronEngine:   cronEngine,
+		cronEntries:  make(map[string]cron.EntryID),
+		store:        store,
+		orchestrator: config.Orchestrator,
+		registry:     config.Registry,
+		tracer:       config.Tracer,
+		logger:       config.Logger,
+		stopCh:       make(chan struct{}),
+		config:       config,
 	}
 
 	// Create loader if hot-reload enabled
@@ -148,26 +161,116 @@ func (s *Scheduler) Start(ctx context.Context) error {
 	return nil
 }
 
-// Stop gracefully shuts down the scheduler.
+// shutdownCancelReason is the reason recorded against runs that Stop had to
+// signal because its grace period ran out. It reads as an operator-visible
+// explanation in the history entry, which is the whole point of recording a
+// reason at all.
+const shutdownCancelReason = "scheduler shutting down"
+
+// beginRun reserves a slot for one execution and reports whether the caller may
+// launch it. Every launch site must go through it, and must call
+// s.inFlight.Done() once the execution's last store write has happened.
+//
+// The Add is done under the same lock Stop uses to set stopped, so a run can
+// never join after Stop has decided what it is waiting for — the happens-before
+// that makes the subsequent inFlight.Wait sound. Refusing the launch matters as
+// much as counting it: after Stop the store is closed, and a run that started
+// anyway would spend its whole life writing to a closed database.
+func (s *Scheduler) beginRun() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.stopped {
+		return false
+	}
+	s.inFlight.Add(1)
+	return true
+}
+
+// cancelAllRunning signals every cancellable execution and reports how many it
+// signaled. Used by Stop when the shutdown deadline expires.
+func (s *Scheduler) cancelAllRunning(reason string) int {
+	s.mu.Lock()
+	cancels := make([]context.CancelFunc, 0, len(s.runs))
+	for _, run := range s.runs {
+		if run.settled || run.canceled {
+			continue
+		}
+		run.canceled = true
+		run.reason = reason
+		cancels = append(cancels, run.cancel)
+	}
+	s.mu.Unlock()
+
+	// Outside the lock, for the same reason CancelExecution does it: an
+	// unwinding run may take the scheduler lock on its way out.
+	for _, cancel := range cancels {
+		cancel()
+	}
+	return len(cancels)
+}
+
+// signalShutdown asks every still-cancellable run to unwind because the
+// shutdown grace period is over. It signals only; Stop does the waiting.
+func (s *Scheduler) signalShutdown() {
+	signaled := s.cancelAllRunning(shutdownCancelReason)
+	s.logger.Warn("Scheduler shutdown deadline passed; canceled in-flight executions",
+		zap.Int("canceled", signaled))
+}
+
+// Stop shuts the scheduler down and waits for in-flight executions to finish
+// writing before the store is closed.
+//
+// ctx bounds the grace period, not the shutdown: when it expires with work
+// still running, Stop signals those runs and then waits for them anyway. Giving
+// up instead would close the database while a run is recording its outcome, so
+// the last thing an operator sees of a workflow — its history entry — would be
+// the thing lost.
 func (s *Scheduler) Stop(ctx context.Context) error {
 	s.logger.Info("Stopping workflow scheduler")
+
+	// Refuse new runs first. Paired with beginRun's Add under the same lock,
+	// this fixes the set of executions the wait below has to cover.
+	s.mu.Lock()
+	s.stopped = true
+	s.mu.Unlock()
 
 	// Signal shutdown
 	close(s.stopCh)
 
-	// Stop cron engine (stops accepting new executions)
-	cronCtx := s.cronEngine.Stop()
+	// Stop the cron engine so nothing further is scheduled. Jobs already
+	// running are counted in inFlight, so they are waited for below rather
+	// than through the context this returns.
+	s.cronEngine.Stop()
 
 	// Wait for hot-reload watcher
 	s.wg.Wait()
 
-	// Wait for cron entries to complete or context timeout
-	select {
-	case <-cronCtx.Done():
-		s.logger.Info("All scheduled tasks completed")
-	case <-ctx.Done():
-		s.logger.Warn("Scheduler shutdown timeout, some tasks may still be running")
+	drained := make(chan struct{})
+	go func() {
+		s.inFlight.Wait()
+		close(drained)
+	}()
+
+	// A caller whose deadline has already passed gets no grace period; anyone
+	// else gets until ctx expires for runs to finish on their own.
+	if ctx.Err() != nil {
+		s.signalShutdown()
+	} else {
+		select {
+		case <-drained:
+			s.logger.Info("All scheduled tasks completed")
+		case <-ctx.Done():
+			s.signalShutdown()
+		}
 	}
+
+	// This final wait has no deadline on purpose. The store cannot be closed
+	// while a run is writing its record, and every remaining run has had its
+	// context canceled, so the wait is bounded in practice by the executor
+	// honoring that context and by the store's SQLite busy timeout — not by
+	// max_execution_seconds.
+	<-drained
 
 	// Close store
 	if err := s.store.Close(); err != nil {
@@ -363,9 +466,7 @@ func (s *Scheduler) TriggerNow(ctx context.Context, scheduleID string, skipIfRun
 
 	// Check skip-if-running
 	if skipIfRunning {
-		s.mu.RLock()
-		executionID := s.runningWorkflows[scheduleID]
-		s.mu.RUnlock()
+		executionID := s.runningExecutionFor(scheduleID)
 
 		if executionID != "" {
 			return "", fmt.Errorf("previous execution still running: %s", executionID)
@@ -383,62 +484,187 @@ func (s *Scheduler) TriggerNow(ctx context.Context, scheduleID string, skipIfRun
 		mergedVars[k] = v
 	}
 
+	// Reserve the run before spawning it. A trigger that arrives during
+	// shutdown is refused rather than started, because the store it would
+	// write to is about to close.
+	if !s.beginRun() {
+		return "", fmt.Errorf("scheduler is stopped")
+	}
+
 	// Execute workflow
 	executionID := uuid.New().String()
-	go s.executeWorkflow(context.Background(), schedule, executionID, mergedVars) // #nosec -- intentional: background worker goroutine that must outlive request context
+	go func() { // #nosec G118 -- intentional: background worker goroutine that must outlive the request context
+		// Done only once executeWorkflow has returned, so it covers the
+		// bookkeeping tail as well as the workflow itself.
+		defer s.inFlight.Done()
+		s.executeWorkflow(context.Background(), schedule, executionID, mergedVars)
+	}()
 
 	return executionID, nil
 }
 
-// CancelExecution stops a running execution.
+// CancelOutcome is what a cancellation request actually did.
 //
-// Returns false when no execution with that ID is in flight — already finished,
-// or never started. That is deliberately not an error: someone cancelling a run
-// that just completed has got the outcome they wanted, and turning the race into
-// a failure would only make the UI apologise for succeeding.
+// The three values are kept distinct because collapsing them loses the one
+// distinction an operator cares about: whether the thing they were trying to
+// stop was ever stoppable in the first place.
+type CancelOutcome int
+
+const (
+	// CancelOutcomeNotFound means no execution with that ID exists in this
+	// scheduler, neither in flight nor in the recorded history. The usual cause
+	// is an ID from the ExecuteWorkflow/StreamWorkflow namespace, which this
+	// scheduler does not own.
+	CancelOutcomeNotFound CancelOutcome = iota
+
+	// CancelOutcomeAlreadyFinished means the execution is one this scheduler
+	// ran, but it had already reached its verdict before the request arrived.
+	// Nothing was signaled and the recorded outcome stands.
+	CancelOutcomeAlreadyFinished
+
+	// CancelOutcomeSignaled means the execution was in flight and its context
+	// was canceled. The run unwinds at its next context check and is then
+	// recorded as canceled.
+	CancelOutcomeSignaled
+)
+
+// String makes the outcome readable in logs and test failures.
+func (o CancelOutcome) String() string {
+	switch o {
+	case CancelOutcomeNotFound:
+		return "not_found"
+	case CancelOutcomeAlreadyFinished:
+		return "already_finished"
+	case CancelOutcomeSignaled:
+		return "signaled"
+	default:
+		return fmt.Sprintf("CancelOutcome(%d)", int(o))
+	}
+}
+
+// runState is one in-flight execution.
 //
-// Cancellation is cooperative. The execution's context is cancelled, which
+// settled is the pivot. It is set at the single point where executeWorkflow
+// reads its verdict, and from that instant the run is no longer cancellable
+// even though its bookkeeping tail — four SQLite writes — is still running.
+// Without that pivot a cancel arriving during the tail would be accepted and
+// would overwrite the verdict the run had already reached, discarding a real
+// success or a real failure and leaving the counters behind.
+//
+// The entry itself outlives settled, because skip_if_running must keep blocking
+// new runs for this schedule until the tail has finished writing.
+type runState struct {
+	scheduleID string
+	cancel     context.CancelFunc
+	reason     string
+	canceled   bool
+	settled    bool
+}
+
+// CancelExecution stops a scheduled execution that is in flight.
+//
+// The three outcomes are deliberate. CancelOutcomeAlreadyFinished is not an
+// error: someone stopping a run that completed a moment earlier got the state
+// they asked for, and turning that race into a failure would make the UI
+// apologise for winning it. CancelOutcomeNotFound is reported separately
+// because saying "already finished" about an ID this scheduler never minted is
+// a lie an operator would act on — most often it means an execution ID from
+// ExecuteWorkflow or StreamWorkflow, which belongs to another namespace.
+//
+// Cancellation is cooperative. The execution's context is canceled, which
 // unwinds the orchestrator at its next context check; work already committed by
-// earlier stages is not rolled back. The reason is recorded so the history entry
-// reads as an operator stop rather than a crash.
-func (s *Scheduler) CancelExecution(ctx context.Context, executionID, reason string) (bool, error) {
+// earlier stages is not rolled back. The reason is recorded first, so
+// executeWorkflow cannot observe a canceled context before it can see why.
+func (s *Scheduler) CancelExecution(ctx context.Context, executionID, reason string) (CancelOutcome, error) {
 	if executionID == "" {
-		return false, fmt.Errorf("execution_id is required")
+		return CancelOutcomeNotFound, fmt.Errorf("execution_id is required")
 	}
 
 	s.mu.Lock()
-	cancel, running := s.runningCancels[executionID]
-	if running {
-		// Recorded before cancelling so executeWorkflow's classification cannot
-		// observe the cancelled context before it can see the reason.
-		s.cancelReasons[executionID] = reason
+	run, tracked := s.runs[executionID]
+	cancellable := tracked && !run.settled
+	var cancel context.CancelFunc
+	if cancellable {
+		cancel = run.cancel
+		// Written before the signal so executeWorkflow's classification cannot
+		// see a canceled context before it can see the reason. Only the first
+		// cancel wins: two operators racing should leave the history naming the
+		// one whose signal actually stopped the run, not whichever arrived last.
+		if !run.canceled {
+			run.canceled = true
+			run.reason = reason
+		}
 	}
 	s.mu.Unlock()
 
-	if !running {
-		return false, nil
+	if cancellable {
+		s.logger.Info("Canceling workflow execution",
+			zap.String("schedule_id", run.scheduleID),
+			zap.String("execution_id", executionID),
+			zap.String("reason", reason))
+
+		// Called outside s.mu: a cancel func whose unwinding path takes the
+		// scheduler lock would otherwise self-deadlock.
+		cancel()
+		return CancelOutcomeSignaled, nil
 	}
 
-	s.logger.Info("Cancelling workflow execution",
-		zap.String("execution_id", executionID),
-		zap.String("reason", reason))
+	if tracked {
+		// Known, in the map, but past its linearization point.
+		return CancelOutcomeAlreadyFinished, nil
+	}
 
-	cancel()
-	return true, nil
+	// Not in flight. Distinguish a run this scheduler finished from an ID it has
+	// never seen, so the caller is not told a live workflow "already finished".
+	known, err := s.store.ExecutionExists(ctx, executionID)
+	if err != nil {
+		return CancelOutcomeNotFound, fmt.Errorf("failed to look up execution: %w", err)
+	}
+	if known {
+		return CancelOutcomeAlreadyFinished, nil
+	}
+
+	return CancelOutcomeNotFound, nil
 }
 
-// RunningExecutions returns the execution IDs currently in flight, keyed by
-// schedule ID. Useful for an operations view that needs to offer a stop button
-// only where there is something to stop.
+// RunningExecutions returns the executions that can still be canceled, keyed by
+// schedule ID.
+//
+// Settled runs are excluded on purpose. This accessor exists so an operations
+// view can offer a stop button only where there is something to stop, so
+// anything it reports must still be cancellable when the operator clicks —
+// listing a run whose cancel would come back "already finished" is the exact
+// mismatch this is meant to avoid.
 func (s *Scheduler) RunningExecutions() map[string]string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	out := make(map[string]string, len(s.runningWorkflows))
-	for scheduleID, execID := range s.runningWorkflows {
-		out[scheduleID] = execID
+	out := make(map[string]string, len(s.runs))
+	for execID, run := range s.runs {
+		if !run.settled {
+			out[run.scheduleID] = execID
+		}
 	}
 	return out
+}
+
+// runningExecutionFor returns the execution currently occupying a schedule's
+// slot, or "" if the schedule is idle.
+//
+// This deliberately counts settled runs too. skip_if_running has to keep
+// blocking until the previous run's bookkeeping tail has finished writing:
+// letting a new run start mid-tail would have the old run's teardown clear the
+// new run's current_execution_id and drop its entry.
+func (s *Scheduler) runningExecutionFor(scheduleID string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for execID, run := range s.runs {
+		if run.scheduleID == scheduleID {
+			return execID
+		}
+	}
+	return ""
 }
 
 // GetSchedule retrieves a schedule by ID.
@@ -470,6 +696,13 @@ func (s *Scheduler) addScheduleToCron(ctx context.Context, schedule *loomv1.Sche
 
 	// Create job function
 	jobFunc := func() {
+		// Same reservation as TriggerNow: a tick that fires while Stop is
+		// draining must not open a new run against a closing store.
+		if !s.beginRun() {
+			return
+		}
+		defer s.inFlight.Done()
+
 		execCtx := context.Background()
 		executionID := uuid.New().String()
 
@@ -505,9 +738,7 @@ func (s *Scheduler) executeWorkflow(ctx context.Context, schedule *loomv1.Schedu
 
 	// Check skip-if-running
 	if schedule.Schedule.SkipIfRunning {
-		s.mu.RLock()
-		currentExecID := s.runningWorkflows[schedule.Id]
-		s.mu.RUnlock()
+		currentExecID := s.runningExecutionFor(schedule.Id)
 
 		if currentExecID != "" {
 			s.logger.Info("Skipping execution, previous still running",
@@ -521,14 +752,26 @@ func (s *Scheduler) executeWorkflow(ctx context.Context, schedule *loomv1.Schedu
 		}
 	}
 
-	// Mark as running
+	// Set execution timeout. Built before the run is advertised so that the
+	// cancel func exists to register in the same breath.
+	timeout := time.Duration(schedule.Schedule.MaxExecutionSeconds) * time.Second
+	if timeout == 0 {
+		timeout = 1 * time.Hour // Default timeout
+	}
+	execCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Mark as running and publish the cancel func in one critical section, so
+	// there is no window in which the run is advertised as running — including
+	// via current_execution_id, the field callers are told to pass to
+	// CancelScheduledExecution — but a cancel would come back "not running".
 	s.mu.Lock()
-	s.runningWorkflows[schedule.Id] = executionID
+	s.runs[executionID] = &runState{scheduleID: schedule.Id, cancel: cancel}
 	s.mu.Unlock()
 
 	defer func() {
 		s.mu.Lock()
-		delete(s.runningWorkflows, schedule.Id)
+		delete(s.runs, executionID)
 		s.mu.Unlock()
 
 		if err := s.store.UpdateCurrentExecution(ctx, schedule.Id, ""); err != nil {
@@ -540,26 +783,6 @@ func (s *Scheduler) executeWorkflow(ctx context.Context, schedule *loomv1.Schedu
 	if err := s.store.UpdateCurrentExecution(ctx, schedule.Id, executionID); err != nil {
 		s.logger.Error("Failed to update current execution", zap.Error(err))
 	}
-
-	// Set execution timeout
-	timeout := time.Duration(schedule.Schedule.MaxExecutionSeconds) * time.Second
-	if timeout == 0 {
-		timeout = 1 * time.Hour // Default timeout
-	}
-	execCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	// Publish the cancel func so CancelExecution can reach this run. Registered
-	// after the running-marker above and torn down alongside it.
-	s.mu.Lock()
-	s.runningCancels[executionID] = cancel
-	s.mu.Unlock()
-	defer func() {
-		s.mu.Lock()
-		delete(s.runningCancels, executionID)
-		delete(s.cancelReasons, executionID)
-		s.mu.Unlock()
-	}()
 
 	// Set workflow_id for session continuity in RESUME mode
 	if schedule.Schedule.SessionMode == loomv1.ScheduledSessionMode_SCHEDULED_SESSION_MODE_RESUME {
@@ -574,6 +797,34 @@ func (s *Scheduler) executeWorkflow(ctx context.Context, schedule *loomv1.Schedu
 	// Execute workflow via orchestrator
 	// TODO: Add variable interpolation support
 	_, err := s.orchestrator.ExecutePattern(execCtx, schedule.Pattern)
+
+	// Linearization point. Reading the cancel state and closing the run to
+	// further cancellation happen in one critical section, immediately on
+	// return, so the verdict below is decided against exactly one state.
+	//
+	// The whole bookkeeping tail that follows — UpdateLastWorkflowID, the
+	// Record* calls, RecordExecution, UpdateNextExecution — is four SQLite
+	// writes serialised on the store lock, not a few instructions. Leaving the
+	// run cancellable across it meant a cancel arriving in that window was
+	// accepted, relabelled a completed or failed run as canceled, threw away
+	// its real error, and skipped its counters entirely.
+	s.mu.Lock()
+	var wasCanceled bool
+	var cancelReason string
+	if run, ok := s.runs[executionID]; ok {
+		wasCanceled = run.canceled
+		cancelReason = run.reason
+		run.settled = true
+	} else {
+		// Unreachable: the entry is registered before ExecutePattern and removed
+		// only by this function's own deferred teardown. Logged rather than
+		// dereferenced because this runs on a background goroutine, where a nil
+		// deref would take the whole server down.
+		s.logger.Error("Execution missing from run map at classification",
+			zap.String("schedule_id", schedule.Id),
+			zap.String("execution_id", executionID))
+	}
+	s.mu.Unlock()
 
 	duration := time.Since(startTime)
 
@@ -597,23 +848,25 @@ func (s *Scheduler) executeWorkflow(ctx context.Context, schedule *loomv1.Schedu
 		WorkflowId:  workflowID,
 	}
 
-	// A cancelled run is not a failed run. Counting an operator's stop as a
+	// A canceled run is not a failed run. Counting an operator's stop as a
 	// failure would corrupt the success rate the UI uses to convey trust, and
 	// would make a deliberately stopped routine look broken.
-	s.mu.RLock()
-	cancelReason, wasCancelled := s.cancelReasons[executionID]
-	s.mu.RUnlock()
-
+	//
+	// The err != nil conjunct matters: cancellation is cooperative, so a run can
+	// be signaled and still finish on its own before it next checks its
+	// context. That run reached a real verdict and must be recorded as such —
+	// its counters move like any other. Only a run the signal actually stopped
+	// is recorded as canceled.
 	switch {
-	case wasCancelled:
-		execution.Status = "cancelled"
+	case wasCanceled && err != nil:
+		execution.Status = "canceled"
 		if cancelReason != "" {
 			execution.Error = cancelReason
 		} else {
-			execution.Error = "cancelled by operator"
+			execution.Error = "canceled by operator"
 		}
 
-		s.logger.Info("Workflow execution cancelled",
+		s.logger.Info("Workflow execution canceled",
 			zap.String("schedule_id", schedule.Id),
 			zap.String("execution_id", executionID),
 			zap.String("reason", cancelReason),
@@ -621,7 +874,7 @@ func (s *Scheduler) executeWorkflow(ctx context.Context, schedule *loomv1.Schedu
 
 		// Move last_status off the previous run's outcome. Without this a
 		// stopped routine reports itself as having last succeeded.
-		if storeErr := s.store.RecordCancelled(ctx, schedule.Id, execution.Error); storeErr != nil {
+		if storeErr := s.store.RecordCanceled(ctx, schedule.Id, execution.Error); storeErr != nil {
 			s.logger.Error("Failed to record cancellation", zap.Error(storeErr))
 		}
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -7,6 +7,7 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -187,6 +188,31 @@ func (s *Scheduler) beginRun() bool {
 	return true
 }
 
+// beginTriggeredRun reserves a slot the same way beginRun does, and also
+// pre-registers executionID under scheduleID before returning — in the same
+// critical section, so there is no gap between the caller handing this ID out
+// and the scheduler considering it tracked.
+//
+// TriggerNow needs this and the cron path does not: TriggerNow returns
+// executionID to its caller before the goroutine that will run it even starts,
+// so a cancel arriving in that window has to find something. Without
+// pre-registration it would see nothing tracked and report NOT_FOUND for an ID
+// this scheduler had, in fact, already minted. The entry's cancel func is nil
+// until executeWorkflow builds the real context and attaches it; a cancel
+// arriving before then can only set the canceled flag, which executeWorkflow
+// checks and honors immediately once the real cancel func exists.
+func (s *Scheduler) beginTriggeredRun(scheduleID, executionID string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.stopped {
+		return false
+	}
+	s.inFlight.Add(1)
+	s.runs[executionID] = &runState{scheduleID: scheduleID}
+	return true
+}
+
 // cancelAllRunning signals every cancellable execution and reports how many it
 // signaled. Used by Stop when the shutdown deadline expires.
 func (s *Scheduler) cancelAllRunning(reason string) int {
@@ -198,7 +224,12 @@ func (s *Scheduler) cancelAllRunning(reason string) int {
 		}
 		run.canceled = true
 		run.reason = reason
-		cancels = append(cancels, run.cancel)
+		// A pre-registered trigger whose real context has not been attached
+		// yet has a nil cancel func. The flag above is enough: executeWorkflow
+		// checks it as soon as the real func exists and cancels immediately.
+		if run.cancel != nil {
+			cancels = append(cancels, run.cancel)
+		}
 	}
 	s.mu.Unlock()
 
@@ -230,8 +261,14 @@ func (s *Scheduler) Stop(ctx context.Context) error {
 	s.logger.Info("Stopping workflow scheduler")
 
 	// Refuse new runs first. Paired with beginRun's Add under the same lock,
-	// this fixes the set of executions the wait below has to cover.
+	// this fixes the set of executions the wait below has to cover. The
+	// stopped check also makes Stop idempotent: without it, a second call
+	// would close(s.stopCh) again and panic.
 	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		return nil
+	}
 	s.stopped = true
 	s.mu.Unlock()
 
@@ -269,8 +306,24 @@ func (s *Scheduler) Stop(ctx context.Context) error {
 	// while a run is writing its record, and every remaining run has had its
 	// context canceled, so the wait is bounded in practice by the executor
 	// honoring that context and by the store's SQLite busy timeout — not by
-	// max_execution_seconds.
-	<-drained
+	// max_execution_seconds. An unbounded, silent wait is undiagnosable from
+	// the outside, so log periodically rather than going quiet until it
+	// returns or the process is killed.
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+waitForDrain:
+	for {
+		select {
+		case <-drained:
+			break waitForDrain
+		case <-ticker.C:
+			s.mu.RLock()
+			remaining := len(s.runs)
+			s.mu.RUnlock()
+			s.logger.Warn("Still waiting for in-flight executions to finish",
+				zap.Int("remaining", remaining))
+		}
+	}
 
 	// Close store
 	if err := s.store.Close(); err != nil {
@@ -484,20 +537,29 @@ func (s *Scheduler) TriggerNow(ctx context.Context, scheduleID string, skipIfRun
 		mergedVars[k] = v
 	}
 
-	// Reserve the run before spawning it. A trigger that arrives during
-	// shutdown is refused rather than started, because the store it would
-	// write to is about to close.
-	if !s.beginRun() {
+	// Reserve the run and pre-register it under the ID before spawning the
+	// goroutine, both in one critical section. This ID is handed back to the
+	// caller below, before the goroutine even starts; without pre-registration
+	// a cancel arriving in that window finds nothing tracked and reports
+	// NOT_FOUND for an execution this scheduler already minted. A trigger that
+	// arrives during shutdown is refused rather than started, because the
+	// store it would write to is about to close.
+	executionID := uuid.New().String()
+	if !s.beginTriggeredRun(scheduleID, executionID) {
 		return "", fmt.Errorf("scheduler is stopped")
 	}
 
-	// Execute workflow
-	executionID := uuid.New().String()
 	go func() { // #nosec G118 -- intentional: background worker goroutine that must outlive the request context
 		// Done only once executeWorkflow has returned, so it covers the
 		// bookkeeping tail as well as the workflow itself.
 		defer s.inFlight.Done()
-		s.executeWorkflow(context.Background(), schedule, executionID, mergedVars)
+		// checkScheduleSkipIfRunning is false: the skip-if-running decision for
+		// a manual trigger is the request's own skipIfRunning above, already
+		// applied. Re-checking the schedule's persisted setting here would let
+		// stale config silently override an explicit "run it anyway" from the
+		// caller — and would find this run's own pre-registered entry and
+		// report itself as "previous execution still running".
+		s.executeWorkflow(context.Background(), schedule, executionID, mergedVars, false)
 	}()
 
 	return executionID, nil
@@ -603,9 +665,15 @@ func (s *Scheduler) CancelExecution(ctx context.Context, executionID, reason str
 			zap.String("execution_id", executionID),
 			zap.String("reason", reason))
 
+		// cancel is nil for a triggered run whose real context has not been
+		// attached yet — the canceled flag set above is enough, and
+		// executeWorkflow delivers the signal itself once it exists.
+		//
 		// Called outside s.mu: a cancel func whose unwinding path takes the
 		// scheduler lock would otherwise self-deadlock.
-		cancel()
+		if cancel != nil {
+			cancel()
+		}
 		return CancelOutcomeSignaled, nil
 	}
 
@@ -618,7 +686,9 @@ func (s *Scheduler) CancelExecution(ctx context.Context, executionID, reason str
 	// never seen, so the caller is not told a live workflow "already finished".
 	known, err := s.store.ExecutionExists(ctx, executionID)
 	if err != nil {
-		return CancelOutcomeNotFound, fmt.Errorf("failed to look up execution: %w", err)
+		// ExecutionExists already names the execution ID in its own error; do
+		// not wrap "failed to look up execution" a second time around it.
+		return CancelOutcomeNotFound, err
 	}
 	if known {
 		return CancelOutcomeAlreadyFinished, nil
@@ -635,6 +705,13 @@ func (s *Scheduler) CancelExecution(ctx context.Context, executionID, reason str
 // anything it reports must still be cancellable when the operator clicks —
 // listing a run whose cancel would come back "already finished" is the exact
 // mismatch this is meant to avoid.
+//
+// Known gap, recorded rather than solved here: keying by schedule ID means two
+// concurrent runs of the same schedule (skip_if_running disabled) collapse to
+// one entry, and only one of them is reachable through this view. Fixing it
+// means changing the return shape (e.g. []string per schedule, or a slice of
+// execution records), which is a wider API change than this cancellation work
+// should carry.
 func (s *Scheduler) RunningExecutions() map[string]string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -712,7 +789,9 @@ func (s *Scheduler) addScheduleToCron(ctx context.Context, schedule *loomv1.Sche
 			variables = make(map[string]string)
 		}
 
-		s.executeWorkflow(execCtx, schedule, executionID, variables)
+		// true: a cron tick has no request-level override to defer to, so it
+		// must honor the schedule's own persisted skip_if_running.
+		s.executeWorkflow(execCtx, schedule, executionID, variables, true)
 	}
 
 	// Add to cron engine
@@ -728,7 +807,16 @@ func (s *Scheduler) addScheduleToCron(ctx context.Context, schedule *loomv1.Sche
 }
 
 // executeWorkflow executes a scheduled workflow.
-func (s *Scheduler) executeWorkflow(ctx context.Context, schedule *loomv1.ScheduledWorkflow, executionID string, variables map[string]string) {
+//
+// checkScheduleSkipIfRunning gates the schedule's own persisted
+// skip_if_running setting. A cron tick has no other opinion on the matter and
+// must pass true. A manually triggered run must pass false: TriggerNow already
+// applied the request's own skip_if_running override — using it, not the
+// schedule's config — before this executionID existed anywhere, and by the
+// time control reaches here that ID is already registered in s.runs, so
+// re-checking here would find that entry and report the run as colliding with
+// itself.
+func (s *Scheduler) executeWorkflow(ctx context.Context, schedule *loomv1.ScheduledWorkflow, executionID string, variables map[string]string, checkScheduleSkipIfRunning bool) {
 	startTime := time.Now()
 
 	s.logger.Info("Executing scheduled workflow",
@@ -737,7 +825,7 @@ func (s *Scheduler) executeWorkflow(ctx context.Context, schedule *loomv1.Schedu
 		zap.String("workflow_name", schedule.WorkflowName))
 
 	// Check skip-if-running
-	if schedule.Schedule.SkipIfRunning {
+	if checkScheduleSkipIfRunning && schedule.Schedule.SkipIfRunning {
 		currentExecID := s.runningExecutionFor(schedule.Id)
 
 		if currentExecID != "" {
@@ -765,9 +853,24 @@ func (s *Scheduler) executeWorkflow(ctx context.Context, schedule *loomv1.Schedu
 	// there is no window in which the run is advertised as running — including
 	// via current_execution_id, the field callers are told to pass to
 	// CancelScheduledExecution — but a cancel would come back "not running".
+	//
+	// A triggered run already has an entry here, pre-registered by
+	// beginTriggeredRun before this executionID was ever handed to a caller;
+	// attach the real cancel func to it rather than replacing it. If a cancel
+	// landed in the window before this func existed, deliver it now — the flag
+	// is the only thing a caller with a nil cancel func could set.
+	var deliverPendingCancel bool
 	s.mu.Lock()
-	s.runs[executionID] = &runState{scheduleID: schedule.Id, cancel: cancel}
+	if run, exists := s.runs[executionID]; exists {
+		run.cancel = cancel
+		deliverPendingCancel = run.canceled
+	} else {
+		s.runs[executionID] = &runState{scheduleID: schedule.Id, cancel: cancel}
+	}
 	s.mu.Unlock()
+	if deliverPendingCancel {
+		cancel()
+	}
 
 	defer func() {
 		s.mu.Lock()
@@ -852,13 +955,18 @@ func (s *Scheduler) executeWorkflow(ctx context.Context, schedule *loomv1.Schedu
 	// failure would corrupt the success rate the UI uses to convey trust, and
 	// would make a deliberately stopped routine look broken.
 	//
-	// The err != nil conjunct matters: cancellation is cooperative, so a run can
-	// be signaled and still finish on its own before it next checks its
-	// context. That run reached a real verdict and must be recorded as such —
-	// its counters move like any other. Only a run the signal actually stopped
-	// is recorded as canceled.
+	// The errors.Is conjunct matters: cancellation is cooperative, so a run can
+	// be signaled and still finish on its own — successfully, or with a real
+	// failure unrelated to the signal — before it next checks its context.
+	// That run reached a real verdict and must be recorded as such — its
+	// counters move like any other. err != nil alone is not enough: a run
+	// signaled early enough can fail for an unrelated reason (e.g. "pipeline
+	// has no stages") without the cancellation ever reaching the context, and
+	// that failure must not be discarded and relabelled canceled. Only a run
+	// whose own error actually carries context.Canceled up the chain is
+	// recorded as canceled.
 	switch {
-	case wasCanceled && err != nil:
+	case wasCanceled && errors.Is(err, context.Canceled):
 		execution.Status = "canceled"
 		if cancelReason != "" {
 			execution.Error = cancelReason

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -347,9 +347,9 @@ func TestScheduler_SkipIfRunning(t *testing.T) {
 	err := scheduler.AddSchedule(ctx, schedule)
 	require.NoError(t, err)
 
-	// Mark workflow as running by adding to runningWorkflows map
+	// Mark workflow as running by registering an in-flight run
 	scheduler.mu.Lock()
-	scheduler.runningWorkflows[schedule.Id] = "execution-1"
+	scheduler.runs["execution-1"] = &runState{scheduleID: schedule.Id, cancel: func() {}}
 	scheduler.mu.Unlock()
 
 	// Trigger execution (should be skipped because SkipIfRunning=true and workflow is marked as running)
@@ -359,7 +359,7 @@ func TestScheduler_SkipIfRunning(t *testing.T) {
 
 	// Clean up
 	scheduler.mu.Lock()
-	delete(scheduler.runningWorkflows, schedule.Id)
+	delete(scheduler.runs, "execution-1")
 	scheduler.mu.Unlock()
 }
 

--- a/pkg/scheduler/stop_drain_test.go
+++ b/pkg/scheduler/stop_drain_test.go
@@ -290,3 +290,19 @@ func TestStopDrainsInFlightRuns(t *testing.T) {
 		})
 	}
 }
+
+// TestStopIsIdempotent covers N5: a second Stop call must not panic. Stop
+// closes s.stopCh unconditionally; without a guard on s.stopped, calling Stop
+// twice — a plausible shutdown-path mistake, not just a test artifact — closes
+// an already-closed channel and panics instead of returning cleanly.
+func TestStopIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	s := setupTestScheduler(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.Stop(ctx))
+	assert.NotPanics(t, func() {
+		require.NoError(t, s.Stop(ctx))
+	})
+}

--- a/pkg/scheduler/stop_drain_test.go
+++ b/pkg/scheduler/stop_drain_test.go
@@ -169,6 +169,30 @@ func agentWorkflow(id string) *loomv1.ScheduledWorkflow {
 	}
 }
 
+// forkJoinWorkflow returns a schedule whose pattern runs the test agent twice
+// in parallel via fork-join. Both branches block on the same LLM, so a cancel
+// lands on both at once and the pattern's own error-joining path is what gets
+// exercised, not just a single agent's.
+func forkJoinWorkflow(id string) *loomv1.ScheduledWorkflow {
+	return &loomv1.ScheduledWorkflow{
+		Id:           id,
+		WorkflowName: "blocking-fork-join",
+		Pattern: &loomv1.WorkflowPattern{
+			Pattern: &loomv1.WorkflowPattern_ForkJoin{
+				ForkJoin: &loomv1.ForkJoinPattern{
+					Prompt:   "go",
+					AgentIds: []string{drainAgentName, drainAgentName},
+				},
+			},
+		},
+		Schedule: &loomv1.ScheduleConfig{
+			Cron:     "0 0 * * *",
+			Timezone: "UTC",
+			Enabled:  true,
+		},
+	}
+}
+
 // awaitDrainCond fails the test instead of hanging. Every wait here goes
 // through it: the failure this file guards against is a shutdown that never
 // finishes, and a bare channel receive would report that as a CI timeout with

--- a/pkg/scheduler/stop_drain_test.go
+++ b/pkg/scheduler/stop_drain_test.go
@@ -193,6 +193,32 @@ func forkJoinWorkflow(id string) *loomv1.ScheduledWorkflow {
 	}
 }
 
+// parallelWorkflow returns a schedule whose pattern runs the test agent twice
+// in parallel via the parallel pattern (not fork-join). Both tasks block on
+// the same LLM, so a cancel lands on both at once and parallel_executor.go's
+// own error-joining path is what gets exercised.
+func parallelWorkflow(id string) *loomv1.ScheduledWorkflow {
+	return &loomv1.ScheduledWorkflow{
+		Id:           id,
+		WorkflowName: "blocking-parallel",
+		Pattern: &loomv1.WorkflowPattern{
+			Pattern: &loomv1.WorkflowPattern_Parallel{
+				Parallel: &loomv1.ParallelPattern{
+					Tasks: []*loomv1.AgentTask{
+						{AgentId: drainAgentName, Prompt: "go"},
+						{AgentId: drainAgentName, Prompt: "go"},
+					},
+				},
+			},
+		},
+		Schedule: &loomv1.ScheduleConfig{
+			Cron:     "0 0 * * *",
+			Timezone: "UTC",
+			Enabled:  true,
+		},
+	}
+}
+
 // awaitDrainCond fails the test instead of hanging. Every wait here goes
 // through it: the failure this file guards against is a shutdown that never
 // finishes, and a bare channel receive would report that as a CI timeout with

--- a/pkg/scheduler/stop_drain_test.go
+++ b/pkg/scheduler/stop_drain_test.go
@@ -172,10 +172,10 @@ func agentWorkflow(id string) *loomv1.ScheduledWorkflow {
 // awaitDrainCond fails the test instead of hanging. Every wait here goes
 // through it: the failure this file guards against is a shutdown that never
 // finishes, and a bare channel receive would report that as a CI timeout with
-// nothing to read.
+// nothing to read. The bound is hangGuard, for the reasons given there.
 func awaitDrainCond(t *testing.T, what string, cond func() bool) {
 	t.Helper()
-	require.Eventually(t, cond, 10*time.Second, 5*time.Millisecond, what)
+	require.Eventually(t, cond, hangGuard, 5*time.Millisecond, what)
 }
 
 // TestStopDrainsInFlightRuns covers F6.
@@ -198,10 +198,13 @@ func TestStopDrainsInFlightRuns(t *testing.T) {
 		wantError  string
 	}{
 		{
-			name:       "hung run is signaled and its record still lands",
-			inFlight:   true,
-			grace:      200 * time.Millisecond,
-			maxStop:    10 * time.Second,
+			name:     "hung run is signaled and its record still lands",
+			inFlight: true,
+			grace:    200 * time.Millisecond,
+			// Far below max_execution_seconds (an hour by default), which is
+			// what this proves Stop does not wait out; generous enough not to
+			// be a performance assertion on a slow runner.
+			maxStop:    hangGuard,
 			wantStatus: "canceled",
 			wantError:  shutdownCancelReason,
 		},
@@ -231,7 +234,7 @@ func TestStopDrainsInFlightRuns(t *testing.T) {
 
 				select {
 				case <-h.llm.started:
-				case <-time.After(10 * time.Second):
+				case <-time.After(hangGuard):
 					t.Fatal("the workflow never reached the agent, so nothing was in flight to drain")
 				}
 				awaitDrainCond(t, "the run should be advertised as cancellable", func() bool {

--- a/pkg/scheduler/stop_drain_test.go
+++ b/pkg/scheduler/stop_drain_test.go
@@ -1,0 +1,289 @@
+// Copyright © 2026 Teradata Corporation - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package scheduler
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"github.com/teradata-labs/loom/pkg/agent"
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+	"github.com/teradata-labs/loom/pkg/observability"
+	"github.com/teradata-labs/loom/pkg/orchestration"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+)
+
+// drainBlockingLLM is an LLM provider that never answers. It stands in for the
+// hung external call this whole cancellation path exists for: the run is real,
+// it holds its schedule's slot, and the only thing that will end it is its
+// context being canceled.
+type drainBlockingLLM struct {
+	started   chan struct{}
+	startOnce sync.Once
+}
+
+func newDrainBlockingLLM() *drainBlockingLLM {
+	return &drainBlockingLLM{started: make(chan struct{})}
+}
+
+func (l *drainBlockingLLM) Chat(ctx context.Context, _ []llmtypes.Message, _ []shuttle.Tool) (*llmtypes.LLMResponse, error) {
+	l.startOnce.Do(func() { close(l.started) })
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (l *drainBlockingLLM) Name() string  { return "blocking" }
+func (l *drainBlockingLLM) Model() string { return "blocking" }
+
+// drainTestScheduler is a scheduler wired to a real registry and orchestrator
+// whose single agent blocks, plus the pieces a test needs to inspect it after
+// shutdown.
+type drainTestScheduler struct {
+	scheduler *Scheduler
+	llm       *drainBlockingLLM
+	dbPath    string
+	// stop is idempotent so a test can call it and still leave the cleanup in
+	// place: Stop closes the store and closing it twice is not the test's
+	// business.
+	stop func(ctx context.Context) error
+}
+
+// newDrainTestScheduler builds a scheduler whose single agent never answers.
+func newDrainTestScheduler(t *testing.T) *drainTestScheduler {
+	t.Helper()
+
+	llm := newDrainBlockingLLM()
+	h := newAgentTestScheduler(t, llm)
+	return &drainTestScheduler{scheduler: h.scheduler, llm: llm, dbPath: h.dbPath, stop: h.stop}
+}
+
+// agentTestScheduler is a scheduler wired to a real registry and orchestrator
+// with one agent backed by the given provider.
+type agentTestScheduler struct {
+	scheduler *Scheduler
+	dbPath    string
+	stop      func(ctx context.Context) error
+}
+
+// newAgentTestScheduler builds a scheduler that can actually execute a
+// workflow. The orchestrator is real on purpose: what is under test is the
+// order of the scheduler's own bookkeeping against a run that is genuinely
+// inside ExecutePattern, which a stubbed orchestrator cannot reproduce.
+func newAgentTestScheduler(t *testing.T, llm agent.LLMProvider) *agentTestScheduler {
+	t.Helper()
+
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	agentDir := t.TempDir()
+	registry, err := agent.NewRegistry(agent.RegistryConfig{
+		ConfigDir:   agentDir,
+		DBPath:      filepath.Join(agentDir, "registry.db"),
+		LLMProvider: llm,
+		Logger:      logger,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = registry.Close() })
+
+	// Empty provider and model make the registry fall back to the provider
+	// above, which is the blocking one.
+	registry.RegisterConfig(&loomv1.AgentConfig{
+		Name:        drainAgentName,
+		Description: "Test agent that never answers",
+		Llm: &loomv1.LLMConfig{
+			Temperature: 0.7,
+			MaxTokens:   4096,
+		},
+		SystemPrompt: "Respond to the prompt",
+		Memory:       &loomv1.MemoryConfig{Type: "memory", MaxHistory: 50},
+		Behavior:     &loomv1.BehaviorConfig{MaxIterations: 10, TimeoutSeconds: 300},
+	})
+
+	orchestrator := orchestration.NewOrchestrator(orchestration.Config{
+		Registry:    registry,
+		Tracer:      observability.NewNoOpTracer(),
+		Logger:      logger,
+		LLMProvider: llm,
+	})
+
+	dbPath := filepath.Join(t.TempDir(), "scheduler.db")
+	scheduler, err := NewScheduler(ctx, Config{
+		DBPath:       dbPath,
+		Orchestrator: orchestrator,
+		Registry:     registry,
+		Tracer:       observability.NewNoOpTracer(),
+		Logger:       logger,
+	})
+	require.NoError(t, err)
+
+	var (
+		once    sync.Once
+		stopErr error
+	)
+	stop := func(stopCtx context.Context) error {
+		once.Do(func() { stopErr = scheduler.Stop(stopCtx) })
+		return stopErr
+	}
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = stop(stopCtx)
+	})
+
+	return &agentTestScheduler{scheduler: scheduler, dbPath: dbPath, stop: stop}
+}
+
+const drainAgentName = "blocker"
+
+// agentWorkflow returns a schedule whose single stage runs the test agent.
+func agentWorkflow(id string) *loomv1.ScheduledWorkflow {
+	return &loomv1.ScheduledWorkflow{
+		Id:           id,
+		WorkflowName: "blocking-workflow",
+		Pattern: &loomv1.WorkflowPattern{
+			Pattern: &loomv1.WorkflowPattern_Pipeline{
+				Pipeline: &loomv1.PipelinePattern{
+					InitialPrompt: "start",
+					Stages: []*loomv1.PipelineStage{
+						{AgentId: drainAgentName, PromptTemplate: "go"},
+					},
+				},
+			},
+		},
+		Schedule: &loomv1.ScheduleConfig{
+			Cron:     "0 0 * * *",
+			Timezone: "UTC",
+			Enabled:  true,
+		},
+	}
+}
+
+// awaitDrainCond fails the test instead of hanging. Every wait here goes
+// through it: the failure this file guards against is a shutdown that never
+// finishes, and a bare channel receive would report that as a CI timeout with
+// nothing to read.
+func awaitDrainCond(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	require.Eventually(t, cond, 10*time.Second, 5*time.Millisecond, what)
+}
+
+// TestStopDrainsInFlightRuns covers F6.
+//
+// Stop used to close the store as soon as it had signaled the in-flight runs.
+// Those runs then spent their entire teardown — four SQLite writes, including
+// the history entry an operator opened the view to read — failing against a
+// closed database, on a goroutine with nobody to report to. The record of why
+// the workflow stopped was the thing lost.
+func TestStopDrainsInFlightRuns(t *testing.T) {
+	tests := []struct {
+		name string
+		// launch a run and leave it hung inside the orchestrator.
+		inFlight bool
+		// grace is what Stop is given before it starts signaling.
+		grace time.Duration
+		// maxStop bounds how long the whole shutdown may take.
+		maxStop    time.Duration
+		wantStatus string
+		wantError  string
+	}{
+		{
+			name:       "hung run is signaled and its record still lands",
+			inFlight:   true,
+			grace:      200 * time.Millisecond,
+			maxStop:    10 * time.Second,
+			wantStatus: "canceled",
+			wantError:  shutdownCancelReason,
+		},
+		{
+			name: "idle scheduler stops without waiting out its grace period",
+			// Nothing is running, so Stop must return long before this
+			// deadline rather than sitting on it.
+			grace:   10 * time.Second,
+			maxStop: 5 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			h := newDrainTestScheduler(t)
+			s := h.scheduler
+
+			schedule := agentWorkflow("sched-drain")
+			require.NoError(t, s.AddSchedule(ctx, schedule))
+
+			var executionID string
+			if tt.inFlight {
+				var err error
+				executionID, err = s.TriggerNow(ctx, schedule.Id, false, nil)
+				require.NoError(t, err)
+
+				select {
+				case <-h.llm.started:
+				case <-time.After(10 * time.Second):
+					t.Fatal("the workflow never reached the agent, so nothing was in flight to drain")
+				}
+				awaitDrainCond(t, "the run should be advertised as cancellable", func() bool {
+					return s.RunningExecutions()[schedule.Id] == executionID
+				})
+			}
+
+			stopCtx, cancel := context.WithTimeout(ctx, tt.grace)
+			defer cancel()
+
+			start := time.Now()
+			require.NoError(t, h.stop(stopCtx))
+			elapsed := time.Since(start)
+			assert.Less(t, elapsed, tt.maxStop,
+				"Stop took %s; it should not outlast the runs it canceled", elapsed)
+
+			// A trigger after shutdown must be refused, not started: the store
+			// it would write to is closed.
+			_, err := s.TriggerNow(ctx, schedule.Id, false, nil)
+			require.Error(t, err, "TriggerNow started a run after the store was closed")
+			assert.Contains(t, err.Error(), "stopped")
+
+			if !tt.inFlight {
+				return
+			}
+
+			// Read the outcome back through a fresh store: Stop closed the one
+			// the scheduler held, so anything still visible here was written
+			// before the database went away.
+			reopened, err := NewStore(ctx, h.dbPath, zap.NewNop())
+			require.NoError(t, err)
+			defer func() { _ = reopened.Close() }()
+
+			history, err := reopened.GetExecutionHistory(ctx, schedule.Id, 10)
+			require.NoError(t, err)
+			require.Len(t, history, 1,
+				"the canceled run recorded no history; the store closed while it was still writing")
+			assert.Equal(t, executionID, history[0].ExecutionId)
+			assert.Equal(t, tt.wantStatus, history[0].Status)
+			assert.Equal(t, tt.wantError, history[0].Error)
+
+			got, err := reopened.Get(ctx, schedule.Id)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantStatus, got.Stats.LastStatus)
+			assert.Equal(t, tt.wantError, got.Stats.LastError)
+			// A run the scheduler stopped on its way down reached no verdict,
+			// so it must not move the counters a success rate is derived from.
+			assert.Equal(t, int32(0), got.Stats.TotalExecutions)
+			assert.Equal(t, int32(0), got.Stats.SuccessfulExecutions)
+			assert.Equal(t, int32(0), got.Stats.FailedExecutions)
+			assert.Empty(t, got.CurrentExecutionId,
+				"current_execution_id still names a run that is over")
+		})
+	}
+}

--- a/pkg/scheduler/store.go
+++ b/pkg/scheduler/store.go
@@ -600,6 +600,39 @@ func (s *Store) RecordFailure(ctx context.Context, scheduleID, errorMsg string) 
 }
 
 // IncrementSkipped increments the skipped execution counter.
+// RecordCancelled marks a schedule's last run as cancelled.
+//
+// Like a skip, a cancelled run reached no verdict, so it does not increment
+// total_executions and is not counted among successes or failures — that keeps
+// the success rate consumers derive from those counters honest.
+//
+// What it must do is move last_status. Without this a cancelled run would leave
+// last_status showing the *previous* run's outcome, so a routine someone just
+// stopped would report itself as having last succeeded.
+//
+// Cancellations remain visible in schedule_executions. Giving them their own
+// counter would mean a new column and a new ScheduleStats field, which is a
+// schema change worth making on its own rather than inside this one.
+func (s *Store) RecordCancelled(ctx context.Context, scheduleID, reason string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	query := `
+		UPDATE scheduled_workflows
+		SET last_status = 'cancelled',
+		    last_error = ?,
+		    updated_at = ?
+		WHERE id = ?
+	`
+
+	_, err := s.db.ExecContext(ctx, query, reason, time.Now().Unix(), scheduleID)
+	if err != nil {
+		return fmt.Errorf("failed to record cancellation: %w", err)
+	}
+
+	return nil
+}
+
 func (s *Store) IncrementSkipped(ctx context.Context, scheduleID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/scheduler/store.go
+++ b/pkg/scheduler/store.go
@@ -605,6 +605,14 @@ func (s *Store) RecordFailure(ctx context.Context, scheduleID, errorMsg string) 
 // total_executions and is not counted among successes or failures — that keeps
 // the success rate consumers derive from those counters honest.
 //
+// last_execution_at is left alone for the same reason, and that is deliberate
+// rather than an oversight: RecordSuccess and RecordFailure both move it
+// because they record a run that produced an outcome, while IncrementSkipped
+// leaves it untouched because a skipped run never happened. A canceled run sits
+// on the skip's side of that line — it ran, but it reached nothing worth
+// dating, and moving the field would tell an operator the schedule last
+// executed at a moment when nothing was actually delivered.
+//
 // What it must do is move last_status. Without this a canceled run would leave
 // last_status showing the *previous* run's outcome, so a routine someone just
 // stopped would report itself as having last succeeded.

--- a/pkg/scheduler/store.go
+++ b/pkg/scheduler/store.go
@@ -599,27 +599,26 @@ func (s *Store) RecordFailure(ctx context.Context, scheduleID, errorMsg string) 
 	return nil
 }
 
-// IncrementSkipped increments the skipped execution counter.
-// RecordCancelled marks a schedule's last run as cancelled.
+// RecordCanceled marks a schedule's last run as canceled.
 //
-// Like a skip, a cancelled run reached no verdict, so it does not increment
+// Like a skip, a canceled run reached no verdict, so it does not increment
 // total_executions and is not counted among successes or failures — that keeps
 // the success rate consumers derive from those counters honest.
 //
-// What it must do is move last_status. Without this a cancelled run would leave
+// What it must do is move last_status. Without this a canceled run would leave
 // last_status showing the *previous* run's outcome, so a routine someone just
 // stopped would report itself as having last succeeded.
 //
 // Cancellations remain visible in schedule_executions. Giving them their own
 // counter would mean a new column and a new ScheduleStats field, which is a
 // schema change worth making on its own rather than inside this one.
-func (s *Store) RecordCancelled(ctx context.Context, scheduleID, reason string) error {
+func (s *Store) RecordCanceled(ctx context.Context, scheduleID, reason string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	query := `
 		UPDATE scheduled_workflows
-		SET last_status = 'cancelled',
+		SET last_status = 'canceled',
 		    last_error = ?,
 		    updated_at = ?
 		WHERE id = ?
@@ -633,6 +632,7 @@ func (s *Store) RecordCancelled(ctx context.Context, scheduleID, reason string) 
 	return nil
 }
 
+// IncrementSkipped increments the skipped execution counter.
 func (s *Store) IncrementSkipped(ctx context.Context, scheduleID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -651,6 +651,32 @@ func (s *Store) IncrementSkipped(ctx context.Context, scheduleID string) error {
 	}
 
 	return nil
+}
+
+// ExecutionExists reports whether an execution ID appears in the schedule
+// execution history.
+//
+// CancelExecution needs this to tell two states apart that would otherwise look
+// identical from the in-flight map alone: an execution this scheduler ran and
+// has since finished, and an ID it has never heard of. Reporting the second as
+// "already finished" is the failure mode that matters, because the IDs minted by
+// ExecuteWorkflow and StreamWorkflow live in a different namespace, and an
+// operator who pastes one deserves to be told it cannot be canceled here rather
+// than that the run they are watching has stopped.
+func (s *Store) ExecutionExists(ctx context.Context, executionID string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var exists int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM schedule_executions WHERE execution_id = ?)`,
+		executionID,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("failed to look up execution %s: %w", executionID, err)
+	}
+
+	return exists == 1, nil
 }
 
 // RecordExecution stores an execution record for audit trail.

--- a/pkg/scheduler/store_test.go
+++ b/pkg/scheduler/store_test.go
@@ -546,3 +546,54 @@ func createTestSchedule(id, workflowName string) *loomv1.ScheduledWorkflow {
 		Stats:     &loomv1.ScheduleStats{},
 	}
 }
+
+// A cancelled run must move last_status off the previous run's outcome.
+//
+// This is the failure this test exists to prevent: RecordSuccess and
+// RecordFailure both set last_status, so a cancelled run that called neither
+// would leave a just-stopped routine reporting that it last succeeded.
+func TestStore_RecordCancelled(t *testing.T) {
+	ctx := context.Background()
+	store := setupTestStore(t)
+	defer func() { _ = store.Close() }()
+
+	schedule := &loomv1.ScheduledWorkflow{
+		Id:           "sched-cancel",
+		WorkflowName: "cancellable",
+		Pattern: &loomv1.WorkflowPattern{
+			Pattern: &loomv1.WorkflowPattern_Pipeline{
+				Pipeline: &loomv1.PipelinePattern{InitialPrompt: "p"},
+			},
+		},
+		Schedule:  &loomv1.ScheduleConfig{Cron: "0 * * * *", Timezone: "UTC", Enabled: true},
+		CreatedAt: time.Now().Unix(),
+		UpdatedAt: time.Now().Unix(),
+	}
+	require.NoError(t, store.Create(ctx, schedule))
+
+	// A successful run first, so the test proves last_status actually moves
+	// rather than merely starting empty.
+	require.NoError(t, store.RecordSuccess(ctx, schedule.Id))
+	after, err := store.Get(ctx, schedule.Id)
+	require.NoError(t, err)
+	require.Equal(t, "success", after.Stats.LastStatus)
+	successTotal := after.Stats.TotalExecutions
+	successCount := after.Stats.SuccessfulExecutions
+
+	require.NoError(t, store.RecordCancelled(ctx, schedule.Id, "stopped by operator"))
+
+	got, err := store.Get(ctx, schedule.Id)
+	require.NoError(t, err)
+
+	assert.Equal(t, "cancelled", got.Stats.LastStatus,
+		"last_status still shows the previous run; a stopped routine would report success")
+	assert.Equal(t, "stopped by operator", got.Stats.LastError)
+
+	// A cancelled run reached no verdict, so it must not inflate the counters
+	// consumers derive a success rate from — same treatment as a skip.
+	assert.Equal(t, successTotal, got.Stats.TotalExecutions,
+		"a cancelled run should not count as an execution")
+	assert.Equal(t, successCount, got.Stats.SuccessfulExecutions)
+	assert.Equal(t, int32(0), got.Stats.FailedExecutions,
+		"a cancellation must not be counted as a failure")
+}

--- a/pkg/scheduler/store_test.go
+++ b/pkg/scheduler/store_test.go
@@ -547,12 +547,12 @@ func createTestSchedule(id, workflowName string) *loomv1.ScheduledWorkflow {
 	}
 }
 
-// A cancelled run must move last_status off the previous run's outcome.
+// A canceled run must move last_status off the previous run's outcome.
 //
 // This is the failure this test exists to prevent: RecordSuccess and
-// RecordFailure both set last_status, so a cancelled run that called neither
+// RecordFailure both set last_status, so a canceled run that called neither
 // would leave a just-stopped routine reporting that it last succeeded.
-func TestStore_RecordCancelled(t *testing.T) {
+func TestStore_RecordCanceled(t *testing.T) {
 	ctx := context.Background()
 	store := setupTestStore(t)
 	defer func() { _ = store.Close() }()
@@ -580,19 +580,19 @@ func TestStore_RecordCancelled(t *testing.T) {
 	successTotal := after.Stats.TotalExecutions
 	successCount := after.Stats.SuccessfulExecutions
 
-	require.NoError(t, store.RecordCancelled(ctx, schedule.Id, "stopped by operator"))
+	require.NoError(t, store.RecordCanceled(ctx, schedule.Id, "stopped by operator"))
 
 	got, err := store.Get(ctx, schedule.Id)
 	require.NoError(t, err)
 
-	assert.Equal(t, "cancelled", got.Stats.LastStatus,
+	assert.Equal(t, "canceled", got.Stats.LastStatus,
 		"last_status still shows the previous run; a stopped routine would report success")
 	assert.Equal(t, "stopped by operator", got.Stats.LastError)
 
-	// A cancelled run reached no verdict, so it must not inflate the counters
+	// A canceled run reached no verdict, so it must not inflate the counters
 	// consumers derive a success rate from — same treatment as a skip.
 	assert.Equal(t, successTotal, got.Stats.TotalExecutions,
-		"a cancelled run should not count as an execution")
+		"a canceled run should not count as an execution")
 	assert.Equal(t, successCount, got.Stats.SuccessfulExecutions)
 	assert.Equal(t, int32(0), got.Stats.FailedExecutions,
 		"a cancellation must not be counted as a failure")

--- a/pkg/server/multi_agent.go
+++ b/pkg/server/multi_agent.go
@@ -4747,6 +4747,46 @@ func (s *MultiAgentServer) PauseSchedule(ctx context.Context, req *loomv1.PauseS
 
 // ResumeSchedule resumes a paused schedule.
 // The schedule will start executing again according to its cron expression.
+// CancelWorkflowExecution stops an execution that is currently running.
+//
+// Pausing a schedule prevents future runs but leaves one already in flight
+// alone, and max_execution_seconds only notices a stuck run once its deadline
+// passes. This is the stop button in between.
+func (s *MultiAgentServer) CancelWorkflowExecution(ctx context.Context, req *loomv1.CancelWorkflowExecutionRequest) (*loomv1.CancelWorkflowExecutionResponse, error) {
+	if req.ExecutionId == "" {
+		return nil, status.Error(codes.InvalidArgument, "execution_id is required")
+	}
+
+	s.mu.RLock()
+	sched := s.scheduler
+	s.mu.RUnlock()
+
+	if sched == nil {
+		return nil, status.Error(codes.FailedPrecondition, "scheduler not configured")
+	}
+
+	cancelled, err := sched.CancelExecution(ctx, req.ExecutionId, req.Reason)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to cancel execution: %v", err)
+	}
+
+	// Not-running is a successful no-op, not an error: an execution that
+	// finished a moment before the request already gave the caller what they
+	// asked for. Reporting NotFound here would make the UI apologise for a race
+	// it won.
+	if !cancelled {
+		return &loomv1.CancelWorkflowExecutionResponse{
+			Cancelled: false,
+			Message:   "execution is not running — it already finished, or never started",
+		}, nil
+	}
+
+	return &loomv1.CancelWorkflowExecutionResponse{
+		Cancelled: true,
+		Message:   "cancellation signalled; the run stops at its next checkpoint",
+	}, nil
+}
+
 func (s *MultiAgentServer) ResumeSchedule(ctx context.Context, req *loomv1.ResumeScheduleRequest) (*emptypb.Empty, error) {
 	if req.ScheduleId == "" {
 		return nil, status.Error(codes.InvalidArgument, "schedule_id is required")

--- a/pkg/server/multi_agent.go
+++ b/pkg/server/multi_agent.go
@@ -4745,14 +4745,21 @@ func (s *MultiAgentServer) PauseSchedule(ctx context.Context, req *loomv1.PauseS
 	return &emptypb.Empty{}, nil
 }
 
-// ResumeSchedule resumes a paused schedule.
-// The schedule will start executing again according to its cron expression.
-// CancelWorkflowExecution stops an execution that is currently running.
+// CancelScheduledExecution stops a scheduled execution that is in flight.
 //
 // Pausing a schedule prevents future runs but leaves one already in flight
 // alone, and max_execution_seconds only notices a stuck run once its deadline
 // passes. This is the stop button in between.
-func (s *MultiAgentServer) CancelWorkflowExecution(ctx context.Context, req *loomv1.CancelWorkflowExecutionRequest) (*loomv1.CancelWorkflowExecutionResponse, error) {
+//
+// Scope: only executions the scheduler minted. An execution ID from
+// ExecuteWorkflow or StreamWorkflow lives in the workflowStore namespace that
+// GetWorkflowExecution reads, and returns NotFound here rather than being
+// silently reported as already finished.
+//
+// No CLI or TUI surface invokes this yet: the schedule RPC family has no CLI
+// commands at all, so wiring one up is a follow-up for the family rather than
+// for this RPC alone.
+func (s *MultiAgentServer) CancelScheduledExecution(ctx context.Context, req *loomv1.CancelScheduledExecutionRequest) (*loomv1.CancelScheduledExecutionResponse, error) {
 	if req.ExecutionId == "" {
 		return nil, status.Error(codes.InvalidArgument, "execution_id is required")
 	}
@@ -4765,28 +4772,47 @@ func (s *MultiAgentServer) CancelWorkflowExecution(ctx context.Context, req *loo
 		return nil, status.Error(codes.FailedPrecondition, "scheduler not configured")
 	}
 
-	cancelled, err := sched.CancelExecution(ctx, req.ExecutionId, req.Reason)
+	outcome, err := sched.CancelExecution(ctx, req.ExecutionId, req.Reason)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to cancel execution: %v", err)
 	}
 
-	// Not-running is a successful no-op, not an error: an execution that
-	// finished a moment before the request already gave the caller what they
-	// asked for. Reporting NotFound here would make the UI apologise for a race
-	// it won.
-	if !cancelled {
-		return &loomv1.CancelWorkflowExecutionResponse{
-			Cancelled: false,
-			Message:   "execution is not running — it already finished, or never started",
-		}, nil
-	}
+	switch outcome {
+	case scheduler.CancelOutcomeNotFound:
+		// The scheduler has never heard of this ID, in flight or in history.
+		// Saying "already finished" here would be a lie an operator acts on, so
+		// name the namespace boundary instead.
+		return nil, status.Errorf(codes.NotFound,
+			"no scheduled execution %q, in flight or in history; execution IDs returned by "+
+				"ExecuteWorkflow or StreamWorkflow are a different namespace and cannot be canceled here",
+			req.ExecutionId)
 
-	return &loomv1.CancelWorkflowExecutionResponse{
-		Cancelled: true,
-		Message:   "cancellation signalled; the run stops at its next checkpoint",
-	}, nil
+	case scheduler.CancelOutcomeAlreadyFinished:
+		// A successful no-op, not an error: an execution that reached its
+		// verdict a moment before the request already gave the caller what they
+		// asked for. Reporting an error here would make the UI apologize for a
+		// race it won.
+		return &loomv1.CancelScheduledExecutionResponse{
+			Canceled: false,
+			Message:  "execution already finished before the request; its recorded outcome stands",
+		}, nil
+
+	case scheduler.CancelOutcomeSignaled:
+		return &loomv1.CancelScheduledExecutionResponse{
+			Canceled: true,
+			Message:  "cancellation signaled; the run stops at its next checkpoint and is recorded as canceled",
+		}, nil
+
+	default:
+		// A new outcome the scheduler grew and this handler has not learned.
+		// Mapping it onto one of the cases above would report a state that was
+		// never observed, so fail loudly instead.
+		return nil, status.Errorf(codes.Internal, "unhandled cancel outcome %v", outcome)
+	}
 }
 
+// ResumeSchedule resumes a paused schedule.
+// The schedule will start executing again according to its cron expression.
 func (s *MultiAgentServer) ResumeSchedule(ctx context.Context, req *loomv1.ResumeScheduleRequest) (*emptypb.Empty, error) {
 	if req.ScheduleId == "" {
 		return nil, status.Error(codes.InvalidArgument, "schedule_id is required")

--- a/pkg/server/scheduler_rpc_test.go
+++ b/pkg/server/scheduler_rpc_test.go
@@ -58,6 +58,20 @@ func setupTestSchedulerServer(t *testing.T) (*MultiAgentServer, *scheduler.Sched
 	})
 	require.NoError(t, err)
 
+	// Stop the scheduler before the test's temp directory is torn down. Stop is
+	// what closes the store, and an open SQLite handle makes t.TempDir's
+	// RemoveAll fail on Windows ("being used by another process") — a failure
+	// CI cannot see, because unit tests only run on ubuntu. Registered after
+	// t.TempDir above, so cleanups run in the order this needs: handle closed
+	// first, directory removed second.
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if stopErr := sched.Stop(stopCtx); stopErr != nil {
+			t.Errorf("stopping the test scheduler: %v", stopErr)
+		}
+	})
+
 	// Create server
 	server := &MultiAgentServer{
 		agents:        make(map[string]*agent.Agent),

--- a/pkg/server/scheduler_rpc_test.go
+++ b/pkg/server/scheduler_rpc_test.go
@@ -8,6 +8,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -42,11 +43,13 @@ func setupTestSchedulerServer(t *testing.T) (*MultiAgentServer, *scheduler.Sched
 		LLMProvider: nil,
 	})
 
-	// Create scheduler with in-memory database
-	// Each call to setupTestSchedulerServer gets its own isolated :memory: database
+	// Create scheduler with a per-test database file. Not :memory: — the store
+	// opens its DSN with cache=shared, and for :memory: that means every
+	// scheduler in the process shares one database, so a test's schedule IDs
+	// collide with its own earlier runs under -count>1.
 	sched, err := scheduler.NewScheduler(ctx, scheduler.Config{
 		WorkflowDir:  "",
-		DBPath:       ":memory:",
+		DBPath:       filepath.Join(t.TempDir(), "scheduler.db"),
 		Orchestrator: orchestrator,
 		Registry:     registry,
 		Tracer:       observability.NewNoOpTracer(),
@@ -933,11 +936,13 @@ func TestCancelScheduledExecution_AlreadyFinished(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, trig.ExecutionId)
 
-	// Wait for the run to be recorded before cancelling it.
+	// Wait for the run to be recorded before cancelling it. The bound is a hang
+	// guard, not a performance assertion: it only has to fail with a message
+	// rather than let a stuck run hit the package timeout.
 	require.Eventually(t, func() bool {
 		hist, err := server.GetScheduleHistory(ctx, &loomv1.GetScheduleHistoryRequest{ScheduleId: schedule.Id})
 		return err == nil && len(hist.Executions) == 1
-	}, 5*time.Second, 5*time.Millisecond, "the triggered run never recorded a verdict")
+	}, 30*time.Second, 5*time.Millisecond, "the triggered run never recorded a verdict")
 
 	resp, err := server.CancelScheduledExecution(ctx, &loomv1.CancelScheduledExecutionRequest{
 		ExecutionId: trig.ExecutionId,

--- a/pkg/server/scheduler_rpc_test.go
+++ b/pkg/server/scheduler_rpc_test.go
@@ -840,3 +840,118 @@ func TestGetScheduleHistory_Success(t *testing.T) {
 	// History should be empty since we haven't executed yet
 	assert.Equal(t, 0, len(histResp.Executions))
 }
+
+// TestCancelScheduledExecution_Validation covers the three outcomes an operator
+// can reach without a run in flight: a missing ID, a server with no scheduler,
+// and an ID the scheduler has never seen. The last one is the point of the RPC's
+// rename — an unknown ID must be NotFound, not a cheerful "already finished",
+// because IDs from ExecuteWorkflow/StreamWorkflow are a different namespace.
+func TestCancelScheduledExecution_Validation(t *testing.T) {
+	tests := []struct {
+		name           string
+		req            *loomv1.CancelScheduledExecutionRequest
+		setupScheduler bool
+		expectCode     codes.Code
+		expectError    string
+	}{
+		{
+			name:           "missing execution_id",
+			req:            &loomv1.CancelScheduledExecutionRequest{ExecutionId: ""},
+			setupScheduler: true,
+			expectCode:     codes.InvalidArgument,
+			expectError:    "execution_id is required",
+		},
+		{
+			name:           "scheduler not configured",
+			req:            &loomv1.CancelScheduledExecutionRequest{ExecutionId: "exec-1"},
+			setupScheduler: false,
+			expectCode:     codes.FailedPrecondition,
+			expectError:    "scheduler not configured",
+		},
+		{
+			name:           "unknown execution_id",
+			req:            &loomv1.CancelScheduledExecutionRequest{ExecutionId: "exec-never-existed"},
+			setupScheduler: true,
+			expectCode:     codes.NotFound,
+			expectError:    "no scheduled execution",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var server *MultiAgentServer
+			if tt.setupScheduler {
+				server, _ = setupTestSchedulerServer(t)
+			} else {
+				// Server without scheduler
+				server = &MultiAgentServer{
+					agents:        make(map[string]*agent.Agent),
+					workflowStore: NewWorkflowStore(),
+				}
+			}
+
+			_, err := server.CancelScheduledExecution(context.Background(), tt.req)
+
+			require.Error(t, err)
+			st, ok := status.FromError(err)
+			require.True(t, ok, "Expected gRPC status error")
+			assert.Equal(t, tt.expectCode, st.Code(), "Status code mismatch")
+			assert.Contains(t, st.Message(), tt.expectError, "Error message mismatch")
+		})
+	}
+}
+
+// TestCancelScheduledExecution_AlreadyFinished covers the one response the
+// handler returns without an error: the execution exists in the scheduler's
+// history but had already reached its verdict. That is deliberately a
+// successful no-op — an operator stopping a run that just ended got the state
+// they asked for — and the recorded outcome must be left alone.
+func TestCancelScheduledExecution_AlreadyFinished(t *testing.T) {
+	server, sched := setupTestSchedulerServer(t)
+	ctx := context.Background()
+
+	// An empty pipeline is rejected by the orchestrator before anything runs,
+	// so the execution reaches a deterministic verdict without an LLM.
+	schedule := &loomv1.ScheduledWorkflow{
+		Id:           "sched-finished",
+		WorkflowName: "finishes-at-once",
+		Pattern: &loomv1.WorkflowPattern{
+			Pattern: &loomv1.WorkflowPattern_Pipeline{
+				Pipeline: &loomv1.PipelinePattern{},
+			},
+		},
+		Schedule: &loomv1.ScheduleConfig{
+			Cron:    "0 0 * * *",
+			Enabled: true,
+		},
+	}
+	require.NoError(t, sched.AddSchedule(ctx, schedule))
+
+	trig, err := server.TriggerScheduledWorkflow(ctx, &loomv1.TriggerScheduledWorkflowRequest{
+		ScheduleId: schedule.Id,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, trig.ExecutionId)
+
+	// Wait for the run to be recorded before cancelling it.
+	require.Eventually(t, func() bool {
+		hist, err := server.GetScheduleHistory(ctx, &loomv1.GetScheduleHistoryRequest{ScheduleId: schedule.Id})
+		return err == nil && len(hist.Executions) == 1
+	}, 5*time.Second, 5*time.Millisecond, "the triggered run never recorded a verdict")
+
+	resp, err := server.CancelScheduledExecution(ctx, &loomv1.CancelScheduledExecutionRequest{
+		ExecutionId: trig.ExecutionId,
+		Reason:      "operator stop",
+	})
+	require.NoError(t, err, "cancelling a finished execution must not be an error")
+	assert.False(t, resp.Canceled)
+	assert.Contains(t, resp.Message, "already finished")
+
+	// The verdict the run reached on its own must still be what history shows.
+	hist, err := server.GetScheduleHistory(ctx, &loomv1.GetScheduleHistoryRequest{ScheduleId: schedule.Id})
+	require.NoError(t, err)
+	require.Len(t, hist.Executions, 1)
+	assert.Equal(t, trig.ExecutionId, hist.Executions[0].ExecutionId)
+	assert.Equal(t, "failed", hist.Executions[0].Status,
+		"a late cancel must not relabel a finished run")
+}

--- a/pkg/tui/client/schedules.go
+++ b/pkg/tui/client/schedules.go
@@ -218,25 +218,31 @@ func (c *Client) GetWorkflowExecution(ctx context.Context, executionID string) (
 	return c.client.GetWorkflowExecution(ctx, req)
 }
 
-// CancelExecution stops a workflow execution that is currently running.
+// CancelScheduledExecution stops a scheduled execution that is in flight.
 //
-// The boolean in the response distinguishes "signalled" from "there was nothing
-// to signal" — an execution that finished a moment earlier is not an error, so
-// callers should report the message rather than treating false as a failure.
+// The ID must be one the scheduler minted — the current_execution_id on a
+// schedule, or the ID returned by a manual trigger. An ID the scheduler has
+// never seen, including one from a direct workflow execution, surfaces as a
+// gRPC error with code NotFound.
+//
+// The boolean distinguishes "signaled" from "there was nothing to signal": a
+// false with a message means the execution had already finished before the
+// request, which is not an error, so callers should report the message rather
+// than treating false as a failure.
 //
 // Cancellation is cooperative: the run stops at its next context check, so a
 // caller that wants to show the final state should re-read the schedule's
 // history rather than assume the run has already ended.
-func (c *Client) CancelExecution(ctx context.Context, executionID, reason string) (bool, string, error) {
-	req := &loomv1.CancelWorkflowExecutionRequest{
+func (c *Client) CancelScheduledExecution(ctx context.Context, executionID, reason string) (canceled bool, message string, err error) {
+	req := &loomv1.CancelScheduledExecutionRequest{
 		ExecutionId: executionID,
 		Reason:      reason,
 	}
 
-	resp, err := c.client.CancelWorkflowExecution(ctx, req)
+	resp, err := c.client.CancelScheduledExecution(ctx, req)
 	if err != nil {
 		return false, "", err
 	}
 
-	return resp.GetCancelled(), resp.GetMessage(), nil
+	return resp.GetCanceled(), resp.GetMessage(), nil
 }

--- a/pkg/tui/client/schedules.go
+++ b/pkg/tui/client/schedules.go
@@ -217,3 +217,26 @@ func (c *Client) GetWorkflowExecution(ctx context.Context, executionID string) (
 
 	return c.client.GetWorkflowExecution(ctx, req)
 }
+
+// CancelExecution stops a workflow execution that is currently running.
+//
+// The boolean in the response distinguishes "signalled" from "there was nothing
+// to signal" — an execution that finished a moment earlier is not an error, so
+// callers should report the message rather than treating false as a failure.
+//
+// Cancellation is cooperative: the run stops at its next context check, so a
+// caller that wants to show the final state should re-read the schedule's
+// history rather than assume the run has already ended.
+func (c *Client) CancelExecution(ctx context.Context, executionID, reason string) (bool, string, error) {
+	req := &loomv1.CancelWorkflowExecutionRequest{
+		ExecutionId: executionID,
+		Reason:      reason,
+	}
+
+	resp, err := c.client.CancelWorkflowExecution(ctx, req)
+	if err != nil {
+		return false, "", err
+	}
+
+	return resp.GetCancelled(), resp.GetMessage(), nil
+}

--- a/pkg/tui/client/schedules_test.go
+++ b/pkg/tui/client/schedules_test.go
@@ -43,6 +43,25 @@ type scheduleMockServer struct {
 	gotUpdate  *loomv1.UpdateScheduledWorkflowRequest
 	gotGet     *loomv1.GetScheduledWorkflowRequest
 	gotGetExec *loomv1.GetWorkflowExecutionRequest
+	gotCancel  *loomv1.CancelWorkflowExecutionRequest
+
+	// cancelResult is what the fake reports back; false models an execution
+	// that had already finished.
+	cancelResult bool
+}
+
+func (m *scheduleMockServer) CancelWorkflowExecution(_ context.Context, req *loomv1.CancelWorkflowExecutionRequest) (*loomv1.CancelWorkflowExecutionResponse, error) {
+	m.gotCancel = req
+	if !m.cancelResult {
+		return &loomv1.CancelWorkflowExecutionResponse{
+			Cancelled: false,
+			Message:   "execution is not running",
+		}, nil
+	}
+	return &loomv1.CancelWorkflowExecutionResponse{
+		Cancelled: true,
+		Message:   "cancellation signalled",
+	}, nil
 }
 
 func (m *scheduleMockServer) ListScheduledWorkflows(_ context.Context, req *loomv1.ListScheduledWorkflowsRequest) (*loomv1.ListScheduledWorkflowsResponse, error) {
@@ -427,5 +446,47 @@ func TestWrapBorrowsConnection(t *testing.T) {
 func TestWrapNilConn(t *testing.T) {
 	if got := Wrap(nil); got != nil {
 		t.Errorf("Wrap(nil) = %v, want nil", got)
+	}
+}
+
+// Cancel must forward the reason — the history entry depends on it to read as an
+// operator stop rather than a crash.
+func TestCancelExecution(t *testing.T) {
+	c, mock := setupScheduleServer(t)
+	mock.cancelResult = true
+
+	cancelled, msg, err := c.CancelExecution(context.Background(), "exec-1", "operator stop")
+	if err != nil {
+		t.Fatalf("CancelExecution: %v", err)
+	}
+	if !cancelled {
+		t.Error("cancelled = false, want true")
+	}
+	if msg == "" {
+		t.Error("message is empty; callers show it directly")
+	}
+	if mock.gotCancel.ExecutionId != "exec-1" {
+		t.Errorf("ExecutionId = %q", mock.gotCancel.ExecutionId)
+	}
+	if mock.gotCancel.Reason != "operator stop" {
+		t.Errorf("Reason = %q, want it forwarded", mock.gotCancel.Reason)
+	}
+}
+
+// An already-finished execution comes back as cancelled=false with no error.
+// Treating that as a failure would have the UI apologise for a race it won.
+func TestCancelExecutionAlreadyFinished(t *testing.T) {
+	c, mock := setupScheduleServer(t)
+	mock.cancelResult = false
+
+	cancelled, msg, err := c.CancelExecution(context.Background(), "exec-done", "")
+	if err != nil {
+		t.Fatalf("an already-finished execution must not error: %v", err)
+	}
+	if cancelled {
+		t.Error("cancelled = true for a finished execution")
+	}
+	if msg == "" {
+		t.Error("message is empty; it is the only thing distinguishing this case")
 	}
 }

--- a/pkg/tui/client/schedules_test.go
+++ b/pkg/tui/client/schedules_test.go
@@ -20,7 +20,9 @@ import (
 
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
@@ -43,24 +45,31 @@ type scheduleMockServer struct {
 	gotUpdate  *loomv1.UpdateScheduledWorkflowRequest
 	gotGet     *loomv1.GetScheduledWorkflowRequest
 	gotGetExec *loomv1.GetWorkflowExecutionRequest
-	gotCancel  *loomv1.CancelWorkflowExecutionRequest
+	gotCancel  *loomv1.CancelScheduledExecutionRequest
 
 	// cancelResult is what the fake reports back; false models an execution
 	// that had already finished.
 	cancelResult bool
+
+	// cancelErr, when set, is returned instead of a response — the server does
+	// this for an execution ID it has never seen.
+	cancelErr error
 }
 
-func (m *scheduleMockServer) CancelWorkflowExecution(_ context.Context, req *loomv1.CancelWorkflowExecutionRequest) (*loomv1.CancelWorkflowExecutionResponse, error) {
+func (m *scheduleMockServer) CancelScheduledExecution(_ context.Context, req *loomv1.CancelScheduledExecutionRequest) (*loomv1.CancelScheduledExecutionResponse, error) {
 	m.gotCancel = req
+	if m.cancelErr != nil {
+		return nil, m.cancelErr
+	}
 	if !m.cancelResult {
-		return &loomv1.CancelWorkflowExecutionResponse{
-			Cancelled: false,
-			Message:   "execution is not running",
+		return &loomv1.CancelScheduledExecutionResponse{
+			Canceled: false,
+			Message:  "execution already finished before the request",
 		}, nil
 	}
-	return &loomv1.CancelWorkflowExecutionResponse{
-		Cancelled: true,
-		Message:   "cancellation signalled",
+	return &loomv1.CancelScheduledExecutionResponse{
+		Canceled: true,
+		Message:  "cancellation signaled",
 	}, nil
 }
 
@@ -449,44 +458,86 @@ func TestWrapNilConn(t *testing.T) {
 	}
 }
 
-// Cancel must forward the reason — the history entry depends on it to read as an
-// operator stop rather than a crash.
-func TestCancelExecution(t *testing.T) {
-	c, mock := setupScheduleServer(t)
-	mock.cancelResult = true
+// The three outcomes the wrapper has to keep distinct. Only one of them is an
+// error, and the caller's UI branches on all three, so collapsing any pair
+// would make the client lie about what happened to the run.
+//
+// The reason must also reach the server: the history entry depends on it to
+// read as an operator stop rather than a crash.
+func TestCancelScheduledExecution(t *testing.T) {
+	tests := []struct {
+		name         string
+		executionID  string
+		reason       string
+		cancelResult bool
+		cancelErr    error
+		wantCanceled bool
+		wantMessage  bool
+		wantCode     codes.Code
+		wantErr      bool
+	}{
+		{
+			name:         "signaled",
+			executionID:  "exec-1",
+			reason:       "operator stop",
+			cancelResult: true,
+			wantCanceled: true,
+			wantMessage:  true,
+		},
+		{
+			name:         "already finished is not an error",
+			executionID:  "exec-done",
+			reason:       "",
+			cancelResult: false,
+			wantCanceled: false,
+			wantMessage:  true,
+		},
+		{
+			name:        "unknown id surfaces as NotFound",
+			executionID: "exec-never-existed",
+			reason:      "operator stop",
+			cancelErr: status.Error(codes.NotFound,
+				"no scheduled execution, in flight or in history"),
+			wantCanceled: false,
+			wantErr:      true,
+			wantCode:     codes.NotFound,
+		},
+	}
 
-	cancelled, msg, err := c.CancelExecution(context.Background(), "exec-1", "operator stop")
-	if err != nil {
-		t.Fatalf("CancelExecution: %v", err)
-	}
-	if !cancelled {
-		t.Error("cancelled = false, want true")
-	}
-	if msg == "" {
-		t.Error("message is empty; callers show it directly")
-	}
-	if mock.gotCancel.ExecutionId != "exec-1" {
-		t.Errorf("ExecutionId = %q", mock.gotCancel.ExecutionId)
-	}
-	if mock.gotCancel.Reason != "operator stop" {
-		t.Errorf("Reason = %q, want it forwarded", mock.gotCancel.Reason)
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, mock := setupScheduleServer(t)
+			mock.cancelResult = tt.cancelResult
+			mock.cancelErr = tt.cancelErr
 
-// An already-finished execution comes back as cancelled=false with no error.
-// Treating that as a failure would have the UI apologise for a race it won.
-func TestCancelExecutionAlreadyFinished(t *testing.T) {
-	c, mock := setupScheduleServer(t)
-	mock.cancelResult = false
+			canceled, msg, err := c.CancelScheduledExecution(context.Background(), tt.executionID, tt.reason)
 
-	cancelled, msg, err := c.CancelExecution(context.Background(), "exec-done", "")
-	if err != nil {
-		t.Fatalf("an already-finished execution must not error: %v", err)
-	}
-	if cancelled {
-		t.Error("cancelled = true for a finished execution")
-	}
-	if msg == "" {
-		t.Error("message is empty; it is the only thing distinguishing this case")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("CancelScheduledExecution: want an error, got nil")
+				}
+				if got := status.Code(err); got != tt.wantCode {
+					t.Errorf("status.Code = %v, want %v", got, tt.wantCode)
+				}
+			} else if err != nil {
+				t.Fatalf("CancelScheduledExecution: %v", err)
+			}
+
+			if canceled != tt.wantCanceled {
+				t.Errorf("canceled = %v, want %v", canceled, tt.wantCanceled)
+			}
+			if tt.wantMessage && msg == "" {
+				t.Error("message is empty; callers show it directly")
+			}
+
+			// The request reaches the server even in the error case, so the
+			// forwarding assertion holds for every row.
+			if mock.gotCancel.GetExecutionId() != tt.executionID {
+				t.Errorf("ExecutionId = %q, want %q", mock.gotCancel.GetExecutionId(), tt.executionID)
+			}
+			if mock.gotCancel.GetReason() != tt.reason {
+				t.Errorf("Reason = %q, want %q forwarded", mock.gotCancel.GetReason(), tt.reason)
+			}
+		})
 	}
 }

--- a/proto/loom/v1/loom.proto
+++ b/proto/loom/v1/loom.proto
@@ -430,6 +430,24 @@ service LoomService {
     option (google.api.http) = {get: "/v1/workflows/schedules/{schedule_id}/history"};
   }
 
+  // CancelWorkflowExecution stops an execution that is currently running.
+  //
+  // Pausing a schedule prevents future runs but does nothing about one already
+  // in flight, and max_execution_seconds only detects a stuck run after the
+  // fact. This is the operator's stop button: without it a workflow that hangs
+  // holds its schedule's slot until the timeout expires, and skip_if_running
+  // silently skips every run in the meantime.
+  //
+  // Cancellation is cooperative — the execution's context is cancelled and the
+  // run is recorded as cancelled. Work already committed by earlier stages is
+  // not rolled back.
+  rpc CancelWorkflowExecution(CancelWorkflowExecutionRequest) returns (CancelWorkflowExecutionResponse) {
+    option (google.api.http) = {
+      post: "/v1/workflows/executions/{execution_id}:cancel"
+      body: "*"
+    };
+  }
+
   // Tri-Modal Communication RPCs
 
   // Broadcast Bus (Pub/Sub) Operations
@@ -2102,6 +2120,28 @@ message GetScheduleHistoryRequest {
 message GetScheduleHistoryResponse {
   // Schedule executions
   repeated ScheduleExecution executions = 1;
+}
+
+// CancelWorkflowExecutionRequest stops a running execution.
+message CancelWorkflowExecutionRequest {
+  // Execution ID to cancel, as reported by ScheduledWorkflow.current_execution_id
+  // or by the response to TriggerScheduledWorkflow.
+  string execution_id = 1;
+
+  // Optional human-readable reason, recorded in the execution history so the
+  // record distinguishes an operator stop from a crash.
+  string reason = 2;
+}
+
+// CancelWorkflowExecutionResponse reports what the cancellation did.
+message CancelWorkflowExecutionResponse {
+  // True when a running execution was found and signalled. False means the
+  // execution was already finished or was never running — not an error, since
+  // a user cancelling a run that just completed has got what they wanted.
+  bool cancelled = 1;
+
+  // Human-readable outcome, suitable for showing directly.
+  string message = 2;
 }
 
 // ScheduleExecution represents a single execution of a scheduled workflow.

--- a/proto/loom/v1/loom.proto
+++ b/proto/loom/v1/loom.proto
@@ -430,7 +430,7 @@ service LoomService {
     option (google.api.http) = {get: "/v1/workflows/schedules/{schedule_id}/history"};
   }
 
-  // CancelWorkflowExecution stops an execution that is currently running.
+  // CancelScheduledExecution stops a scheduled execution that is in flight.
   //
   // Pausing a schedule prevents future runs but does nothing about one already
   // in flight, and max_execution_seconds only detects a stuck run after the
@@ -438,12 +438,33 @@ service LoomService {
   // holds its schedule's slot until the timeout expires, and skip_if_running
   // silently skips every run in the meantime.
   //
-  // Cancellation is cooperative — the execution's context is cancelled and the
-  // run is recorded as cancelled. Work already committed by earlier stages is
-  // not rolled back.
-  rpc CancelWorkflowExecution(CancelWorkflowExecutionRequest) returns (CancelWorkflowExecutionResponse) {
+  // Scope: this cancels executions minted by the scheduler — the IDs reported
+  // in ScheduledWorkflow.current_execution_id and in the response to
+  // TriggerScheduledWorkflow. Execution IDs from ExecuteWorkflow and
+  // StreamWorkflow live in a different namespace (the one GetWorkflowExecution
+  // and ListWorkflowExecutions read) and cannot be canceled here; passing one
+  // returns NOT_FOUND.
+  //
+  // NOT_FOUND means no scheduled execution with that ID exists, neither in
+  // flight nor in the schedule's history. A response with canceled = false and
+  // a message means the execution was found but had already reached its verdict
+  // before the request arrived; that is deliberately not an error, because a
+  // caller stopping a run that just finished got the state it asked for.
+  //
+  // Cancellation is cooperative — the execution's context is canceled and the
+  // run is recorded as canceled once it unwinds. Work already committed by
+  // earlier stages is not rolled back.
+  //
+  // Authorization: like the sibling schedule RPCs (PauseSchedule,
+  // ResumeSchedule, DeleteScheduledWorkflow, TriggerScheduledWorkflow), this
+  // performs no ownership check — the scheduled_workflows table has no owner
+  // column, so there is nothing to check against. Any caller that reaches the
+  // service can stop any scheduled execution. Adding ownership is a follow-up
+  // for the whole schedule surface rather than something this one RPC can
+  // solve; it is recorded here so the gap is not mistaken for an oversight.
+  rpc CancelScheduledExecution(CancelScheduledExecutionRequest) returns (CancelScheduledExecutionResponse) {
     option (google.api.http) = {
-      post: "/v1/workflows/executions/{execution_id}:cancel"
+      post: "/v1/workflows/schedules/executions/{execution_id}:cancel"
       body: "*"
     };
   }
@@ -2122,10 +2143,15 @@ message GetScheduleHistoryResponse {
   repeated ScheduleExecution executions = 1;
 }
 
-// CancelWorkflowExecutionRequest stops a running execution.
-message CancelWorkflowExecutionRequest {
+// CancelScheduledExecutionRequest stops a scheduled execution that is in
+// flight.
+//
+// The ID must be one the scheduler minted. IDs returned by ExecuteWorkflow and
+// StreamWorkflow belong to a different namespace and yield NOT_FOUND.
+message CancelScheduledExecutionRequest {
   // Execution ID to cancel, as reported by ScheduledWorkflow.current_execution_id
-  // or by the response to TriggerScheduledWorkflow.
+  // or by the response to TriggerScheduledWorkflow. An ID that names no
+  // scheduled execution — in flight or in history — returns NOT_FOUND.
   string execution_id = 1;
 
   // Optional human-readable reason, recorded in the execution history so the
@@ -2133,14 +2159,23 @@ message CancelWorkflowExecutionRequest {
   string reason = 2;
 }
 
-// CancelWorkflowExecutionResponse reports what the cancellation did.
-message CancelWorkflowExecutionResponse {
-  // True when a running execution was found and signalled. False means the
-  // execution was already finished or was never running — not an error, since
-  // a user cancelling a run that just completed has got what they wanted.
-  bool cancelled = 1;
+// CancelScheduledExecutionResponse reports what the cancellation did.
+//
+// Reaching this message at all means the execution exists in the scheduler's
+// namespace; an unknown ID is a NOT_FOUND error instead.
+message CancelScheduledExecutionResponse {
+  // True when the execution was in flight and its context was canceled; the
+  // run is recorded as canceled once it unwinds. False means the execution had
+  // already reached its verdict before the request arrived, so nothing was
+  // signaled and the recorded outcome stands — not an error, since a caller
+  // stopping a run that just completed got the state it asked for.
+  //
+  // Cancellation is cooperative: true says the signal was delivered, not that
+  // the run has stopped yet, and work already committed is not rolled back.
+  bool canceled = 1;
 
-  // Human-readable outcome, suitable for showing directly.
+  // Human-readable outcome, suitable for showing directly. It is the only thing
+  // that distinguishes "signaled" from "already finished" beyond the boolean.
   string message = 2;
 }
 
@@ -2155,7 +2190,9 @@ message ScheduleExecution {
   // Completed at timestamp (Unix seconds)
   int64 completed_at = 3;
 
-  // Status: "success", "failed", "skipped"
+  // Status: "success", "failed", "skipped", "canceled"
+  // The US spelling matches WorkflowStatus "canceled" in the workflow-execution
+  // namespace, so both surfaces report the same word for the same outcome.
   string status = 4;
 
   // Error message (if failed)

--- a/proto/loom/v1/orchestration.proto
+++ b/proto/loom/v1/orchestration.proto
@@ -904,7 +904,7 @@ message ScheduleStats {
   // Number of skipped executions (due to previous run still active)
   int32 skipped_executions = 4;
 
-  // Last execution status: "success", "failed", "skipped"
+  // Last execution status: "success", "failed", "skipped", "canceled"
   string last_status = 5;
 
   // Last error message (if failed)


### PR DESCRIPTION
> **No longer stacked.** #363 (the SDK schedule surface) is merged and is this PR's base, so the diff below is just the cancel work.

`executeWorkflow` already builds a cancellable context, but the cancel func was only `defer`red — never reachable from outside. So the only way to stop a hung workflow was to wait out `max_execution_seconds` (default **one hour**), and because `skip_if_running` defaults on, that one hung run silently suppresses **every scheduled run behind it** for the duration. Pausing the schedule does not help: it prevents future runs and leaves the current one going.

The scheduler now tracks each in-flight execution in a single `runState` entry (its owning schedule, cancel func, cancel reason, and whether it has settled) and exposes `CancelExecution`, which returns one of three outcomes, and `RunningExecutions`.

## The RPC: `CancelScheduledExecution`

`POST /v1/workflows/schedules/executions/{execution_id}:cancel`, alongside its sibling schedule RPCs.

It was originally named `CancelWorkflowExecution` under `/v1/workflows/executions/…`. That name and path shared a REST resource with `GetWorkflowExecution`, which reads a **different ID namespace** (IDs minted by `ExecuteWorkflow`/`StreamWorkflow`). This RPC only ever cancelled scheduler-minted IDs, so passing an `ExecuteWorkflow` ID returned *"already finished"* for a run executing right now. Renamed while the surface is still unmerged; renaming after merge would be a breaking change under `buf breaking`.

**Outcomes:**
- **`canceled = true`** — the run was in flight and its context was canceled. Cooperative: the signal was delivered; the run stops at its next context check and is then recorded as `canceled`. Work already committed by earlier stages is not rolled back.
- **`canceled = false` + message** — the execution exists in this scheduler's history but had already reached its verdict. Deliberately **not an error**: a caller stopping a run that just finished got the state they asked for, and the recorded outcome stands.
- **`NOT_FOUND`** — no scheduled execution with that ID, in flight or in history. Most often an `ExecuteWorkflow`/`StreamWorkflow` ID. Distinguished from "already finished" so an operator is never told a live workflow has stopped.

## Correctness: cancel vs. completion

The run **settles** in one critical section the instant `ExecutePattern` returns: the cancel state is read and the run is closed to further cancellation together. Before this, the run stayed cancellable across its entire bookkeeping tail — four SQLite writes — so a cancel landing there was accepted, relabelled a completed or failed run as `canceled`, replaced its real error with the operator's reason, and skipped its counters. The classification's canceled branch requires `errors.Is(err, context.Canceled)`, not just `err != nil`: a run signaled before the orchestrator ever ran can still fail for a reason that has nothing to do with the signal (a misconfigured pipeline fails the same way whether or not anyone canceled it), and that real error must not be discarded and relabelled `canceled` just because a signal happened to land first. A run that was signaled but finished on its own before its next context check reached a real verdict and is recorded as such.

Registration is likewise one critical section, **before** the first store write, so there is no window where a run is advertised (including via `current_execution_id`, the field callers are told to pass) but a cancel says "not running". `RunningExecutions()` excludes settled runs — everything it lists is still cancellable — while `skip_if_running` keeps counting settled runs until teardown finishes writing.

## Recorded semantics

- **A canceled run is recorded with status `"canceled"`, not `"failed"`** — counting an operator's stop as a failure would distort the success rate consumers use to judge whether a routine is trustworthy. Spelling matches `WorkflowStatusCanceled` in the workflow-execution namespace.
- **`RecordCanceled` moves `last_status` but does not touch the counters.** Like a skip, a canceled run reached no verdict. Cancellations stay visible in `schedule_executions`; a dedicated counter would need a schema change worth doing on its own.
- **Only the first cancel's reason is kept** — two operators racing should leave the history naming the one whose signal actually stopped the run.

## `Stop()` now drains

Previously `Stop` closed the store while `executeWorkflow` goroutines could still be writing to it. Launches now go through `admitRun()` (an `inFlight` WaitGroup incremented under the same lock `Stop` uses to refuse further launches — the ordering that makes the `Wait` sound). When `Stop`'s grace period expires it signals remaining runs and then waits for them before closing the store, so the history entry of a run stopped at shutdown actually lands. **Trade-off, flagged deliberately:** that final wait has no deadline. It is bounded in practice by the executor honoring the canceled context down to the LLM HTTP call, and by the store's SQLite busy timeout — not by `max_execution_seconds`. It now logs "still waiting on N executions" every 10s instead of going silent, so a shutdown stuck there is diagnosable rather than just slow. Triggers arriving after `Stop` are refused rather than started, and `Stop` itself is idempotent — a second call returns immediately instead of panicking on a double `close` of the internal shutdown channel.

## Known gaps, recorded rather than solved here

- **Authorization (F4).** Like every sibling schedule RPC (`PauseSchedule`, `ResumeSchedule`, `DeleteScheduledWorkflow`, `TriggerScheduledWorkflow`), this performs no ownership check — `scheduled_workflows` has no owner column, so there is nothing to check against. Any caller that reaches the service can stop any scheduled execution. Adding ownership is a follow-up for the whole schedule surface; it is documented in the proto and handler so the gap is not mistaken for an oversight.
- **No CLI/TUI surface (F6, part).** The schedule RPC family has no CLI commands at all, so wiring one is a follow-up for the family rather than this RPC. The SDK method `Client.CancelScheduledExecution` exists for it.
- **`RunningExecutions()` keys by schedule ID (N7).** Two concurrent runs of the same schedule (`skip_if_running` disabled) collapse to one entry, so only one is reachable through this view. Fixing it changes the return shape (e.g. a slice per schedule), which is wider than this cancellation work should carry.

## Testing

Table-driven throughout. The classification path is exercised through real `executeWorkflow` runs, not seeded maps:
- Deterministic: a cancel landing **after** the verdict is reported as already finished and leaves both a real failure (error, `failed_executions`) and a real success (`successful_executions`) intact. With the pre-fix mechanism restored locally, both fail exactly as the review described — `signaled` for a settled run, the real error replaced by the cancel reason, counters at 0.
- Deterministic: a cancel landing **before** the orchestrator runs is recorded as `canceled` with the reason, `last_status` moves, counters do not.
- Deterministic (F3): a run parked between being marked running and reaching the orchestrator is both advertised and cancellable.
- A 100-iteration cancel-vs-completion loop, deterministically parked (a controllable LLM the test releases or cancels while the run is genuinely in-flight inside the agent call), asserting the history record and the counters agree on every interleaving — the class of bug `-race` cannot see. Timing-based jitter was tried first and discarded: a real run's settle time is dominated by agent-dispatch overhead that varies by an order of magnitude between the first call and later ones, so no fixed window reliably straddles it without becoming flaky on a loaded runner.
- `Stop` drain with a real orchestrator and an agent that never answers: the hung run is signaled, its history entry lands, and a post-shutdown trigger is refused.
- Server-level: `NOT_FOUND` for an unknown ID; the not-an-error "already finished" response through the real handler.
- Every wait is bounded, so a lock-ordering regression fails with a message instead of hanging CI.

## Update: rebase + review round 2 (N1, N2, N3, N5)

Rebased onto current `main` (2 commits ahead, unrelated to this package — clean, no conflicts). Addresses the two majors and two of the minors from the second review pass:

- **N1.** The canceled branch's condition was `wasCanceled && err != nil` — true for *any* error, not just one the signal actually caused. A cancel landing before the orchestrator ever ran could still see an unrelated config failure (e.g. an empty pipeline, which never touches `ctx`) and relabel it `canceled`, discarding the real error and skipping `failed_executions`. Fixed to `wasCanceled && errors.Is(err, context.Canceled)` — a genuine cancellation does carry `context.Canceled` up the chain through the agent/LLM call's `%w` wrapping. `TestCancelBeforeOrchestratorWithUnrelatedFailureIsNotMislabeledCanceled` pins this, and `TestExecuteWorkflowRecordsGenuineCancellation` now goes through a real blocking agent call instead of a config-error pattern, so it actually exercises `errors.Is`.
- **N2.** `TriggerNow` minted an ID and returned it before the spawned goroutine had registered anything, so a cancel arriving in that window found nothing tracked and reported `NOT_FOUND` for an ID this scheduler had, in fact, just handed out (transient — reproduced 12-100% of the time depending on load). Separately, `executeWorkflow` re-checked the *schedule's own persisted* `skip_if_running` regardless of what the trigger request asked for, so an explicit "run it anyway" override against a `skip_if_running: true` schedule with a run in flight could silently skip — permanently minting an ID nothing ever registered. Fixed by having `TriggerNow` pre-register the run's `runState` (schedule ID, nil cancel func) in the same critical section as its `inFlight` reservation, before the ID is returned; `executeWorkflow` attaches the real cancel func to that existing entry once its context exists, delivering any cancel that landed in between immediately. `executeWorkflow` also takes a `checkScheduleSkipIfRunning` flag now: `true` for cron ticks (no other opinion to defer to), `false` for triggered runs (the request's own override already decided). `TestTriggerNowRegistersBeforeReturningTheID` and `TestTriggerNowOverridesScheduleSkipIfRunning` cover the two halves.
- **N3.** `CancelExecution` re-wrapped `ExecutionExists`'s own error ("failed to look up execution: failed to look up execution X: ..."). Now returns it unwrapped.
- **N5.** A second `Stop()` call panicked on a double `close` of the shutdown channel. `Stop` now checks `stopped` under the same lock and returns immediately on a repeat call. `TestStopIsIdempotent` covers it.
- **N4** (minor, not blocking): `Stop`'s unbounded final wait now logs "still waiting on N executions" every 10s.
- **N7** (minor, not blocking): documented as a known gap above rather than changing `RunningExecutions`'s return shape.
- **N6**: fixed the stale "200-iteration" line above (the loop is 100 iterations, and no longer timing-based — see above).

Verified: `go build -tags fts5 ./...`, `go vet -tags fts5 ./...`, `gofmt -l` all clean. `buf lint`, `buf breaking --against main`, `buf generate` (zero diff) all clean — no proto changes in this round. `go test -tags fts5 -race -covermode=atomic ./pkg/scheduler/... ./pkg/server/... ./pkg/tui/client/...` green, plus `-cpu=1,2,4 -count=3` on `pkg/scheduler` for the concurrency-sensitive tests specifically.

## Update: review round 5 — one admission point (2 majors, 1 minor, 2 nits)

Both majors from the last round were the same shape: deciding whether a run may start, reserving its drain slot, and registering it as cancellable were three separate steps.

- **Major — `Stop` could miss a cron run and wait past its own deadline.** `beginRun` reserved the `inFlight` slot, but the run was not in `s.runs` until `executeWorkflow` got to it. `Stop`'s grace expiry signals exactly once, so a run inside that gap was never signaled, and the deadline-free final drain then waited for it anyway — shutdown bounded by `max_execution_seconds` (an hour) instead of the 30s context `cmd_serve.go` passes.
- **Major — concurrent manual triggers could both pass `skip_if_running=true`.** `TriggerNow` read "is this schedule busy?" under one lock and recorded the answer under another. A regression, not a pre-existing hazard: the manual path passes `checkScheduleSkipIfRunning=false`, so the schedule-level recheck in `executeWorkflow` no longer provided a fallback — and overlapping runs are exactly what RESUME-mode schedules use `skip_if_running` to prevent.

Fixed by making the three decisions one decision. `beginRun`/`beginTriggeredRun` are replaced by **`admitRun`**, which under a single exclusive lock hold checks `stopped`, applies `skip_if_running`, reserves the drain slot and registers the execution. A run is therefore cancellable from the instant it occupies its schedule's slot, and no two runs can occupy it at once. The cron path mints its execution ID before admission and owns the skipped-counter write; the `skip_if_running` recheck and its `checkScheduleSkipIfRunning` parameter are gone from `executeWorkflow`, whose remaining job is to attach the real cancel func to the entry `admitRun` created.

Three tests, each verified red against the pre-fix code:

- `TestShutdownSignalReachesRunAdmittedBeforeItStarts` **parks** the handoff rather than racing it: the run is admitted, then held outside `executeWorkflow` for the whole of `Stop`'s expired-grace signal. With reservation and registration split, `Stop` waits out the execution timeout and the run is recorded `failed: context deadline exceeded`; with them merged it is `canceled` / "scheduler shutting down" and `Stop` returns at once.
- `TestSkipIfRunningIsDecidedUnderOneLockHold` is the deterministic pin for the admission race: a reader holds `s.mu` for the whole call, and a verdict arriving before it lets go can only have come from a snapshot another admission was free to invalidate. Two-phase admission fails it every run.
- `TestConcurrentTriggersHonorSkipIfRunning` asserts the promise itself: eight triggers released together admit exactly one run, and every refusal names the execution that actually holds the slot. Kept as the behavioural check, not as the pin — it cannot force the interleaving and passed against the bug on 3×8 attempts.

Also in this round:

- **Minor — Windows test-helper leak.** `pkg/server/scheduler_rpc_test.go`'s helper left its file-backed SQLite store open, so `t.TempDir` cleanup failed on Windows with the database still in use (CI runs unit tests on `ubuntu-latest` only, so it could not see this). Added a `t.Cleanup` that stops the scheduler — which is what closes the store — before the directory is removed.
- **Nit — `RecordCanceled` doc.** Now states why `last_execution_at` is deliberately left alone, mirroring `IncrementSkipped` rather than `RecordSuccess`/`RecordFailure`, so a future reader does not "fix" it as an oversight.
- **Nit — PR title.** Retitled to name the RPC that actually landed, `CancelScheduledExecution`, so the squashed commit on `main` names the real API.
- **N10 follow-up (from the prior round, non-blocking).** `TestEmptyPatternsAreRejectedByTheExecutor` closes it: the existing empty fork-join/parallel cases go through the builders, whose own "at least 1 agent/task" check fires first, so both kept passing with the executor guard removed. The new case hands the pattern straight to `ExecutePattern` — the path a schedule actually takes — and asserts the executor's own message plus the absence of `%!w(<nil>)`.

Verified: `go build -tags fts5 ./...`, `go vet`, `gofmt -l` clean; `golangci-lint run` 0 issues on `pkg/scheduler`, `pkg/server`, `pkg/orchestration`; `go test -tags fts5 -race -count=1` green on all three; the concurrency-sensitive tests also green under `-race -cpu=1,2,4 -count=3`; `buf lint` clean (no proto changes this round).

🤖 Generated with [Claude Code](https://claude.com/claude-code)