### PR TITLE
fix(sqlite): render per-connection PRAGMAs into the DSN so every pooled connection gets them

### DIFF
--- a/cmd/looms/cmd_eval.go
+++ b/cmd/looms/cmd_eval.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/spf13/cobra"
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
-	_ "github.com/teradata-labs/loom/internal/sqlitedriver" // SQLite driver
+	"github.com/teradata-labs/loom/internal/sqlitedriver"
 	"github.com/teradata-labs/loom/pkg/agent"
 	"github.com/teradata-labs/loom/pkg/evals"
 	"github.com/teradata-labs/loom/pkg/evals/judges"
@@ -222,8 +222,10 @@ func runEval(cmd *cobra.Command, args []string) {
 	// Create pattern tracker for judge metrics if multi-judge is configured
 	var patternTracker *learning.PatternEffectivenessTracker
 	if suite.Spec.MultiJudge != nil && judgeOrch != nil {
-		// Open database connection for pattern tracking
-		db, err := sql.Open("sqlite3", evalStoreDB)
+		// Open database connection for pattern tracking. busy_timeout rides in
+		// the DSN so every pooled connection waits on lock contention instead
+		// of failing instantly with SQLITE_BUSY.
+		db, err := sql.Open("sqlite3", sqlitedriver.DSN(evalStoreDB, sqlitedriver.Options{BusyTimeoutMS: 5000}))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "⚠️  Warning: Failed to open database for pattern tracking: %v\n", err)
 			fmt.Fprintf(os.Stderr, "    Judge metrics will not be recorded for learning loop\n")

--- a/cmd/looms/cmd_serve.go
+++ b/cmd/looms/cmd_serve.go
@@ -29,7 +29,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/teradata-labs/loom/embedded"
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
-	_ "github.com/teradata-labs/loom/internal/sqlitedriver"
+	"github.com/teradata-labs/loom/internal/sqlitedriver"
 	"github.com/teradata-labs/loom/pkg/agent"
 	"github.com/teradata-labs/loom/pkg/artifacts"
 	"github.com/teradata-labs/loom/pkg/communication"
@@ -2740,7 +2740,9 @@ func runServe(cmd *cobra.Command, args []string) {
 		if learningDBPath == "" {
 			learningDBPath = filepath.Join(loomconfig.GetLoomDataDir(), "learning.db")
 		}
-		learningDB, err := sql.Open("sqlite3", learningDBPath)
+		// busy_timeout rides in the DSN so every pooled connection waits on
+		// lock contention instead of failing instantly with SQLITE_BUSY.
+		learningDB, err := sql.Open("sqlite3", sqlitedriver.DSN(learningDBPath, sqlitedriver.Options{BusyTimeoutMS: 5000}))
 		if err != nil {
 			logger.Fatal("Failed to open database for learning agent", zap.Error(err))
 		}

--- a/internal/sqlitedriver/driver_cgo.go
+++ b/internal/sqlitedriver/driver_cgo.go
@@ -3,9 +3,27 @@
 package sqlitedriver
 
 import (
+	"strconv"
+
 	_ "github.com/mutecomm/go-sqlcipher/v4" // registers "sqlite3" driver with encryption
 )
 
 // EncryptionSupported indicates whether the active SQLite driver supports
 // SQLCipher encryption (PRAGMA key). True when built with CGO.
 const EncryptionSupported = true
+
+// dsnParams renders opts in mattn/go-sqlite3 DSN syntax, which go-sqlcipher
+// (a mattn fork) applies to every new connection at open time.
+func dsnParams(opts Options) []string {
+	var p []string
+	if opts.BusyTimeoutMS > 0 {
+		p = append(p, "_busy_timeout="+strconv.Itoa(opts.BusyTimeoutMS))
+	}
+	if opts.WAL {
+		p = append(p, "_journal_mode=WAL")
+	}
+	if opts.ForeignKeys {
+		p = append(p, "_foreign_keys=on")
+	}
+	return p
+}

--- a/internal/sqlitedriver/driver_nocgo.go
+++ b/internal/sqlitedriver/driver_nocgo.go
@@ -4,6 +4,7 @@ package sqlitedriver
 
 import (
 	"database/sql"
+	"strconv"
 
 	"modernc.org/sqlite"
 )
@@ -15,3 +16,21 @@ func init() {
 // EncryptionSupported indicates whether the active SQLite driver supports
 // SQLCipher encryption (PRAGMA key). False when built without CGO.
 const EncryptionSupported = false
+
+// dsnParams renders opts in modernc.org/sqlite's native "_pragma=name(value)"
+// DSN syntax, which the driver applies to every new connection at open time.
+// (modernc v1.55.0+ also accepts the mattn shorthand keys, but the _pragma
+// form is the documented contract on every modernc release.)
+func dsnParams(opts Options) []string {
+	var p []string
+	if opts.BusyTimeoutMS > 0 {
+		p = append(p, "_pragma=busy_timeout("+strconv.Itoa(opts.BusyTimeoutMS)+")")
+	}
+	if opts.WAL {
+		p = append(p, "_pragma=journal_mode(WAL)")
+	}
+	if opts.ForeignKeys {
+		p = append(p, "_pragma=foreign_keys(1)")
+	}
+	return p
+}

--- a/internal/sqlitedriver/dsn.go
+++ b/internal/sqlitedriver/dsn.go
@@ -1,0 +1,60 @@
+package sqlitedriver
+
+import "strings"
+
+// Options selects per-connection SQLite settings rendered into a DSN by DSN.
+//
+// PRAGMA busy_timeout and PRAGMA foreign_keys are per-connection settings:
+// executing them with db.Exec on a pooled *sql.DB configures only the single
+// connection that happens to run the statement, leaving every other pooled
+// connection at the SQLite defaults (busy_timeout=0, so writers fail
+// instantly with SQLITE_BUSY under contention; foreign_keys=OFF). Rendering
+// them into the DSN is the only way to guarantee every connection
+// database/sql opens gets them.
+type Options struct {
+	// BusyTimeoutMS sets PRAGMA busy_timeout in milliseconds on every
+	// connection. 0 leaves the driver default (no busy handler: lock
+	// contention fails immediately with SQLITE_BUSY).
+	BusyTimeoutMS int
+
+	// WAL sets PRAGMA journal_mode=WAL. journal_mode is a persistent,
+	// database-level setting (stored in the file header), so unlike the
+	// other options a one-time post-open Exec also works; carrying it in
+	// the DSN keeps the intent with the open call and covers fresh files
+	// without a follow-up statement. Ignored by ":memory:" databases
+	// (the PRAGMA reports "memory" and does not error).
+	WAL bool
+
+	// ForeignKeys sets PRAGMA foreign_keys=ON on every connection
+	// (per-connection setting, default OFF).
+	ForeignKeys bool
+}
+
+// DSN renders path plus opts into a DSN for the registered "sqlite3" driver.
+//
+// The query-parameter syntax differs between the two drivers this package can
+// register (mattn-style "_busy_timeout=5000" for go-sqlcipher under CGO,
+// "_pragma=busy_timeout(5000)" for modernc.org/sqlite without CGO); the
+// build-tagged dsnParams in driver_cgo.go / driver_nocgo.go supplies the
+// correct one, so callers never spell driver-specific parameters themselves.
+//
+// Query parameters already present in path (e.g. "file:x.db?cache=shared")
+// are preserved. ":memory:" paths work with both drivers.
+//
+// An empty path is returned unchanged: to SQLite it means a private temporary
+// database, and appending parameters would turn it into a literal file named
+// "?_busy_timeout=..." in the working directory.
+func DSN(path string, opts Options) string {
+	if path == "" {
+		return path
+	}
+	params := dsnParams(opts)
+	if len(params) == 0 {
+		return path
+	}
+	sep := "?"
+	if strings.Contains(path, "?") {
+		sep = "&"
+	}
+	return path + sep + strings.Join(params, "&")
+}

--- a/internal/sqlitedriver/dsn_test.go
+++ b/internal/sqlitedriver/dsn_test.go
@@ -1,0 +1,189 @@
+package sqlitedriver
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDSNRendering checks the driver-agnostic properties of DSN: identity
+// with zero options, existing query parameters preserved, and the timeout
+// value present when requested.
+func TestDSNRendering(t *testing.T) {
+	t.Run("zero options is identity", func(t *testing.T) {
+		assert.Equal(t, "/tmp/x.db", DSN("/tmp/x.db", Options{}))
+		assert.Equal(t, ":memory:", DSN(":memory:", Options{}))
+	})
+
+	t.Run("empty path stays empty", func(t *testing.T) {
+		// "" means a private temporary database to SQLite; appending params
+		// would create a literal file named "?_busy_timeout=..." in the cwd.
+		assert.Equal(t, "", DSN("", Options{BusyTimeoutMS: 5000, WAL: true, ForeignKeys: true}))
+	})
+
+	t.Run("existing query params preserved", func(t *testing.T) {
+		got := DSN("file:/tmp/x.db?cache=shared&mode=rwc", Options{BusyTimeoutMS: 5000, WAL: true})
+		assert.True(t, strings.HasPrefix(got, "file:/tmp/x.db?cache=shared&mode=rwc&"),
+			"caller params must survive: %s", got)
+		assert.Contains(t, got, "busy_timeout")
+		assert.NotContains(t, got[len("file:/tmp/x.db"):], "?cache=shared?", "must not add a second '?'")
+	})
+
+	t.Run("plain path gains query separator", func(t *testing.T) {
+		got := DSN("/tmp/x.db", Options{BusyTimeoutMS: 5000})
+		assert.True(t, strings.HasPrefix(got, "/tmp/x.db?"), got)
+		assert.Contains(t, got, "5000")
+	})
+}
+
+// pinConns acquires n distinct physical connections from db. Holding every
+// *sql.Conn while acquiring the next forces the pool to open fresh
+// connections rather than reuse one.
+func pinConns(t *testing.T, db *sql.DB, n int) []*sql.Conn {
+	t.Helper()
+	conns := make([]*sql.Conn, n)
+	for i := range conns {
+		c, err := db.Conn(context.Background())
+		require.NoError(t, err, "pin connection %d", i)
+		conns[i] = c
+	}
+	t.Cleanup(func() {
+		for _, c := range conns {
+			_ = c.Close()
+		}
+	})
+	return conns
+}
+
+// TestDSNBusyTimeoutOnEveryPooledConn is the regression test for the fleet
+// SQLITE_BUSY incident: PRAGMA busy_timeout set via db.Exec on a pooled
+// *sql.DB configures only the one connection that runs the statement; every
+// other pooled connection keeps the driver default and fails instantly under
+// write contention on nocgo builds (modernc's default is 0; the CGO mattn
+// fork defaults to 5000, which masked the bug in CGO builds). The tests use
+// a non-default value (7500) so the Exec-once approach demonstrably fails
+// under BOTH drivers, while the DSN approach configures EVERY connection.
+func TestDSNBusyTimeoutOnEveryPooledConn(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "pool.db")
+
+	t.Run("old Exec-once approach leaves pooled connections unconfigured", func(t *testing.T) {
+		db, err := sql.Open("sqlite3", dbPath)
+		require.NoError(t, err)
+		defer func() { _ = db.Close() }()
+		db.SetMaxOpenConns(4)
+		db.SetMaxIdleConns(4)
+
+		// The buggy pattern this fix removes from production code.
+		_, err = db.Exec("PRAGMA busy_timeout = 7500")
+		require.NoError(t, err)
+
+		configured := 0
+		for i, c := range pinConns(t, db, 4) {
+			var v int
+			require.NoError(t, c.QueryRowContext(context.Background(), "PRAGMA busy_timeout").Scan(&v))
+			t.Logf("exec-once: conn %d busy_timeout=%d", i, v)
+			if v == 7500 {
+				configured++
+			}
+		}
+		assert.Less(t, configured, 4,
+			"db.Exec(PRAGMA busy_timeout) must not configure all pooled connections; "+
+				"if it does, this regression test no longer proves anything")
+	})
+
+	t.Run("DSN configures every pooled connection", func(t *testing.T) {
+		db, err := sql.Open("sqlite3", DSN(dbPath, Options{BusyTimeoutMS: 7500, WAL: true, ForeignKeys: true}))
+		require.NoError(t, err)
+		defer func() { _ = db.Close() }()
+		db.SetMaxOpenConns(4)
+		db.SetMaxIdleConns(4)
+
+		for i, c := range pinConns(t, db, 4) {
+			var busy int
+			require.NoError(t, c.QueryRowContext(context.Background(), "PRAGMA busy_timeout").Scan(&busy))
+			assert.Equal(t, 7500, busy, "conn %d: busy_timeout must be 7500 on every pooled connection", i)
+
+			var fk int
+			require.NoError(t, c.QueryRowContext(context.Background(), "PRAGMA foreign_keys").Scan(&fk))
+			assert.Equal(t, 1, fk, "conn %d: foreign_keys must be ON on every pooled connection", i)
+
+			var jm string
+			require.NoError(t, c.QueryRowContext(context.Background(), "PRAGMA journal_mode").Scan(&jm))
+			assert.Equal(t, "wal", strings.ToLower(jm), "conn %d: journal_mode must be WAL", i)
+		}
+	})
+}
+
+// TestDSNMemoryPath ensures ":memory:" DSNs built by the helper open and work.
+func TestDSNMemoryPath(t *testing.T) {
+	db, err := sql.Open("sqlite3", DSN(":memory:", Options{BusyTimeoutMS: 5000, WAL: true, ForeignKeys: true}))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	// Single connection: a pooled :memory: DB is a different database per
+	// connection, which is not what this test is probing.
+	db.SetMaxOpenConns(1)
+
+	_, err = db.Exec("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+	require.NoError(t, err)
+	_, err = db.Exec("INSERT INTO t (v) VALUES ('x')")
+	require.NoError(t, err)
+
+	var busy int
+	require.NoError(t, db.QueryRow("PRAGMA busy_timeout").Scan(&busy))
+	assert.Equal(t, 5000, busy)
+
+	var jm string
+	require.NoError(t, db.QueryRow("PRAGMA journal_mode").Scan(&jm))
+	assert.Equal(t, "memory", strings.ToLower(jm), ":memory: databases report journal_mode=memory")
+}
+
+// TestDSNConcurrentWritersSurviveContention proves the production fix:
+// concurrent writers on a WAL database opened through DSN with a busy
+// timeout survive a write-contention burst that produced SQLITE_BUSY under
+// the old Exec-once approach (busy_timeout=0 on most pooled connections).
+func TestDSNConcurrentWritersSurviveContention(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "contention.db")
+	db, err := sql.Open("sqlite3", DSN(dbPath, Options{BusyTimeoutMS: 5000, WAL: true}))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(4)
+	db.SetMaxIdleConns(4)
+
+	_, err = db.Exec("CREATE TABLE burst (id INTEGER PRIMARY KEY AUTOINCREMENT, writer INT, seq INT)")
+	require.NoError(t, err)
+
+	const (
+		writers = 4
+		perGoro = 50
+	)
+	var wg sync.WaitGroup
+	errCh := make(chan error, writers)
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(writer int) {
+			defer wg.Done()
+			for seq := 0; seq < perGoro; seq++ {
+				if _, err := db.Exec("INSERT INTO burst (writer, seq) VALUES (?, ?)", writer, seq); err != nil {
+					errCh <- fmt.Errorf("writer %d seq %d: %w", writer, seq, err)
+					return
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Errorf("concurrent write failed (SQLITE_BUSY regression): %v", err)
+	}
+
+	var n int
+	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM burst").Scan(&n))
+	assert.Equal(t, writers*perGoro, n, "every write must land")
+}

--- a/pkg/agent/db_config.go
+++ b/pkg/agent/db_config.go
@@ -57,8 +57,16 @@ type DBConfig struct {
 //	    EncryptionKey: os.Getenv("LOOM_DB_KEY"),
 //	})
 func OpenDB(config DBConfig) (*sql.DB, error) {
-	// Open database using pre-registered "sqlite3" driver from sqlcipher
-	db, err := sql.Open("sqlite3", config.Path)
+	// Open database using the pre-registered "sqlite3" driver. busy_timeout
+	// and foreign_keys are per-connection settings, so they must ride in the
+	// DSN to reach every pooled connection — a post-open db.Exec configures
+	// only the one connection that runs it. Both PRAGMAs are safe before
+	// PRAGMA key on encrypted databases (neither touches data pages).
+	dsn := sqlitedriver.DSN(config.Path, sqlitedriver.Options{
+		BusyTimeoutMS: 5000,
+		ForeignKeys:   true,
+	})
+	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
@@ -110,14 +118,9 @@ func OpenDB(config DBConfig) (*sql.DB, error) {
 		)
 	}
 
-	// Enable foreign keys for CASCADE operations
-	// This must be set for each connection as it defaults to OFF in SQLite
-	if _, err := db.Exec("PRAGMA foreign_keys=ON"); err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("failed to enable foreign keys: %w", err),
-			db.Close(),
-		)
-	}
+	// Foreign keys are enabled via the DSN above: PRAGMA foreign_keys is
+	// per-connection (default OFF), and only the DSN reaches every pooled
+	// connection.
 
 	return db, nil
 }

--- a/pkg/agent/in_turn_payload.go
+++ b/pkg/agent/in_turn_payload.go
@@ -105,6 +105,12 @@ func (a *Agent) inTurnSQLite(sessionID string, messageID int64, payload string) 
 	if err != nil {
 		return nil, fmt.Errorf("open in-turn sqlite: %w", err)
 	}
+	// A pooled ":memory:" DSN is a DIFFERENT empty database per physical
+	// connection: if database/sql ever opened a second connection, queries on
+	// it would fail with "no such table: results". Pin the pool to the single
+	// connection that loads the table. Contention settings (busy_timeout) are
+	// moot with one private in-memory connection.
+	db.SetMaxOpenConns(1)
 
 	quoted := make([]string, len(columns))
 	placeholders := make([]string, len(columns))

--- a/pkg/agent/session_store.go
+++ b/pkg/agent/session_store.go
@@ -124,7 +124,13 @@ func NewSessionStoreWithConfig(config DBConfig, tracer observability.Tracer) (*S
 		return nil, err
 	}
 
-	// Enable WAL mode for better concurrency
+	// Enable WAL mode for better concurrency. journal_mode is a persistent
+	// database-level setting (stored in the file header), so a one-time Exec
+	// is sufficient — unlike busy_timeout/foreign_keys, which are
+	// per-connection and set via the DSN in OpenDB. Kept as an Exec here
+	// because OpenDB is also used for databases that must not be converted
+	// to WAL (and PRAGMA key on encrypted databases must precede any
+	// statement that touches data pages, which journal_mode does).
 	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
 		return nil, fmt.Errorf("failed to enable WAL mode: %w", err)
 	}

--- a/pkg/artifacts/store.go
+++ b/pkg/artifacts/store.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/teradata-labs/loom/internal/sqlitedriver"
 	"github.com/teradata-labs/loom/pkg/config"
 	"github.com/teradata-labs/loom/pkg/observability"
 )
