### PR TITLE
feat(artifacts): put session scoping on the wire

### DIFF
--- a/docs/architecture/artifacts.md
+++ b/docs/architecture/artifacts.md
@@ -1306,6 +1306,19 @@ session-scoped RPC uses.
 Denial is reported as `NotFound`, not `PermissionDenied`, so a caller cannot
 distinguish "exists but not yours" from "no such session" by probing.
 
+**Soft-deleted sessions stay readable by their owner.** Postgres `DeleteSession`
+only sets `deleted_at`, and a session's artifacts outlive it — `purge_soft_deleted`
+reaps artifacts by their *own* `deleted_at`, and the `artifacts.session_id`
+CASCADE fires only on the later hard purge. Because `LoadSession` and
+`SessionExists` both filter `deleted_at IS NULL`, neither can tell an owner's
+just-deleted session from one that never existed. Ownership therefore falls back
+to `SessionStore.CallerOwnsSession`, an owner-scoped existence check that ignores
+`deleted_at`, so the owner keeps the session-filtered view of artifacts the store
+still returns unfiltered. It is exposed as an optional capability
+(`sessionOwnershipProbe`) rather than a `SessionStorage` method, because that
+interface is implemented outside this repo; a store without it keeps the
+fail-closed behaviour.
+
 Two limits worth stating plainly, because "session scoping" reads broader than what
 is enforced:
 

--- a/docs/architecture/artifacts.md
+++ b/docs/architecture/artifacts.md
@@ -1319,6 +1319,14 @@ still returns unfiltered. It is exposed as an optional capability
 interface is implemented outside this repo; a store without it keeps the
 fail-closed behaviour.
 
+Only the Postgres store needs this, and so only it implements the capability.
+SQLite hard-deletes sessions and its `artifacts.session_id` foreign key is
+`ON DELETE CASCADE`, so a deleted session's artifacts are already gone — there is
+nothing to be locked out of. The two backends therefore answer the same request
+differently in *shape*: with enforcement on, scoping to a deleted session yields
+an empty list on Postgres and `NotFound` on SQLite. Both mean "no artifacts";
+a client that distinguishes the two should treat `NotFound` as empty here.
+
 Two limits worth stating plainly, because "session scoping" reads broader than what
 is enforced:
 

--- a/docs/architecture/artifacts.md
+++ b/docs/architecture/artifacts.md
@@ -823,7 +823,9 @@ LIMIT 100;
 **Rationale**:
 - **Search**: Session-scoped by default for isolation
 - **List**: Only show artifacts in current session (avoid clutter)
