### PR TITLE
feat(cli): loom scheduler — observe and tune the LLM slot scheduler

### DIFF
--- a/cmd/loom/main.go
+++ b/cmd/loom/main.go
@@ -80,6 +80,7 @@ Support:
 	rootCmd.AddCommand(artifactsCmd)
 	rootCmd.AddCommand(mcpCmd)
 	rootCmd.AddCommand(providersCmd)
+	rootCmd.AddCommand(schedulerCmd)
 	rootCmd.AddCommand(skillsCmd)
 }
 

--- a/cmd/loom/scheduler.go
+++ b/cmd/loom/scheduler.go
@@ -1,0 +1,243 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+)
+
+var schedulerCmd = &cobra.Command{
+	Use:   "scheduler",
+	Short: "Inspect and tune the LLM slot scheduler",
+	Long: `Read the server's LLM slot-scheduler state and adjust a scope's ceiling.
+
+The scheduler admits LLM calls per provider quota scope: a call that cannot
+fit the current window parks until capacity frees rather than failing. These
+commands expose what it is doing — how much capacity it believes it has, who
+is parked and in which priority class — and let an operator override the
+ceiling on a running server (for a drain, or to reproduce contention).`,
+}
+
+var schedulerScope string
+
+var schedulerStateCmd = &cobra.Command{
+	Use:   "state",
+	Short: "Show per-scope capacity and queue depth",
+	Run:   runSchedulerState,
+}
+
+var schedulerWaitersCmd = &cobra.Command{
+	Use:   "waiters",
+	Short: "List slot requests currently parked, oldest first",
+	Run:   runSchedulerWaiters,
+}
+
+var (
+	setTPM           int64
+	setStarvationAge int32
+	setUtilization   float32
+	setHeadroom      float32
+)
+
+var schedulerSetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Override a scope's scheduler configuration",
+	Long: `Override scheduler configuration for one provider quota scope.
+
+Only the flags you pass are changed. --tpm 0 restores calibration from
+provider response headers (or the scope's rate_limit configuration when the
+provider states no telemetry).`,
+	Run: runSchedulerSet,
+}
+
+func init() {
+	schedulerCmd.PersistentFlags().StringVar(&schedulerScope, "scope", "", "Provider quota scope (default: all scopes)")
+
+	schedulerSetCmd.Flags().Int64Var(&setTPM, "tpm", -1, "Enforced tokens per minute (0 = recalibrate from provider headers)")
+	schedulerSetCmd.Flags().Int32Var(&setStarvationAge, "starvation-age-s", -1, "Seconds before a parked request is promoted one priority class")
+	schedulerSetCmd.Flags().Float32Var(&setUtilization, "utilization", -1, "Target utilization of measured capacity, (0, 1]")
+	schedulerSetCmd.Flags().Float32Var(&setHeadroom, "interactive-headroom", -1, "Fraction of the budget reserved for interactive turns, [0, 1)")
+
+	schedulerCmd.AddCommand(schedulerStateCmd)
+	schedulerCmd.AddCommand(schedulerWaitersCmd)
+	schedulerCmd.AddCommand(schedulerSetCmd)
+}
+
+func schedulerClient() (loomv1.LLMSchedulerServiceClient, func(), error) {
+	c, cleanup, err := newClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	return c.SchedulerClient(), cleanup, nil
+}
+
+func runSchedulerState(_ *cobra.Command, _ []string) {
+	sc, cleanup, err := schedulerClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := sc.GetSlotState(ctx, &loomv1.GetSlotStateRequest{Scope: schedulerScope})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading slot state: %v\n", err)
+		os.Exit(1)
+	}
+	if len(resp.States) == 0 {
+		fmt.Println("No scheduler scopes. The slot scheduler is enabled per server with llm.scheduler_enabled;")
+		fmt.Println("a scope appears once its provider has served a call.")
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "SCOPE\tTPM\tPARKED\tRESERVED\tGRANTS\tPROMOTIONS\tACTIVE\tDOOR Q\tNEXT WAKE")
+	_, _ = fmt.Fprintln(w, "-----\t---\t------\t--------\t------\t----------\t------\t------\t---------")
+	for _, s := range resp.States {
+		wake := "-"
+		if s.NextWake != nil {
+			if d := time.Until(s.NextWake.AsTime()); d > 0 {
+				wake = d.Truncate(time.Millisecond).String()
+			}
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\n",
+			s.Scope, s.EffectiveTokensPerMinute, s.ParkedRequests, s.ReservedTokensOutstanding,
+			s.GrantsTotal, s.PromotionsTotal, s.ActiveConversations, s.DoorQueueDepth, wake)
+	}
+	_ = w.Flush()
+}
+
+func runSchedulerWaiters(_ *cobra.Command, _ []string) {
+	sc, cleanup, err := schedulerClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := sc.ListWaiters(ctx, &loomv1.ListWaitersRequest{Scope: schedulerScope})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error listing waiters: %v\n", err)
+		os.Exit(1)
+	}
+	if len(resp.Waiters) == 0 {
+		fmt.Println("No parked slot requests — every call is being admitted on arrival.")
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "WAITING\tCLASS\tORIGIN\tPROMOTIONS\tAGENT\tCONVERSATION")
+	_, _ = fmt.Fprintln(w, "-------\t-----\t------\t----------\t-----\t------------")
+	for _, waiter := range resp.Waiters {
+		age := "-"
+		if waiter.WaitingSince != nil {
+			age = time.Since(waiter.WaitingSince.AsTime()).Truncate(time.Second).String()
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%s\n",
+			age, shortClass(waiter.Class), shortOrigin(waiter.Origin),
+			waiter.Promotions, waiter.AgentName, waiter.ConversationId)
+	}
+	_ = w.Flush()
+}
+
+// shortClass renders the priority class without its proto prefix.
+func shortClass(c loomv1.SlotPriorityClass) string {
+	switch c {
+	case loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_NEW:
+		return "new"
+	case loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_IN_FLIGHT:
+		return "in-flight"
+	case loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_RESOURCE_HOLDER:
+		return "holder"
+	default:
+		return "unspecified"
+	}
+}
+
+// shortOrigin renders the band without its proto prefix.
+func shortOrigin(o loomv1.SlotOrigin) string {
+	switch o {
+	case loomv1.SlotOrigin_SLOT_ORIGIN_INTERACTIVE:
+		return "interactive"
+	case loomv1.SlotOrigin_SLOT_ORIGIN_BATCH:
+		return "batch"
+	default:
+		return "unspecified"
+	}
+}
+
+func runSchedulerSet(_ *cobra.Command, _ []string) {
+	if schedulerScope == "" {
+		fmt.Fprintln(os.Stderr, "Error: --scope is required (see `loom scheduler state` for scope names)")
+		os.Exit(1)
+	}
+	cfg := &loomv1.LLMSchedulerConfig{}
+	changed := false
+	if setTPM >= 0 {
+		cfg.TokensPerMinute = setTPM
+		changed = true
+	}
+	if setStarvationAge >= 0 {
+		cfg.StarvationAgeS = setStarvationAge
+		changed = true
+	}
+	if setUtilization >= 0 {
+		cfg.UtilizationTarget = setUtilization
+		changed = true
+	}
+	if setHeadroom >= 0 {
+		cfg.InteractiveHeadroom = setHeadroom
+		changed = true
+	}
+	if !changed {
+		fmt.Fprintln(os.Stderr, "Error: pass at least one of --tpm, --starvation-age-s, --utilization, --interactive-headroom")
+		os.Exit(1)
+	}
+
+	sc, cleanup, err := schedulerClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := sc.SetSchedulerConfig(ctx, &loomv1.SetSchedulerConfigRequest{Scope: schedulerScope, Config: cfg})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error setting scheduler config: %v\n", err)
+		os.Exit(1)
+	}
+	if resp.State != nil {
+		fmt.Printf("scope %s: effective %d tokens/min, %d parked, %d reserved\n",
+			resp.State.Scope, resp.State.EffectiveTokensPerMinute,
+			resp.State.ParkedRequests, resp.State.ReservedTokensOutstanding)
+		return
+	}
+	fmt.Println("Applied.")
+}