@@ -238,20 +239,17 @@ type SQLiteStore struct {
 // NewSQLiteStore creates a new SQLite-backed artifact store.
 // It reuses the existing loom.db database and creates the artifacts table if needed.
 func NewSQLiteStore(dbPath string, tracer observability.Tracer) (*SQLiteStore, error) {
-	// Open database (reuse existing session DB connection pattern)
-	db, err := sql.Open("sqlite3", dbPath)
+	// Open database (reuse existing session DB connection pattern).
+	// WAL, foreign_keys, and busy_timeout ride in the DSN so every pooled
+	// connection gets them; busy_timeout and foreign_keys are per-connection
+	// settings that a post-open db.Exec would set on only one connection.
+	db, err := sql.Open("sqlite3", sqlitedriver.DSN(dbPath, sqlitedriver.Options{
+		BusyTimeoutMS: 5000,
+		WAL:           true,
+		ForeignKeys:   true,
+	}))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
-	}
-
-	// Enable WAL mode for better concurrency
-	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
-		return nil, fmt.Errorf("failed to enable WAL mode: %w", err)
-	}
-
-	// Enable foreign keys
-	if _, err := db.Exec("PRAGMA foreign_keys=ON"); err != nil {
-		return nil, fmt.Errorf("failed to enable foreign keys: %w", err)
 	}
 
 	store := &SQLiteStore{

--- a/pkg/communication/interrupt/queue.go
+++ b/pkg/communication/interrupt/queue.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	_ "github.com/teradata-labs/loom/internal/sqlitedriver" // SQLite driver
+	"github.com/teradata-labs/loom/internal/sqlitedriver" // SQLite driver
 	"github.com/teradata-labs/loom/pkg/observability"
 	"github.com/teradata-labs/loom/pkg/types"
 )
