### PR TITLE
feat(shuttle): backend-agnostic resource-lease contract drives RESOURCE_HOLDER scheduling

### DIFF
--- a/docs/architecture/llm-slot-scheduler.md
+++ b/docs/architecture/llm-slot-scheduler.md
@@ -1,0 +1,508 @@
+# LLM Slot Scheduler: Ending LLM Starvation
+
+**Status**: ⚠️ Partial — implemented: the scheduler core (`pkg/llm/scheduler`: priority classes, in-process park-and-wake, starvation aging, interactive headroom, AIMD + header capacity calibration, `LLMSchedulerService`; PR #352), door admission control (PR #353), and the resource-lease binding (§11). Still 📋 planned: durable parked-conversation persistence (suspend/resume through the session store), weighted fair queuing per tenant, and §11.3's follow-ups. The body of this document is the original design proposal; where it disagrees with the code, the code is the reference.
+**Related**: issues #346, #348, #349; PRs #347 (keyed shared limiters), #350 (limiter on every construction path, concurrent dispatch, YAML `rate_limit` loading, retryable 429s), #352 (scheduler core), #353 (door admission)
+**Field data**: 512-agent load campaign against Azure OpenAI gpt-4o + teradata-mcp-v2, 2026-08-20/21
+
+---
+
+## 1. Problem
+
+When a fleet of agents shares one LLM quota, loom currently **blocks and dies**. An
+agent's conversation loop makes a synchronous LLM call through a shared rate
+limiter; if the limiter's FIFO queue keeps it waiting past `QueueTimeout`
+(default 5 minutes), the *entire conversation* fails. While waiting, the agent
+continues to hold every scarce resource it owns — most importantly Teradata
+session handles and MCP session slots. Nothing upstream learns that the LLM is
+saturated until agents start dying.
+
+This is polling-with-a-watchdog. The watchdog does not recover the system; it
+shoots the workload.
+
+### 1.1 What the field runs measured
+
+Five separate defects compounded, each found and fixed (or scoped) during the
+2026-08 load campaign. They matter here because the scheduler design must
+prevent the *class*, not the instances:
+
+| Run | Config | Outcome | Root cause |
+|---|---|---|---|
+| R7a (512 agents, laptop) | provider defaults | 274/512 dead: `queue timeout after 5m0s`; 0 completed | first-wins limiter singleton at 2 rps (#346) |
+| R7b (512, laptop) | 100 rps / 1.2M TPM in YAML | 91 completed; 88 queue deaths; 253 hit 40m deadlines; Azure metered **88K TPM actual** (6% of budget) | serial dispatch — one goroutine ran each call to completion (#349); *and* the YAML `rate_limit` block was silently dropped by the loader (#348 follow-up) |
+| az512b (512, Azure VM) | 15 rps, working keyed limiter | 503/512 dead on real Azure 429s within 6 min (419 in one minute); **zero retries fired** | 429s never surfaced inside the limiter (`http.Client.Do` returns nil error on any status), so retry machinery was dead code; plus Azure charges TPM as prompt + `max_tokens` *reservation* — 15 rps × ~8K reserved ≈ 7M TPM demanded vs 1.5M quota |
+| az512c (512, Azure VM) | 4 rps, `max_tokens` 1024, all PR #350 fixes | 0 errors, 0 429s through completion of the fleet | admission paced below reservation-derived capacity |
+
+Two structural observations survive all four runs:
+
+1. **The MCP/database side was never the limit.** At 512 concurrent agents the
+   teradata-mcp server sat at its configured handle ceiling with zero
+   rejections in every run. Starvation is an LLM-side phenomenon.
+2. **az512c "works" by slowing everyone uniformly.** 4 rps global admission is
+   a blunt instrument: it prevents death by making *every* agent equally slow.
+   Aggregate throughput is fine; latency for any individual agent is terrible,
+   and nothing prioritizes an agent that is one call away from finishing (and
+   releasing a database handle) over one that has not started.
+
+### 1.2 The prior art inside this repo
+
+The MCP handle-contention study (rounds R1–R4) already litigated the core
+question. R3 added park-and-wake for session handles — agents parked on a
+`resource_link`, subscribed, and retried on `notifications/resources/updated` —
+and it **starved**, because nothing created churn: parked agents waited on
+slots that were never released. R4 fixed it by making the runtime own the
+resource lifecycle (auto-release at conversation end), and completion-driven
+churn made parking work: 59/59 correct.
+
+The lesson generalizes and is the backbone of this design:
+
+> **Waiting only works when completion creates churn, and completion only
+> happens when the runtime — not the agent, not a timeout — owns the resource
+> lifecycle.**
+
+## 2. Design principles
+
+1. **Waiting is a state, not an error.** A conversation waiting for LLM
+   capacity must never be killed by the *limiter's* clock. The only deadline
+   that can fail a conversation is the conversation's own budget (its
+   `--timeout`, its token budget, its cost ceiling).
+2. **Run-to-completion beats fairness.** Finishing a conversation releases
+   *all* of its resources: its LLM share, its Teradata handle, its MCP slot,
+   its memory. A scheduler biased toward in-flight work drains the system;
+   one that admits everything equally half-runs everyone and finishes no one.
+3. **The runtime owns the lifecycle.** Agents never voluntarily release
+   resources (measured: 0/192 voluntary handle releases across R1–R3).
+   Parking, resource release, wake, and resume are runtime decisions.
+4. **Capacity is measured, not configured.** Providers state their quota on
+   every response (`x-ratelimit-remaining-*`, `Retry-After`). Static YAML
+   numbers are the fallback, not the source of truth.
+5. **Backpressure belongs at the door.** Starving an agent mid-task wastes
+   held resources and partial work; refusing (or queueing) a conversation at
+   admission costs nothing.
+
+## 3. Architecture
+
+```
+                        ┌─────────────────────────────────────────────┐
+                        │                looms server                 │
+                        │                                             │
+ loom chat ──────────►  │  Admission Controller                       │
+ (new conversation)     │  ├─ per-scope active-conversation cap       │
+                        │  ├─ derived from SlotScheduler capacity     │
+                        │  └─ queue at door OR RESOURCE_EXHAUSTED     │
+                        │        │ admit                              │
+                        │        ▼                                    │
+                        │  Conversation loop (runConversationLoop)    │
+                        │        │ needs LLM call                     │
+                        │        ▼                                    │
+                        │  SlotScheduler (per provider scope)         │
+                        │  ├─ priority classes + aging                │
+                        │  ├─ priority inheritance (held handles)     │
+                        │  ├─ reservation-aware TPM accounting        │
+                        │  ├─ grant ──► SharedRateLimiter.Do(...)     │◄── PR #347/#350
+                        │  └─ no slot ──► PARK conversation           │    primitives
+                        │        │                 ▲                  │
+                        │        ▼                 │ wake             │
+                        │  Parked Conversation Store                  │
+                        │  (persisted state + waiter registration)    │
+                        │                                             │
+                        │  Capacity Feedback ◄── provider response    │
+                        │  (remaining-tokens, Retry-After, 429s)      │
+                        └─────────────────────────────────────────────┘
+```
+
+Four components. The first two are the deep work; the last two upgrade
+machinery that already exists.
+
+### 3.1 SlotScheduler
+
+One scheduler per provider quota scope — the same scope keys PR #347
+introduced (`azure-openai|endpoint|deployment`, `bedrock|region|model`, …).
+The scheduler *grants call slots*; the existing `SharedRateLimiter` becomes
+its execution arm (pacing within a grant, retrying throttles within a grant).
+
+The correct mental model is an **I/O scheduler** (deadline/elevator), not an
+interrupt controller in the strict sense: the scarce resource is
+tokens-per-minute, calls take seconds, and interrupt *latency* is irrelevant —
+what matters is completion-driven wakeups, priority classes, and starvation
+aging. The interrupt-style part is the contract: **requesters never spin and
+never die waiting; they park and are woken.**
+
+Priority classes, highest first:
+
+| Class | Who | Why |
+|---|---|---|
+| `RESOURCE_HOLDER` | conversation holding an external scarce resource (Teradata session handle, MCP slot) — declared by the backend through the lease contract (§11) | priority inheritance: it is blocking other agents who are burning LLM budget trying to acquire what it holds |
+| `IN_FLIGHT` | conversation that has completed ≥1 LLM call | run-to-completion: finishing releases everything |
+| `NEW` | first call of a conversation | admitted as churn allows |
+
+Within a class: weighted fair queuing per tenant/agent, FIFO within a weight.
+**Aging**: a waiter that has waited longer than `starvation_age_s` is promoted
+one class, so `NEW` cannot be starved forever by a hot fleet. One outstanding
+slot per conversation (the conversation loop is sequential anyway).
+
+Grant lifetime: a slot covers one LLM call *including its throttle retries*.
+The grant carries a token reservation (§3.4); the reservation is trued-up from
+the response's actual usage when it completes.
+
+### 3.2 Park and wake
+
+When the scheduler has no slot, the conversation **parks** instead of blocking
+a goroutine inside the limiter queue:
+
+1. The conversation loop reaches its LLM call and receives `ErrParked` with a
+   waiter handle instead of blocking.
+2. Conversation state is persisted through the existing session-persistence
+   machinery (messages, tool state, budgets). This is a suspend point exactly
+   like the existing HITL-approval suspend, which already proves
+   `runConversationLoop` can be re-entered mid-conversation.
+3. **Resource disposition** — the runtime decides per resource what parking
+   means:
+   - MCP session handles: marked *reclaimable-under-pressure*, not eagerly
+     released. Handles can pin state that cannot be rebuilt (volatile tables,
+     transactions). The MCP server may reclaim a reclaimable handle if its own
+     budget saturates; the owning conversation then reacquires on resume and
+     replays its idempotent setup (this is a documented, bounded cost — and
+     conversations holding non-reclaimable state keep `RESOURCE_HOLDER`
+     priority precisely so their parks are short).
+   - In-process memory: retained (parking is expected to be seconds-to-minutes).
+4. The scheduler wakes the waiter when churn creates a slot (a grant
+   completes, capacity feedback raises the ceiling, or aging promotes it).
+   Wake resumes the loop at the pending LLM call.
+5. Crash recovery: parked conversations are durable. On looms restart, parked
+   waiters re-register from the store; grants in flight at crash are simply
+   lost (the call is retried on resume — LLM calls are idempotent from the
+   conversation's perspective).
+
+Why park at all when goroutines are cheap: not to save threads — to make
+waiting **observable, schedulable, and non-fatal**, and to give the runtime a
+hook to reclaim resources from waiters instead of letting them squat.
+
+### 3.3 Admission control
+
+The front door. `looms` tracks, per provider scope, the number of *active*
+(admitted, not parked) conversations. When a new conversation would exceed
+`max_active_conversations` for its scope, the server either:
+
+- **queues it at the door** (default): the `loom chat` stream opens and waits;
+  the client sees a progress event (`queued: position N, estimated wait`), not
+  silence; or
+- **rejects with backpressure** (`RESOURCE_EXHAUSTED` + retry-after) when the
+  door queue itself exceeds `max_door_queue`.
+
+`max_active_conversations` is derived, not hand-tuned:
+
+```
+capacity_calls_per_s = min(measured_remaining_tokens_per_minute,
+                           configured_tpm) / 60 / reservation_per_call
+max_active = capacity_calls_per_s × p50_call_duration_s × utilization_target
+```
+
+With the campaign's measured constants (≈7K reserved tokens/call at
+`max_tokens` 1024, ≈3 s median call, 1.5M TPM quota, 0.8 target): ≈85 active
+conversations. A 512-agent launch becomes: 85 admitted, 427 queued at the
+door, continuous admission as conversations complete — same aggregate
+throughput as today's uniform slowdown, zero mid-flight starvation, and door
+wait is visible to the caller instead of manifesting as a dead agent.
+
+### 3.4 Capacity feedback and reservation-aware accounting
+
+Two facts the current limiter ignores:
+
+1. **Providers charge quota on reservations, not usage.** Azure debits
+   `estimated_prompt + max_tokens` per request at admission time. az512b
+   demonstrated the gap: actual usage ≈1.4K tokens/call, reserved ≈8K —
+   a 5× invisible oversubscription. The scheduler accounts the same way the
+   provider does: debit the reservation at grant, credit back
+   `reservation − actual` at completion.
+2. **Most providers state their limits on every response — but not all.**
+   Measured against our Azure deployment (2026-08-21), Azure returns the full
+   telemetry set on every 200:
+
+   ```
+   x-ratelimit-limit-requests: 9000        x-ratelimit-limit-tokens: 1500000
+   x-ratelimit-remaining-requests: 8999    x-ratelimit-remaining-tokens: 745399
+   x-ratelimit-renewalperiod-requests: 10  x-ratelimit-renewalperiod-tokens: 60
+   x-ratelimit-reset-requests: 0           x-ratelimit-reset-tokens: 30
+   ```
+
+   Per-provider signal matrix:
+
+   | Provider | Per-response signal | Calibration strategy |
+   |---|---|---|
+   | OpenAI | `x-ratelimit-{limit,remaining,reset}-{requests,tokens}`, `Retry-After` | header-driven |
+   | Azure OpenAI | full set incl. renewal periods (verified above) | header-driven |
+   | Anthropic | `anthropic-ratelimit-{requests,tokens,input-tokens,output-tokens}-{limit,remaining,reset}`, `retry-after` | header-driven |
+   | LiteLLM proxy | emulates OpenAI-style headers, forwards upstream hints | header-driven |
+   | Gemini | no headers; 429 body carries `google.rpc.RetryInfo.retryDelay` | error-body hint + AIMD |
+   | Bedrock | none (`ThrottlingException` only; quota via Service Quotas/CloudWatch out-of-band) | AIMD |
+   | Ollama | none (local; capacity = host parallelism) | fixed concurrency |
+
+   The feedback loop is therefore layered:
+   - **Header-driven** (precise): remaining-token/request headers continuously
+     calibrate the scope's effective TPM and window phase (quota changes,
+     other consumers on the same deployment, burst windows); `Retry-After`
+     schedules the *precise* wake for a throttled grant.
+   - **Error-body hints**: Gemini's `retryDelay` is honored like `Retry-After`.
+   - **AIMD fallback** (signal-free providers): additive-increase /
+     multiplicative-decrease of the effective ceiling driven by observed
+     throttle errors — TCP congestion control without ECN. A clean interval
+     raises the ceiling by a step; any throttle halves it.
+   - In every mode, a 429 storm collapses the admission ceiling immediately
+     rather than after N corpses.
+
+This also finally makes `tokens_per_minute` a real gate. Today it is
+metrics-only (discovered during #349): the sliding window is logged and never
+enforced. Under this design the scheduler *is* the TPM enforcement, with the
+provider's own numbers as calibration.
+
+## 4. Proto (law first)
+
+New file `proto/loom/v1/llm_scheduler.proto` — sketch, names final only after
+`buf lint`:
+
+```proto
+syntax = "proto3";
+package loom.v1;
+
+// Priority class of a slot request. Order is semantic: higher classes are
+// served first; aging promotes a starved waiter one class.
+enum SlotPriorityClass {
+  SLOT_PRIORITY_CLASS_UNSPECIFIED = 0;
+  SLOT_PRIORITY_CLASS_NEW = 1;              // first call of a conversation
+  SLOT_PRIORITY_CLASS_IN_FLIGHT = 2;        // conversation mid-task
+  SLOT_PRIORITY_CLASS_RESOURCE_HOLDER = 3;  // holds an external scarce resource
+}
+
+// LLMSchedulerConfig configures one provider-scope scheduler.
+message LLMSchedulerConfig {
+  // Enforced tokens-per-minute for the scope. 0 = calibrate purely from
+  // provider response headers (with rate_limit defaults as the floor).
+  int64 tokens_per_minute = 1;
+  // Reservation per call when the provider charges reservations
+  // (prompt estimate + max_tokens). 0 = derive from agent max_tokens.
+  int32 reservation_tokens_per_call = 2;
+  // Active-conversation ceiling. 0 = derive from capacity (see design doc).
+  int32 max_active_conversations = 3;
+  // Door-queue depth beyond which new conversations are rejected with
+  // RESOURCE_EXHAUSTED instead of queued.
+  int32 max_door_queue = 4;
+  // Seconds after which a waiting slot request is promoted one class.
+  int32 starvation_age_s = 5;
+  // Target utilization of measured capacity (0,1]; default 0.8.
+  float utilization_target = 6;
+}
+
+// SlotState is the observable state of one scheduler scope.
+message SlotState {
+  string scope = 1;                    // e.g. "azure-openai|<endpoint>|<deployment>"
+  int32 active_conversations = 2;
+  int32 parked_conversations = 3;
+  int32 door_queue_depth = 4;
+  int64 effective_tokens_per_minute = 5;  // calibrated, not configured
+  int64 reserved_tokens_outstanding = 6;
+  google.protobuf.Timestamp next_wake = 7;
+}
+
+// LLMSchedulerService is the admin/observability surface. Slot request/grant
+// itself is in-process (the conversation loop), not RPC.
+service LLMSchedulerService {
+  rpc GetSlotState(GetSlotStateRequest) returns (GetSlotStateResponse);
+  rpc ListWaiters(ListWaitersRequest) returns (ListWaitersResponse);
+  rpc SetSchedulerConfig(SetSchedulerConfigRequest) returns (SetSchedulerConfigResponse);
+}
+```
+
+`AgentConfig.spec.llm.rate_limit` (`LLMRateLimitConfig`) keeps its role: it is
+the per-agent *request shaping* input (and, post-#350, actually loads from
+YAML). The scheduler consumes it; it does not replace it.
+
+## 5. What changes where
+
+| Piece | Today | Under this design |
+|---|---|---|
+| `RateLimiter.Do` queue timeout | kills the conversation at 5m | applies only within a *grant* (a call + its retries); waiting for a grant cannot kill anything |
+| `SharedRateLimiter` (PR #347) | the whole policy | execution arm under the scheduler: paces within grants, retries throttles |
+| `runConversationLoop` | blocks synchronously on LLM call | requests slot; on `ErrParked` suspends via the session-persistence path (same shape as HITL suspend) and resumes on wake |
+| MCP handle auto-release | at conversation end | unchanged; plus *reclaimable-under-pressure* marking while parked, and handle-holding feeds `RESOURCE_HOLDER` priority |
+| `tokens_per_minute` | metrics-only, never enforced | enforced by the scheduler, reservation-aware, header-calibrated |
+| 429 handling | in-grant blind exponential backoff (working as of PR #350) | in-grant retry with `Retry-After`-scheduled wake; storm collapses admission ceiling |
+| `loom chat` under saturation | agents die mid-flight | queued at the door with visible position/estimate, or `RESOURCE_EXHAUSTED` + retry-after |
+
+## 6. Failure modes and invariants
+
+- **No death by waiting.** Invariant: the scheduler never returns a fatal
+  error for lack of capacity. Fatal outcomes come only from the
+  conversation's own budget/deadline or a non-retryable provider error.
+- **Bounded starvation.** Aging guarantees any waiter reaches the top class in
+  `≤ 2 × starvation_age_s`. (Trade-off: a saturated system with aging degrades
+  toward FIFO — acceptable; aging exists for liveness, not throughput.)
+- **Bounded priority inversion.** `RESOURCE_HOLDER` inheritance is one level
+  and non-transitive; a holder that parks with non-reclaimable state keeps the
+  boost so its park is short.
+- **Quota collapse mid-run** (another consumer appears on the deployment):
+  header calibration shrinks effective TPM; the admission ceiling drops; new
+  conversations queue at the door; in-flight conversations finish on the
+  reduced budget. No deaths — throughput degrades, liveness holds.
+- **Scheduler crash**: parked conversations are durable; waiters re-register
+  on restart; outstanding reservations are rebuilt as zero (worst case: one
+  brief over-admission burst absorbed by in-grant 429 retry).
+- **Thundering wake**: wakes are granted one slot at a time from the scheduler
+  loop; a completion wakes exactly one waiter. No herd re-forms.
+
+## 7. Observability
+
+Per scope: `loom_llm_slots_active`, `loom_llm_parked`, `loom_llm_door_queue`,
+`loom_llm_effective_tpm`, `loom_llm_reserved_outstanding`,
+`loom_llm_wait_seconds` (histogram, by priority class),
+`loom_llm_promotions_total` (aging events), `loom_llm_admission_rejects_total`.
+Every park/wake/grant is a span event on the conversation trace, so a slow
+agent's timeline shows *where* it waited and *why* it was woken. Scheduler
+state queryable live via `LLMSchedulerService.GetSlotState`.
+
+## 8. Phasing
+
+**Phase 0 — shipped groundwork** (PRs #347, #350): keyed per-scope limiters;
+limiter attached on every construction path; concurrent admission-paced
+dispatch; YAML `rate_limit` actually loads; 429s retryable. az512c validated:
+512 agents, zero starvation deaths at conservative static tuning.
+
+**Phase 1 — cheap wins, no new proto** (small PRs):
+1. Honor `Retry-After` in `executeWithRetry`; parse and expose
+   `x-ratelimit-remaining-*` per response.
+2. Make grant-wait non-fatal: split `QueueTimeout` into in-grant retry budget
+   vs (removed) wait-to-enter timeout; waiting bounded only by caller context.
+3. Two-class priority (IN_FLIGHT > NEW) inside `SharedRateLimiter`.
+4. Static `max_active_conversations` admission cap in looms with door
+   queueing and a progress event.
+
+**Phase 2 — the scheduler** (proto first, then implementation):
+`llm_scheduler.proto`; SlotScheduler with classes/aging/fair share;
+reservation-aware TPM enforcement with header calibration; park/wake through
+the session-persistence suspend path; `LLMSchedulerService`.
+
+**Phase 3 — cross-system integration**: `RESOURCE_HOLDER` inheritance wired to
+MCP handle state; reclaimable-under-pressure handle marking; door-queue
+estimates fed from scheduler telemetry.
+
+Each phase is independently shippable and independently validated by re-running
+the 512-agent gauntlet (the campaign scripts and measured baselines are
+retained; see `docs/architecture/` load-test notes and the session artifacts).
+
+## 9. Open questions
+
+1. **Park threshold**: park immediately when no slot, or spin briefly
+   (100–500 ms) to avoid persistence churn under transient contention?
+   Proposal: spin ≤ `p50_call_duration`, then park.
+2. **Multi-scope conversations** (an agent that talks to two providers): slot
+   requests are per-scope; does a conversation hold grants on two scopes
+   simultaneously? Proposal: yes, grants are independent; inversion analysis
+   covers only external resources, not cross-scope LLM grants.
+3. **Fairness unit**: per-agent, per-tenant, or per-conversation weights?
+   Multi-tenant deployments (loom-cloud) need per-tenant; default single-tenant
+   weight is uniform.
+4. **Door-queue persistence**: does a queued-at-door conversation survive a
+   looms restart, or is the door queue ephemeral (client retries)? Proposal:
+   ephemeral — the client holds the intent; only *admitted* state is durable.
+5. **Reservation estimate for prompt tokens**: provider-side estimators differ
+   (Azure uses a character heuristic); do we mirror per provider or
+   over-reserve uniformly? Needs a small measurement matrix.
+
+## 10. Measured constants (2026-08 campaign)
+
+For deriving defaults; re-measure per deployment:
+
+- Azure gpt-4o GlobalStandard, capacity 1500: 1.5M TPM / 9,000 RPM; quota
+  charged as prompt-estimate + `max_tokens` reservation at request time.
+- Task profile (12-tool MCP agent, analytic SQL task): ≈7K Azure-metered
+  tokens per conversation; ≈1.4K actual tokens per call; ≈8–10 calls per
+  conversation; median call ≈3 s.
+- Sustainable call rate at 1.5M TPM: ≈17 calls/s at 1024-token reservation;
+  ≈3 calls/s at 4096.
+- MCP server (teradata-mcp-v2, one instance): 512 concurrent agents, 256
+  handle budget, zero rejections, <50 MB RSS — never the constraint.
+
+## 11. Resource leases
+
+**Status**: ✅ Implemented — the tool-result contract (`pkg/shuttle`), the
+scheduler mark/unmark lifecycle (`pkg/llm/scheduler`), and the agent's
+per-session lease ledger (`pkg/agent/lease_ledger.go`). The MCP adapter
+migration and the express lane are 📋 planned (§11.3).
+
+The `RESOURCE_HOLDER` class (§3.1) needs to know *when* a conversation holds
+a scarce backend resource — without loom knowing what the resource is. The
+binding is backend-agnostic by contract: the **backend** declares what is a
+scarce lease, through the tool-result contract, and loom reacts generically.
+Kind and ID are backend-defined opaque strings (e.g. `"db-session"` /
+`"sess-42"`); loom never interprets them beyond identity.
+
+### 11.1 The tool-result contract (pkg/shuttle) ✅
+
+**Lease events** ride `Result.Metadata` under the well-known key
+`loom.lease_events` (`shuttle.MetadataLeaseEvents`). Each entry is a map with
+string fields `action` (`"acquired"` | `"released"`), `kind`, and `id`, so
+any backend adapter — or a YAML-declared tool that shapes its own metadata —
+can emit them without importing loom types. Go emitters use the typed
+helpers:
+
+```go
+shuttle.AppendLeaseEvent(res, shuttle.LeaseEvent{
+    Action: shuttle.LeaseAcquired, Kind: "db-session", ID: "sess-42",
+})
+events := shuttle.LeaseEventsFrom(res)
+```
+
+Emitting `acquired` tells loom "this conversation now holds a scarce backend
+resource"; `released` tells it the lease ended. A release matches an acquire
+only when both Kind and ID are equal. Parsing is tolerant by contract: tool
+results are data, so a malformed entry is skipped, never an error, and the
+stored form survives JSON marshal/unmarshal boundaries unchanged.
+
+**Backpressure hint**: the park-and-wake contract PR #355 introduced at the
+MCP layer is hoisted here as a generic `Error.Details` slot —
+`loom.backpressure` (`shuttle.DetailsBackpressure`), typed as
+`shuttle.BackpressureHint{Code, RetryAfterS, WaitParam, MaxWaitS}` with
+`(*Error).SetBackpressure` / `(*Error).Backpressure()` accessors and the
+same wire field names (`code`, `retry_after_s`, `wait_param`, `max_wait_s`).
+A hint declares the failure to be capacity flow control, not a fault: the
+identical call, re-issued after a wait, is expected to succeed. This is the
+contract only — no wait loop lives at the shuttle layer; the MCP adapter's
+freeze loop migrates onto it when PR #355 merges.
+
+### 11.2 The mark/unmark lifecycle (pkg/agent + pkg/llm/scheduler) ✅
+
+The agent keeps a per-session **lease ledger**: the set of (Kind, ID) pairs
+the session's conversation currently holds.
+
+- **After every tool execution**, the conversation loop folds the result's
+  lease events into the ledger. While the session holds any lease, the
+  turn's `SlotInfo` is marked (`scheduler.MarkResourceHolder`) and the
+  conversation's remaining LLM calls classify `RESOURCE_HOLDER`; when the
+  last lease is released, the mark is cleared
+  (`scheduler.UnmarkResourceHolder`) and the class falls back to the
+  call-count progression. Results without lease events never touch scheduler
+  state.
+- **Cross-turn seeding**: leases outlive turns (a session handle survives
+  the think time between turns), but a turn's `SlotInfo` does not — the
+  server installs a fresh one per turn. The agent therefore re-marks each
+  turn from the ledger at turn start, so a lease-holding session *starts*
+  its next turn as `RESOURCE_HOLDER`. Installers that know the lease state
+  up front can seed it directly via `scheduler.WithSlotInfoHolding`.
+- **Retirement**: the ledger entry is dropped with the session
+  (`DeleteSession`, `ClearAllSessions`) — a leaked entry on a deleted
+  session would pin `RESOURCE_HOLDER` priority forever.
+- **Tolerance**: re-acquire of a held lease is idempotent; double-release
+  and release-of-unknown are no-ops; a session's lease count never goes
+  negative.
+- **Inert when unwired**: with scheduling disabled or no `SlotInfo`
+  installed, the ledger still tracks leases and the mark/unmark calls are
+  no-ops — unwired deployments behave exactly as before.
+
+### 11.3 Planned follow-ups 📋
+
+- **MCP adapter migration**: PR #355's MCP-level backpressure hint and
+  freeze loop move onto the shuttle contract when that PR merges, and MCP
+  session handles then declare themselves as lease events instead of
+  adapter-private state.
+- **Express lane**: reserved scheduler headroom for `RESOURCE_HOLDER`
+  acquisitions (analogous to the interactive headroom), so a holder never
+  waits behind a saturated general queue.

--- a/docs/architecture/llm-slot-scheduler.md
+++ b/docs/architecture/llm-slot-scheduler.md
@@ -457,7 +457,7 @@ only when both Kind and ID are equal. Parsing is tolerant by contract: tool
 results are data, so a malformed entry is skipped, never an error, and the
 stored form survives JSON marshal/unmarshal boundaries unchanged.
 
-**Backpressure hint**: the park-and-wake contract PR #355 introduced at the
+**Backpressure hint**: the park-and-wake contract from PR #355 (📋 open, unmerged) at the
 MCP layer is hoisted here as a generic `Error.Details` slot —
 `loom.backpressure` (`shuttle.DetailsBackpressure`), typed as
 `shuttle.BackpressureHint{Code, RetryAfterS, WaitParam, MaxWaitS}` with
@@ -466,7 +466,7 @@ same wire field names (`code`, `retry_after_s`, `wait_param`, `max_wait_s`).
 A hint declares the failure to be capacity flow control, not a fault: the
 identical call, re-issued after a wait, is expected to succeed. This is the
 contract only — no wait loop lives at the shuttle layer; the MCP adapter's
-freeze loop migrates onto it when PR #355 merges.
+freeze loop migrates onto it when PR #355 merges. On this branch the hint is contract-only: it has no producer or consumer yet.
 
 ### 11.2 The mark/unmark lifecycle (pkg/agent + pkg/llm/scheduler) ✅
 
@@ -499,6 +499,8 @@ the session's conversation currently holds.
 
 ### 11.3 Planned follow-ups 📋
 
+- **Trust model**: lease events are taken at the emitting tool's word — any tool that shapes `Result.Metadata` can assert or release any lease. Operator-chosen backends are trusted; deployments running untrusted tool servers must strip these keys at their adapter boundary (see the doc block in `pkg/shuttle/lease.go`).
+- **Ledger durability**: the lease ledger is process memory only. After a `looms` restart the ledger is empty — a backend lease that survived the restart (e.g. a remote HTTP-MCP session) loses RESOURCE_HOLDER seeding until its next lease event. Durable seeding is 📋 planned alongside durable park persistence.
 - **MCP adapter migration**: PR #355's MCP-level backpressure hint and
   freeze loop move onto the shuttle contract when that PR merges, and MCP
   session handles then declare themselves as lease events instead of

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1827,6 +1827,11 @@ func (a *Agent) chat(ctx context.Context, sessionID string, userMessage string, 
 	// Get or create session with agent metadata for proper ReferenceStore namespacing
 	session := a.memory.GetOrCreateSessionWithAgent(ctx, sessionID, a.config.Name, "")
 
+	// A session holding backend leases from a previous turn starts this turn
+	// in the RESOURCE_HOLDER class — the previous turn's SlotInfo died with
+	// it, so the ledger re-marks the fresh one the server installed.
+	a.seedLeaseHolding(ctx, sessionID)
+
 	// TURN END for the previous turn (HLD §1, §7.3): a new turn is starting —
 	// in-memory full payloads are replaced by their persisted-row form and the
 	// in-turn SQLite is dropped. Rows and summary versions are all that remains.
@@ -3018,6 +3023,13 @@ func (a *Agent) executeToolWithSelfCorrection(ctx Context, toolName string, inpu
 		result, err = a.executor.Execute(ctxWithAgent, toolName, input)
 	}
 
+	// Backend-declared lease events ride the result's metadata: fold them
+	// into the session's ledger and the turn's scheduler class. This is the
+	// one seam every executed tool result passes through (the loop's dedup
+	// path replays cached results without re-executing, so replayed events
+	// are never double-applied).
+	a.applyLeaseEvents(ctx, sessionID, result)
+
 	// If execution succeeded and guardrails enabled, clear error record
 	if err == nil && result != nil && result.Success && a.guardrails != nil {
 		a.guardrails.ClearErrorRecord(sessionID)
@@ -3488,6 +3500,9 @@ func (a *Agent) DeleteSession(sessionID string) {
 	// In-turn SQLite databases are normally dropped at the session's next turn
 	// start; a deleted session has no next turn, so drop them here.
 	a.dropInTurnSQLite(sessionID)
+	// Retire the session's resource leases: a leaked ledger entry on a
+	// deleted session would pin RESOURCE_HOLDER priority forever.
+	a.leases.forget(sessionID)
 }
 
 // ApprovedSet returns the executor's approved-set accessor; nil until one is
@@ -3523,6 +3538,7 @@ func (a *Agent) ClearAllSessions() {
 	a.sessionToolLedger = make(map[string]map[string]bool)
 	a.mu.Unlock()
 	a.dropAllInTurnSQLite()
+	a.leases.reset()
 }
 
 // CreateSession creates a new session without sending a message to the LLM.

--- a/pkg/agent/lease_ledger.go
+++ b/pkg/agent/lease_ledger.go
@@ -54,7 +54,14 @@ type leaseLedger struct {
 // of a held lease is idempotent; double-release and release-of-unknown are
 // tolerated no-ops — tool results are data, so the ledger never errors and
 // a session's count never goes negative.
-func (l *leaseLedger) apply(sessionID string, events []shuttle.LeaseEvent) bool {
+// apply folds events into the session's held set and invokes onOutcome with
+// the resulting holding state WHILE STILL HOLDING the ledger mutex. Running
+// the outcome under the lock makes decision+mark one atomic step: two
+// concurrent turns on the same session (background chats, parallel Weaves)
+// cannot interleave a release's unmark with an acquire's mark and leave a
+// turn's SlotInfo contradicting the ledger. onOutcome must be brief and must
+// not call back into the ledger.
+func (l *leaseLedger) apply(sessionID string, events []shuttle.LeaseEvent, onOutcome func(holding bool)) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	for _, ev := range events {
@@ -77,7 +84,9 @@ func (l *leaseLedger) apply(sessionID string, events []shuttle.LeaseEvent) bool 
 			}
 		}
 	}
-	return len(l.held[sessionID]) > 0
+	if onOutcome != nil {
+		onOutcome(len(l.held[sessionID]) > 0)
+	}
 }
 
 // holds reports whether the session has any outstanding lease.
@@ -110,20 +119,22 @@ func (l *leaseLedger) reset() {
 // failed results too — the backend's declaration is authoritative (a failing
 // tool can still have released its handle).
 //
-// The ledger read and the mark are not one atomic step, which is safe
-// because a conversation's tool calls execute sequentially in the loop; the
-// ledger's own mutex covers cross-session concurrency, and sessions never
-// share a SlotInfo.
+// The ledger decision and the SlotInfo mark run as one atomic step under the
+// ledger mutex (see leaseLedger.apply), so concurrent turns on the same
+// session — background chats, parallel Weaves — cannot leave a turn's class
+// contradicting the ledger.
 func (a *Agent) applyLeaseEvents(ctx context.Context, sessionID string, res *shuttle.Result) {
 	events := shuttle.LeaseEventsFrom(res)
 	if len(events) == 0 {
 		return
 	}
-	if a.leases.apply(sessionID, events) {
-		scheduler.MarkResourceHolder(ctx)
-	} else {
-		scheduler.UnmarkResourceHolder(ctx)
-	}
+	a.leases.apply(sessionID, events, func(holding bool) {
+		if holding {
+			scheduler.MarkResourceHolder(ctx)
+		} else {
+			scheduler.UnmarkResourceHolder(ctx)
+		}
+	})
 }
 
 // seedLeaseHolding starts a turn in the RESOURCE_HOLDER class when the

--- a/pkg/agent/lease_ledger.go
+++ b/pkg/agent/lease_ledger.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package agent
+
+import (
+	"context"
+	"sync"
+
+	"github.com/teradata-labs/loom/pkg/llm/scheduler"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+)
+
+// The generic RESOURCE_HOLDER binding: backends declare scarce leases through
+// lease events on tool results (pkg/shuttle/lease.go); the agent folds them
+// into a per-session ledger and mirrors the outcome onto the LLM slot
+// scheduler. loom never knows what the leased resource is — Kind and ID are
+// backend-defined opaque strings, tracked purely by identity.
+
+// leaseKey identifies one outstanding lease: the backend-defined (Kind, ID)
+// pair, matched exactly.
+type leaseKey struct {
+	kind string
+	id   string
+}
+
+// leaseLedger tracks, per session, the scarce backend resources the session's
+// conversation currently holds. Leases outlive turns (a Teradata session
+// handle survives the multi-minute think time between turns), so the ledger
+// lives on the agent, keyed by session ID, and is retired with the session
+// (DeleteSession / ClearAllSessions) — a leaked entry on a deleted session
+// would pin RESOURCE_HOLDER priority forever.
+//
+// Self-guarded (own mutex, zero value ready): tool executions within one
+// conversation are sequential, but distinct sessions apply events
+// concurrently on a multi-session agent.
+type leaseLedger struct {
+	mu   sync.Mutex
+	held map[string]map[leaseKey]struct{}
+}
+
+// apply folds tool-result lease events into the ledger, in emit order, and
+// reports whether the session still holds any lease afterwards. Re-acquire
+// of a held lease is idempotent; double-release and release-of-unknown are
+// tolerated no-ops — tool results are data, so the ledger never errors and
+// a session's count never goes negative.
+func (l *leaseLedger) apply(sessionID string, events []shuttle.LeaseEvent) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, ev := range events {
+		key := leaseKey{kind: ev.Kind, id: ev.ID}
+		switch ev.Action {
+		case shuttle.LeaseAcquired:
+			if l.held == nil {
+				l.held = make(map[string]map[leaseKey]struct{})
+			}
+			if l.held[sessionID] == nil {
+				l.held[sessionID] = make(map[leaseKey]struct{})
+			}
+			l.held[sessionID][key] = struct{}{}
+		case shuttle.LeaseReleased:
+			if set := l.held[sessionID]; set != nil {
+				delete(set, key)
+				if len(set) == 0 {
+					delete(l.held, sessionID)
+				}
+			}
+		}
+	}
+	return len(l.held[sessionID]) > 0
+}
+
+// holds reports whether the session has any outstanding lease.
+func (l *leaseLedger) holds(sessionID string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.held[sessionID]) > 0
+}
+
+// forget retires a session's leases. Called from every session-retirement
+// path, mirroring sessionToolLedger's lifecycle.
+func (l *leaseLedger) forget(sessionID string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	delete(l.held, sessionID)
+}
+
+// reset drops every session's leases (ClearAllSessions).
+func (l *leaseLedger) reset() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.held = nil
+}
+
+// applyLeaseEvents folds one tool result's backend-declared lease events into
+// the session's ledger and mirrors the outcome onto the turn's SlotInfo:
+// while the session holds any lease, the conversation's remaining LLM calls
+// ride the RESOURCE_HOLDER class; the last release drops them back. Results
+// without lease events never touch scheduler state. Events are honored on
+// failed results too — the backend's declaration is authoritative (a failing
+// tool can still have released its handle).
+//
+// The ledger read and the mark are not one atomic step, which is safe
+// because a conversation's tool calls execute sequentially in the loop; the
+// ledger's own mutex covers cross-session concurrency, and sessions never
+// share a SlotInfo.
+func (a *Agent) applyLeaseEvents(ctx context.Context, sessionID string, res *shuttle.Result) {
+	events := shuttle.LeaseEventsFrom(res)
+	if len(events) == 0 {
+		return
+	}
+	if a.leases.apply(sessionID, events) {
+		scheduler.MarkResourceHolder(ctx)
+	} else {
+		scheduler.UnmarkResourceHolder(ctx)
+	}
+}
+
+// seedLeaseHolding starts a turn in the RESOURCE_HOLDER class when the
+// session already holds leases from a previous turn: leases outlive turns,
+// but the turn's SlotInfo does not (the server installs a fresh one per
+// turn), so each turn re-marks from the ledger. No-op without SlotInfo.
+func (a *Agent) seedLeaseHolding(ctx context.Context, sessionID string) {
+	if a.leases.holds(sessionID) {
+		scheduler.MarkResourceHolder(ctx)
+	}
+}

--- a/pkg/agent/lease_ledger_test.go
+++ b/pkg/agent/lease_ledger_test.go
@@ -1,0 +1,333 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"github.com/teradata-labs/loom/pkg/llm/scheduler"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+	llmtypes "github.com/teradata-labs/loom/pkg/types"
+)
+
+var (
+	classNew      = loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_NEW
+	classInFlight = loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_IN_FLIGHT
+	classHolder   = loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_RESOURCE_HOLDER
+)
+
+// leaseScriptLLM returns scripted responses and records the scheduler
+// priority class visible at each LLM call — the observable the lifecycle
+// test asserts on (the same SlotInfo.Class the scheduler's AcquireForCall
+// classifies with).
+type leaseScriptLLM struct {
+	mu        sync.Mutex
+	responses []mockLLMResponse
+	idx       int
+	classes   []loomv1.SlotPriorityClass
+}
+
+func (m *leaseScriptLLM) Chat(ctx context.Context, _ []Message, _ []shuttle.Tool) (*LLMResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	class := loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_UNSPECIFIED
+	if si := scheduler.SlotInfoFrom(ctx); si != nil {
+		class = si.Class()
+	}
+	m.classes = append(m.classes, class)
+	if m.idx >= len(m.responses) {
+		return &LLMResponse{Content: "done", Usage: llmtypes.Usage{TotalTokens: 10}}, nil
+	}
+	r := m.responses[m.idx]
+	m.idx++
+	return &LLMResponse{
+		Content:   r.content,
+		ToolCalls: r.toolCalls,
+		Usage:     llmtypes.Usage{InputTokens: 5, OutputTokens: 5, TotalTokens: 10},
+	}, nil
+}
+
+func (m *leaseScriptLLM) Name() string  { return "lease-script" }
+func (m *leaseScriptLLM) Model() string { return "lease-v1" }
+
+func (m *leaseScriptLLM) capturedClasses() []loomv1.SlotPriorityClass {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]loomv1.SlotPriorityClass(nil), m.classes...)
+}
+
+// leaseTool acquires or releases the backend-defined lease
+// "db-session"/"sess-42" via the shuttle lease-event contract, driven by the
+// "op" parameter.
+func leaseTool() *shuttle.MockTool {
+	return &shuttle.MockTool{
+		MockName:        "lease_tool",
+		MockDescription: "Acquires or releases a backend session lease",
+		MockExecute: func(_ context.Context, params map[string]interface{}) (*shuttle.Result, error) {
+			res := &shuttle.Result{Success: true, Data: "ok"}
+			switch params["op"] {
+			case "acquire":
+				shuttle.AppendLeaseEvent(res, shuttle.LeaseEvent{Action: shuttle.LeaseAcquired, Kind: "db-session", ID: "sess-42"})
+			case "release":
+				shuttle.AppendLeaseEvent(res, shuttle.LeaseEvent{Action: shuttle.LeaseReleased, Kind: "db-session", ID: "sess-42"})
+			}
+			return res, nil
+		},
+	}
+}
+
+func newLeaseTestAgent(llm LLMProvider) *Agent {
+	cfg := DefaultConfig()
+	cfg.PatternConfig = DefaultPatternConfig()
+	cfg.PatternConfig.UseLLMClassifier = false
+	ag := NewAgent(&mockBackend{}, llm, WithConfig(cfg))
+	ag.RegisterTool(leaseTool())
+	return ag
+}
+
+// The full lease lifecycle across turns: a tool's LeaseAcquired lifts the
+// turn's remaining LLM calls to RESOURCE_HOLDER; a following turn on the
+// same session STARTS as holder (fresh SlotInfo, seeded from the ledger);
+// LeaseReleased empties the ledger and the class falls back to the
+// call-count progression.
+func TestLeaseLifecycleAcrossTurns(t *testing.T) {
+	llm := &leaseScriptLLM{responses: []mockLLMResponse{
+		// Turn 1: acquire the lease, then synthesize.
+		{toolCalls: []llmtypes.ToolCall{{ID: "c1", Name: "lease_tool", Input: map[string]interface{}{"op": "acquire"}}}},
+		{content: "acquired"},
+		// Turn 2: no tools — the first (only) LLM call probes the seed.
+		{content: "still holding"},
+		// Turn 3: release the lease, then synthesize.
+		{toolCalls: []llmtypes.ToolCall{{ID: "c2", Name: "lease_tool", Input: map[string]interface{}{"op": "release"}}}},
+		{content: "released"},
+		// Turn 4: no tools — nothing seeds after the release.
+		{content: "not holding"},
+	}}
+	ag := newLeaseTestAgent(llm)
+	const sessionID = "lease-lifecycle-session"
+
+	// Turn 1: fresh conversation, fresh SlotInfo (as the server installs
+	// per turn: priorCalls=0 on an unresumed session).
+	ctx1 := scheduler.WithSlotInfo(context.Background(), loomv1.SlotOrigin_SLOT_ORIGIN_BATCH, 0)
+	_, err := ag.Chat(ctx1, sessionID, "acquire the lease")
+	require.NoError(t, err)
+	classes := llm.capturedClasses()
+	require.Len(t, classes, 2)
+	assert.Equal(t, classNew, classes[0], "first call of a fresh conversation classifies NEW")
+	assert.Equal(t, classHolder, classes[1], "the call after LeaseAcquired classifies RESOURCE_HOLDER")
+	si1 := scheduler.SlotInfoFrom(ctx1)
+	require.NotNil(t, si1)
+	assert.Equal(t, classHolder, si1.Class(), "the turn's SlotInfo stays marked after the turn")
+	assert.True(t, ag.leases.holds(sessionID))
+
+	// Turn 2: a FRESH SlotInfo — the mark died with turn 1's. The session's
+	// ledger seeds the new turn, so its first call classifies RESOURCE_HOLDER
+	// (without the seed it would classify IN_FLIGHT via priorCalls).
+	ctx2 := scheduler.WithSlotInfo(context.Background(), loomv1.SlotOrigin_SLOT_ORIGIN_BATCH, 1)
+	_, err = ag.Chat(ctx2, sessionID, "keep working")
+	require.NoError(t, err)
+	classes = llm.capturedClasses()
+	require.Len(t, classes, 3)
+	assert.Equal(t, classHolder, classes[2], "a turn on a lease-holding session STARTS as RESOURCE_HOLDER")
+
+	// Turn 3: the tool releases the lease mid-turn. The turn starts seeded
+	// (the session still held the lease), then the ledger empties and the
+	// synthesis call falls back to IN_FLIGHT.
+	ctx3 := scheduler.WithSlotInfo(context.Background(), loomv1.SlotOrigin_SLOT_ORIGIN_BATCH, 1)
+	_, err = ag.Chat(ctx3, sessionID, "release the lease")
+	require.NoError(t, err)
+	classes = llm.capturedClasses()
+	require.Len(t, classes, 5)
+	assert.Equal(t, classHolder, classes[3], "still holding at turn start")
+	assert.Equal(t, classInFlight, classes[4], "after LeaseReleased the class falls back to IN_FLIGHT")
+	assert.False(t, ag.leases.holds(sessionID), "the ledger must be empty after the release")
+
+	// Turn 4: nothing seeds — a released session schedules like any other.
+	ctx4 := scheduler.WithSlotInfo(context.Background(), loomv1.SlotOrigin_SLOT_ORIGIN_BATCH, 1)
+	_, err = ag.Chat(ctx4, sessionID, "carry on")
+	require.NoError(t, err)
+	classes = llm.capturedClasses()
+	require.Len(t, classes, 6)
+	assert.Equal(t, classInFlight, classes[5], "a lease-free resumed turn classifies IN_FLIGHT")
+}
+
+// A brand-new session on the same agent is unaffected by another session's
+// leases, and classifies NEW on its first call.
+func TestLeaseSeedingIsPerSession(t *testing.T) {
+	llm := &leaseScriptLLM{responses: []mockLLMResponse{
+		{toolCalls: []llmtypes.ToolCall{{ID: "c1", Name: "lease_tool", Input: map[string]interface{}{"op": "acquire"}}}},
+		{content: "acquired"},
+		{content: "other session"},
+	}}
+	ag := newLeaseTestAgent(llm)
+
+	ctx1 := scheduler.WithSlotInfo(context.Background(), loomv1.SlotOrigin_SLOT_ORIGIN_BATCH, 0)
+	_, err := ag.Chat(ctx1, "holder-session", "acquire the lease")
+	require.NoError(t, err)
+	require.True(t, ag.leases.holds("holder-session"))
+
+	ctx2 := scheduler.WithSlotInfo(context.Background(), loomv1.SlotOrigin_SLOT_ORIGIN_BATCH, 0)
+	_, err = ag.Chat(ctx2, "fresh-session", "hello")
+	require.NoError(t, err)
+	classes := llm.capturedClasses()
+	require.Len(t, classes, 3)
+	assert.Equal(t, classNew, classes[2], "another session must not inherit the holder's class")
+	assert.False(t, ag.leases.holds("fresh-session"))
+}
+
+// Session deletion retires the session's leases — a leaked ledger entry on a
+// deleted session would pin RESOURCE_HOLDER priority forever.
+func TestDeleteSessionRetiresLeases(t *testing.T) {
+	llm := &leaseScriptLLM{responses: []mockLLMResponse{
+		{toolCalls: []llmtypes.ToolCall{{ID: "c1", Name: "lease_tool", Input: map[string]interface{}{"op": "acquire"}}}},
+		{content: "acquired"},
+	}}
+	ag := newLeaseTestAgent(llm)
+	const sessionID = "lease-delete-session"
+
+	ctx := scheduler.WithSlotInfo(context.Background(), loomv1.SlotOrigin_SLOT_ORIGIN_BATCH, 0)
+	_, err := ag.Chat(ctx, sessionID, "acquire the lease")
+	require.NoError(t, err)
+	require.True(t, ag.leases.holds(sessionID))
+
+	ag.DeleteSession(sessionID)
+	assert.False(t, ag.leases.holds(sessionID))
+	ag.leases.mu.Lock()
+	_, leaked := ag.leases.held[sessionID]
+	ag.leases.mu.Unlock()
+	assert.False(t, leaked, "DeleteSession must remove the ledger entry, not just empty it")
+}
+
+// ClearAllSessions is DeleteSession's sibling retirement path.
+func TestClearAllSessionsRetiresLeases(t *testing.T) {
+	ag := newLeaseTestAgent(&leaseScriptLLM{})
+	ag.leases.apply("s1", []shuttle.LeaseEvent{{Action: shuttle.LeaseAcquired, Kind: "db-session", ID: "a"}})
+	ag.leases.apply("s2", []shuttle.LeaseEvent{{Action: shuttle.LeaseAcquired, Kind: "db-session", ID: "b"}})
+
+	ag.ClearAllSessions()
+	assert.False(t, ag.leases.holds("s1"))
+	assert.False(t, ag.leases.holds("s2"))
+}
+
+func TestLeaseLedgerApply(t *testing.T) {
+	acquire := func(kind, id string) shuttle.LeaseEvent {
+		return shuttle.LeaseEvent{Action: shuttle.LeaseAcquired, Kind: kind, ID: id}
+	}
+	release := func(kind, id string) shuttle.LeaseEvent {
+		return shuttle.LeaseEvent{Action: shuttle.LeaseReleased, Kind: kind, ID: id}
+	}
+
+	tests := []struct {
+		name   string
+		events []shuttle.LeaseEvent
+		want   bool
+	}{
+		{
+			name:   "acquire holds",
+			events: []shuttle.LeaseEvent{acquire("db-session", "s1")},
+			want:   true,
+		},
+		{
+			name:   "acquire then release empties",
+			events: []shuttle.LeaseEvent{acquire("db-session", "s1"), release("db-session", "s1")},
+			want:   false,
+		},
+		{
+			name:   "re-acquire is idempotent",
+			events: []shuttle.LeaseEvent{acquire("db-session", "s1"), acquire("db-session", "s1"), release("db-session", "s1")},
+			want:   false,
+		},
+		{
+			name:   "double release is a tolerated no-op",
+			events: []shuttle.LeaseEvent{acquire("db-session", "s1"), release("db-session", "s1"), release("db-session", "s1")},
+			want:   false,
+		},
+		{
+			name:   "release of unknown is a tolerated no-op",
+			events: []shuttle.LeaseEvent{release("db-session", "never-acquired")},
+			want:   false,
+		},
+		{
+			name:   "release then acquire still holds",
+			events: []shuttle.LeaseEvent{release("db-session", "s1"), acquire("db-session", "s1")},
+			want:   true,
+		},
+		{
+			name:   "one of two released still holds",
+			events: []shuttle.LeaseEvent{acquire("db-session", "s1"), acquire("api-slot", "7"), release("db-session", "s1")},
+			want:   true,
+		},
+		{
+			name:   "identity is the exact kind+id pair",
+			events: []shuttle.LeaseEvent{acquire("db-session", "s1"), release("other-kind", "s1")},
+			want:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var l leaseLedger
+			got := l.apply("sess", tt.events)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want, l.holds("sess"))
+		})
+	}
+}
+
+// Concurrent tool results emitting lease events on the same session: each
+// worker acquires and releases its own lease; the ledger must end empty with
+// no double-count drift and no data race (run under -race).
+func TestLeaseLedgerConcurrentToolResults(t *testing.T) {
+	ag := &Agent{} // zero-value ledger is ready; no other agent state is touched
+	ctx := scheduler.WithSlotInfo(context.Background(), loomv1.SlotOrigin_SLOT_ORIGIN_BATCH, 0)
+	const sessionID = "race-session"
+	const workers = 32
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			id := fmt.Sprintf("lease-%d", n)
+			acq := &shuttle.Result{Success: true}
+			shuttle.AppendLeaseEvent(acq, shuttle.LeaseEvent{Action: shuttle.LeaseAcquired, Kind: "db-session", ID: id})
+			ag.applyLeaseEvents(ctx, sessionID, acq)
+			ag.seedLeaseHolding(ctx, sessionID)
+			rel := &shuttle.Result{Success: true}
+			shuttle.AppendLeaseEvent(rel, shuttle.LeaseEvent{Action: shuttle.LeaseReleased, Kind: "db-session", ID: id})
+			ag.applyLeaseEvents(ctx, sessionID, rel)
+		}(i)
+	}
+	wg.Wait()
+
+	assert.False(t, ag.leases.holds(sessionID), "every acquire was matched by a release")
+}
+
+// Without SlotInfo (unwired path) lease events still track in the ledger and
+// the scheduler calls are no-ops — nothing panics, nothing leaks.
+func TestApplyLeaseEventsWithoutSlotInfo(t *testing.T) {
+	ag := &Agent{}
+	res := &shuttle.Result{Success: true}
+	shuttle.AppendLeaseEvent(res, shuttle.LeaseEvent{Action: shuttle.LeaseAcquired, Kind: "db-session", ID: "s1"})
+	ag.applyLeaseEvents(context.Background(), "bare", res)
+	assert.True(t, ag.leases.holds("bare"))
+	ag.seedLeaseHolding(context.Background(), "bare")
+}

