### PR TITLE
feat(mcp): declare session handles as leases on the shuttle contract

### DIFF
--- a/docs/architecture/llm-slot-scheduler.md
+++ b/docs/architecture/llm-slot-scheduler.md
@@ -466,7 +466,7 @@ same wire field names (`code`, `retry_after_s`, `wait_param`, `max_wait_s`).
 A hint declares the failure to be capacity flow control, not a fault: the
 identical call, re-issued after a wait, is expected to succeed. This is the
 contract only — no wait loop lives at the shuttle layer; the MCP adapter's
-freeze loop migrates onto it when PR #355 merges. On this branch the hint is contract-only: it has no producer or consumer yet.
+freeze loop is now merged, and the MCP adapter is the contract's first producer: a capacity condition that outlives the freeze stamps its hint onto the shuttle error, so consumers outside `pkg/mcp` read flow control without knowing MCP. The freeze loop itself still parses the MCP-level hint (it needs the wire-level `wait_param` re-invoke).
 
 ### 11.2 The mark/unmark lifecycle (pkg/agent + pkg/llm/scheduler) ✅
 
@@ -497,14 +497,29 @@ the session's conversation currently holds.
   installed, the ledger still tracks leases and the mark/unmark calls are
   no-ops — unwired deployments behave exactly as before.
 
+### 11.2a MCP session handles ✅
+
+The MCP adapter is the lease contract's first producer. A tool result whose
+minted `session_handle` the runtime tracks (issue #345, schema-gated on both
+ends) carries a `LeaseAcquired` event keyed `mcp-session-handle` with the
+server-scoped handle identity; an agent-driven release and the
+end-of-conversation auto-release pass both emit the matching `LeaseReleased`
+for the identical `(Kind, ID)`. The ledger and the slot scheduler consume
+those events generically — no MCP-specific code on the loom side.
+
+The conversation-end pass runs outside any tool result, so `ReleaseAll`
+returns its released identities and the agent's chat loop applies them to the
+ledger directly; without that, the next turn would seed `RESOURCE_HOLDER` for
+handles the conversation had already given back.
+
 ### 11.3 Planned follow-ups 📋
 
 - **Trust model**: lease events are taken at the emitting tool's word — any tool that shapes `Result.Metadata` can assert or release any lease. Operator-chosen backends are trusted; deployments running untrusted tool servers must strip these keys at their adapter boundary (see the doc block in `pkg/shuttle/lease.go`).
 - **Ledger durability**: the lease ledger is process memory only. After a `looms` restart the ledger is empty — a backend lease that survived the restart (e.g. a remote HTTP-MCP session) loses RESOURCE_HOLDER seeding until its next lease event. Durable seeding is 📋 planned alongside durable park persistence.
-- **MCP adapter migration**: PR #355's MCP-level backpressure hint and
-  freeze loop move onto the shuttle contract when that PR merges, and MCP
-  session handles then declare themselves as lease events instead of
-  adapter-private state.
+- **Express lane** (📋, lives in `teradata-mcp-v2`): a reserved slice of
+  physical connections for stateless per-statement calls, so one-shot reads
+  never queue behind session holders. The loom side needs nothing — express
+  calls simply hold no lease.
 - **Express lane**: reserved scheduler headroom for `RESOURCE_HOLDER`
   acquisitions (analogous to the interactive headroom), so a holder never
   waits behind a saturated general queue.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1797,7 +1797,13 @@ func (a *Agent) chat(ctx context.Context, sessionID string, userMessage string, 
 	// discretion doesn't work — in a 3×64-agent live study, zero agents
 	// released a handle — so the runtime owns the cleanup.
 	ctx, handleCollector := mcpadapter.WithHandleCollector(ctx)
-	defer handleCollector.ReleaseAll(zap.L())
+	defer func() {
+		// The auto-release happens outside any tool result, so the ledger
+		// learns about it here instead of through applyLeaseEvents — without
+		// this the next turn would seed RESOURCE_HOLDER for handles this
+		// conversation already gave back.
+		a.leases.apply(sessionID, handleCollector.ReleaseAll(zap.L()), nil)
+	}()
 
 	// Start trace span — always created; NoOpTracer handles disabled case
 	startTime := time.Now()

--- a/pkg/mcp/adapter/backpressure_wait_test.go
+++ b/pkg/mcp/adapter/backpressure_wait_test.go
@@ -211,3 +211,54 @@ func TestBackpressureCallerParamsNotMutated(t *testing.T) {
 		"the model-owned params map must never see injected flow control")
 	assert.Equal(t, map[string]interface{}{"query": "SELECT 1"}, callerParams)
 }