@@ -96,7 +96,9 @@ CREATE INDEX IF NOT EXISTS idx_created_at ON interrupt_queue(created_at);
 // NewPersistentQueue creates a new persistent interrupt queue.
 // dbPath is the path to the SQLite database file.
 func NewPersistentQueue(ctx context.Context, dbPath string, router *Router) (*PersistentQueue, error) {
-	db, err := sql.Open("sqlite3", dbPath)
+	// busy_timeout rides in the DSN so every pooled connection waits on lock
+	// contention instead of failing instantly with SQLITE_BUSY.
+	db, err := sql.Open("sqlite3", sqlitedriver.DSN(dbPath, sqlitedriver.Options{BusyTimeoutMS: 5000}))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}

--- a/pkg/communication/queue.go
+++ b/pkg/communication/queue.go
@@ -23,7 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	_ "github.com/teradata-labs/loom/internal/sqlitedriver"
+	"github.com/teradata-labs/loom/internal/sqlitedriver"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -123,17 +123,23 @@ func NewMessageQueue(dbPath string, tracer observability.Tracer, logger *zap.Log
 		logger = zap.NewNop()
 	}
 
-	// Open SQLite database
-	// Add pragmas for better concurrency:
+	// Open SQLite database with pragmas for better concurrency, rendered
+	// into the DSN so every pooled connection gets them (busy_timeout is
+	// per-connection; a post-open db.Exec would configure only one of the
+	// 10 pooled connections):
 	// - busy_timeout: Wait up to 5s if database is locked
 	// - journal_mode=WAL: Write-Ahead Logging for concurrent reads/writes