-- **Read**: Session-scoped for security (no cross-session access)
+- **Read**: Session-scoped for the agent tool path (no cross-session access); on the
+  gRPC API an explicit `session_id` is accepted and authorized against the caller
+  (see [Session Isolation](#session-isolation))
 - **API-level**: Cross-session search available for server-side operations
 
 ---
@@ -1274,9 +1276,9 @@ db.Exec("PRAGMA foreign_keys=ON")
 3. **Storage-level**: SQLite queries filtered by session_id
 4. **Filesystem-level**: Paths constructed from validated session ID only
 
-**Bypass Prevention**:
+**Bypass Prevention (agent tool path)**:
 ```go
-// Agent cannot override session ID via tool parameters
+// The agent cannot override session ID via tool parameters
 // Session ID comes from context, not user-controllable input
 
 func (t *WorkspaceTool) Execute(ctx context.Context, params map[string]interface{}) (*shuttle.Result, error) {
@@ -1284,6 +1286,34 @@ func (t *WorkspaceTool) Execute(ctx context.Context, params map[string]interface
     // params["session_id"] is ignored - session ID always from context
 }
 ```
+
+This holds for the in-process agent tool (`pkg/shuttle/builtin/workspace.go`), which
+is the path an agent drives. It is **not** a statement about the gRPC API — see below.
+
+**gRPC API path (`ListArtifacts`, `GetArtifact`)**: these accept an explicit
+`session_id` on the request, because a remote surface has no session in its call
+context and still has to answer "which files did this session produce?". A
+request-supplied session id is caller-declared rather than server-derived, so it is
+authorized before it selects anything: `MultiAgentServer.authorizeSessionScope`
+runs the same per-user isolation predicate (`sessionAccessibleBy`) that every other
+session-scoped RPC uses.
+
+| Deployment | Effect of an explicit `session_id` |
+|---|---|
+| Ownership enforcement on (authenticated) | Must resolve to a session the caller owns, or the call returns `NotFound`. A blank identity is never a wildcard. |
+| Single-tenant (default, unauthenticated) | Permitted, matching the mode's documented trust model — `looms serve` states all data is accessible to all callers and there is no per-user isolation. |
+
+Denial is reported as `NotFound`, not `PermissionDenied`, so a caller cannot
+distinguish "exists but not yours" from "no such session" by probing.
+
+Two limits worth stating plainly, because "session scoping" reads broader than what
+is enforced:
+
+- **ID lookups are not session-scoped.** `GetArtifact` by `id`, `GetArtifactContent`,
+  and `DeleteArtifact` ignore session entirely — artifact IDs are global, and
+  scoping them would only manufacture spurious not-founds. Session scoping is a
+  filtering and name-resolution boundary, not an access-control boundary on IDs.
+- **The write path is not session-scoped.** `UploadArtifact` has no `session_id`.
 
 **Coordinator Exception**: Agents configured with `restrictReads=all_sessions` can read across sessions for research purposes, but write access remains session-scoped.
 

--- a/gen/go/loom/v1/loom.pb.go
+++ b/gen/go/loom/v1/loom.pb.go
@@ -9443,7 +9443,12 @@ type Artifact struct {
 	// Additional metadata (JSON-serializable key-value pairs)
 	Metadata map[string]string `protobuf:"bytes,15,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Soft delete timestamp (Unix seconds, optional)
-	DeletedAt     int64 `protobuf:"varint,16,opt,name=deleted_at,json=deletedAt,proto3" json:"deleted_at,omitempty"`
+	DeletedAt int64 `protobuf:"varint,16,opt,name=deleted_at,json=deletedAt,proto3" json:"deleted_at,omitempty"`
+	// Session this artifact belongs to. Empty for artifacts created outside a
+	// session (user uploads, pre-session tooling). The store has recorded this
+	// since sessions were introduced; it was simply never put on the wire, which
+	// left remote clients unable to tell whose files they were looking at.
+	SessionId     string `protobuf:"bytes,17,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -9590,6 +9595,13 @@ func (x *Artifact) GetDeletedAt() int64 {
 	return 0
 }
 
+func (x *Artifact) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
 // ListArtifactsRequest lists artifacts with optional filtering.
 type ListArtifactsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -9605,8 +9617,14 @@ type ListArtifactsRequest struct {
 	Offset int32 `protobuf:"varint,5,opt,name=offset,proto3" json:"offset,omitempty"`
 	// Include soft-deleted artifacts
 	IncludeDeleted bool `protobuf:"varint,6,opt,name=include_deleted,json=includeDeleted,proto3" json:"include_deleted,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Filter to artifacts belonging to one session (optional). Unset means no
+	// session filtering, preserving existing behaviour. This is what lets a
+	// remote surface render "the files this session produced" — the local
+	// artifact store has always supported it (artifacts.Filter.SessionID); the
+	// request message could not express it.
+	SessionId     string `protobuf:"bytes,7,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ListArtifactsRequest) Reset() {
@@ -9681,6 +9699,13 @@ func (x *ListArtifactsRequest) GetIncludeDeleted() bool {
 	return false
 }
 
+func (x *ListArtifactsRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
 // ListArtifactsResponse returns a list of artifacts.
 type ListArtifactsResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -9742,7 +9767,12 @@ type GetArtifactRequest struct {
 	// Artifact ID (primary lookup)
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// Artifact name (alternative lookup if ID not provided)
-	Name          string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	// Session to scope a name lookup to (optional). Names are only unique within
+	// a session, so a bare name lookup from a remote client is ambiguous without
+	// this. Ignored when id is set. Unset falls back to the session carried in
+	// the call context, preserving existing behaviour for in-session callers.
+	SessionId     string `protobuf:"bytes,3,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -9787,6 +9817,13 @@ func (x *GetArtifactRequest) GetId() string {
 func (x *GetArtifactRequest) GetName() string {
 	if x != nil {
 		return x.Name
+	}
+	return ""
+}
+
+func (x *GetArtifactRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
 	}
 	return ""
 }
@@ -11539,7 +11576,7 @@ const file_loom_v1_loom_proto_rawDesc = "" +
 	"\vtotal_count\x18\x02 \x01(\x05R\n" +
 	"totalCount\x12\x1f\n" +
 	"\vserver_name\x18\x03 \x01(\tR\n" +
-	"serverName\"\xb2\x04\n" +
+	"serverName\"\xd1\x04\n" +
 	"\bArtifact\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x12\n" +
@@ -11561,24 +11598,30 @@ const file_loom_v1_loom_proto_rawDesc = "" +
 	"\x04tags\x18\x0e \x03(\tR\x04tags\x12;\n" +
 	"\bmetadata\x18\x0f \x03(\v2\x1f.loom.v1.Artifact.MetadataEntryR\bmetadata\x12\x1d\n" +
 	"\n" +
-	"deleted_at\x18\x10 \x01(\x03R\tdeletedAt\x1a;\n" +
+	"deleted_at\x18\x10 \x01(\x03R\tdeletedAt\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x11 \x01(\tR\tsessionId\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xbc\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xdb\x01\n" +
 	"\x14ListArtifactsRequest\x12\x16\n" +
 	"\x06source\x18\x01 \x01(\tR\x06source\x12!\n" +
 	"\fcontent_type\x18\x02 \x01(\tR\vcontentType\x12\x12\n" +
 	"\x04tags\x18\x03 \x03(\tR\x04tags\x12\x14\n" +
 	"\x05limit\x18\x04 \x01(\x05R\x05limit\x12\x16\n" +
 	"\x06offset\x18\x05 \x01(\x05R\x06offset\x12'\n" +
-	"\x0finclude_deleted\x18\x06 \x01(\bR\x0eincludeDeleted\"i\n" +
+	"\x0finclude_deleted\x18\x06 \x01(\bR\x0eincludeDeleted\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\a \x01(\tR\tsessionId\"i\n" +
 	"\x15ListArtifactsResponse\x12/\n" +
 	"\tartifacts\x18\x01 \x03(\v2\x11.loom.v1.ArtifactR\tartifacts\x12\x1f\n" +
 	"\vtotal_count\x18\x02 \x01(\x05R\n" +
-	"totalCount\"8\n" +
+	"totalCount\"W\n" +
 	"\x12GetArtifactRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
-	"\x04name\x18\x02 \x01(\tR\x04name\"D\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x03 \x01(\tR\tsessionId\"D\n" +
 	"\x13GetArtifactResponse\x12-\n" +
 	"\bartifact\x18\x01 \x01(\v2\x11.loom.v1.ArtifactR\bartifact\"\xb3\x01\n" +
 	"\x15UploadArtifactRequest\x12\x12\n" +

--- a/gen/openapiv2/loom/v1/loom.swagger.json
+++ b/gen/openapiv2/loom/v1/loom.swagger.json
@@ -618,6 +618,13 @@
             "in": "query",
             "required": false,
             "type": "boolean"
+          },
+          {
+            "name": "sessionId",
+            "description": "Filter to artifacts belonging to one session (optional). Unset means no\nsession filtering, preserving existing behaviour. This is what lets a\nremote surface render \"the files this session produced\" — the local\nartifact store has always supported it (artifacts.Filter.SessionID); the\nrequest message could not express it.",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "tags": [
@@ -709,6 +716,13 @@
           {
             "name": "name",
             "description": "Artifact name (alternative lookup if ID not provided)",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "sessionId",
+            "description": "Session to scope a name lookup to (optional). Names are only unique within\na session, so a bare name lookup from a remote client is ambiguous without\nthis. Ignored when id is set. Unset falls back to the session carried in\nthe call context, preserving existing behaviour for in-session callers.",
             "in": "query",
             "required": false,
             "type": "string"
@@ -4212,6 +4226,10 @@
           "type": "string",
           "format": "int64",
           "title": "Soft delete timestamp (Unix seconds, optional)"
+        },
+        "sessionId": {
+          "type": "string",
+          "description": "Session this artifact belongs to. Empty for artifacts created outside a\nsession (user uploads, pre-session tooling). The store has recorded this\nsince sessions were introduced; it was simply never put on the wire, which\nleft remote clients unable to tell whose files they were looking at."
         }
       },
       "title": "Artifact represents a file in $LOOM_DATA_DIR/artifacts/"

--- a/pkg/mcp/server/bridge_artifact_session_test.go
+++ b/pkg/mcp/server/bridge_artifact_session_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"google.golang.org/grpc"
+
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"github.com/teradata-labs/loom/pkg/mcp/protocol"
+)
+
+// artifactSessionMockClient captures the artifact requests the bridge builds.
+// The shared mockLoomClient leaves these RPCs on the nil embedded interface,
+// so this test carries its own.
+type artifactSessionMockClient struct {
+	loomv1.LoomServiceClient
+
+	gotList *loomv1.ListArtifactsRequest
+	gotGet  *loomv1.GetArtifactRequest
+}
+
+func (m *artifactSessionMockClient) ListArtifacts(_ context.Context, in *loomv1.ListArtifactsRequest, _ ...grpc.CallOption) (*loomv1.ListArtifactsResponse, error) {
+	m.gotList = in
+	return &loomv1.ListArtifactsResponse{}, nil
+}
+
+func (m *artifactSessionMockClient) GetArtifact(_ context.Context, in *loomv1.GetArtifactRequest, _ ...grpc.CallOption) (*loomv1.GetArtifactResponse, error) {
+	m.gotGet = in
+	return &loomv1.GetArtifactResponse{Artifact: &loomv1.Artifact{Id: "a1"}}, nil
+}
+
+// A field that works but is not advertised is unreachable for a model driving
+// the tool from its published schema, which is the surface loom-mcp exposes.
+// These two tools are the read path a model uses to find a session's files.
+func TestLoomBridge_ArtifactToolsAdvertiseSessionID(t *testing.T) {
+	bridge := NewLoomBridgeFromClient(&artifactSessionMockClient{}, nil, zaptest.NewLogger(t))
+
+	tools, err := bridge.ListTools(context.Background())
+	require.NoError(t, err)
+
+	byName := make(map[string]protocol.Tool, len(tools))
+	for _, tl := range tools {
+		byName[tl.Name] = tl
+	}
+
+	for _, name := range []string{"loom_list_artifacts", "loom_get_artifact"} {
+		t.Run(name, func(t *testing.T) {
+			tl, ok := byName[name]
+			require.Truef(t, ok, "%s should be advertised", name)
+
+			props, _ := tl.InputSchema["properties"].(map[string]interface{})
+			require.NotNilf(t, props, "%s should have schema properties", name)
+
+			raw, has := props["session_id"]
+			require.Truef(t, has, "%s should expose session_id", name)
+
+			spec, _ := raw.(map[string]interface{})
+			require.NotNilf(t, spec, "%s session_id should be an object spec", name)
+			assert.Equal(t, "string", spec["type"], "%s session_id should be a string", name)
+			assert.NotEmptyf(t, spec["description"], "%s session_id needs a description a model can act on", name)
+		})
+	}
+}
+
+// The bridge marshals raw tool args straight into the proto request, so the
+// schema addition and the wire behaviour have to agree: an advertised
+// session_id must actually arrive as ListArtifactsRequest.session_id /
+// GetArtifactRequest.session_id.
+func TestLoomBridge_ArtifactToolsForwardSessionID(t *testing.T) {
+	mock := &artifactSessionMockClient{}
+	bridge := NewLoomBridgeFromClient(mock, nil, zaptest.NewLogger(t))
+	ctx := context.Background()
+
+	res, err := bridge.CallTool(ctx, "loom_list_artifacts", map[string]interface{}{"session_id": "sess-1"})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.NotNil(t, mock.gotList, "loom_list_artifacts should have reached the client")
+	assert.Equal(t, "sess-1", mock.gotList.SessionId)
+
+	res, err = bridge.CallTool(ctx, "loom_get_artifact", map[string]interface{}{
+		"name":       "report.md",
+		"session_id": "sess-2",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.NotNil(t, mock.gotGet, "loom_get_artifact should have reached the client")
+	assert.Equal(t, "report.md", mock.gotGet.Name)
+	assert.Equal(t, "sess-2", mock.gotGet.SessionId)
+}

--- a/pkg/mcp/server/bridge_tools.go
+++ b/pkg/mcp/server/bridge_tools.go
@@ -379,10 +379,15 @@ func (b *LoomBridge) buildToolDefinitions() []protocol.Tool {
 			prop("source", "string", "Filter by source: user, generated, or agent (optional)"),
 			prop("content_type", "string", "Filter by MIME type, e.g. text/csv (optional)"),
 			prop("limit", "integer", "Maximum number of results (default: 50)"),
+			prop("session_id", "string", "Filter to one session's artifacts (optional; omit for all sessions)"),
 		), "", mv, ro),
-		tool("loom_get_artifact", "Get artifact metadata.", objectSchema(
-			reqProp("id", "string", "Artifact ID"),
+		// id is deliberately NOT required: the server accepts either id or
+		// name, and declaring id required made the name lookup undrivable from
+		// a schema-reading model even though the RPC has always supported it.
+		tool("loom_get_artifact", "Get artifact metadata. Provide either id, or name (optionally with session_id).", objectSchema(
+			prop("id", "string", "Artifact ID (either id or name is required)"),
 			prop("name", "string", "Artifact name (alternative lookup if ID not provided)"),
+			prop("session_id", "string", "Session to resolve the name in (optional; names are only unique within a session). Ignored when id is set."),
 		), "", mv, ro),
 		tool("loom_upload_artifact", "Upload a file to artifact storage.", objectSchema(
 			reqProp("name", "string", "Artifact filename"),

--- a/pkg/server/artifacts.go
+++ b/pkg/server/artifacts.go
@@ -49,6 +49,13 @@ func (s *MultiAgentServer) ListArtifacts(ctx context.Context, req *loomv1.ListAr
 		filter.Tags = req.Tags
 	}
 
+	// Session scoping. The store has supported this since sessions were
+	// introduced; the request message could not express it until now, which is
+	// why remote surfaces could not render a per-session file listing.
+	if req.SessionId != "" {
+		filter.SessionID = &req.SessionId
+	}
+
 	// Apply default limit
 	if filter.Limit == 0 {
 		filter.Limit = 50
@@ -84,8 +91,13 @@ func (s *MultiAgentServer) GetArtifact(ctx context.Context, req *loomv1.GetArtif
 	if req.Id != "" {
 		art, err = s.artifactStore.Get(ctx, req.Id)
 	} else if req.Name != "" {
-		// Extract session ID from context for scoped lookup
-		sessionID := session.SessionIDFromContext(ctx)
+		// Names are only unique within a session. An explicit session_id on the
+		// request wins; otherwise fall back to the session carried in the call
+		// context, which is how in-session callers have always been scoped.
+		sessionID := req.SessionId
+		if sessionID == "" {
+			sessionID = session.SessionIDFromContext(ctx)
+		}
 		art, err = s.artifactStore.GetByName(ctx, req.Name, sessionID)
 	} else {
 		return nil, status.Error(codes.InvalidArgument, "either id or name must be provided")
@@ -487,6 +499,7 @@ func artifactToProto(art *artifacts.Artifact) *loomv1.Artifact {
 		AccessCount:   types.SafeInt32(art.AccessCount),
 		Tags:          art.Tags,
 		Metadata:      art.Metadata,
+		SessionId:     art.SessionID,
 	}
 
 	if art.LastAccessedAt != nil {

--- a/pkg/server/artifacts.go
+++ b/pkg/server/artifacts.go
@@ -52,7 +52,14 @@ func (s *MultiAgentServer) ListArtifacts(ctx context.Context, req *loomv1.ListAr
 	// Session scoping. The store has supported this since sessions were
 	// introduced; the request message could not express it until now, which is
 	// why remote surfaces could not render a per-session file listing.
+	//
+	// The id is caller-supplied, so it is authorized before it selects
+	// anything — otherwise the filter would let any caller read another
+	// session's listing simply by naming it.
 	if req.SessionId != "" {
+		if err := s.authorizeSessionScope(ctx, req.SessionId); err != nil {
+			return nil, err
+		}
 		filter.SessionID = &req.SessionId
 	}
 
@@ -94,9 +101,15 @@ func (s *MultiAgentServer) GetArtifact(ctx context.Context, req *loomv1.GetArtif
 		// Names are only unique within a session. An explicit session_id on the
 		// request wins; otherwise fall back to the session carried in the call
 		// context, which is how in-session callers have always been scoped.
+		//
+		// Only the request field needs authorizing: the context value is
+		// server-derived, while an explicit one is the caller choosing which
+		// session's namespace to resolve the name in.
 		sessionID := req.SessionId
 		if sessionID == "" {
 			sessionID = session.SessionIDFromContext(ctx)
+		} else if err := s.authorizeSessionScope(ctx, sessionID); err != nil {
+			return nil, err
 		}
 		art, err = s.artifactStore.GetByName(ctx, req.Name, sessionID)
 	} else {

--- a/pkg/server/artifacts_session_test.go
+++ b/pkg/server/artifacts_session_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package server
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+	"github.com/teradata-labs/loom/pkg/agent"
+	"github.com/teradata-labs/loom/pkg/artifacts"
+	"github.com/teradata-labs/loom/pkg/observability"
+	"github.com/teradata-labs/loom/pkg/storage/backend"
+)
+
+// setupArtifactServer builds a server over a real SQLite artifact store seeded
+// with artifacts across two sessions plus one session-less artifact — the three
+// populations session scoping has to keep apart.
+func setupArtifactServer(t *testing.T) *MultiAgentServer {
+	t.Helper()
+
+	// The artifacts schema is created by the storage backend's migrations, not
+	// by NewSQLiteStore itself, so build the store the way production does:
+	// through the backend.
+	sb, err := backend.NewSQLiteBackend(&loomv1.SQLiteStorageConfig{
+		Path: filepath.Join(t.TempDir(), "loom.db"),
+	}, observability.NewNoOpTracer())
+	if err != nil {
+		t.Fatalf("create backend: %v", err)
+	}
+	t.Cleanup(func() { _ = sb.Close() })
+	store := sb.ArtifactStore()
+
+	ctx := context.Background()
+
+	// The artifacts table has a foreign key onto sessions, so the sessions must
+	// exist first — the same invariant production maintains, since an artifact
+	// is always written from inside a session.
+	for _, id := range []string{"sess-1", "sess-2"} {
+		if err := sb.SessionStorage().SaveSession(ctx, &agent.Session{ID: id}); err != nil {
+			t.Fatalf("create session %s: %v", id, err)
+		}
+	}
+	seed := []*artifacts.Artifact{
+		{ID: "a1", Name: "report.md", Path: "/tmp/a1", Source: artifacts.SourceAgent, SessionID: "sess-1"},
+		{ID: "a2", Name: "data.csv", Path: "/tmp/a2", Source: artifacts.SourceAgent, SessionID: "sess-1"},
+		{ID: "b1", Name: "report.md", Path: "/tmp/b1", Source: artifacts.SourceAgent, SessionID: "sess-2"},
+		{ID: "u1", Name: "upload.txt", Path: "/tmp/u1", Source: artifacts.SourceUser},
+	}
+	for _, a := range seed {
+		if err := store.Index(ctx, a); err != nil {
+			t.Fatalf("seed %s: %v", a.ID, err)
+		}
+	}
+
+	srv := NewMultiAgentServer(nil, nil)
+	srv.SetArtifactStore(store)
+	return srv
+}
+
+// The point of the field: a session filter returns that session's artifacts and
+// nothing else. This is what lets a remote surface render "the files this
+// session produced" — the failure mode without it is every surface showing
+// every session's files mixed together.
+func TestListArtifactsFiltersBySession(t *testing.T) {
+	srv := setupArtifactServer(t)
+	ctx := context.Background()
+
+	resp, err := srv.ListArtifacts(ctx, &loomv1.ListArtifactsRequest{SessionId: "sess-1"})
+	if err != nil {
+		t.Fatalf("ListArtifacts: %v", err)
+	}
+	if len(resp.Artifacts) != 2 {
+		t.Fatalf("got %d artifacts for sess-1, want 2", len(resp.Artifacts))
+	}
+	for _, a := range resp.Artifacts {
+		// The response must also SAY which session each artifact belongs to —
+		// the message carried no session_id before, so clients could not even
+		// filter for themselves.
+		if a.SessionId != "sess-1" {
+			t.Errorf("artifact %s reports session %q, want sess-1", a.Id, a.SessionId)
+		}
+	}
+}
+
+// No session filter must behave exactly as before: everything comes back.
+func TestListArtifactsUnfilteredIsUnchanged(t *testing.T) {
+	srv := setupArtifactServer(t)
+
+	resp, err := srv.ListArtifacts(context.Background(), &loomv1.ListArtifactsRequest{})
+	if err != nil {
+		t.Fatalf("ListArtifacts: %v", err)
+	}
+	if len(resp.Artifacts) != 4 {
+		t.Errorf("got %d artifacts unfiltered, want all 4", len(resp.Artifacts))
+	}
+}
+
+// Names are only unique within a session: both sessions have a report.md, and
+// the explicit session_id is what disambiguates them for a remote caller that
+// has no session in its call context.
+func TestGetArtifactByNameScopedToSession(t *testing.T) {
+	srv := setupArtifactServer(t)
+	ctx := context.Background()
+
+	for _, tt := range []struct {
+		session string
+		wantID  string
+	}{
+		{"sess-1", "a1"},
+		{"sess-2", "b1"},
+	} {
+		resp, err := srv.GetArtifact(ctx, &loomv1.GetArtifactRequest{Name: "report.md", SessionId: tt.session})
+		if err != nil {
+			t.Fatalf("GetArtifact(report.md, %s): %v", tt.session, err)
+		}
+		if resp.Artifact.Id != tt.wantID {
+			t.Errorf("report.md in %s resolved to %s, want %s", tt.session, resp.Artifact.Id, tt.wantID)
+		}
+	}
+}
+
+// An ID lookup ignores session entirely — IDs are globally unique, and scoping
+// them would only manufacture spurious not-founds.
+func TestGetArtifactByIDIgnoresSession(t *testing.T) {
+	srv := setupArtifactServer(t)
+
+	resp, err := srv.GetArtifact(context.Background(), &loomv1.GetArtifactRequest{Id: "b1", SessionId: "sess-1"})
+	if err != nil {
+		t.Fatalf("GetArtifact by id: %v", err)
+	}
+	if resp.Artifact.Id != "b1" {
+		t.Errorf("got %s, want b1", resp.Artifact.Id)
+	}
+}

--- a/pkg/server/artifacts_session_test.go
+++ b/pkg/server/artifacts_session_test.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -295,4 +296,101 @@ func TestGetArtifactByIDRemainsUnscopedUnderEnforcement(t *testing.T) {
 	if resp.Artifact.Id != "b1" {
 		t.Errorf("got %s, want b1", resp.Artifact.Id)
 	}
+}
+
+// A Postgres DeleteSession is a SOFT delete (session_store.go: "UPDATE sessions
+// SET deleted_at = NOW()"), and the artifact rows outlive it — purge_soft_deleted
+// reaps artifacts by their OWN deleted_at, and the session_id CASCADE only fires
+// on the later hard purge. But LoadSession filters `deleted_at IS NULL`, so for
+// the whole grace window an owner's own session stops resolving.
+//
+// The gate must not turn that into a lockout: the same caller still gets those
+// exact artifacts from an UNFILTERED list, so refusing the FILTERED view would
+// deny an owner the one question this feature exists to answer, on precisely
+// the deployments the gate is for (enforceOwnership tracks Auth.Enabled).
+type softDeletedSessionStore struct {
+	agent.SessionStorage // only LoadSession is exercised by the gate
+
+	ownedByCaller map[string]string // sessionID -> owner, ignoring soft-delete
+	probed        bool
+}
+
+// Models the post-soft-delete state: the row exists but the owner-scoped,
+// deleted_at-filtering read cannot see it.
+func (s *softDeletedSessionStore) LoadSession(_ context.Context, sessionID string) (*agent.Session, error) {
+	return nil, fmt.Errorf("session not found: %s", sessionID)
+}
+
+func (s *softDeletedSessionStore) CallerOwnsSession(ctx context.Context, sessionID string) (bool, error) {
+	s.probed = true
+	owner, ok := s.ownedByCaller[sessionID]
+	return ok && owner == types.UserIDFromContext(ctx), nil
+}
+
+func setupSoftDeletedServer(t *testing.T) (*MultiAgentServer, *softDeletedSessionStore) {
+	t.Helper()
+
+	sb, err := backend.NewSQLiteBackend(&loomv1.SQLiteStorageConfig{
+		Path: filepath.Join(t.TempDir(), "loom.db"),
+	}, observability.NewNoOpTracer())
+	if err != nil {
+		t.Fatalf("create backend: %v", err)
+	}
+	t.Cleanup(func() { _ = sb.Close() })
+
+	// Seed through the live session so the artifacts FK is satisfied, then the
+	// stub store stands in for a session that has since been soft-deleted.
+	if err := sb.SessionStorage().SaveSession(context.Background(), &agent.Session{ID: "sess-gone"}); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	store := sb.ArtifactStore()
+	if err := store.Index(context.Background(), &artifacts.Artifact{
+		ID: "g1", Name: "report.md", Path: "/tmp/g1", Source: artifacts.SourceAgent, SessionID: "sess-gone",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	stub := &softDeletedSessionStore{ownedByCaller: map[string]string{"sess-gone": "alice"}}
+	srv := NewMultiAgentServer(nil, stub)
+	srv.SetArtifactStore(store)
+	srv.SetEnforceSessionOwnership(true)
+	return srv, stub
+}
+
+func TestListArtifactsAllowsOwnerOfSoftDeletedSession(t *testing.T) {
+	srv, stub := setupSoftDeletedServer(t)
+	aliceCtx := types.ContextWithUserID(context.Background(), "alice")
+
+	// The asymmetry that makes this a bug and not a policy: unfiltered works.
+	all, err := srv.ListArtifacts(aliceCtx, &loomv1.ListArtifactsRequest{})
+	if err != nil {
+		t.Fatalf("unfiltered list: %v", err)
+	}
+	if len(all.Artifacts) == 0 {
+		t.Fatalf("fixture broken: unfiltered list returned nothing")
+	}
+
+	resp, err := srv.ListArtifacts(aliceCtx, &loomv1.ListArtifactsRequest{SessionId: "sess-gone"})
+	if err != nil {
+		t.Fatalf("owner denied the filtered view of their own soft-deleted session: %v", err)
+	}
+	if len(resp.Artifacts) != 1 || resp.Artifacts[0].Id != "g1" {
+		t.Fatalf("got %d artifacts, want just g1", len(resp.Artifacts))
+	}
+	if !stub.probed {
+		t.Error("ownership probe was never consulted")
+	}
+}
+
+// The probe must not become a bypass: a session the caller does NOT own stays
+// denied even though the same LoadSession miss occurs.
+func TestListArtifactsStillDeniesForeignUnresolvableSession(t *testing.T) {
+	srv, _ := setupSoftDeletedServer(t)
+	bobCtx := types.ContextWithUserID(context.Background(), "bob")
+
+	_, err := srv.ListArtifacts(bobCtx, &loomv1.ListArtifactsRequest{SessionId: "sess-gone"})
+	requireNotFound(t, err, "bob naming alice's soft-deleted session")
+
+	_, err = srv.ListArtifacts(bobCtx, &loomv1.ListArtifactsRequest{SessionId: "sess-never-existed"})
+	requireNotFound(t, err, "bob naming an unknown session")
 }

--- a/pkg/server/artifacts_session_test.go
+++ b/pkg/server/artifacts_session_test.go
@@ -23,6 +23,9 @@ import (
 	"github.com/teradata-labs/loom/pkg/artifacts"
 	"github.com/teradata-labs/loom/pkg/observability"
 	"github.com/teradata-labs/loom/pkg/storage/backend"
+	"github.com/teradata-labs/loom/pkg/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // setupArtifactServer builds a server over a real SQLite artifact store seeded
@@ -140,6 +143,154 @@ func TestGetArtifactByIDIgnoresSession(t *testing.T) {
 	resp, err := srv.GetArtifact(context.Background(), &loomv1.GetArtifactRequest{Id: "b1", SessionId: "sess-1"})
 	if err != nil {
 		t.Fatalf("GetArtifact by id: %v", err)
+	}
+	if resp.Artifact.Id != "b1" {
+		t.Errorf("got %s, want b1", resp.Artifact.Id)
+	}
+}
+
+// setupOwnedArtifactServer builds a server whose sessions have real owners and
+// whose session store is wired, so the ownership predicate has something to
+// resolve. alice owns sess-a, bob owns sess-b, and each has a report.md — the
+// name collision that makes an unauthorized scope worth reaching for.
+//
+// Sessions are saved under the owner's own context because both backends take
+// the owner from the context, not from Session.UserID (session_store.go:
+// "cannot claim another owner by presetting session.UserID").
+func setupOwnedArtifactServer(t *testing.T, enforce bool) *MultiAgentServer {
+	t.Helper()
+
+	sb, err := backend.NewSQLiteBackend(&loomv1.SQLiteStorageConfig{
+		Path: filepath.Join(t.TempDir(), "loom.db"),
+	}, observability.NewNoOpTracer())
+	if err != nil {
+		t.Fatalf("create backend: %v", err)
+	}
+	t.Cleanup(func() { _ = sb.Close() })
+
+	sessions := sb.SessionStorage()
+	for _, o := range []struct{ user, session string }{
+		{"alice", "sess-a"},
+		{"bob", "sess-b"},
+	} {
+		ownerCtx := types.ContextWithUserID(context.Background(), o.user)
+		if err := sessions.SaveSession(ownerCtx, &agent.Session{ID: o.session}); err != nil {
+			t.Fatalf("create session %s: %v", o.session, err)
+		}
+	}
+
+	store := sb.ArtifactStore()
+	seed := []*artifacts.Artifact{
+		{ID: "a1", Name: "report.md", Path: "/tmp/a1", Source: artifacts.SourceAgent, SessionID: "sess-a"},
+		{ID: "b1", Name: "report.md", Path: "/tmp/b1", Source: artifacts.SourceAgent, SessionID: "sess-b"},
+	}
+	for _, a := range seed {
+		if err := store.Index(context.Background(), a); err != nil {
+			t.Fatalf("seed %s: %v", a.ID, err)
+		}
+	}
+
+	srv := NewMultiAgentServer(nil, sessions)
+	srv.SetArtifactStore(store)
+	srv.SetEnforceSessionOwnership(enforce)
+	return srv
+}
+
+// requireNotFound asserts a denial is reported as NotFound rather than
+// PermissionDenied: a caller must not be able to tell "exists but not yours"
+// from "no such session" by probing.
+func requireNotFound(t *testing.T, err error, what string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("%s: got no error, want NotFound — a caller reached another user's session", what)
+	}
+	if got := status.Code(err); got != codes.NotFound {
+		t.Errorf("%s: got code %v, want NotFound", what, got)
+	}
+}
+
+// The denial case the happy-path tests cannot cover: session_id arrives in the
+// REQUEST, so it is caller-declared. On an ownership-enforcing deployment,
+// naming another user's session must not read it — before the authorization
+// check, this returned bob's listing to alice.
+func TestListArtifactsDeniesForeignSession(t *testing.T) {
+	srv := setupOwnedArtifactServer(t, true)
+	aliceCtx := types.ContextWithUserID(context.Background(), "alice")
+
+	_, err := srv.ListArtifacts(aliceCtx, &loomv1.ListArtifactsRequest{SessionId: "sess-b"})
+	requireNotFound(t, err, "alice listing bob's session")
+}
+
+// The same boundary on the name path, which is the one an explicit session_id
+// exists for: both sessions hold a report.md, so without the check alice could
+// resolve bob's copy by naming his session.
+func TestGetArtifactByNameDeniesForeignSession(t *testing.T) {
+	srv := setupOwnedArtifactServer(t, true)
+	aliceCtx := types.ContextWithUserID(context.Background(), "alice")
+
+	_, err := srv.GetArtifact(aliceCtx, &loomv1.GetArtifactRequest{Name: "report.md", SessionId: "sess-b"})
+	requireNotFound(t, err, "alice resolving report.md in bob's session")
+}
+
+// Enforcement must not be a blanket deny — the owner still reads her own
+// session, which is what makes the check an isolation boundary rather than a
+// feature switch.
+func TestOwnerStillReadsOwnSessionUnderEnforcement(t *testing.T) {
+	srv := setupOwnedArtifactServer(t, true)
+	aliceCtx := types.ContextWithUserID(context.Background(), "alice")
+
+	resp, err := srv.ListArtifacts(aliceCtx, &loomv1.ListArtifactsRequest{SessionId: "sess-a"})
+	if err != nil {
+		t.Fatalf("alice listing her own session: %v", err)
+	}
+	if len(resp.Artifacts) != 1 || resp.Artifacts[0].Id != "a1" {
+		t.Fatalf("got %d artifacts, want just a1", len(resp.Artifacts))
+	}
+
+	got, err := srv.GetArtifact(aliceCtx, &loomv1.GetArtifactRequest{Name: "report.md", SessionId: "sess-a"})
+	if err != nil {
+		t.Fatalf("alice resolving her own report.md: %v", err)
+	}
+	if got.Artifact.Id != "a1" {
+		t.Errorf("report.md in sess-a resolved to %s, want a1", got.Artifact.Id)
+	}
+}
+
+// With ownership enforcement on, a blank identity is never a wildcard — the
+// rule sessionAccessibleBy already applies to every other session-scoped RPC.
+func TestAnonymousCallerDeniedUnderEnforcement(t *testing.T) {
+	srv := setupOwnedArtifactServer(t, true)
+
+	_, err := srv.ListArtifacts(context.Background(), &loomv1.ListArtifactsRequest{SessionId: "sess-a"})
+	requireNotFound(t, err, "anonymous caller scoping to a session")
+}
+
+// Single-tenant deployments keep the permissive behaviour their trust model
+// documents (cmd/looms: "All data is accessible to all callers"). This is the
+// regression guard for the default mode: adding the authorization check must
+// not break local session filtering.
+func TestSingleTenantSessionScopeStillPermitted(t *testing.T) {
+	srv := setupOwnedArtifactServer(t, false)
+
+	resp, err := srv.ListArtifacts(context.Background(), &loomv1.ListArtifactsRequest{SessionId: "sess-b"})
+	if err != nil {
+		t.Fatalf("single-tenant session filter: %v", err)
+	}
+	if len(resp.Artifacts) != 1 || resp.Artifacts[0].Id != "b1" {
+		t.Fatalf("got %d artifacts, want just b1", len(resp.Artifacts))
+	}
+}
+
+// An ID lookup stays unscoped by design, so it is NOT an isolation boundary:
+// this records that explicitly rather than leaving it implied by the happy-path
+// test, because "session scoping" could otherwise be read as protecting ids too.
+func TestGetArtifactByIDRemainsUnscopedUnderEnforcement(t *testing.T) {
+	srv := setupOwnedArtifactServer(t, true)
+	aliceCtx := types.ContextWithUserID(context.Background(), "alice")
+
+	resp, err := srv.GetArtifact(aliceCtx, &loomv1.GetArtifactRequest{Id: "b1"})
+	if err != nil {
+		t.Fatalf("id lookup under enforcement: %v", err)
 	}
 	if resp.Artifact.Id != "b1" {
 		t.Errorf("got %s, want b1", resp.Artifact.Id)

--- a/pkg/server/multi_agent.go
+++ b/pkg/server/multi_agent.go
@@ -619,6 +619,18 @@ func (s *MultiAgentServer) ownerAccessibleBy(callerUserID, ownerUserID string) b
 	return callerUserID == "" || ownerUserID == "" || ownerUserID == callerUserID
 }
 
+// selfOwnedAccessible reports whether a caller may act on a session the store
+// has already confirmed is the caller's OWN.
+//
+// It is ownerAccessibleBy with owner == caller, which collapses to the
+// blank-identity rule: under enforcement an anonymous caller is not a wildcard
+// even for a session nominally "its own", and without enforcement everything is
+// permitted. Named rather than inlined because ownerAccessibleBy(id, id) reads
+// as a tautology at the call site while actually carrying that rule.
+func (s *MultiAgentServer) selfOwnedAccessible(callerUserID string) bool {
+	return s.ownerAccessibleBy(callerUserID, callerUserID)
+}
+
 // sessionOwnershipProbe is an OPTIONAL session-store capability: it answers
 // "is this session the caller's own?" without filtering soft-deleted rows,
 // which the owner-scoped LoadSession cannot do.
@@ -704,13 +716,14 @@ func (s *MultiAgentServer) authorizeSessionScope(ctx context.Context, sessionID 
 	// id. Without this probe the fail-closed branch would refuse an owner the
 	// FILTERED view of artifacts the store still hands them UNFILTERED, for the
 	// entire soft-delete grace window — and "which files did this session
-	// produce?" is the question this field exists to answer. The probe is
-	// owner-scoped, so a hit means the owner IS the caller; routing that through
-	// ownerAccessibleBy keeps the blank-identity rule in one place instead of
-	// restating it here.
+	// produce?" is the question this field exists to answer.
+	//
+	// The probe is owner-scoped, so a hit already means the owner IS the caller;
+	// selfOwnedAccessible then applies the blank-identity rule to that fact
+	// rather than restating it here.
 	if probe, ok := s.sessionStore.(sessionOwnershipProbe); ok {
 		owned, err := probe.CallerOwnsSession(ctx, sessionID)
-		if err == nil && owned && s.ownerAccessibleBy(callerUserID, callerUserID) {
+		if err == nil && owned && s.selfOwnedAccessible(callerUserID) {
 			return nil
 		}
 	}

--- a/pkg/server/multi_agent.go
+++ b/pkg/server/multi_agent.go
@@ -606,11 +606,36 @@ func (s *MultiAgentServer) findSessionOwner(ctx context.Context, sessionID, call
 // behavior holds: identity-less callers see everything and pre-stamping
 // sessions (UserID == "") stay reachable so upgrades do not strand them.
 func (s *MultiAgentServer) sessionAccessibleBy(callerUserID string, session *agent.Session) bool {
-	if s.enforceOwnership {
-		return callerUserID != "" && session.UserID == callerUserID
-	}
-	return callerUserID == "" || session.UserID == "" || session.UserID == callerUserID
+	return s.ownerAccessibleBy(callerUserID, session.UserID)
 }
+
+// ownerAccessibleBy is sessionAccessibleBy's rule expressed over the owner id
+// alone, so a caller that learned ownership without loading the session (an
+// ownership probe) applies the identical policy rather than a copy of it.
+func (s *MultiAgentServer) ownerAccessibleBy(callerUserID, ownerUserID string) bool {
+	if s.enforceOwnership {
+		return callerUserID != "" && ownerUserID == callerUserID
+	}
+	return callerUserID == "" || ownerUserID == "" || ownerUserID == callerUserID
+}
+
+// sessionOwnershipProbe is an OPTIONAL session-store capability: it answers
+// "is this session the caller's own?" without filtering soft-deleted rows,
+// which the owner-scoped LoadSession cannot do.
+//
+// It is a capability rather than a SessionStorage method on purpose — that
+// interface is implemented outside this repo, so adding a method to it would
+// break those implementations. A store that does not implement this simply
+// keeps the fail-closed behaviour below.
+type sessionOwnershipProbe interface {
+	CallerOwnsSession(ctx context.Context, sessionID string) (bool, error)
+}
+
+// The postgres store is the reason this capability exists — it is the backend
+// that soft-deletes sessions. Asserting the match here means a signature drift
+// fails the build instead of silently reverting the type assertion to false and
+// locking owners out again.
+var _ sessionOwnershipProbe = (*postgres.SessionStore)(nil)
 
 // authorizeSessionScope authorizes a session id that arrived in a REQUEST
 // rather than in the call context.
@@ -625,11 +650,16 @@ func (s *MultiAgentServer) sessionAccessibleBy(callerUserID string, session *age
 // Denial is reported as NotFound, matching DeleteSession: a caller must not be
 // able to tell "exists but not yours" from "does not exist" by probing.
 //
-// An unresolvable id — no session store configured, or one the store has never
-// seen — defers to the deployment's tenancy mode instead of a blanket allow or
-// deny. Enforcing deployments fail closed, the same stance findSessionOwner
-// takes on ids it cannot verify; single-tenant deployments stay permissive,
-// which is the trust model they already document.
+// An id that still cannot be resolved — no session store configured, an id the
+// store has never seen, or one whose ownership no probe can establish — defers
+// to the deployment's tenancy mode instead of a blanket allow or deny.
+// Enforcing deployments fail closed, the same stance findSessionOwner takes on
+// ids it cannot verify; single-tenant deployments stay permissive, which is the
+// trust model they already document.
+//
+// Between the load and that fallback sits sessionOwnershipProbe, because a
+// soft-deleted session reads as unresolvable while still belonging to the
+// caller.
 func (s *MultiAgentServer) authorizeSessionScope(ctx context.Context, sessionID string) error {
 	if sessionID == "" {
 		return nil
@@ -665,6 +695,22 @@ func (s *MultiAgentServer) authorizeSessionScope(ctx context.Context, sessionID 
 			if !s.sessionAccessibleBy(callerUserID, stored) {
 				return status.Error(codes.NotFound, "session not found")
 			}
+			return nil
+		}
+	}
+
+	// A soft-deleted session is still the caller's own, but LoadSession filters
+	// `deleted_at IS NULL`, so it reports the same miss as a foreign or unknown
+	// id. Without this probe the fail-closed branch would refuse an owner the
+	// FILTERED view of artifacts the store still hands them UNFILTERED, for the
+	// entire soft-delete grace window — and "which files did this session
+	// produce?" is the question this field exists to answer. The probe is
+	// owner-scoped, so a hit means the owner IS the caller; routing that through
+	// ownerAccessibleBy keeps the blank-identity rule in one place instead of
+	// restating it here.
+	if probe, ok := s.sessionStore.(sessionOwnershipProbe); ok {
+		owned, err := probe.CallerOwnsSession(ctx, sessionID)
+		if err == nil && owned && s.ownerAccessibleBy(callerUserID, callerUserID) {
 			return nil
 		}
 	}

--- a/pkg/server/multi_agent.go
+++ b/pkg/server/multi_agent.go
@@ -612,6 +612,69 @@ func (s *MultiAgentServer) sessionAccessibleBy(callerUserID string, session *age
 	return callerUserID == "" || session.UserID == "" || session.UserID == callerUserID
 }
 
+// authorizeSessionScope authorizes a session id that arrived in a REQUEST
+// rather than in the call context.
+//
+// The distinction is the whole point: a context session id is server-derived
+// and therefore trusted, while a request field is the caller naming whose data
+// to read. Handing the latter straight to the store would make session scope
+// self-declared, so it runs the same per-user isolation predicate every other
+// session-scoped RPC uses (sessionAccessibleBy) before it is allowed to select
+// anything.
+//
+// Denial is reported as NotFound, matching DeleteSession: a caller must not be
+// able to tell "exists but not yours" from "does not exist" by probing.
+//
+// An unresolvable id — no session store configured, or one the store has never
+// seen — defers to the deployment's tenancy mode instead of a blanket allow or
+// deny. Enforcing deployments fail closed, the same stance findSessionOwner
+// takes on ids it cannot verify; single-tenant deployments stay permissive,
+// which is the trust model they already document.
+func (s *MultiAgentServer) authorizeSessionScope(ctx context.Context, sessionID string) error {
+	if sessionID == "" {
+		return nil
+	}
+
+	callerUserID := postgres.UserIDFromContext(ctx)
+
+	s.mu.RLock()
+	for _, ag := range s.agents {
+		sess, ok := ag.GetSession(sessionID)
+		if !ok {
+			continue
+		}
+		accessible := s.sessionAccessibleBy(callerUserID, sess)
+		s.mu.RUnlock()
+		if !accessible {
+			return status.Error(codes.NotFound, "session not found")
+		}
+		return nil
+	}
+	s.mu.RUnlock()
+
+	if s.sessionStore != nil {
+		// LoadSession is owner-scoped in both backends, so a hit is already
+		// evidence the session is the caller's own. A miss is not: the SQLite
+		// store reports it as an error and Postgres as a nil session, and
+		// neither separates "belongs to someone else" from "no such id". So a
+		// miss falls through to the tenancy decision below instead of
+		// surfacing as a failure — turning an unknown session id into an
+		// Internal error here would break filtering for every caller whose
+		// session predates the session store.
+		if stored, err := s.sessionStore.LoadSession(ctx, sessionID); err == nil && stored != nil {
+			if !s.sessionAccessibleBy(callerUserID, stored) {
+				return status.Error(codes.NotFound, "session not found")
+			}
+			return nil
+		}
+	}
+
+	if s.enforceOwnership {
+		return status.Error(codes.NotFound, "session not found")
+	}
+	return nil
+}
+
 // SetEnforceSessionOwnership selects the tenancy mode: pass true on
 // deployments that authenticate callers so blank identities stop acting as
 // ownership wildcards. Single-tenant compatibility is the explicit false.

--- a/pkg/storage/postgres/artifact_session_scope_test.go
+++ b/pkg/storage/postgres/artifact_session_scope_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/teradata-labs/loom/pkg/artifacts"
+	"github.com/teradata-labs/loom/pkg/observability"
+)
+
+// ListArtifacts/GetArtifact accept a caller-supplied session_id. The server
+// authorizes it against the caller's own sessions, but in a multi-tenant
+// deployment the layer that actually contains a foreign session id is this
+// store's unconditional `user_id = $1` predicate — session_id is only ever
+// additive on top of it, never a substitute.
+//
+// These tests pin that composition, because it is the invariant the server
+// delegates to rather than duplicates: if session_id ever started replacing
+// the user predicate, the server-level tests in pkg/server would still pass
+// and only these would fail.
+//
+// They run in the ORDINARY gate (no build tag, matching
+// human_request_store_test.go): CI provides a postgres service and sets
+// TEST_POSTGRES_URL; a local run without one skips. The `integration`-tagged
+// helpers of this shape are invisible to untagged builds, so the fixture is
+// local to this file.
+
+func artifactScopeStore(t *testing.T) (*ArtifactStore, *pgxpool.Pool) {
+	t.Helper()
+	dsn := os.Getenv("TEST_POSTGRES_URL")
+	if dsn == "" {
+		t.Skip("TEST_POSTGRES_URL not set; skipping PostgreSQL store test")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	require.NoError(t, err, "failed to connect to PostgreSQL")
+	t.Cleanup(pool.Close)
+
+	migrator, err := NewMigrator(pool, observability.NewNoOpTracer())
+	require.NoError(t, err)
+	require.NoError(t, migrator.MigrateUp(ctx), "failed to run migrations")
+
+	return NewArtifactStore(pool, observability.NewNoOpTracer()), pool
+}
+
+// asUniqueID returns a test-unique identifier (the integration-tagged helper
+// of the same shape is invisible to untagged builds).
+func asUniqueID(prefix string) string {
+	return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
+}
+
+// seedArtifactSession satisfies the artifacts.session_id foreign key.
+func seedArtifactSession(t *testing.T, pool *pgxpool.Pool, sessionID string) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(),
+		"INSERT INTO sessions (id, agent_id) VALUES ($1, 'agent-1') ON CONFLICT (id) DO NOTHING", sessionID)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), "DELETE FROM sessions WHERE id = $1", sessionID)
+	})
+}
+
+// seedUserArtifact indexes one artifact as userID, which is where the store
+// takes user_id from (Index reads UserIDFromContext).
+func seedUserArtifact(t *testing.T, store *ArtifactStore, pool *pgxpool.Pool, userID, sessionID, id, name string) {
+	t.Helper()
+	require.NoError(t, store.Index(ContextWithUserID(context.Background(), userID), &artifacts.Artifact{
+		ID:        id,
+		Name:      name,
+		Path:      "/tmp/" + id,
+		Source:    artifacts.SourceAgent,
+		SessionID: sessionID,
+	}), "index artifact %s for %s", id, userID)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), "DELETE FROM artifacts WHERE id = $1", id)
+	})
+}
+
+// A session filter must not reach across the user boundary: naming another
+// tenant's session returns nothing, not that tenant's files.
+func TestPGListSessionFilterStaysWithinUser(t *testing.T) {
+	store, pool := artifactScopeStore(t)
+
+	alice, bob := asUniqueID("alice"), asUniqueID("bob")
+	aliceSession, bobSession := asUniqueID("sess-alice"), asUniqueID("sess-bob")
+	seedArtifactSession(t, pool, aliceSession)
+	seedArtifactSession(t, pool, bobSession)
+
+	aliceArtifact, bobArtifact := asUniqueID("art-alice"), asUniqueID("art-bob")
+	seedUserArtifact(t, store, pool, alice, aliceSession, aliceArtifact, "report.md")
+	seedUserArtifact(t, store, pool, bob, bobSession, bobArtifact, "report.md")
+
+	aliceCtx := ContextWithUserID(context.Background(), alice)
+
+	own, err := store.List(aliceCtx, &artifacts.Filter{SessionID: &aliceSession})
+	require.NoError(t, err)
+	require.Len(t, own, 1, "alice should see exactly her own artifact")
+	require.Equal(t, aliceArtifact, own[0].ID)
+
+	foreign, err := store.List(aliceCtx, &artifacts.Filter{SessionID: &bobSession})
+	require.NoError(t, err)
+	require.Empty(t, foreign, "a session filter must not cross the user_id boundary")
+}
+
+// The same boundary on the name path, which is what an explicit session_id
+// exists for. Both users have a report.md, so a leak here would hand back the
+// wrong tenant's file under a name the caller legitimately owns.
+func TestPGGetByNameSessionScopeStaysWithinUser(t *testing.T) {
+	store, pool := artifactScopeStore(t)
+
+	alice, bob := asUniqueID("alice"), asUniqueID("bob")
+	aliceSession, bobSession := asUniqueID("sess-alice"), asUniqueID("sess-bob")
+	seedArtifactSession(t, pool, aliceSession)
+	seedArtifactSession(t, pool, bobSession)
+
+	aliceArtifact, bobArtifact := asUniqueID("art-alice"), asUniqueID("art-bob")
+	seedUserArtifact(t, store, pool, alice, aliceSession, aliceArtifact, "report.md")
+	seedUserArtifact(t, store, pool, bob, bobSession, bobArtifact, "report.md")
+
+	aliceCtx := ContextWithUserID(context.Background(), alice)
+
+	got, err := store.GetByName(aliceCtx, "report.md", aliceSession)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, aliceArtifact, got.ID, "alice's own name lookup resolves to her artifact")
+
+	// A miss surfaces as an error from this store; either shape is acceptable.
+	// The one outcome that must never occur is bob's artifact coming back.
+	leaked, err := store.GetByName(aliceCtx, "report.md", bobSession)
+	if err == nil && leaked != nil {
+		require.NotEqual(t, bobArtifact, leaked.ID,
+			"a name lookup scoped to another user's session returned that user's artifact")
+	}
+}

--- a/pkg/storage/postgres/artifact_session_scope_test.go
+++ b/pkg/storage/postgres/artifact_session_scope_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
+	"github.com/teradata-labs/loom/pkg/agent"
 	"github.com/teradata-labs/loom/pkg/artifacts"
 	"github.com/teradata-labs/loom/pkg/observability"
 )
@@ -150,4 +151,49 @@ func TestPGGetByNameSessionScopeStaysWithinUser(t *testing.T) {
 		require.NotEqual(t, bobArtifact, leaked.ID,
 			"a name lookup scoped to another user's session returned that user's artifact")
 	}
+}
+
+// The soft-delete case, end to end on the real backend. DeleteSession only sets
+// deleted_at, and the artifact rows outlive it, so an owner asking "which files
+// did this session produce?" right after deleting it must still be recognised as
+// the owner. LoadSession and SessionExists both filter `deleted_at IS NULL` and
+// cannot answer that; CallerOwnsSession is what the server's gate falls back to.
+func TestCallerOwnsSessionSurvivesSoftDelete(t *testing.T) {
+	_, pool := artifactScopeStore(t)
+	sessions := NewSessionStore(pool, observability.NewNoOpTracer(), nil)
+
+	alice, bob := asUniqueID("alice"), asUniqueID("bob")
+	sessionID := asUniqueID("sess-soft")
+
+	aliceCtx := ContextWithUserID(context.Background(), alice)
+	require.NoError(t, sessions.SaveSession(aliceCtx, &agent.Session{
+		ID: sessionID, AgentID: "agent-1", CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+	}))
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), "DELETE FROM sessions WHERE id = $1", sessionID)
+	})
+
+	owns, err := sessions.CallerOwnsSession(aliceCtx, sessionID)
+	require.NoError(t, err)
+	require.True(t, owns, "owner should own a live session")
+
+	require.NoError(t, sessions.DeleteSession(aliceCtx, sessionID))
+
+	// The premise: the owner-scoped reads can no longer see it.
+	loaded, err := sessions.LoadSession(aliceCtx, sessionID)
+	require.NoError(t, err)
+	require.Nil(t, loaded, "LoadSession filters deleted_at, so it must miss")
+	exists, err := sessions.SessionExists(aliceCtx, sessionID)
+	require.NoError(t, err)
+	require.False(t, exists, "SessionExists filters deleted_at too")
+
+	// The fix: ownership still resolves, so the gate lets the owner through.
+	owns, err = sessions.CallerOwnsSession(aliceCtx, sessionID)
+	require.NoError(t, err)
+	require.True(t, owns, "a soft-deleted session is still the owner's own")
+
+	// And it is not a bypass: it stays owner-scoped after the delete.
+	owns, err = sessions.CallerOwnsSession(ContextWithUserID(context.Background(), bob), sessionID)
+	require.NoError(t, err)
+	require.False(t, owns, "another user must not be told the session is theirs")
 }

--- a/pkg/storage/postgres/session_store.go
+++ b/pkg/storage/postgres/session_store.go
@@ -923,6 +923,42 @@ func (s *SessionStore) SoftDeleteSession(ctx context.Context, sessionID string) 
 	return s.DeleteSession(ctx, sessionID)
 }
 
+// CallerOwnsSession reports whether sessionID belongs to the caller, counting
+// soft-deleted sessions.
+//
+// This exists because DeleteSession is a soft delete while a session's
+// artifacts outlive it: purge_soft_deleted reaps artifacts by their own
+// deleted_at, and the artifacts.session_id CASCADE only fires on the later
+// hard purge. LoadSession and SessionExists both filter `deleted_at IS NULL`,
+// so during the grace window neither can tell an owner's just-deleted session
+// from one that never existed — which would leave the owner able to list those
+// artifacts unfiltered but not scoped to the session that produced them.
+//
+// Owner-scoped like every other read here, so a true result is proof of the
+// caller's own ownership and never discloses a foreign session's existence.
+// This is an authorization primitive, not a data read: it returns no session
+// data (compare SessionStorage.SessionExists).
+func (s *SessionStore) CallerOwnsSession(ctx context.Context, sessionID string) (bool, error) {
+	ctx, span := s.tracer.StartSpan(ctx, "pg_session_store.caller_owns_session")
+	defer s.tracer.EndSpan(span)
+	span.SetAttribute("session_id", sessionID)
+
+	var owns bool
+	err := execInTx(ctx, s.pool, func(ctx context.Context, tx pgx.Tx) error {
+		userID := UserIDFromContext(ctx)
+		return tx.QueryRow(ctx,
+			"SELECT EXISTS(SELECT 1 FROM sessions WHERE id = $1 AND user_id = $2)",
+			sessionID, userID,
+		).Scan(&owns)
+	})
+	if err != nil {
+		span.RecordError(err)
+		return false, fmt.Errorf("failed to check session ownership: %w", err)
+	}
+	span.SetAttribute("owns", owns)
+	return owns, nil
+}
+
 // RestoreSession restores a soft-deleted session by clearing deleted_at.
 func (s *SessionStore) RestoreSession(ctx context.Context, sessionID string) error {
 	ctx, span := s.tracer.StartSpan(ctx, "pg_session_store.restore_session")

--- a/pkg/tui/client/artifacts.go
+++ b/pkg/tui/client/artifacts.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package client
+
+// Session-scoped artifact lookups.
+//
+// Loom keeps one artifact catalog per server, shared by every surface that
+// talks to it: a file written through the workspace tool in one client is
+// listable from all of them. The general artifact methods live in client.go;
+// these two exist because names are only unique per session, and until the
+// wire carried session_id a remote surface could not ask "the files this
+// session produced" at all.
+
+import (
+	"context"
+
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+)
+
+// ListSessionArtifacts returns the artifacts belonging to one session.
+//
+// This is the "files this session produced" listing. limit of 0 asks for the
+// server default.
+func (c *Client) ListSessionArtifacts(ctx context.Context, sessionID string, limit, offset int32) ([]*loomv1.Artifact, error) {
+	req := &loomv1.ListArtifactsRequest{
+		SessionId: sessionID,
+		Limit:     limit,
+		Offset:    offset,
+	}
+
+	resp, err := c.client.ListArtifacts(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Artifacts, nil
+}
+
+// GetArtifactByName resolves an artifact by name within a session.
+//
+// Names are only unique per session, so the session is required here: a bare
+// name lookup from outside the session's own call context is ambiguous.
+func (c *Client) GetArtifactByName(ctx context.Context, name, sessionID string) (*loomv1.Artifact, error) {
+	req := &loomv1.GetArtifactRequest{
+		Name:      name,
+		SessionId: sessionID,
+	}
+
+	resp, err := c.client.GetArtifact(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Artifact, nil
+}

--- a/pkg/tui/client/artifacts.go
+++ b/pkg/tui/client/artifacts.go
@@ -24,6 +24,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
 )
@@ -41,7 +42,7 @@ func (c *Client) ListSessionArtifacts(ctx context.Context, sessionID string, lim
 
 	resp, err := c.client.ListArtifacts(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to list session artifacts: %w", err)
 	}
 
 	return resp.Artifacts, nil
@@ -59,7 +60,7 @@ func (c *Client) GetArtifactByName(ctx context.Context, name, sessionID string) 
 
 	resp, err := c.client.GetArtifact(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get artifact by name: %w", err)
 	}
 
 	return resp.Artifact, nil

--- a/pkg/tui/client/artifacts_test.go
+++ b/pkg/tui/client/artifacts_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package client
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+)
+
+// These two wrappers are the only artifact entry points a remote surface uses,
+// and the whole reason they exist is to put session_id on the wire. A wrapper
+// that quietly dropped the field would still compile, still return artifacts,
+// and hand every surface the session-blind listing this change set out to fix
+// — so what is asserted here is that the field actually reaches the request.
+//
+// The fixture is local rather than the shared mockLoomServiceServer, which does
+// not implement the artifact RPCs; recording the request needs a stub of its own
+// anyway.
+type artifactRecordingServer struct {
+	loomv1.UnimplementedLoomServiceServer
+
+	gotList *loomv1.ListArtifactsRequest
+	gotGet  *loomv1.GetArtifactRequest
+}
+
+func (s *artifactRecordingServer) ListArtifacts(_ context.Context, req *loomv1.ListArtifactsRequest) (*loomv1.ListArtifactsResponse, error) {
+	s.gotList = req
+	return &loomv1.ListArtifactsResponse{
+		Artifacts: []*loomv1.Artifact{
+			{Id: "a1", Name: "report.md", SessionId: req.SessionId},
+		},
+		TotalCount: 1,
+	}, nil
+}
+
+func (s *artifactRecordingServer) GetArtifact(_ context.Context, req *loomv1.GetArtifactRequest) (*loomv1.GetArtifactResponse, error) {
+	s.gotGet = req
+	return &loomv1.GetArtifactResponse{
+		Artifact: &loomv1.Artifact{Id: "a1", Name: req.Name, SessionId: req.SessionId},
+	}, nil
+}
+
+func setupArtifactClient(t *testing.T) (*Client, *artifactRecordingServer) {
+	t.Helper()
+
+	lis := bufconn.Listen(1024 * 1024)
+	stub := &artifactRecordingServer{}
+	server := grpc.NewServer()
+	loomv1.RegisterLoomServiceServer(server, stub)
+	go func() {
+		if err := server.Serve(lis); err != nil {
+			t.Logf("server error: %v", err)
+		}
+	}()
+	t.Cleanup(server.Stop)
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return &Client{
+		conn:   conn,
+		client: loomv1.NewLoomServiceClient(conn),
+		addr:   "passthrough:///bufnet",
+	}, stub
+}
+
+func TestListSessionArtifactsSendsSessionID(t *testing.T) {
+	c, stub := setupArtifactClient(t)
+
+	arts, err := c.ListSessionArtifacts(context.Background(), "sess-1", 10, 5)
+	if err != nil {
+		t.Fatalf("ListSessionArtifacts: %v", err)
+	}
+
+	if stub.gotList == nil {
+		t.Fatal("server received no ListArtifacts request")
+	}
+	if stub.gotList.SessionId != "sess-1" {
+		t.Errorf("session_id on the wire = %q, want sess-1", stub.gotList.SessionId)
+	}
+	if stub.gotList.Limit != 10 || stub.gotList.Offset != 5 {
+		t.Errorf("limit/offset = %d/%d, want 10/5", stub.gotList.Limit, stub.gotList.Offset)
+	}
+	if len(arts) != 1 || arts[0].SessionId != "sess-1" {
+		t.Errorf("got %d artifacts, want 1 reporting sess-1", len(arts))
+	}
+}
+
+// limit 0 must stay 0 on the wire so the server applies its own default rather
+// than the client inventing one.
+func TestListSessionArtifactsLeavesDefaultLimitToServer(t *testing.T) {
+	c, stub := setupArtifactClient(t)
+
+	if _, err := c.ListSessionArtifacts(context.Background(), "sess-1", 0, 0); err != nil {
+		t.Fatalf("ListSessionArtifacts: %v", err)
+	}
+	if stub.gotList.Limit != 0 {
+		t.Errorf("limit = %d, want 0 so the server default applies", stub.gotList.Limit)
+	}
+}
+
+func TestGetArtifactByNameSendsNameAndSession(t *testing.T) {
+	c, stub := setupArtifactClient(t)
+
+	art, err := c.GetArtifactByName(context.Background(), "report.md", "sess-2")
+	if err != nil {
+		t.Fatalf("GetArtifactByName: %v", err)
+	}
+
+	if stub.gotGet == nil {
+		t.Fatal("server received no GetArtifact request")
+	}
+	if stub.gotGet.Name != "report.md" || stub.gotGet.SessionId != "sess-2" {
+		t.Errorf("request = (name %q, session %q), want (report.md, sess-2)",
+			stub.gotGet.Name, stub.gotGet.SessionId)
+	}
+	// Names are only unique per session, so the name path must not fall back to
+	// an id lookup — an id here would silently ignore the session.
+	if stub.gotGet.Id != "" {
+		t.Errorf("id = %q, want empty so the lookup resolves by name within the session", stub.gotGet.Id)
+	}
+	if art.SessionId != "sess-2" {
+		t.Errorf("returned artifact reports session %q, want sess-2", art.SessionId)
+	}
+}

--- a/proto/loom/v1/loom.proto
+++ b/proto/loom/v1/loom.proto
@@ -2675,6 +2675,12 @@ message Artifact {
 
   // Soft delete timestamp (Unix seconds, optional)
   int64 deleted_at = 16;
+
+  // Session this artifact belongs to. Empty for artifacts created outside a
+  // session (user uploads, pre-session tooling). The store has recorded this
+  // since sessions were introduced; it was simply never put on the wire, which
+  // left remote clients unable to tell whose files they were looking at.
+  string session_id = 17;
 }
 
 // ListArtifactsRequest lists artifacts with optional filtering.
@@ -2696,6 +2702,13 @@ message ListArtifactsRequest {
 
   // Include soft-deleted artifacts
   bool include_deleted = 6;
+
+  // Filter to artifacts belonging to one session (optional). Unset means no
+  // session filtering, preserving existing behaviour. This is what lets a
+  // remote surface render "the files this session produced" — the local
+  // artifact store has always supported it (artifacts.Filter.SessionID); the
+  // request message could not express it.
+  string session_id = 7;
 }
 
 // ListArtifactsResponse returns a list of artifacts.
@@ -2714,6 +2727,12 @@ message GetArtifactRequest {
 
   // Artifact name (alternative lookup if ID not provided)
   string name = 2;
+
+  // Session to scope a name lookup to (optional). Names are only unique within
+  // a session, so a bare name lookup from a remote client is ambiguous without
+  // this. Ignored when id is set. Unset falls back to the session carried in
+  // the call context, preserving existing behaviour for in-session callers.
+  string session_id = 3;
 }
 
 // GetArtifactResponse returns artifact metadata.


### PR DESCRIPTION
Loom keeps **one artifact catalog per server**, shared by every surface that talks to it — and the store has been session-aware since sessions were introduced: `artifacts.Filter` has a `SessionID` field, `GetByName` takes a session, and every artifact row records which session produced it.

**None of that is on the wire.** `ListArtifactsRequest` cannot express a session filter, `GetArtifactRequest` can only scope a name lookup through the session carried in the call context, and the `Artifact` message itself has no `session_id` — so a remote client cannot even filter a full listing for itself.

The consequence: a surface talking to a shared `looms` cannot answer *"which files did this session produce?"* — the first question every file panel asks. This applies to `loom-mcp` too: `loom_list_artifacts` gives MCP hosts the same session-blind view.

## Changes

`session_id` added to `Artifact`, `ListArtifactsRequest`, and `GetArtifactRequest`, wired through:

- **`ListArtifacts`** maps a non-empty `session_id` onto the store filter it already had. Unset means unfiltered — existing behaviour exactly.
- **`GetArtifact`** prefers an explicit `session_id` over the call-context session for name lookups. Names are only unique per session, so a bare name from a remote caller was ambiguous. **ID lookups ignore session** — IDs are global, and scoping them would only manufacture spurious not-founds.
- **A request-supplied `session_id` is authorized before it selects anything.** It is caller-declared, unlike a context session id, so both RPCs run it through `MultiAgentServer.authorizeSessionScope`, which applies `sessionAccessibleBy` — the same per-user isolation predicate every other session-scoped RPC uses. Denial is `NotFound`, so "exists but not yours" is indistinguishable from "no such session". Under ownership enforcement the session must be the caller's; single-tenant deployments stay permissive, exactly as before. The context-derived session id remains trusted and unchecked.
- **A soft-deleted session still resolves for its owner.** Postgres `DeleteSession` only sets `deleted_at` and the artifact rows outlive it, while `LoadSession` and `SessionExists` both filter `deleted_at IS NULL` — so ownership falls back to `SessionStore.CallerOwnsSession`, an owner-scoped existence check that ignores `deleted_at`. Without it the gate refused an owner the session-filtered view of artifacts the store still returns unfiltered, for the whole grace window. It is wired as an optional capability rather than a `SessionStorage` method, since that interface is implemented outside this repo.
- **`artifactToProto`** carries `SessionID` out, so responses say which session each artifact belongs to.

SDK gains the two session-scoped calls (`ListSessionArtifacts`, `GetArtifactByName`); the general artifact methods already existed.

`loom-mcp` now advertises `session_id` on the `loom_list_artifacts` and `loom_get_artifact` schemas, so a model driving them can actually reach the field. `loom_get_artifact` also declared `id` **required**, which made the name lookup undrivable from the schema even though the RPC has always accepted either — a name lookup is precisely what `session_id` is for, so `id` is now optional.

**Not in scope**, and now stated in the architecture doc rather than left implied: ID lookups (`GetArtifact` by id, `GetArtifactContent`, `DeleteArtifact`) are unscoped by design, and the write path (`UploadArtifact`) is not session-aware. Session scoping here is a filtering and name-resolution boundary, not an access-control boundary on IDs.

## Testing

The fixture seeds two sessions that **both contain a `report.md`** — the name collision is precisely the case the explicit session exists for — plus a session-less user upload. Tests assert filtered, unfiltered (unchanged), scoped-name, and by-ID behaviour against a real SQLite store built through the storage backend, FK constraints and all.

Three denial tests cover the boundary the happy-path cases cannot: a foreign session is refused on both the listing and the name path, and a blank identity is refused under enforcement. Each was confirmed to **fail without the authorization check**. Alongside them: the owner still reads her own session (so the check is an isolation boundary, not a feature switch), single-tenant mode stays permissive (regression guard for the default), and the ID carve-out is pinned as deliberate.

`pkg/storage/postgres/artifact_session_scope_test.go` pins that `session_id` composes with — never substitutes for — the store's unconditional `user_id = $1` predicate, on both `List` and `GetByName`. It is deliberately **untagged**: every `//go:build integration` file in that package is invisible to CI, which runs `-tags fts5` only, so a tagged test would have been dead coverage. It follows `human_request_store_test.go` instead and skips without `TEST_POSTGRES_URL`, so CI is the first place it runs.

The two SDK wrappers are covered against a bufconn stub that records the request, since putting `session_id` on the wire is the only reason they exist: a wrapper that dropped it would still compile and still return artifacts. Those tests also pin that `limit: 0` stays 0 (the server applies its default, not the client) and that the name path sends no `id`, which would otherwise make the server ignore the session.

`gofmt`, `go vet`, `golangci-lint` (0 issues), `buf lint` clean. **`buf breaking --against main` clean** — three new optional fields, nothing modified. `buf generate` re-run with no diff against the committed generated files. `pkg/server`, `pkg/artifacts`, `pkg/tui/client`, `pkg/storage/postgres`, and `pkg/mcp/server` pass under `-race` with `-count=1`.

## Rebase

Replayed onto current `main` (was 20 commits behind) — no conflicts. The three field numbers (`Artifact` 17, `ListArtifactsRequest` 7, `GetArtifactRequest` 3) were re-verified as still next-available on current `main`, and the base's own changes to `pkg/artifacts/store.go` (a SQLite DSN/pragma refactor) and `loom.proto` (comments on `WeaveProgress`) leave this change's dependencies intact.

Independent of #363/#364 — branches directly from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