+
+// TestBackpressureHintReachesShuttleError: a capacity condition that outlives
+// the freeze (here: an already-expired deadline, so there is no budget to
+// wait in) carries its hint onto the generic shuttle contract, so consumers
+// outside pkg/mcp read flow control without knowing anything about MCP.
+func TestBackpressureHintReachesShuttleError(t *testing.T) {
+	ft := newWaitTransport(
+		backpressureResult("session_handle_budget_full", 412, "wait_s", 300),
+	)
+	adapter := waitAdapter(t, ft)
+
+	// A live ctx whose remaining time is inside the freeze's deadline margin:
+	// the call reaches the server and comes back with the contract, but there
+	// is no budget to wait in, so the error surfaces unchanged.
+	ctx, cancel := context.WithTimeout(context.Background(), backpressureDeadlineMargin)
+	defer cancel()
+
+	res, err := adapter.Execute(ctx, map[string]interface{}{})
+	require.NoError(t, err)
+	require.False(t, res.Success)
+	require.NotNil(t, res.Error)
+
+	hint := res.Error.Backpressure()
+	require.NotNil(t, hint, "the shuttle error must carry the backpressure hint")
+	assert.Equal(t, "session_handle_budget_full", hint.Code)
+	assert.Equal(t, int64(412), hint.RetryAfterS)
+	assert.Equal(t, "wait_s", hint.WaitParam)
+	assert.Equal(t, int64(300), hint.MaxWaitS)
+	assert.Equal(t, 1, ft.calls(), "no re-invoke without budget")
+}
+
+// TestTaskFailureCarriesNoHint: an ordinary tool failure (no retryable
+// contract — the shape a non-retryable server code like express_ineligible
+// produces) reaches the model unchanged and stamps no hint.
+func TestTaskFailureCarriesNoHint(t *testing.T) {
+	plain, _ := json.Marshal(protocol.CallToolResult{
+		IsError: true,
+		Content: []protocol.Content{{Type: "text", Text: `{"code":"express_ineligible","message":"session-scoped SQL is not express-eligible"}`}},
+	})
+	ft := newWaitTransport(plain)
+	adapter := waitAdapter(t, ft)
+
+	res, err := adapter.Execute(context.Background(), map[string]interface{}{})
+	require.NoError(t, err)
+	require.False(t, res.Success)
+	require.NotNil(t, res.Error)
+	assert.Nil(t, res.Error.Backpressure(), "a task-level failure carries no flow-control hint")
+	assert.Equal(t, 1, ft.calls(), "a non-retryable failure must not be re-invoked")
+	assert.Contains(t, res.Error.Message, "express_ineligible",
+		"the model sees the server's own reason")
+}

--- a/pkg/mcp/adapter/session_handles.go
+++ b/pkg/mcp/adapter/session_handles.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+
+	"github.com/teradata-labs/loom/pkg/shuttle"
 )
 
 // Session-handle auto-release (issue #345). A 3×64-agent live study showed
@@ -84,9 +86,16 @@ func collectorFrom(ctx context.Context) *HandleCollector {
 	return c
 }
 
+// sessionHandleLeaseKind is the Kind the adapter stamps on the lease events
+// it emits for MCP session handles (pkg/shuttle/lease.go). Opaque to loom —
+// the ledger and the LLM slot scheduler match it purely by identity.
+const sessionHandleLeaseKind = "mcp-session-handle"
+
 // collectorKey scopes dedup to the minting server: two servers can mint
 // identical handle strings, and a release on one must never forget the