--- a/cmd/loom/scheduler_test.go
+++ b/cmd/loom/scheduler_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+)
+
+// TestSchedulerRenderers pins the human-facing shortenings: the tables are
+// the only window operators have into the scheduler, so an unmapped enum
+// must read as "unspecified" rather than a raw proto constant.
+func TestSchedulerRenderers(t *testing.T) {
+	classes := map[loomv1.SlotPriorityClass]string{
+		loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_NEW:             "new",
+		loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_IN_FLIGHT:       "in-flight",
+		loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_RESOURCE_HOLDER: "holder",
+		loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_UNSPECIFIED:     "unspecified",
+	}
+	for in, want := range classes {
+		assert.Equal(t, want, shortClass(in))
+	}
+
+	origins := map[loomv1.SlotOrigin]string{
+		loomv1.SlotOrigin_SLOT_ORIGIN_INTERACTIVE: "interactive",
+		loomv1.SlotOrigin_SLOT_ORIGIN_BATCH:       "batch",
+		loomv1.SlotOrigin_SLOT_ORIGIN_UNSPECIFIED: "unspecified",
+	}
+	for in, want := range origins {
+		assert.Equal(t, want, shortOrigin(in))
+	}
+}
+
+// TestSchedulerSetFlagsDefaultToUnset pins the partial-update contract: the
+// sentinel is negative, so a caller that passes only --tpm must not silently
+// zero the other fields (0 is meaningful for every one of them).
+func TestSchedulerSetFlagsDefaultToUnset(t *testing.T) {
+	assert.Negative(t, setTPM, "tpm sentinel must be negative so 0 can mean recalibrate")
+	assert.Negative(t, setStarvationAge)
+	assert.Negative(t, setUtilization)
+	assert.Negative(t, setHeadroom)
+}