--- a/pkg/agent/lease_ledger_test.go
+++ b/pkg/agent/lease_ledger_test.go
@@ -220,8 +220,8 @@ func TestDeleteSessionRetiresLeases(t *testing.T) {
 // ClearAllSessions is DeleteSession's sibling retirement path.
 func TestClearAllSessionsRetiresLeases(t *testing.T) {
 	ag := newLeaseTestAgent(&leaseScriptLLM{})
-	ag.leases.apply("s1", []shuttle.LeaseEvent{{Action: shuttle.LeaseAcquired, Kind: "db-session", ID: "a"}})
-	ag.leases.apply("s2", []shuttle.LeaseEvent{{Action: shuttle.LeaseAcquired, Kind: "db-session", ID: "b"}})
+	ag.leases.apply("s1", []shuttle.LeaseEvent{{Action: shuttle.LeaseAcquired, Kind: "db-session", ID: "a"}}, nil)
+	ag.leases.apply("s2", []shuttle.LeaseEvent{{Action: shuttle.LeaseAcquired, Kind: "db-session", ID: "b"}}, nil)
 
 	ag.ClearAllSessions()
 	assert.False(t, ag.leases.holds("s1"))
@@ -285,7 +285,8 @@ func TestLeaseLedgerApply(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var l leaseLedger
-			got := l.apply("sess", tt.events)
+			var got bool
+			l.apply("sess", tt.events, func(h bool) { got = h })
 			assert.Equal(t, tt.want, got)
 			assert.Equal(t, tt.want, l.holds("sess"))
 		})

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -203,6 +203,13 @@ type Agent struct {
 	baseToolNames     map[string]bool
 	baseToolsOnce     sync.Once
 
+	// Per-session resource-lease ledger: the scarce backend resources each
+	// session's conversation currently holds, tracked from backend-declared
+	// lease events on tool results and mirrored onto the LLM slot scheduler's
+	// RESOURCE_HOLDER class. Self-guarded (own mutex); zero value ready.
+	// Retired with the session, like sessionToolLedger. See lease_ledger.go.
+	leases leaseLedger
+
 	// Graph-backed episodic memory (optional).
 	graphMemoryStore  memory.GraphMemoryStore
 	graphMemoryConfig *loomv1.GraphMemoryConfig

--- a/pkg/llm/scheduler/wiring.go
+++ b/pkg/llm/scheduler/wiring.go
@@ -27,10 +27,11 @@ import (
 //     AcquireForCall, which reads class and origin from the SlotInfo, and
 //     feeds ObserveThrottleForScope/ObserveSuccessForScope from call
 //     outcomes — the provider-agnostic AIMD seam.
-//   - MarkResourceHolder lifts a conversation's remaining calls to the
-//     RESOURCE_HOLDER class (priority inheritance). Its call sites arrive
-//     with the resource-lease integration (MCP session handles); nothing
-//     invokes it on this branch yet.
+//   - MarkResourceHolder / UnmarkResourceHolder lift and restore a
+//     conversation's class around resource leases (priority inheritance).
+//     The agent's per-session lease ledger (pkg/agent/lease_ledger.go)
+//     drives both from backend-declared lease events on tool results
+//     (pkg/shuttle/lease.go) — loom never knows what the resource is.
 
 var (
 	defaultRegistry = NewRegistry(nil)
@@ -70,8 +71,19 @@ type slotInfoKey struct{}
 // seeds the call counter so a resumed conversation classifies as IN_FLIGHT
 // from its first call of the new turn.
 func WithSlotInfo(ctx context.Context, origin loomv1.SlotOrigin, priorCalls int64) context.Context {
+	return WithSlotInfoHolding(ctx, origin, priorCalls, false)
+}
+
+// WithSlotInfoHolding is WithSlotInfo for a conversation that already holds
+// a scarce backend resource from a previous turn: leases outlive turns, but
+// a SlotInfo does not, so an installer that knows the conversation's lease
+// state seeds holding=true and the turn classifies RESOURCE_HOLDER from its
+// first LLM call. Installers without that knowledge use WithSlotInfo; the
+// agent then re-marks from its lease ledger at turn start.
+func WithSlotInfoHolding(ctx context.Context, origin loomv1.SlotOrigin, priorCalls int64, holding bool) context.Context {
 	si := &SlotInfo{origin: origin}
 	si.calls.Store(priorCalls)
+	si.resourceHolder.Store(holding)
 	return context.WithValue(ctx, slotInfoKey{}, si)
 }
 
@@ -88,6 +100,29 @@ func MarkResourceHolder(ctx context.Context) {
 	if si := SlotInfoFrom(ctx); si != nil {
 		si.resourceHolder.Store(true)
 	}
+}
+
+// UnmarkResourceHolder clears the mark when the conversation's last
+// outstanding lease is released; its later LLM calls fall back to the
+// call-count classes. No-op when no SlotInfo is installed.
+func UnmarkResourceHolder(ctx context.Context) {
+	if si := SlotInfoFrom(ctx); si != nil {
+		si.resourceHolder.Store(false)
+	}
+}
+
+// Class returns the priority class the SlotInfo's next LLM call schedules
+// under. RESOURCE_HOLDER outranks the call-count progression: a conversation
+// holding a scarce backend resource blocks other agents, so it must finish
+// and release first (priority inheritance).
+func (si *SlotInfo) Class() loomv1.SlotPriorityClass {
+	if si.resourceHolder.Load() {
+		return loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_RESOURCE_HOLDER
+	}
+	if si.calls.Load() > 0 {
+		return loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_IN_FLIGHT
+	}
+	return loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_NEW
 }
 
 // ScopeProvider is optionally implemented by LLM clients that know their
@@ -120,15 +155,8 @@ func AcquireForCall(ctx context.Context, scope string, reservationTokens int64) 
 	if si == nil {
 		return nil, nil
 	}
-	class := loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_NEW
-	if si.calls.Load() > 0 {
-		class = loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_IN_FLIGHT
-	}
-	if si.resourceHolder.Load() {
-		class = loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_RESOURCE_HOLDER
-	}
 	g, err := defaultRegistry.For(scope, Config{}).Acquire(ctx, Request{
-		Class:             class,
+		Class:             si.Class(),
 		Origin:            si.origin,
 		ReservationTokens: reservationTokens,
 	})

--- a/pkg/llm/scheduler/wiring_test.go
+++ b/pkg/llm/scheduler/wiring_test.go
@@ -7,6 +7,7 @@ package scheduler
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,6 +64,79 @@ func TestWithSlotInfoPriorCallsSeedsInFlight(t *testing.T) {
 	si := SlotInfoFrom(ctx)
 	require.NotNil(t, si)
 	assert.Equal(t, int64(7), si.calls.Load())
+}
+
+func TestSlotInfoClass(t *testing.T) {
+	tests := []struct {
+		name       string
+		priorCalls int64
+		holding    bool
+		want       loomv1.SlotPriorityClass
+	}{
+		{"fresh conversation is NEW", 0, false, loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_NEW},
+		{"mid-task conversation is IN_FLIGHT", 1, false, loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_IN_FLIGHT},
+		{"lease outranks NEW", 0, true, loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_RESOURCE_HOLDER},
+		{"lease outranks IN_FLIGHT", 5, true, loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_RESOURCE_HOLDER},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := WithSlotInfoHolding(context.Background(), loomv1.SlotOrigin_SLOT_ORIGIN_BATCH, tt.priorCalls, tt.holding)
+			si := SlotInfoFrom(ctx)
+			require.NotNil(t, si)
+			assert.Equal(t, tt.want, si.Class())
+		})
+	}
+}
+
+func TestUnmarkResourceHolder(t *testing.T) {
+	t.Run("no SlotInfo is a no-op", func(t *testing.T) {
+		UnmarkResourceHolder(context.Background())
+	})
+
+	t.Run("mark then unmark restores the call-count class", func(t *testing.T) {
+		ctx := WithSlotInfo(context.Background(), loomv1.SlotOrigin_SLOT_ORIGIN_BATCH, 1)
+		si := SlotInfoFrom(ctx)
+		require.NotNil(t, si)
+
+		MarkResourceHolder(ctx)
+		assert.Equal(t, loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_RESOURCE_HOLDER, si.Class())
+
+		UnmarkResourceHolder(ctx)
+		assert.Equal(t, loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_IN_FLIGHT, si.Class())
+	})
+
+	t.Run("unmark without a prior mark stays unmarked", func(t *testing.T) {
+		ctx := WithSlotInfo(context.Background(), loomv1.SlotOrigin_SLOT_ORIGIN_BATCH, 0)
+		UnmarkResourceHolder(ctx)
+		assert.Equal(t, loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_NEW, SlotInfoFrom(ctx).Class())
+	})
+}
+
+// Mark, unmark, and classification race on the shared per-turn SlotInfo:
+// tool results flip the holder flag while LLM acquisitions read it.
+func TestMarkUnmarkClassConcurrent(t *testing.T) {
+	ctx := WithSlotInfo(context.Background(), loomv1.SlotOrigin_SLOT_ORIGIN_BATCH, 0)
+	si := SlotInfoFrom(ctx)
+	require.NotNil(t, si)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				switch n % 3 {
+				case 0:
+					MarkResourceHolder(ctx)
+				case 1:
+					UnmarkResourceHolder(ctx)
+				default:
+					_ = si.Class()
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
 }
 
 type scopedStub struct{ scope string }

--- a/pkg/shuttle/backpressure.go
+++ b/pkg/shuttle/backpressure.go
@@ -30,9 +30,10 @@ const DetailsBackpressure = "loom.backpressure"
 // model. Task-level failures (SQL errors, timeouts, deadlocks) never carry
 // the hint and must reach the model.
 //
-// This type is the contract only — no wait loop lives at the shuttle layer.
-// The MCP adapter's freeze loop (PR #355) migrates onto this contract when
-// that PR merges; until then it parses its own MCP-level hint.
+// This type is the contract only — no wait loop lives at the shuttle layer,
+// and on this branch the hint has no producer or consumer yet. The MCP
+// adapter's freeze loop lives on open PR #355 with its own MCP-level parse;
+// it migrates onto this contract when that PR merges.
 type BackpressureHint struct {
 	// Code names the capacity condition (e.g. "session_handle_budget_full").
 	// Backend-defined; loom treats it as an opaque label.

--- a/pkg/shuttle/backpressure.go
+++ b/pkg/shuttle/backpressure.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package shuttle
+
+import "encoding/json"
+
+// DetailsBackpressure is the well-known Error.Details key carrying a
+// BackpressureHint. The value is a map[string]interface{} with "code",
+// "retry_after_s", "wait_param", and "max_wait_s" fields — the same wire
+// names the MCP-level contract uses, so a backend can copy a hint through
+// unchanged.
+const DetailsBackpressure = "loom.backpressure"
+
+// BackpressureHint is the machine-readable park-and-wake contract a backend
+// may attach to a tool error: the failure is capacity flow control, not a
+// fault — the identical call, re-issued after a wait, is expected to succeed
+// once load drains or a slot frees. A runtime that honors the hint parks the
+// calling conversation and re-invokes instead of surfacing the error to the
+// model. Task-level failures (SQL errors, timeouts, deadlocks) never carry
+// the hint and must reach the model.
+//
+// This type is the contract only — no wait loop lives at the shuttle layer.
+// The MCP adapter's freeze loop (PR #355) migrates onto this contract when
+// that PR merges; until then it parses its own MCP-level hint.
+type BackpressureHint struct {
+	// Code names the capacity condition (e.g. "session_handle_budget_full").
+	// Backend-defined; loom treats it as an opaque label.
+	Code string
+	// RetryAfterS is the backend's worst-case estimate, in seconds, of when
+	// the retry will succeed (capacity may free sooner). 0 = no estimate.
+	RetryAfterS int64
+	// WaitParam names a tool argument that parks the retry backend-side for
+	// up to MaxWaitS seconds, waking on freed capacity instead of polling.
+	// Empty = the backend offers no server-side wait.
+	WaitParam string
+	// MaxWaitS caps one backend-side wait in seconds. 0 = backend default.
+	MaxWaitS int64
+}
+
+// SetBackpressure attaches the hint to the error under DetailsBackpressure,
+// initializing Details as needed, and marks the error Retryable — capacity
+// flow control is by definition retryable. The hint is stored in its
+// JSON-shaped form so it parses identically after a marshal/unmarshal
+// round trip. A nil error is a no-op.
+func (e *Error) SetBackpressure(h BackpressureHint) {
+	if e == nil {
+		return
+	}
+	if e.Details == nil {
+		e.Details = make(map[string]interface{})
+	}
+	e.Details[DetailsBackpressure] = map[string]interface{}{
+		"code":          h.Code,
+		"retry_after_s": h.RetryAfterS,
+		"wait_param":    h.WaitParam,
+		"max_wait_s":    h.MaxWaitS,
+	}
+	e.Retryable = true
+}
+
+// Backpressure extracts the hint, or nil when the error declares none. The
+// key's presence is the declaration; parsing is tolerant by contract — tool
+// results are data, so a malformed value (wrong type) yields nil, never an
+// error, and wrong-typed fields inside a well-formed map read as zero.
+func (e *Error) Backpressure() *BackpressureHint {
+	if e == nil || e.Details == nil {
+		return nil
+	}
+	switch v := e.Details[DetailsBackpressure].(type) {
+	case BackpressureHint:
+		h := v
+		return &h
+	case map[string]interface{}:
+		code, _ := v["code"].(string)
+		waitParam, _ := v["wait_param"].(string)
+		return &BackpressureHint{
+			Code:        code,
+			RetryAfterS: detailsInt64(v["retry_after_s"]),
+			WaitParam:   waitParam,
+			MaxWaitS:    detailsInt64(v["max_wait_s"]),
+		}
+	default:
+		return nil
+	}
+}
+
+// detailsInt64 reads an integer that may arrive as any of the numeric types
+// a Go emitter or a JSON round trip produces. Anything else reads as 0.
+func detailsInt64(v interface{}) int64 {
+	switch n := v.(type) {
+	case int64:
+		return n
+	case int:
+		return int64(n)
+	case int32:
+		return int64(n)
+	case float64:
+		return int64(n)
+	case json.Number:
+		if i, err := n.Int64(); err == nil {
+			return i
+		}
+	}
+	return 0
+}

--- a/pkg/shuttle/backpressure_test.go
+++ b/pkg/shuttle/backpressure_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package shuttle
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetBackpressureRoundTrip(t *testing.T) {
+	hint := BackpressureHint{
+		Code:        "session_handle_budget_full",
+		RetryAfterS: 42,
+		WaitParam:   "wait_s",
+		MaxWaitS:    300,
+	}
+
+	e := &Error{Code: "BUDGET_FULL", Message: "no handles free"}
+	e.SetBackpressure(hint)
+
+	got := e.Backpressure()
+	require.NotNil(t, got)
+	assert.Equal(t, hint, *got)
+	assert.True(t, e.Retryable, "backpressure is by definition retryable")
+}
+
+func TestSetBackpressureNilReceiverIsNoOp(t *testing.T) {
+	var e *Error
+	e.SetBackpressure(BackpressureHint{Code: "x"})
+	assert.Nil(t, e.Backpressure())
+}
+
+func TestBackpressureTolerantParse(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *Error
+		want *BackpressureHint
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: nil,
+		},
+		{
+			name: "nil details",
+			err:  &Error{Code: "X"},
+			want: nil,
+		},
+		{
+			name: "missing key",
+			err:  &Error{Details: map[string]interface{}{"other": 1}},
+			want: nil,
+		},
+		{
+			name: "malformed value yields nil, never an error",
+			err:  &Error{Details: map[string]interface{}{DetailsBackpressure: "busy"}},
+			want: nil,
+		},
+		{
+			name: "typed hint stored directly",
+			err: &Error{Details: map[string]interface{}{
+				DetailsBackpressure: BackpressureHint{Code: "c", RetryAfterS: 1},
+			}},
+			want: &BackpressureHint{Code: "c", RetryAfterS: 1},
+		},
+		{
+			name: "JSON numbers arrive as float64",
+			err: &Error{Details: map[string]interface{}{
+				DetailsBackpressure: map[string]interface{}{
+					"code":          "budget_full",
+					"retry_after_s": float64(42),
+					"wait_param":    "wait_s",
+					"max_wait_s":    float64(300),
+				},
+			}},
+			want: &BackpressureHint{Code: "budget_full", RetryAfterS: 42, WaitParam: "wait_s", MaxWaitS: 300},
+		},
+		{
+			name: "wrong-typed fields inside a well-formed map read as zero",
+			err: &Error{Details: map[string]interface{}{
+				DetailsBackpressure: map[string]interface{}{
+					"code":          7,
+					"retry_after_s": "soon",
+					"wait_param":    true,
+					"max_wait_s":    nil,
+				},
+			}},
+			want: &BackpressureHint{},
+		},
+		{
+			name: "empty map is a declaration with no estimate",
+			err: &Error{Details: map[string]interface{}{
+				DetailsBackpressure: map[string]interface{}{},
+			}},
+			want: &BackpressureHint{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.err.Backpressure())
+		})
+	}
+}
+
+// The stored form must survive a JSON marshal/unmarshal boundary and parse
+// to the identical hint on the other side.
+func TestBackpressureSurvivesJSONRoundTrip(t *testing.T) {
+	e := &Error{Code: "BUDGET_FULL", Message: "no handles free"}
+	e.SetBackpressure(BackpressureHint{Code: "budget_full", RetryAfterS: 5, WaitParam: "wait_s", MaxWaitS: 60})
+
+	raw, err := json.Marshal(e.Details)
+	require.NoError(t, err)
+	var back map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &back))
+
+	assert.Equal(t, e.Backpressure(), (&Error{Details: back}).Backpressure())
+}
+
+func TestDetailsInt64(t *testing.T) {
+	tests := []struct {
+		name string
+		in   interface{}
+		want int64
+	}{
+		{"int64", int64(9), 9},
+		{"int", int(8), 8},
+		{"int32", int32(7), 7},
+		{"float64", float64(6), 6},
+		{"json.Number", json.Number("5"), 5},
+		{"json.Number malformed", json.Number("x"), 0},
+		{"string", "4", 0},
+		{"nil", nil, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, detailsInt64(tt.in))
+		})
+	}
+}