-// other's handle.
+// other's handle. The same key doubles as the lease event ID, so a mint's
+// LeaseAcquired, an explicit release's LeaseReleased, and ReleaseAll's
+// end-of-conversation LeaseReleased all name the identical (Kind, ID) pair.
 func collectorKey(a *MCPToolAdapter, handle string) string {
 	return a.serverName + "\x00" + handle
 }
@@ -157,14 +166,28 @@ const releaseAllConcurrency = 4
 // required fields; otherwise the handle is skipped with a warning and left
 // to the server's TTL (the pre-#345 behavior), which beats a call the
 // client-side schema validation is guaranteed to reject.
-func (c *HandleCollector) ReleaseAll(logger *zap.Logger) {
+//
+// The returned LeaseReleased events name every handle the collector stopped
+// tracking, including ones whose wire release was skipped or failed: the
+// conversation is over, so the runtime no longer holds them either way and
+// the ledger must not keep seeding RESOURCE_HOLDER for a dead conversation.
+// The caller applies them to the agent's per-session lease ledger.
+func (c *HandleCollector) ReleaseAll(logger *zap.Logger) []shuttle.LeaseEvent {
 	c.mu.Lock()
 	minted := c.minted
 	c.minted = nil
 	c.present = map[string]bool{}
 	c.mu.Unlock()
 	if len(minted) == 0 {
-		return
+		return nil
+	}
+	released := make([]shuttle.LeaseEvent, 0, len(minted))
+	for _, m := range minted {
+		released = append(released, shuttle.LeaseEvent{
+			Action: shuttle.LeaseReleased,
+			Kind:   sessionHandleLeaseKind,
+			ID:     collectorKey(m.adapter, m.handle),
+		})
 	}
 	if logger == nil {
 		logger = zap.NewNop()
@@ -185,6 +208,7 @@ func (c *HandleCollector) ReleaseAll(logger *zap.Logger) {
 		}(m)
 	}
 	wg.Wait()
+	return released
 }
 
 // releaseOne attempts a single best-effort release, deriving the wire
@@ -276,22 +300,47 @@ func releaseSatisfiesRequired(schema map[string]interface{}, prop string) bool {
 // declares a release property, i.e. the server opted into the convention.
 // A successful call that carried a release argument (either spelling)
 // removes that handle from tracking (the agent cleaned up itself).
-func trackSessionHandles(ctx context.Context, a *MCPToolAdapter, params map[string]interface{}, data interface{}) {
+//
+// The returned lease events mirror the collector mutations onto the generic
+// shuttle contract (pkg/shuttle/lease.go): a mint yields LeaseAcquired, an
+// explicit release yields LeaseReleased, in observation order. The caller
+// (Execute) appends them to the outgoing shuttle.Result, so the agent's
+// per-session ledger and the LLM slot scheduler track MCP session handles
+// with zero MCP-specific code. Without a collector in ctx (workflow paths,
+// direct executor use) nothing is tracked and no events are emitted —
+// unchanged behavior.
+func trackSessionHandles(ctx context.Context, a *MCPToolAdapter, params map[string]interface{}, data interface{}) []shuttle.LeaseEvent {
 	c := collectorFrom(ctx)
 	if c == nil {
-		return
+		return nil
 	}
+	var events []shuttle.LeaseEvent
 	for _, key := range []string{"release_handle", "releaseHandle"} {
 		if released, ok := params[key].(string); ok && released != "" {
 			c.forget(a, released)
+			// The release event is emitted even for a handle the collector
+			// never tracked: the server processed the release on a successful
+			// call, and the backend's declaration is authoritative (the
+			// ledger tolerates release-of-unknown as a no-op).
+			events = append(events, shuttle.LeaseEvent{
+				Action: shuttle.LeaseReleased,
+				Kind:   sessionHandleLeaseKind,
+				ID:     collectorKey(a, released),
+			})
 		}
 	}
 	if _, declared := releaseHandleProperty(a.tool.InputSchema); !declared {
-		return // server never declared the convention: do not track
+		return events // server never declared the convention: do not track
 	}
 	if h := sessionHandleFromData(data); h != "" {
 		c.add(a, h)
+		events = append(events, shuttle.LeaseEvent{
+			Action: shuttle.LeaseAcquired,
+			Kind:   sessionHandleLeaseKind,
+			ID:     collectorKey(a, h),
+		})
 	}
+	return events
 }
 
 // sessionHandleFromData extracts a top-level session_handle string from a

--- a/pkg/mcp/adapter/session_handles_test.go
+++ b/pkg/mcp/adapter/session_handles_test.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/teradata-labs/loom/pkg/mcp/protocol"
+	"github.com/teradata-labs/loom/pkg/shuttle"
 )
 
 // mintSchemaSnake declares the release convention with the snake_case
@@ -428,4 +429,98 @@ func TestHandleCollectorScopedPerServer(t *testing.T) {
 	if survivor.adapter.serverName != "server-a" {
 		t.Fatalf("wrong survivor: %s", survivor.adapter.serverName)
 	}
+}
+
+// TestMintEmitsLeaseAcquiredEvent: a tracked mint rides out on the Result as
+// a generic shuttle lease event, so the agent's ledger and the LLM slot
+// scheduler learn the conversation holds a scarce backend resource without
+// any MCP-specific code.
+func TestMintEmitsLeaseAcquiredEvent(t *testing.T) {
+	released, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
+		{Type: "text", Text: `{"target":"released"}`},
+	}})
+	ft := newWaitTransportWithSchema(mintSchemaSnake(), mintResult("tdsh_lease1"), released)
+	adapter := waitAdapter(t, ft)
+
+	ctx, collector := WithHandleCollector(context.Background())
+	res, err := adapter.Execute(ctx, map[string]interface{}{})
+	require.NoError(t, err)
+	require.True(t, res.Success)
+
+	events := shuttle.LeaseEventsFrom(res)
+	require.Len(t, events, 1, "the mint must emit exactly one lease event")
+	assert.Equal(t, shuttle.LeaseAcquired, events[0].Action)
+	assert.Equal(t, sessionHandleLeaseKind, events[0].Kind)
+	assert.Equal(t, collectorKey(adapter, "tdsh_lease1"), events[0].ID,
+		"the event ID is the server-scoped collector key")
+	require.Equal(t, 1, collector.Count())
+}
+
+// TestExplicitReleaseEmitsLeaseReleasedEvent: an agent-driven release is
+// mirrored onto the contract with the identical (Kind, ID) the mint used, so
+// the ledger's set-based accounting cancels exactly.
+func TestExplicitReleaseEmitsLeaseReleasedEvent(t *testing.T) {
+	releasedResult, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
+		{Type: "text", Text: `{"target":"released"}`},
+	}})
+	ft := newWaitTransportWithSchema(mintSchemaSnake(), mintResult("tdsh_lease2"), releasedResult)
+	adapter := waitAdapter(t, ft)
+
+	ctx, collector := WithHandleCollector(context.Background())
+	mintRes, err := adapter.Execute(ctx, map[string]interface{}{})
+	require.NoError(t, err)
+	acquired := shuttle.LeaseEventsFrom(mintRes)
+	require.Len(t, acquired, 1)
+
+	relRes, err := adapter.Execute(ctx, map[string]interface{}{"release_handle": "tdsh_lease2"})
+	require.NoError(t, err)
+	events := shuttle.LeaseEventsFrom(relRes)
+	require.Len(t, events, 1)
+	assert.Equal(t, shuttle.LeaseReleased, events[0].Action)
+	assert.Equal(t, acquired[0].Kind, events[0].Kind)
+	assert.Equal(t, acquired[0].ID, events[0].ID,
+		"release must name the identical (Kind, ID) the mint used")
+	assert.Equal(t, 0, collector.Count())
+}
+
+// TestReleaseAllEmitsLeaseReleasedEvents: the end-of-conversation pass runs
+// outside any tool result, so it hands its released identities back to the
+// caller — without them the agent's ledger would keep seeding
+// RESOURCE_HOLDER for a conversation whose handles are gone.
+func TestReleaseAllEmitsLeaseReleasedEvents(t *testing.T) {
+	releasedResult, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
+		{Type: "text", Text: `{"target":"released"}`},
+	}})
+	ft := newWaitTransportWithSchema(mintSchemaSnake(), mintResult("tdsh_lease3"), releasedResult)
+	adapter := waitAdapter(t, ft)
+
+	ctx, collector := WithHandleCollector(context.Background())
+	mintRes, err := adapter.Execute(ctx, map[string]interface{}{})
+	require.NoError(t, err)
+	acquired := shuttle.LeaseEventsFrom(mintRes)
+	require.Len(t, acquired, 1)
+
+	events := collector.ReleaseAll(nil)
+	require.Len(t, events, 1, "every tracked handle yields a release event")
+	assert.Equal(t, shuttle.LeaseReleased, events[0].Action)
+	assert.Equal(t, acquired[0].ID, events[0].ID)
+	assert.Equal(t, 0, collector.Count())
+
+	// A second pass has nothing to release and emits nothing.
+	assert.Empty(t, collector.ReleaseAll(nil))
+}
+
+// TestNoCollectorEmitsNoLeaseEvents: without a collector in ctx (workflow
+// paths, direct executor use) nothing is tracked and no events are emitted.
+func TestNoCollectorEmitsNoLeaseEvents(t *testing.T) {
+	releasedResult, _ := json.Marshal(protocol.CallToolResult{Content: []protocol.Content{
+		{Type: "text", Text: `{"target":"released"}`},
+	}})
+	ft := newWaitTransportWithSchema(mintSchemaSnake(), mintResult("tdsh_lease4"), releasedResult)
+	adapter := waitAdapter(t, ft)
+
+	res, err := adapter.Execute(context.Background(), map[string]interface{}{})
+	require.NoError(t, err)
+	require.True(t, res.Success)
+	assert.Empty(t, shuttle.LeaseEventsFrom(res), "no collector, no lease events")
 }