-	// - cache_size: Increase cache for better performance
+	//   (file-based databases only; ":memory:" reports journal_mode=memory)
 	dbURL := dbPath
 	if dbPath == ":memory:" {
 		// For in-memory databases with shared cache, use file URI format
 		// This allows multiple connections to share the same in-memory database
 		dbURL = "file::memory:?mode=memory&cache=shared"
 	}
+	dbURL = sqlitedriver.DSN(dbURL, sqlitedriver.Options{
+		BusyTimeoutMS: 5000,
+		WAL:           dbPath != ":memory:",
+	})
 	db, err := sql.Open("sqlite3", dbURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
@@ -142,20 +148,6 @@ func NewMessageQueue(dbPath string, tracer observability.Tracer, logger *zap.Log
 	// Set connection pool parameters for better concurrency
 	db.SetMaxOpenConns(10)
 	db.SetMaxIdleConns(5)
-
-	// Enable WAL mode for better concurrent access (for file-based databases)
-	if dbPath != ":memory:" {
-		if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
-			logger.Warn("Failed to enable WAL mode", zap.Error(err))
-			// Continue anyway - not critical
-		}
-	}
-
-	// Set busy timeout for all connections
-	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
-		logger.Warn("Failed to set busy timeout", zap.Error(err))
-		// Continue anyway - not critical
-	}
 
 	// Create tables
 	schema := `

--- a/pkg/communication/sqlite_store.go
+++ b/pkg/communication/sqlite_store.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
-	_ "github.com/teradata-labs/loom/internal/sqlitedriver"
+	"github.com/teradata-labs/loom/internal/sqlitedriver"
 )
 
 // SQLiteStore implements ReferenceStore with SQLite persistence
@@ -49,17 +49,15 @@ func NewSQLiteStore(dbPath string, gcInterval time.Duration) (*SQLiteStore, erro
 		gcInterval = 5 * time.Minute // Default 5 minute GC interval
 	}
 
-	// Open SQLite database
-	db, err := sql.Open("sqlite3", dbPath)
+	// Open SQLite database. WAL and busy_timeout ride in the DSN so every
+	// pooled connection gets them; busy_timeout is per-connection and a
+	// post-open db.Exec would set it on only one connection.
+	db, err := sql.Open("sqlite3", sqlitedriver.DSN(dbPath, sqlitedriver.Options{
+		BusyTimeoutMS: 5000,
+		WAL:           true,
+	}))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
-	}
-
-	// Enable WAL mode for better concurrency
-	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
-		// #nosec G104 -- best-effort cleanup on initialization failure
-		_ = db.Close()
-		return nil, fmt.Errorf("failed to enable WAL mode: %w", err)
 	}
 
 	store := &SQLiteStore{

--- a/pkg/evals/store.go
+++ b/pkg/evals/store.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
-	_ "github.com/teradata-labs/loom/internal/sqlitedriver"
+	"github.com/teradata-labs/loom/internal/sqlitedriver"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -25,7 +25,9 @@ type Store struct {
 // NewStore creates a new eval store
 // Use ":memory:" for in-memory database (useful for testing)
 func NewStore(dbPath string) (*Store, error) {
-	db, err := sql.Open("sqlite3", dbPath)
+	// busy_timeout rides in the DSN so every pooled connection waits on lock
+	// contention instead of failing instantly with SQLITE_BUSY.
+	db, err := sql.Open("sqlite3", sqlitedriver.DSN(dbPath, sqlitedriver.Options{BusyTimeoutMS: 5000}))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}

--- a/pkg/metaagent/learning/collector.go
+++ b/pkg/metaagent/learning/collector.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	_ "github.com/teradata-labs/loom/internal/sqlitedriver"
+	"github.com/teradata-labs/loom/internal/sqlitedriver"
 	"github.com/teradata-labs/loom/pkg/observability"
 )
 
@@ -67,17 +67,16 @@ func NewMetricsCollector(dbPath string, tracer observability.Tracer) (*MetricsCo
 	ctx, span := tracer.StartSpan(ctx, "metaagent.learning.collector.new")
 	defer tracer.EndSpan(span)
 
-	// Open SQLite database
-	db, err := sql.Open("sqlite3", dbPath)
+	// Open SQLite database. WAL and busy_timeout ride in the DSN so every
+	// pooled connection gets them; busy_timeout is per-connection and a
+	// post-open db.Exec would set it on only one connection.
+	db, err := sql.Open("sqlite3", sqlitedriver.DSN(dbPath, sqlitedriver.Options{
+		BusyTimeoutMS: 5000,
+		WAL:           true,
+	}))
 	if err != nil {
 		span.RecordError(err)
 		return nil, fmt.Errorf("failed to open database: %w", err)
-	}
-
-	// Enable WAL mode for better concurrency
-	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
-		span.RecordError(err)
-		return nil, fmt.Errorf("failed to enable WAL mode: %w", err)
 	}
 
 	collector := &MetricsCollector{

--- a/pkg/observability/storage/sqlite.go
+++ b/pkg/observability/storage/sqlite.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"time"
 
-	_ "github.com/teradata-labs/loom/internal/sqlitedriver" // SQLite driver (encryption when CGO available)
+	"github.com/teradata-labs/loom/internal/sqlitedriver" // SQLite driver (encryption when CGO available)
 )
 
 // SQLiteStorage provides persistent trace storage using SQLite.
@@ -38,13 +38,22 @@ func NewSQLiteStorage(dbPath string) (*SQLiteStorage, error) {
 		return nil, fmt.Errorf("database path cannot be empty")
 	}
 
-	// Open database
-	db, err := sql.Open("sqlite3", dbPath)
+	// Open database. busy_timeout rides in the DSN so ALL 10 pooled
+	// connections wait on lock contention instead of failing instantly with
+	// SQLITE_BUSY ("failed to create eval run" under concurrent writers).
+	db, err := sql.Open("sqlite3", sqlitedriver.DSN(dbPath, sqlitedriver.Options{BusyTimeoutMS: 5000}))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
 
-	// Configure connection pool
+	// Configure connection pool.
+	//
+	// NOTE (follow-up): 10 concurrent connections all write to this database
+	// in rollback-journal mode, so writers serialize on the file lock and
+	// burn their busy_timeout waiting on each other. Enabling WAL and/or
+	// splitting the pool into one writer connection + N readers would cut
+	// contention structurally; kept as-is here to keep this change scoped to
+	// the busy_timeout fix.
 	db.SetMaxOpenConns(10)
 	db.SetMaxIdleConns(5)
 	db.SetConnMaxLifetime(time.Hour)

--- a/pkg/scheduler/store.go
+++ b/pkg/scheduler/store.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	_ "github.com/teradata-labs/loom/internal/sqlitedriver"
+	"github.com/teradata-labs/loom/internal/sqlitedriver"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -30,8 +30,15 @@ type Store struct {
 // NewStore creates a new scheduler store with SQLite backend.
 // The dbPath should point to $LOOM_DATA_DIR/scheduler.db.
 func NewStore(ctx context.Context, dbPath string, logger *zap.Logger) (*Store, error) {
-	// Open database with SQLite-specific pragmas
-	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?cache=shared&mode=rwc", dbPath))
+	// Open database with SQLite-specific pragmas. WAL and busy_timeout ride
+	// in the DSN (sqlitedriver.DSN renders the active driver's syntax) so
+	// every pooled connection gets them; a post-open db.Exec would configure
+	// only one of the 25 pooled connections.
+	dsn := sqlitedriver.DSN(
+		fmt.Sprintf("file:%s?cache=shared&mode=rwc", dbPath),
+		sqlitedriver.Options{BusyTimeoutMS: 5000, WAL: true},
+	)
+	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
@@ -40,12 +47,6 @@ func NewStore(ctx context.Context, dbPath string, logger *zap.Logger) (*Store, e
 	db.SetMaxOpenConns(25)
 	db.SetMaxIdleConns(5)
 	db.SetConnMaxLifetime(5 * time.Minute)
-
-	// Enable WAL mode via PRAGMA (not DSN param) for modernc.org/sqlite compatibility
-	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("failed to enable WAL mode: %w", err)
-	}
 
 	store := &Store{
 		db:     db,

--- a/pkg/shuttle/human_store_sqlite.go
+++ b/pkg/shuttle/human_store_sqlite.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"time"
 
-	_ "github.com/teradata-labs/loom/internal/sqlitedriver"
+	"github.com/teradata-labs/loom/internal/sqlitedriver"
 	"github.com/teradata-labs/loom/pkg/observability"
 )
 
@@ -41,22 +41,17 @@ func NewSQLiteHumanRequestStore(config SQLiteConfig) (*SQLiteHumanRequestStore, 
 		config.Tracer = observability.NewNoOpTracer()
 	}
 
-	// Open database
-	db, err := sql.Open("sqlite3", config.Path)
+	// Open database. WAL, foreign_keys, and busy_timeout ride in the DSN so
+	// every pooled connection gets them; busy_timeout and foreign_keys are
+	// per-connection settings that a post-open db.Exec would set on only one
+	// connection. (":memory:" ignores WAL and reports journal_mode=memory.)
+	db, err := sql.Open("sqlite3", sqlitedriver.DSN(config.Path, sqlitedriver.Options{
+		BusyTimeoutMS: 5000,
+		WAL:           true,
+		ForeignKeys:   true,
+	}))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
-	}
-
-	// Enable WAL mode for better concurrency
-	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
-		_ = db.Close() // #nosec G104 -- best-effort cleanup on error path
-		return nil, fmt.Errorf("failed to enable WAL mode: %w", err)
-	}
-
-	// Enable foreign keys
-	if _, err := db.Exec("PRAGMA foreign_keys=ON"); err != nil {
-		_ = db.Close() // #nosec G104 -- best-effort cleanup on error path
-		return nil, fmt.Errorf("failed to enable foreign keys: %w", err)
 	}
 
 	store := &SQLiteHumanRequestStore{

--- a/pkg/storage/backend/sqlite_backend.go
+++ b/pkg/storage/backend/sqlite_backend.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"github.com/teradata-labs/loom/internal/sqlitedriver"
 	"github.com/teradata-labs/loom/pkg/agent"
 	"github.com/teradata-labs/loom/pkg/artifacts"
 	"github.com/teradata-labs/loom/pkg/memory"
@@ -95,8 +96,18 @@ func NewSQLiteBackend(cfg *loomv1.SQLiteStorageConfig, tracer observability.Trac
 		)
 	}
 
+	// Shared DSN: busy_timeout and foreign_keys are per-connection settings,
+	// so they must ride in the DSN to reach every pooled connection.
+	// sqlitedriver.DSN renders the active driver's parameter syntax
+	// (mattn-style under CGO, _pragma-style under modernc).
+	dsn := sqlitedriver.DSN(dbPath, sqlitedriver.Options{
+		BusyTimeoutMS: 5000,
+		WAL:           true,
+		ForeignKeys:   true,
+	})
+
 	// Create migrator for versioned schema management
-	migratorDB, err := sql.Open("sqlite3", dbPath+"?_fk=1&_journal_mode=WAL")
+	migratorDB, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, errors.Join(
 			fmt.Errorf("failed to open DB for migrator: %w", err),
@@ -117,7 +128,7 @@ func NewSQLiteBackend(cfg *loomv1.SQLiteStorageConfig, tracer observability.Trac
 	}
 
 	// Create graph memory store (uses same DB path, separate connection).
-	graphMemDB, err := sql.Open("sqlite3", dbPath+"?_fk=1&_journal_mode=WAL&_busy_timeout=5000")
+	graphMemDB, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, errors.Join(
 			fmt.Errorf("failed to open DB for graph memory: %w", err),
@@ -131,7 +142,7 @@ func NewSQLiteBackend(cfg *loomv1.SQLiteStorageConfig, tracer observability.Trac
 	graphMemoryStore := sqlite.NewGraphMemoryStore(graphMemDB, tc, tracer)
 
 	// Create task store (uses same DB path, separate connection).
-	taskDB, err := sql.Open("sqlite3", dbPath+"?_fk=1&_journal_mode=WAL&_busy_timeout=5000")
+	taskDB, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, errors.Join(
 			fmt.Errorf("failed to open DB for task store: %w", err),
@@ -215,7 +226,7 @@ func (b *SQLiteBackend) Migrator() *sqlite.Migrator {
 
 // Ping verifies the SQLite database is accessible.
 func (b *SQLiteBackend) Ping(ctx context.Context) error {
-	db, err := sql.Open("sqlite3", b.dbPath)
+	db, err := sql.Open("sqlite3", sqlitedriver.DSN(b.dbPath, sqlitedriver.Options{BusyTimeoutMS: 5000}))
 	if err != nil {
 		return fmt.Errorf("SQLite ping failed: %w", err)
 	}

--- a/pkg/storage/sqlite/backup.go
+++ b/pkg/storage/sqlite/backup.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"time"
 
-	_ "github.com/teradata-labs/loom/internal/sqlitedriver" // registers "sqlite3" driver
+	"github.com/teradata-labs/loom/internal/sqlitedriver" // registers "sqlite3" driver
 )
 
 // Backup creates a safe online backup of a SQLite database using VACUUM INTO.
@@ -33,15 +33,14 @@ import (
 func Backup(dbPath string) (backupPath string, err error) {
 	backupPath = dbPath + ".backup." + time.Now().Format("20060102T150405")
 
-	srcDB, err := sql.Open("sqlite3", dbPath)
+	// busy_timeout rides in the DSN so it is guaranteed to apply to the
+	// connection that runs VACUUM INTO (an Exec-then-Exec sequence could land
+	// on two different pooled connections).
+	srcDB, err := sql.Open("sqlite3", sqlitedriver.DSN(dbPath, sqlitedriver.Options{BusyTimeoutMS: 5000}))
 	if err != nil {
 		return "", fmt.Errorf("backup: open source database %q: %w", dbPath, err)
 	}
 	defer func() { _ = srcDB.Close() }()
-
-	if _, err := srcDB.Exec("PRAGMA busy_timeout = 5000"); err != nil {
-		return "", fmt.Errorf("backup: set busy_timeout on %q: %w", dbPath, err)
-	}
 
 	if _, err := srcDB.Exec("VACUUM INTO ?", backupPath); err != nil {
 		_ = os.Remove(backupPath) // best-effort cleanup
@@ -64,7 +63,7 @@ func Backup(dbPath string) (backupPath string, err error) {
 // VerifyBackup opens a SQLite database file and runs PRAGMA integrity_check to
 // confirm the file is a valid, uncorrupted SQLite database.
 func VerifyBackup(backupPath string) error {
-	db, err := sql.Open("sqlite3", backupPath)
+	db, err := sql.Open("sqlite3", sqlitedriver.DSN(backupPath, sqlitedriver.Options{BusyTimeoutMS: 5000}))
 	if err != nil {
 		return fmt.Errorf("verify backup: open %q: %w", backupPath, err)
 	}

--- a/pkg/storage/sqlite/migrator.go
+++ b/pkg/storage/sqlite/migrator.go
@@ -51,13 +51,20 @@ type Migrator struct {
 }
 
 // NewMigrator creates a new migrator with embedded SQL migrations.
-// It sets PRAGMA busy_timeout = 5000 on the database to handle lock contention.
+//
+// The caller should open db with a busy_timeout in the DSN (see
+// internal/sqlitedriver.DSN): PRAGMA busy_timeout is per-connection, so the
+// Exec below only reliably covers a single-connection pool. It is kept as a
+// best-effort safety net because NewMigrator also receives databases opened
+// by callers outside this repository.
 func NewMigrator(db *sql.DB, tracer observability.Tracer) (*Migrator, error) {
 	if tracer == nil {
 		tracer = observability.NewNoOpTracer()
 	}
 
-	// Set busy_timeout so concurrent readers/writers wait instead of failing immediately
+	// Best-effort: set busy_timeout so concurrent readers/writers wait
+	// instead of failing immediately. Only guaranteed to configure the one
+	// pooled connection that runs it — the DSN is the authoritative place.
 	if _, err := db.Exec("PRAGMA busy_timeout = 5000"); err != nil {
 		return nil, fmt.Errorf("failed to set busy_timeout: %w", err)
 	}

--- a/pkg/tools/registry/registry.go
+++ b/pkg/tools/registry/registry.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
-	_ "github.com/teradata-labs/loom/internal/sqlitedriver"
+	"github.com/teradata-labs/loom/internal/sqlitedriver"
 	"github.com/teradata-labs/loom/pkg/observability"
 	"github.com/teradata-labs/loom/pkg/types"
 	"go.uber.org/zap"
@@ -120,8 +120,10 @@ func New(cfg Config) (*Registry, error) {
 		cfg.Logger = zap.NewNop()
 	}
 
-	// Open SQLite database with FTS5 support
-	db, err := sql.Open("sqlite3", cfg.DBPath)
+	// Open SQLite database with FTS5 support. busy_timeout rides in the DSN
+	// so every pooled connection waits on lock contention instead of failing
+	// instantly with SQLITE_BUSY.
+	db, err := sql.Open("sqlite3", sqlitedriver.DSN(cfg.DBPath, sqlitedriver.Options{BusyTimeoutMS: 5000}))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}


### PR DESCRIPTION
## The bug (measured at 512-agent scale)

`PRAGMA busy_timeout` is **per-connection**, but it was being set via a one-shot `db.Exec` on a pooled `*sql.DB` — configuring exactly one connection and leaving the rest of the pool at 0, failing instantly with SQLITE_BUSY under write contention. Tonight's az512m fleet run (the first at full concurrency after the scheduler-stack merge removed the accidental serialization that had been masking this) recorded **291 lost message rows** ("failed to save message: database is locked") and **~27,000 eval-run write failures**.

Two empirical findings that shaped the fix:
- The CGO driver (go-sqlcipher) **defaults** every connection to busy_timeout=5000, which is why dev machines never reproduced this — only `CGO_ENABLED=0` builds (i.e., exactly what fleets ship) run the modernc driver, which has **no default busy handler**.
- modernc only started honoring mattn-style DSN params (`_busy_timeout`, `_journal_mode`, `_fk`) in **v1.55.0** — the mattn-style DSNs already in `pkg/storage/backend` were silently inert on older nocgo builds.

## The fix

- New `sqlitedriver.DSN(path, Options{BusyTimeoutMS, WAL, ForeignKeys})` with **build-tagged rendering**: mattn syntax under CGO, modernc-native `_pragma=...` under nocgo (the guaranteed contract on every modernc release). Preserves caller query params, handles `:memory:`, and leaves an empty path untouched (an empty path is SQLite's private temp DB; appending params would create a literal `?_busy_timeout=...` file).
- All 14+ production open sites converted at busy_timeout=5000 with each site's existing WAL/FK intent moved into the DSN; per-connection-broken `Exec` pragmas removed (journal_mode Execs kept where genuinely correct — it's a persistent database-level setting). `:memory:` payload store pinned to `SetMaxOpenConns(1)` (a pooled `:memory:` DSN is a different empty DB per physical connection). `NewMigrator`'s exported signature untouched (loom-cloud implements against it); its Exec stays as a documented best-effort net for external callers.

## Regression evidence

`TestDSNBusyTimeoutOnEveryPooledConn` (uses 7500 so the CGO default can't mask the old behavior) pins 4 distinct pooled connections: old approach under nocgo reads `7500, 0, 0, 0` — the exact production failure; the DSN approach reads 7500 + WAL + FK on all four. `TestDSNConcurrentWritersSurviveContention`: 4 writers × 50 inserts, zero SQLITE_BUSY. Both verified under CGO (`-race`) and `CGO_ENABLED=0`.

Follow-ups noted in code, deliberately not done here: the observability store runs a 10-connection pool in rollback-journal mode (writers serialize on the file lock — WAL or a single-writer split would cut contention structurally), and the encrypted-DB `PRAGMA key` Exec has the same pooled-connection hazard for pools >1.

## Validation

`gofmt`/`go vet` clean; `go build -tags fts5 ./...` under both CGO and `CGO_ENABLED=0`; `-race -count=2` across all 19 touched-store packages; sqlitedriver suite green under both drivers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)