--- a/pkg/shuttle/lease.go
+++ b/pkg/shuttle/lease.go
@@ -29,6 +29,23 @@ package shuttle
 // the JSON-shaped form (a []interface{} of map[string]interface{} with
 // "action", "kind", "id" string fields) so a metadata map that crosses a
 // JSON marshal/unmarshal boundary parses identically on the other side.
+//
+// TRUST MODEL: lease events are taken at the emitting tool's word. Any tool
+// or backend that can shape Result.Metadata can assert or release a lease
+// for any (Kind, ID) — nothing attributes events to emitters, so a hostile
+// or buggy MCP server can pin its conversations in the RESOURCE_HOLDER
+// scheduling class (a priority-escalation primitive against every other
+// agent sharing the LLM scope), or forge a release and demote a genuine
+// holder. This matches the deployment posture everywhere else in the tool
+// layer: connected backends are operator-chosen and trusted. A deployment
+// that runs untrusted tool servers must strip or ignore these metadata keys
+// at its adapter boundary before results reach the agent.
+//
+// The backend's declaration is authoritative in both directions: an
+// "acquired" on a FAILED result still counts (the lease was minted even
+// though the call errored afterward), and a backend that rolls a lease back
+// server-side MUST emit a matching "released" event or the conversation
+// keeps holder priority until session end.
 
 // MetadataLeaseEvents is the well-known Result.Metadata key carrying the
 // result's lease events. The value is a []interface{} whose entries are