--- a/pkg/mcp/adapter/shuttle.go
+++ b/pkg/mcp/adapter/shuttle.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -307,14 +308,30 @@ func (a *MCPToolAdapter) Execute(ctx context.Context, params map[string]interfac
 
 	if err != nil {
 		// Convert error to shuttle.Result with error
+		shuttleErr := &shuttle.Error{
+			Code:       "MCP_CALL_FAILED",
+			Message:    err.Error(),
+			Retryable:  true,
+			Suggestion: "Check MCP server logs for details",
+		}
+		// A capacity condition that outlived the freeze (budget exhausted,
+		// or a hint that arrived with no wait mechanism) carries its hint
+		// onto the generic contract, so consumers outside pkg/mcp — the
+		// agent loop, observability — read flow control without knowing MCP.
+		var terr *client.ToolResultError
+		if errors.As(err, &terr) {
+			if hint := terr.Backpressure(); hint != nil {
+				shuttleErr.SetBackpressure(shuttle.BackpressureHint{
+					Code:        hint.Code,
+					RetryAfterS: hint.RetryAfterS,
+					WaitParam:   hint.WaitParam,
+					MaxWaitS:    hint.MaxWaitS,
+				})
+			}
+		}
 		return &shuttle.Result{
-			Success: false,
-			Error: &shuttle.Error{
-				Code:       "MCP_CALL_FAILED",
-				Message:    err.Error(),
-				Retryable:  true,
-				Suggestion: "Check MCP server logs for details",
-			},
+			Success:         false,
+			Error:           shuttleErr,
 			ExecutionTimeMs: executionTime,
 		}, nil // Return nil error since we wrapped it in Result.Error
 	}
@@ -340,7 +357,9 @@ func (a *MCPToolAdapter) Execute(ctx context.Context, params map[string]interfac
 
 	// Session-handle lifecycle (issue #345): collect minted handles for
 	// end-of-conversation auto-release; drop ones the agent released itself.
-	trackSessionHandles(ctx, a, params, data)
+	// The events ride out on the Result so the agent's lease ledger and the
+	// LLM slot scheduler learn about the lease generically.
+	leaseEvents := trackSessionHandles(ctx, a, params, data)
 
 	// Cache schema results (#4: Schema Caching)
 	if a.isSchemaLookupTool() {
@@ -355,12 +374,16 @@ func (a *MCPToolAdapter) Execute(ctx context.Context, params map[string]interfac
 		"tool_name":  a.tool.Name,
 	}
 
-	return &shuttle.Result{
+	result := &shuttle.Result{
 		Success:         true,
 		Data:            data,
 		ExecutionTimeMs: executionTime,
 		Metadata:        metadata,
-	}, nil
+	}
+	for _, ev := range leaseEvents {
+		shuttle.AppendLeaseEvent(result, ev)
+	}
+	return result, nil
 }
 
 // Backend implements shuttle.Tool

--- a/pkg/shuttle/backpressure.go
+++ b/pkg/shuttle/backpressure.go
@@ -30,10 +30,12 @@ const DetailsBackpressure = "loom.backpressure"
 // model. Task-level failures (SQL errors, timeouts, deadlocks) never carry
 // the hint and must reach the model.
 //
-// This type is the contract only — no wait loop lives at the shuttle layer,
-// and on this branch the hint has no producer or consumer yet. The MCP
-// adapter's freeze loop lives on open PR #355 with its own MCP-level parse;
-// it migrates onto this contract when that PR merges.
+// This type is the contract only — no wait loop lives at the shuttle layer.
+// The MCP adapter is its first producer: a capacity condition that outlives
+// the adapter's freeze (budget exhausted, or a hint with no wait mechanism)
+// is stamped here on the way out, so consumers outside pkg/mcp read flow
+// control without knowing MCP. The freeze loop itself keeps parsing the
+// MCP-level hint, which it needs for the wire-level wait_param re-invoke.
 type BackpressureHint struct {
 	// Code names the capacity condition (e.g. "session_handle_budget_full").
 	// Backend-defined; loom treats it as an opaque label.


### PR DESCRIPTION
## Summary

Closes the loop opened by #365: the MCP adapter becomes the **first producer** of the backend-agnostic lease contract, so a conversation holding an MCP session handle rides the scheduler's `RESOURCE_HOLDER` class — priority inheritance, because it is blocking other agents — with **zero MCP-specific code on the loom side**.

This is the piece that gives `MarkResourceHolder` a production call site, through the generic seam rather than a direct dependency.

- **Mint → `LeaseAcquired`**, keyed `mcp-session-handle` with the server-scoped handle identity (the same key the collector dedups on). **Agent-driven release → `LeaseReleased`** for the identical `(Kind, ID)`, so the ledger's set-based accounting cancels exactly. Both ride out on the tool `Result`, where the per-session ledger already consumes them.
- **`ReleaseAll` returns the identities it stopped tracking.** The end-of-conversation auto-release runs outside any tool result, so the chat loop applies them to the ledger directly — without this, the next turn would seed `RESOURCE_HOLDER` for handles the conversation had already given back. Events are emitted even for handles whose wire release was skipped or failed: the conversation is over, so the runtime doesn't hold them either way.
- **`BackpressureHint` gets its first producer too**: a capacity condition that outlives the freeze (budget exhausted, or a hint with no wait mechanism) is stamped onto the shuttle error, so consumers outside `pkg/mcp` read flow control without knowing MCP. The freeze loop keeps its MCP-level parse — it needs the wire-level `wait_param` re-invoke.

## Layering

`pkg/agent` already imported `pkg/mcp/adapter` for `WithHandleCollector`, so the conversation-end seam needed no new dependency and no new export — `ReleaseAll` simply returns what it released.

## Tests

Mint / explicit-release / `ReleaseAll` event shapes with identity matching across all three paths; the no-collector path emitting nothing (workflows, direct executor use); the hint reaching `shuttle.Error` on the zero-budget path; and a non-retryable server failure — the shape teradata-mcp-v2's new `express_ineligible` code produces — reaching the model unchanged with no hint and no re-invoke.

Docs: `docs/architecture/llm-slot-scheduler.md` §11.2a (MCP session handles ✅) with the express lane restated as 📋 living in `teradata-mcp-v2`.

## Validation

`gofmt`/`go vet` clean; `go build -tags fts5 ./...`; `-race -count=2` on pkg/mcp/adapter, pkg/shuttle, pkg/agent; `-race` on pkg/server and all of pkg/mcp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)