--- a/pkg/tui/client/client.go
+++ b/pkg/tui/client/client.go
@@ -166,6 +166,13 @@ func (c *Client) Close() error {
 	return nil
 }
 
+// SchedulerClient returns an LLM slot-scheduler client on this connection,
+// so callers reach the scheduler's admin surface with the same address, TLS
+// and bearer-token configuration they already dialed with.
+func (c *Client) SchedulerClient() loomv1.LLMSchedulerServiceClient {
+	return loomv1.NewLLMSchedulerServiceClient(c.conn)
+}
+
 // withSlotOrigin reports this turn's LLM scheduling band to the server
 // (gRPC metadata "loom-slot-origin"): "interactive" when a human at a
 // terminal is waiting on the response — stdin and stdout are TTYs, which is


### PR DESCRIPTION
## Why

`LLMSchedulerService` has been registered on the gRPC server since the slot scheduler landed (#352) and **has had no client anywhere**. Every fleet run to date has inferred scheduler behavior from end-to-end durations, because there was no way to ask the server how deep the slot queue was, who was parked, or in which priority class.

That gap became concrete while designing the proof run for RESOURCE_HOLDER priority inheritance: the scheduler only reorders when calls actually queue, and with Azure sitting around 64% of TPM there was no way to confirm queueing was even happening — much less to induce it deliberately.

## What

- **`loom scheduler state`** — per-scope effective TPM, parked requests, outstanding reservations, grants, aging promotions, door counters, next scheduled wake.
- **`loom scheduler waiters`** — parked requests oldest-first with class, band, age and promotion count. Starvation and priority inheritance become observable instead of assumed.
- **`loom scheduler set --scope X`** — override `tokens_per_minute`, `starvation_age_s`, `utilization_target` or `interactive_headroom` on a running server. Useful for a drain, and for reproducing contention on purpose.

`Client.SchedulerClient()` reuses the caller's existing connection, so the command inherits the address, TLS and bearer-token configuration the rest of the CLI already dials with — no second dial path to keep in sync.

## Details worth reviewing

Set-flags default to a **negative sentinel**, not zero, because 0 is meaningful for every one of these fields (`--tpm 0` means "recalibrate from provider headers"). A partial update must never silently zero a field the caller didn't mention; there's a test pinning that.

Enum rendering strips proto prefixes for the tables, with an explicit `unspecified` fallback so an unmapped value can't surface as a raw constant in the only window operators have into the scheduler.

## Validation

`gofmt`/`go vet` clean, `go build -tags fts5 ./...`, `go test -tags fts5 -race ./cmd/loom/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)