--- a/pkg/shuttle/lease.go
+++ b/pkg/shuttle/lease.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package shuttle
+
+// Lease events are the backend-agnostic contract through which a tool result
+// declares that its conversation acquired or released a scarce,
+// session-scoped backend resource — a database session handle, an API
+// session under a concurrency cap. loom itself never knows what the resource
+// IS: the backend names it (Kind) and identifies it (ID), and loom reacts
+// generically — a conversation with an outstanding lease is scheduled in the
+// LLM slot scheduler's RESOURCE_HOLDER class (priority inheritance: it is
+// blocking other agents, so it must finish and release first), and the last
+// release drops it back to the ordinary classes.
+//
+// Transport is a well-known Result.Metadata key (MetadataLeaseEvents), so any
+// backend adapter — or a YAML-declared tool that shapes its own metadata —
+// can emit lease events without importing these types. Entries are stored in
+// the JSON-shaped form (a []interface{} of map[string]interface{} with
+// "action", "kind", "id" string fields) so a metadata map that crosses a
+// JSON marshal/unmarshal boundary parses identically on the other side.
+
+// MetadataLeaseEvents is the well-known Result.Metadata key carrying the
+// result's lease events. The value is a []interface{} whose entries are
+// map[string]interface{} with "action", "kind", and "id" string fields
+// (typed LeaseEvent entries are also accepted on read).
+const MetadataLeaseEvents = "loom.lease_events"
+
+// LeaseAction says which side of a lease's lifetime an event marks.
+type LeaseAction string
+
+const (
+	// LeaseAcquired tells loom "this conversation now holds a scarce backend
+	// resource": the conversation's remaining LLM calls — this turn and every
+	// following turn on the session, until the lease is released — ride the
+	// RESOURCE_HOLDER scheduling class.
+	LeaseAcquired LeaseAction = "acquired"
+
+	// LeaseReleased tells loom the lease ended. When it was the session's
+	// last outstanding lease, the conversation's LLM calls fall back to the
+	// ordinary call-count classes.
+	LeaseReleased LeaseAction = "released"
+)
+
+// LeaseEvent is one acquire or release of a backend-defined lease. Kind and
+// ID are opaque, backend-defined strings (e.g. "db-session" / "sess-42");
+// loom never interprets them beyond identity — a release matches an acquire
+// only when both Kind and ID are equal.
+type LeaseEvent struct {
+	Action LeaseAction
+	Kind   string
+	ID     string
+}
+
+// valid reports whether the event carries enough to track: a known action
+// and a non-empty ID. Kind may be empty (identity is still the exact
+// (Kind, ID) pair).
+func (ev LeaseEvent) valid() bool {
+	return (ev.Action == LeaseAcquired || ev.Action == LeaseReleased) && ev.ID != ""
+}
+
+// AppendLeaseEvent records a lease event on a tool result, initializing the
+// metadata map and the events slice as needed. The event is stored in the
+// JSON-shaped form so the result parses identically after crossing a
+// marshal/unmarshal boundary. A nil result is a no-op. Existing entries are
+// preserved untouched, valid or not — tool results are data.
+func AppendLeaseEvent(res *Result, ev LeaseEvent) {
+	if res == nil {
+		return
+	}
+	if res.Metadata == nil {
+		res.Metadata = make(map[string]interface{})
+	}
+	entries, _ := res.Metadata[MetadataLeaseEvents].([]interface{})
+	res.Metadata[MetadataLeaseEvents] = append(entries, map[string]interface{}{
+		"action": string(ev.Action),
+		"kind":   ev.Kind,
+		"id":     ev.ID,
+	})
+}
+
+// LeaseEventsFrom extracts the lease events a tool result declares, in emit
+// order. Parsing is tolerant by contract: tool results are data, so a
+// malformed entry — wrong container type, wrong entry type, unknown action,
+// missing ID — is skipped, never an error. A result without the key (or a
+// nil result) yields nil.
+func LeaseEventsFrom(res *Result) []LeaseEvent {
+	if res == nil || res.Metadata == nil {
+		return nil
+	}
+	entries, ok := res.Metadata[MetadataLeaseEvents].([]interface{})
+	if !ok {
+		return nil
+	}
+	var events []LeaseEvent
+	for _, entry := range entries {
+		if ev, ok := leaseEventFromEntry(entry); ok {
+			events = append(events, ev)
+		}
+	}
+	return events
+}
+
+// leaseEventFromEntry parses one metadata entry: the JSON-shaped map form
+// (the stored form, and what any JSON round-trip produces) or a typed
+// LeaseEvent a Go emitter placed directly.
+func leaseEventFromEntry(entry interface{}) (LeaseEvent, bool) {
+	switch v := entry.(type) {
+	case LeaseEvent:
+		return v, v.valid()
+	case map[string]interface{}:
+		action, _ := v["action"].(string)
+		kind, _ := v["kind"].(string)
+		id, _ := v["id"].(string)
+		ev := LeaseEvent{Action: LeaseAction(action), Kind: kind, ID: id}
+		return ev, ev.valid()
+	default:
+		return LeaseEvent{}, false
+	}
+}

--- a/pkg/shuttle/lease_test.go
+++ b/pkg/shuttle/lease_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package shuttle
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppendLeaseEvent(t *testing.T) {
+	t.Run("nil result is a no-op", func(t *testing.T) {
+		AppendLeaseEvent(nil, LeaseEvent{Action: LeaseAcquired, Kind: "db-session", ID: "s1"})
+	})
+
+	t.Run("initializes nil metadata", func(t *testing.T) {
+		res := &Result{Success: true}
+		AppendLeaseEvent(res, LeaseEvent{Action: LeaseAcquired, Kind: "db-session", ID: "s1"})
+		require.NotNil(t, res.Metadata)
+		assert.Equal(t, []LeaseEvent{{Action: LeaseAcquired, Kind: "db-session", ID: "s1"}}, LeaseEventsFrom(res))
+	})
+
+	t.Run("appends in emit order", func(t *testing.T) {
+		res := &Result{Success: true}
+		AppendLeaseEvent(res, LeaseEvent{Action: LeaseAcquired, Kind: "db-session", ID: "s1"})
+		AppendLeaseEvent(res, LeaseEvent{Action: LeaseReleased, Kind: "db-session", ID: "s1"})
+		assert.Equal(t, []LeaseEvent{
+			{Action: LeaseAcquired, Kind: "db-session", ID: "s1"},
+			{Action: LeaseReleased, Kind: "db-session", ID: "s1"},
+		}, LeaseEventsFrom(res))
+	})
+
+	t.Run("preserves malformed sibling entries", func(t *testing.T) {
+		res := &Result{Metadata: map[string]interface{}{
+			MetadataLeaseEvents: []interface{}{"garbage", 42},
+		}}
+		AppendLeaseEvent(res, LeaseEvent{Action: LeaseAcquired, Kind: "k", ID: "i"})
+		entries, ok := res.Metadata[MetadataLeaseEvents].([]interface{})
+		require.True(t, ok)
+		assert.Len(t, entries, 3, "malformed entries stay in the metadata; only parsing skips them")
+		assert.Equal(t, []LeaseEvent{{Action: LeaseAcquired, Kind: "k", ID: "i"}}, LeaseEventsFrom(res))
+	})
+
+	t.Run("replaces a non-slice value under the key", func(t *testing.T) {
+		res := &Result{Metadata: map[string]interface{}{MetadataLeaseEvents: "not-a-slice"}}
+		AppendLeaseEvent(res, LeaseEvent{Action: LeaseAcquired, Kind: "k", ID: "i"})
+		assert.Equal(t, []LeaseEvent{{Action: LeaseAcquired, Kind: "k", ID: "i"}}, LeaseEventsFrom(res))
+	})
+}
+
+func TestLeaseEventsFrom(t *testing.T) {
+	tests := []struct {
+		name string
+		res  *Result
+		want []LeaseEvent
+	}{
+		{
+			name: "nil result",
+			res:  nil,
+			want: nil,
+		},
+		{
+			name: "nil metadata",
+			res:  &Result{Success: true},
+			want: nil,
+		},
+		{
+			name: "missing key",
+			res:  &Result{Metadata: map[string]interface{}{"other": true}},
+			want: nil,
+		},
+		{
+			name: "value is not a slice",
+			res:  &Result{Metadata: map[string]interface{}{MetadataLeaseEvents: "acquired"}},
+			want: nil,
+		},
+		{
+			name: "JSON-shaped map entries",
+			res: &Result{Metadata: map[string]interface{}{
+				MetadataLeaseEvents: []interface{}{
+					map[string]interface{}{"action": "acquired", "kind": "db-session", "id": "sess-42"},
+					map[string]interface{}{"action": "released", "kind": "db-session", "id": "sess-42"},
+				},
+			}},
+			want: []LeaseEvent{
+				{Action: LeaseAcquired, Kind: "db-session", ID: "sess-42"},
+				{Action: LeaseReleased, Kind: "db-session", ID: "sess-42"},
+			},
+		},
+		{
+			name: "typed LeaseEvent entries",
+			res: &Result{Metadata: map[string]interface{}{
+				MetadataLeaseEvents: []interface{}{
+					LeaseEvent{Action: LeaseAcquired, Kind: "api-slot", ID: "7"},
+				},
+			}},
+			want: []LeaseEvent{{Action: LeaseAcquired, Kind: "api-slot", ID: "7"}},
+		},
+		{
+			name: "empty kind is a valid identity",
+			res: &Result{Metadata: map[string]interface{}{
+				MetadataLeaseEvents: []interface{}{
+					map[string]interface{}{"action": "acquired", "id": "bare"},
+				},
+			}},
+			want: []LeaseEvent{{Action: LeaseAcquired, ID: "bare"}},
+		},
+		{
+			name: "malformed entries are skipped, never an error",
+			res: &Result{Metadata: map[string]interface{}{
+				MetadataLeaseEvents: []interface{}{
+					"not-a-map",
+					42,
+					nil,
+					map[string]interface{}{"kind": "db-session", "id": "no-action"},
+					map[string]interface{}{"action": "granted", "kind": "db-session", "id": "bad-action"},
+					map[string]interface{}{"action": "acquired", "kind": "db-session"},
+					map[string]interface{}{"action": "acquired", "kind": "db-session", "id": ""},
+					map[string]interface{}{"action": 1, "kind": "db-session", "id": "typed-wrong"},
+					map[string]interface{}{"action": "acquired", "kind": "db-session", "id": "good"},
+				},
+			}},
+			want: []LeaseEvent{{Action: LeaseAcquired, Kind: "db-session", ID: "good"}},
+		},
+		{
+			name: "all entries malformed yields nil",
+			res: &Result{Metadata: map[string]interface{}{
+				MetadataLeaseEvents: []interface{}{"junk"},
+			}},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, LeaseEventsFrom(tt.res))
+		})
+	}
+}
+
+// The stored form must survive a JSON marshal/unmarshal boundary (backend
+// adapters and subprocess transports serialize Result.Metadata) and parse to
+// the identical events on the other side.
+func TestLeaseEventsSurviveJSONRoundTrip(t *testing.T) {
+	res := &Result{Success: true}
+	AppendLeaseEvent(res, LeaseEvent{Action: LeaseAcquired, Kind: "db-session", ID: "sess-42"})
+	AppendLeaseEvent(res, LeaseEvent{Action: LeaseReleased, Kind: "api-slot", ID: "7"})
+
+	raw, err := json.Marshal(res.Metadata)
+	require.NoError(t, err)
+	var back map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &back))
+
+	assert.Equal(t,
+		LeaseEventsFrom(res),
+		LeaseEventsFrom(&Result{Metadata: back}))
+}


### PR DESCRIPTION
## Summary

Phase 3a of the fleet-contention work: a **backend-agnostic lease contract** on the tool-result path, and the machinery that turns it into scheduler priority. Loom never learns what a "DB handle" is — the backend declares what's scarce, loom reacts generically.

- **`shuttle.LeaseEvent`** (`acquired`/`released`, opaque backend-defined Kind/ID) riding well-known `Result.Metadata` keys, with tolerant parsing (malformed entries are data, never errors). Any adapter or tool can emit them.
- **`shuttle.BackpressureHint`** hoisted to the shuttle layer — `{code, retry_after_s, wait_param, max_wait_s}`, field-compatible with #355's MCP hint so that adapter's migration is a drop-in. Contract only; the wait loop migrates with #355.
- **`UnmarkResourceHolder` + `WithSlotInfoHolding` + `SlotInfo.Class()`** in the scheduler wiring — the mark is no longer a one-way, single-turn flag.
- **Per-session lease ledger in the agent** (mirrors the existing `sessionToolLedger` lifecycle, retired on session delete/clear): tool results flow through the single execution funnel where lease events update the ledger and mark/unmark the turn; turn start seeds RESOURCE_HOLDER when the session already holds leases — so a conversation that acquired a handle last turn keeps priority inheritance until it releases.

## The money test

`TestLeaseLifecycleAcrossTurns`: a mock tool's lease events move a conversation's observed slot class across four turns — `NEW → RESOURCE_HOLDER` (mid-turn acquire), `RESOURCE_HOLDER` (next turn seeded from the ledger), `→ IN_FLIGHT` (mid-turn release), `IN_FLIGHT` (no seeding after release). Plus per-session isolation, ledger retirement on delete/clear, 32-goroutine same-session race coverage, and tolerant-parse tables on both contracts.

## Status (per docs honesty rules)

✅ Contract types, ledger, mark/unmark/seed, tests — this PR
📋 MCP adapter migration to the shuttle contract — lands with #344/#355
📋 Express-lane per-call handle checkout — needs the server half (teradata-mcp-v2)

Docs: §11 "Resource leases" added to `docs/architecture/llm-slot-scheduler.md`. Note: that file currently exists only on the unmerged #351 docs branch; this PR carries a copy with its stale "nothing implemented" status header corrected for merged #352/#353. If #351 merges first, resolving keeps §11.

## Validation

`gofmt`/`go vet` clean; `go build -tags fts5 ./...`; `-race -count=2` on pkg/shuttle, pkg/llm/scheduler, pkg/agent; `-race` on pkg/server. No proto changes (RESOURCE_HOLDER existed; events ride Result.Metadata).

🤖 Generated with [Claude Code](https://claude.com/claude-code)