### PR TITLE
fix(observability,sqlite): WAL for the observability store; key every pooled connection of an encrypted DB

### DIFF
--- a/docs/reference/sqlite-guidance.md
+++ b/docs/reference/sqlite-guidance.md
@@ -43,6 +43,10 @@ Best practices for SQLite usage in Loom - session storage, HITL persistence, ref
 | `temp_store` | `DEFAULT` | `MEMORY` | Store temporary tables in RAM |
 | `mmap_size` | `0` | `268435456` | Memory-mapped I/O (256MB) |
 
+All of these except `journal_mode` are **per-connection** settings, so on a
+pooled `*sql.DB` they must be set in the DSN — see
+[Essential PRAGMAs](#essential-pragmas).
+
 ### Loom Storage Implementations
 
 | Storage Type | Package | Database File | Purpose |
@@ -515,28 +519,52 @@ fmt.Printf("Active refs: %d, Size: %d bytes\n",
 
 ### Essential PRAGMAs
 
-**Set at database open** (used by all Loom storage implementations):
+**Set them in the DSN at open time, not with `db.Exec` afterwards.**
 
-WAL mode is enabled by all three stores (SessionStore, SQLiteHumanRequestStore, SQLiteStore). Foreign keys are enabled by `OpenDB()` in `pkg/agent/db_config.go` for the session store, and explicitly in the HITL store constructor.
+`busy_timeout`, `foreign_keys` and the SQLCipher `key` are *per-connection*
+settings. A `*sql.DB` is a connection pool, so `db.Exec("PRAGMA busy_timeout
+= 5000")` configures only the one connection that happens to run the
+statement; every other connection the pool opens keeps the driver default.
+That defect cost a 512-agent fleet run 291 lost conversation rows and ~27,000
+dropped trace writes before it was fixed (#366).
+
+`internal/sqlitedriver.DSN` renders these into the DSN so the driver applies
+them as each connection is opened, in whichever parameter syntax the active
+driver uses (mattn-style under CGO, `_pragma=` under modernc):
 
 ```go
-db, err := sql.Open("sqlite3", "sessions.db")
+import "github.com/teradata-labs/loom/internal/sqlitedriver"
+
+db, err := sql.Open("sqlite3", sqlitedriver.DSN(path, sqlitedriver.Options{
+    BusyTimeoutMS: 5000,
+    WAL:           true,
+    ForeignKeys:   true,
+}))
 if err != nil {
     return err
 }
-
-// Enable WAL mode (critical for concurrency)
-_, err = db.Exec("PRAGMA journal_mode=WAL")
-if err != nil {
-    return fmt.Errorf("failed to enable WAL: %w", err)
-}
-
-// Enable foreign keys (for referential integrity)
-_, err = db.Exec("PRAGMA foreign_keys=ON")
-if err != nil {
-    return fmt.Errorf("failed to enable foreign keys: %w", err)
-}
 ```
+
+`journal_mode` is the exception: it is a persistent, database-level setting
+stored in the file header, so a single post-open
+`db.Exec("PRAGMA journal_mode=WAL")` also works. `SessionStore` still does it
+that way because `OpenDB()` is shared with callers whose databases must not
+be converted to WAL; everywhere else it rides in the DSN.
+
+**What each store sets** (verified against the code):
+
+| Store | WAL | `busy_timeout` | `foreign_keys` |
+|---|---|---|---|
+| `SessionStore` (`pkg/agent/session_store.go`) | post-open Exec | DSN (via `OpenDB`) | DSN (via `OpenDB`) |
+| `SQLiteHumanRequestStore` (`pkg/shuttle/human_store_sqlite.go`) | DSN | DSN | DSN |
+| Artifact store (`pkg/artifacts/store.go`) | DSN | DSN | DSN |
+| Observability trace store (`pkg/observability/storage/sqlite.go`) | DSN | DSN | not set |
+
+**Encrypted databases** (SQLCipher, CGO builds only) have the same problem in
+a louder form: an unkeyed connection to an encrypted database fails outright
+with `file is not a database`. Use `sqlitedriver.EncryptedDSN(path, key,
+opts)`, which carries the key in the DSN so every pooled connection is keyed.
+`OpenDB()` in `pkg/agent/db_config.go` does this for you.
 
 
 ### Performance PRAGMAs
@@ -565,23 +593,24 @@ PRAGMA automatic_index = ON;
 
 **Apply at startup**:
 
-```go
-// Performance PRAGMAs
-pragmas := []string{
-    "PRAGMA cache_size = 10000",
-    "PRAGMA mmap_size = 268435456",
-    "PRAGMA busy_timeout = 5000",
-    "PRAGMA synchronous = NORMAL",
-    "PRAGMA temp_store = MEMORY",
-    "PRAGMA automatic_index = ON",
-}
+These are all per-connection settings, so on a pooled `*sql.DB` they belong in
+the DSN for the same reason `busy_timeout` does — a `db.Exec` loop reaches one
+connection only. `sqlitedriver.Options` covers `busy_timeout` (plus
+`journal_mode` and `foreign_keys`); add DSN parameters for the rest, or pin
+the pool to a single connection if you must Exec them:
 
-for _, pragma := range pragmas {
-    if _, err := db.Exec(pragma); err != nil {
-        log.Printf("Warning: %s failed: %v", pragma, err)
-    }
-}
+```go
+db, err := sql.Open("sqlite3", sqlitedriver.DSN(path, sqlitedriver.Options{
+    BusyTimeoutMS: 5000,
+    WAL:           true,
+    ForeignKeys:   true,
+})+"&_pragma=cache_size(10000)&_pragma=synchronous(NORMAL)&_pragma=temp_store(MEMORY)")
 ```
+
+Note that the parameter syntax above is modernc's; the CGO driver
+(go-sqlcipher) uses mattn-style keys such as `_cache_size=10000`. That
+difference is exactly why the shared options go through
+`sqlitedriver.Options`, which renders whichever syntax the active build needs.
 
 
 ### Query Current Settings
@@ -936,11 +965,15 @@ _, err := db.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
 
 **Problem**: Writer blocks when another transaction is active.
 
-**Solution**: Wait for lock with `PRAGMA busy_timeout`.
+**Solution**: Wait for the lock with `PRAGMA busy_timeout`, set in the DSN so
+every pooled connection gets it (see [Essential PRAGMAs](#essential-pragmas) —
+a `db.Exec` sets it on one connection only).
 
 ```go
-// Wait up to 5 seconds for lock
-_, err := db.Exec("PRAGMA busy_timeout = 5000")
+// Wait up to 5 seconds for the lock, on every connection the pool opens
+db, err := sql.Open("sqlite3", sqlitedriver.DSN(path, sqlitedriver.Options{
+    BusyTimeoutMS: 5000,
+}))
 ```
 
 **Without timeout**: `database is locked` error immediately.
@@ -1243,11 +1276,12 @@ func measureQuery(db *sql.DB, query string, args ...interface{}) time.Duration {
 
 **Resolution**:
 ```go
-// 1. Enable WAL mode (should already be enabled in Loom)
-db.Exec("PRAGMA journal_mode=WAL")
-
-// 2. Set busy timeout
-db.Exec("PRAGMA busy_timeout = 5000")  // 5 seconds
+// 1 + 2. Enable WAL and a busy timeout on EVERY pooled connection.
+//        (Both are already set this way by Loom's stores.)
+db, err := sql.Open("sqlite3", sqlitedriver.DSN(path, sqlitedriver.Options{
+    BusyTimeoutMS: 5000,
+    WAL:           true,
+}))
 
 // 3. Keep transactions short
 tx, _ := db.Begin()
@@ -1368,28 +1402,28 @@ if fk != 1 {
 
 ```go
 // REQUIRED: Enable WAL at database open
-db, err := sql.Open("sqlite3", "sessions.db")
+db, err := sql.Open("sqlite3", sqlitedriver.DSN(path, sqlitedriver.Options{
+    WAL: true,
+}))
 if err != nil {
     return err
 }
-
-_, err = db.Exec("PRAGMA journal_mode=WAL")
-if err != nil {
-    return fmt.Errorf("failed to enable WAL: %w", err)
-}
 ```
 
-**Why**: Enables concurrent reads + 1 writer, 10x performance improvement.
+**Why**: Readers never block the writer, so a long-running read cannot starve
+writes. Without it, every writer takes an EXCLUSIVE lock on the whole file:
+issue #370 measured ~1,486 dropped trace writes in a single fleet run from
+exactly that.
 
 
 ### 2. Enable Foreign Keys
 
 ```go
-// REQUIRED: Enable foreign keys at database open
-_, err = db.Exec("PRAGMA foreign_keys=ON")
-if err != nil {
-    return fmt.Errorf("failed to enable foreign keys: %w", err)
-}
+// REQUIRED: Enable foreign keys at database open — in the DSN, because
+// PRAGMA foreign_keys is per-connection and defaults to OFF.
+db, err := sql.Open("sqlite3", sqlitedriver.DSN(path, sqlitedriver.Options{
+    ForeignKeys: true,
+}))
 ```
 
 **Why**: Prevents orphaned records, ensures referential integrity.
@@ -1434,10 +1468,14 @@ CREATE INDEX idx_messages_session_timestamp
 ### 5. Set Busy Timeout
 
 ```go
-db.Exec("PRAGMA busy_timeout = 5000")  // 5 seconds
+db, err := sql.Open("sqlite3", sqlitedriver.DSN(path, sqlitedriver.Options{
+    BusyTimeoutMS: 5000,
+}))
 ```
 
-**Why**: Automatic retry on lock contention instead of immediate error.
+**Why**: Automatic retry on lock contention instead of immediate error — and
+in the DSN, so it applies to every connection the pool opens rather than the
+one that ran a `db.Exec`.
 
 
 ### 6. Configure Connection Pool

--- a/internal/sqlitedriver/doc.go
+++ b/internal/sqlitedriver/doc.go
@@ -4,7 +4,18 @@
 // (typical on Windows without GCC) it falls back to the pure-Go
 // modernc.org/sqlite driver — functional but without encryption support.
 //
-// Import this package for its side effects only:
+// Import it for the driver registration side effect, and use DSN to render
+// the per-connection settings that must be applied as each pooled connection
+// is opened rather than with a post-open db.Exec:
 //
-//	import _ "github.com/teradata-labs/loom/internal/sqlitedriver"
+//	import "github.com/teradata-labs/loom/internal/sqlitedriver"
+//
+//	db, err := sql.Open("sqlite3", sqlitedriver.DSN(path, sqlitedriver.Options{
+//		BusyTimeoutMS: 5000,
+//		WAL:           true,
+//		ForeignKeys:   true,
+//	}))
+//
+// EncryptedDSN does the same for SQLCipher-encrypted databases, carrying the
+// key so every pooled connection is keyed (CGO builds only).
 package sqlitedriver

--- a/internal/sqlitedriver/driver_cgo.go
+++ b/internal/sqlitedriver/driver_cgo.go
@@ -3,7 +3,10 @@
 package sqlitedriver
 
 import (
+	"errors"
+	"net/url"
 	"strconv"
+	"strings"
 
 	_ "github.com/mutecomm/go-sqlcipher/v4" // registers "sqlite3" driver with encryption
 )
@@ -26,4 +29,34 @@ func dsnParams(opts Options) []string {
 		p = append(p, "_foreign_keys=on")
 	}
 	return p
+}
+
+// EncryptedDSN renders path plus opts into a DSN that also carries the
+// SQLCipher key, so every connection database/sql opens is keyed.
+//
+// PRAGMA key has the same pooled-connection defect as PRAGMA busy_timeout,
+// only louder: setting it with db.Exec after opening keys the single
+// connection that happens to run the statement, and every other pooled
+// connection then fails outright with "file is not a database" — so an
+// encrypted store works only for as long as its pool never grows past one.
+//
+// go-sqlcipher applies _pragma_key by running PRAGMA key = "<value>" as each
+// connection is opened. Note the DOUBLE quotes: a double quote inside the key
+// is therefore escaped by doubling it, which is SQLite's rule for quoted
+// tokens and round-trips to the same key SQLCipher derives from the
+// single-quoted PRAGMA form. TestEncryptedDSNRoundTrip pins that against the
+// driver, including the awkward key characters.
+func EncryptedDSN(path, key string, opts Options) (string, error) {
+	if path == "" {
+		return "", errors.New("sqlitedriver: encrypted database path cannot be empty")
+	}
+	if key == "" {
+		return "", errors.New("sqlitedriver: encryption key cannot be empty")
+	}
+	sep := "?"
+	if strings.Contains(path, "?") {
+		sep = "&"
+	}
+	keyed := path + sep + "_pragma_key=" + url.QueryEscape(strings.ReplaceAll(key, `"`, `""`))
+	return DSN(keyed, opts), nil
 }

--- a/internal/sqlitedriver/driver_nocgo.go
+++ b/internal/sqlitedriver/driver_nocgo.go
@@ -4,6 +4,7 @@ package sqlitedriver
 
 import (
 	"database/sql"
+	"errors"
 	"strconv"
 
 	"modernc.org/sqlite"
@@ -33,4 +34,14 @@ func dsnParams(opts Options) []string {
 		p = append(p, "_pragma=foreign_keys(1)")
 	}
 	return p
+}
+
+// EncryptedDSN always fails without CGO: modernc.org/sqlite is plain SQLite
+// with no SQLCipher support, so there is no key to render and no way to open
+// an encrypted database at all. It returns an error rather than a silently
+// unkeyed DSN, which would hand the caller a *sql.DB that writes plaintext.
+// Callers gate on EncryptionSupported and report the missing capability with
+// their own wording before reaching this.
+func EncryptedDSN(string, string, Options) (string, error) {
+	return "", errors.New("sqlitedriver: database encryption requires CGO (SQLCipher); not available in this build")
 }

--- a/internal/sqlitedriver/dsn_test.go
+++ b/internal/sqlitedriver/dsn_test.go
@@ -187,3 +187,97 @@ func TestDSNConcurrentWritersSurviveContention(t *testing.T) {
 	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM burst").Scan(&n))
 	assert.Equal(t, writers*perGoro, n, "every write must land")
 }
+
+// TestEncryptedDSNValidation covers the input checks, which behave the same
+// in both builds.
+func TestEncryptedDSNValidation(t *testing.T) {
+	_, err := EncryptedDSN("", "key", Options{})
+	assert.Error(t, err, "empty path must be rejected")
+
+	_, err = EncryptedDSN("/tmp/x.db", "", Options{})
+	assert.Error(t, err, "empty key must be rejected")
+
+	if !EncryptionSupported {
+		_, err := EncryptedDSN("/tmp/x.db", "key", Options{})
+		assert.ErrorContains(t, err, "requires CGO",
+			"without SQLCipher the helper must fail loudly rather than hand back an unkeyed DSN")
+	}
+}
+
+// TestEncryptedDSNRoundTrip is the regression test for the PRAGMA key half of
+// the pooled-connection defect: `db.Exec("PRAGMA key = ...")` keys only the
+// connection that runs it, so every other pooled connection to an encrypted
+// database fails with "file is not a database".
+//
+// It also pins the quoting contract with go-sqlcipher, which applies
+// _pragma_key by running PRAGMA key = "<value>" — double quotes, hence the
+// doubling escape in EncryptedDSN. Each case creates the database with the
+// OLD single-quoted Exec form and reopens it through EncryptedDSN, so a
+// change in either quoting rule shows up as a database that no longer opens.
+func TestEncryptedDSNRoundTrip(t *testing.T) {
+	if !EncryptionSupported {
+		t.Skip("SQLCipher requires CGO")
+	}
+
+	keys := []struct {
+		name string
+		key  string
+	}{
+		{"plain", "passphrase-1234"},
+		{"double quote", `dquote"key`},
+		{"url metacharacters", "space key&amp=1?x"},
+		{"unicode", "ünïcøde-key-🔑"},
+	}
+
+	for _, tc := range keys {
+		t.Run(tc.name, func(t *testing.T) {
+			dbPath := filepath.Join(t.TempDir(), "encrypted.db")
+			opts := Options{BusyTimeoutMS: 5000, ForeignKeys: true}
+
+			// Create the database the way the pre-fix code did, on a pool of
+			// exactly one so the single keyed connection is the one used.
+			seed, err := sql.Open("sqlite3", DSN(dbPath, opts))
+			require.NoError(t, err)
+			seed.SetMaxOpenConns(1)
+			_, err = seed.Exec("PRAGMA key = '" + tc.key + "'")
+			require.NoError(t, err)
+			_, err = seed.Exec("CREATE TABLE secret (id INTEGER PRIMARY KEY, v TEXT)")
+			require.NoError(t, err)
+			_, err = seed.Exec("INSERT INTO secret (v) VALUES ('classified')")
+			require.NoError(t, err)
+			require.NoError(t, seed.Close())
+
+			// Reopen through EncryptedDSN with a pool wide enough to expose
+			// unkeyed connections.
+			dsn, err := EncryptedDSN(dbPath, tc.key, opts)
+			require.NoError(t, err)
+			db, err := sql.Open("sqlite3", dsn)
+			require.NoError(t, err)
+			defer func() { _ = db.Close() }()
+			db.SetMaxOpenConns(4)
+			db.SetMaxIdleConns(4)
+
+			for i, c := range pinConns(t, db, 4) {
+				var v string
+				require.NoError(t,
+					c.QueryRowContext(context.Background(), "SELECT v FROM secret WHERE id = 1").Scan(&v),
+					"conn %d: every pooled connection must be keyed", i)
+				assert.Equal(t, "classified", v, "conn %d", i)
+
+				var busy int
+				require.NoError(t, c.QueryRowContext(context.Background(), "PRAGMA busy_timeout").Scan(&busy))
+				assert.Equal(t, 5000, busy, "conn %d: opts must survive alongside the key", i)
+			}
+
+			// The database really is encrypted: a wrong key must not open it.
+			wrongDSN, err := EncryptedDSN(dbPath, "definitely-the-wrong-key", opts)
+			require.NoError(t, err)
+			wrong, err := sql.Open("sqlite3", wrongDSN)
+			require.NoError(t, err)
+			defer func() { _ = wrong.Close() }()
+			var n int
+			assert.Error(t, wrong.QueryRow("SELECT COUNT(*) FROM secret").Scan(&n),
+				"a wrong key must be rejected; if it is not, the database is not encrypted")
+		})
+	}
+}

--- a/pkg/agent/db_config.go
+++ b/pkg/agent/db_config.go
@@ -57,28 +57,27 @@ type DBConfig struct {
 //	    EncryptionKey: os.Getenv("LOOM_DB_KEY"),
 //	})
 func OpenDB(config DBConfig) (*sql.DB, error) {
-	// Open database using the pre-registered "sqlite3" driver. busy_timeout
-	// and foreign_keys are per-connection settings, so they must ride in the
-	// DSN to reach every pooled connection — a post-open db.Exec configures
-	// only the one connection that runs it. Both PRAGMAs are safe before
-	// PRAGMA key on encrypted databases (neither touches data pages).
-	dsn := sqlitedriver.DSN(config.Path, sqlitedriver.Options{
+	// busy_timeout and foreign_keys are per-connection settings, so they must
+	// ride in the DSN to reach every pooled connection — a post-open db.Exec
+	// configures only the one connection that runs it.
+	opts := sqlitedriver.Options{
 		BusyTimeoutMS: 5000,
 		ForeignKeys:   true,
-	})
-	db, err := sql.Open("sqlite3", dsn)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
+	dsn := sqlitedriver.DSN(config.Path, opts)
 
-	// Set encryption key if encryption is enabled
-	if config.EncryptDatabase && !sqlitedriver.EncryptionSupported {
-		return nil, errors.Join(
-			fmt.Errorf("database encryption requires CGO (SQLCipher); not available in this build"),
-			db.Close(),
-		)
-	}
+	// PRAGMA key is per-connection too, and gets it worse: an unkeyed
+	// connection to an encrypted database fails outright with "file is not a
+	// database". Setting the key with db.Exec after opening keyed only the
+	// connection that ran the statement, and this pool is database/sql's
+	// default (unlimited), so the second concurrent query on an encrypted
+	// store failed. The key rides in the DSN so the driver applies it as each
+	// connection is opened.
 	if config.EncryptDatabase {
+		if !sqlitedriver.EncryptionSupported {
+			return nil, fmt.Errorf("database encryption requires CGO (SQLCipher); not available in this build")
+		}
+
 		// Check for encryption key
 		key := config.EncryptionKey
 		if key == "" {
@@ -86,21 +85,20 @@ func OpenDB(config DBConfig) (*sql.DB, error) {
 			key = os.Getenv("LOOM_DB_KEY")
 		}
 		if key == "" {
-			return nil, errors.Join(
-				fmt.Errorf("encryption enabled but no key provided (set EncryptionKey or LOOM_DB_KEY env var)"),
-				db.Close(),
-			)
+			return nil, fmt.Errorf("encryption enabled but no key provided (set EncryptionKey or LOOM_DB_KEY env var)")
 		}
 
-		// Set encryption key via PRAGMA
-		// Note: This must be the first operation after opening the database
-		_, err = db.Exec(fmt.Sprintf("PRAGMA key = '%s'", key))
+		keyedDSN, err := sqlitedriver.EncryptedDSN(config.Path, key, opts)
 		if err != nil {
-			return nil, errors.Join(
-				fmt.Errorf("failed to set encryption key: %w", err),
-				db.Close(),
-			)
+			return nil, fmt.Errorf("failed to set encryption key: %w", err)
 		}
+		dsn = keyedDSN
+	}
+
+	// Open database using the pre-registered "sqlite3" driver.
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
 
 	// Test the connection

--- a/pkg/agent/db_config_test.go
+++ b/pkg/agent/db_config_test.go
@@ -14,12 +14,18 @@
 package agent
 
 import (
+	"context"
+	"database/sql"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/teradata-labs/loom/internal/sqlitedriver"
 )
 
 func TestOpenDB_Unencrypted(t *testing.T) {
@@ -94,11 +100,12 @@ func TestOpenDB_Encrypted(t *testing.T) {
 		t.Fatal("Expected error when opening encrypted DB with wrong key")
 	}
 	assert.Error(t, err)
-	// SQLCipher returns "file is not a database" when the key is wrong
-	assert.True(t,
-		err.Error() == "failed to set encryption key: file is not a database" ||
-			err.Error() == "failed to verify encryption key (wrong key or corrupted database): file is not a database",
-		"Expected database error, got: %s", err.Error())
+	// The key rides in the DSN, so a wrong key is rejected when the first
+	// connection is opened — i.e. at Ping. SQLCipher reports it as "file is
+	// not a database".
+	assert.Equal(t,
+		"failed to verify encryption key (wrong key or corrupted database): file is not a database",
+		err.Error())
 
 	// Try to open encrypted DB without encryption - should fail
 	dbUnencrypted, err := OpenDB(DBConfig{
@@ -210,4 +217,101 @@ func TestNewSessionStoreWithConfig_Unencrypted(t *testing.T) {
 	err = store.db.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type='table'").Scan(&tableCount)
 	require.NoError(t, err)
 	assert.Greater(t, tableCount, 0, "Expected tables to be created")
+}
+
+// TestOpenDB_EncryptedPooledConnections is the regression test for the
+// PRAGMA-key half of the pooled-connection defect (issues #366, #370).
+//
+// OpenDB used to set the key with db.Exec after opening, which keys only the
+// connection that happens to run the statement. The pool here is
+// database/sql's default — unlimited — so the second connection the pool
+// opened was unkeyed and every query on it failed with "file is not a
+// database". Before the fix this test failed on conns 1..3; the key now rides
+// in the DSN, so the driver applies it as each connection is opened.
+func TestOpenDB_EncryptedPooledConnections(t *testing.T) {
+	if !sqlitedriver.EncryptionSupported {
+		t.Skip("SQLCipher requires CGO")
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "pooled_encrypted.db")
+	db, err := OpenDB(DBConfig{
+		Path:            dbPath,
+		EncryptDatabase: true,
+		EncryptionKey:   "pooled-key-abc123",
+	})
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	_, err = db.Exec("CREATE TABLE secret (id INTEGER PRIMARY KEY, v TEXT)")
+	require.NoError(t, err)
+	_, err = db.Exec("INSERT INTO secret (v) VALUES ('classified')")
+	require.NoError(t, err)
+
+	// Hold each connection while acquiring the next so the pool is forced to
+	// open fresh ones instead of handing back the keyed one.
+	const pinned = 4
+	conns := make([]*sql.Conn, 0, pinned)
+	defer func() {
+		for _, c := range conns {
+			_ = c.Close()
+		}
+	}()
+	for i := 0; i < pinned; i++ {
+		c, err := db.Conn(context.Background())
+		require.NoError(t, err, "conn %d: every pooled connection must be keyed", i)
+		conns = append(conns, c)
+
+		var v string
+		require.NoError(t,
+			c.QueryRowContext(context.Background(), "SELECT v FROM secret WHERE id = 1").Scan(&v),
+			"conn %d: query on a pooled connection must not fail", i)
+		assert.Equal(t, "classified", v, "conn %d", i)
+	}
+	require.Equal(t, pinned, db.Stats().OpenConnections,
+		"connections must be distinct for this test to prove anything")
+}
+
+// TestOpenDB_EncryptedConcurrent exercises the same defect the way production
+// hits it: concurrent goroutines, which make database/sql open more than one
+// connection on its own.
+func TestOpenDB_EncryptedConcurrent(t *testing.T) {
+	if !sqlitedriver.EncryptionSupported {
+		t.Skip("SQLCipher requires CGO")
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "concurrent_encrypted.db")
+	db, err := OpenDB(DBConfig{
+		Path:            dbPath,
+		EncryptDatabase: true,
+		EncryptionKey:   "concurrent-key-xyz",
+	})
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	_, err = db.Exec("CREATE TABLE secret (id INTEGER PRIMARY KEY, v TEXT)")
+	require.NoError(t, err)
+	_, err = db.Exec("INSERT INTO secret (v) VALUES ('classified')")
+	require.NoError(t, err)
+
+	const readers = 8
+	var wg sync.WaitGroup
+	errCh := make(chan error, readers)
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func(reader int) {
+			defer wg.Done()
+			for i := 0; i < 5; i++ {
+				var v string
+				if err := db.QueryRow("SELECT v FROM secret WHERE id = 1").Scan(&v); err != nil {
+					errCh <- fmt.Errorf("reader %d: %w", reader, err)
+					return
+				}
+			}
+		}(r)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Errorf("concurrent read on encrypted database failed: %v", err)
+	}
 }

--- a/pkg/agent/session_store.go
+++ b/pkg/agent/session_store.go
@@ -126,11 +126,10 @@ func NewSessionStoreWithConfig(config DBConfig, tracer observability.Tracer) (*S
 
 	// Enable WAL mode for better concurrency. journal_mode is a persistent
 	// database-level setting (stored in the file header), so a one-time Exec
-	// is sufficient — unlike busy_timeout/foreign_keys, which are
+	// is sufficient — unlike busy_timeout/foreign_keys/key, which are
 	// per-connection and set via the DSN in OpenDB. Kept as an Exec here
 	// because OpenDB is also used for databases that must not be converted
-	// to WAL (and PRAGMA key on encrypted databases must precede any
-	// statement that touches data pages, which journal_mode does).
+	// to WAL.
 	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
 		return nil, fmt.Errorf("failed to enable WAL mode: %w", err)
 	}

--- a/pkg/observability/storage/sqlite.go
+++ b/pkg/observability/storage/sqlite.go
@@ -38,22 +38,43 @@ func NewSQLiteStorage(dbPath string) (*SQLiteStorage, error) {
 		return nil, fmt.Errorf("database path cannot be empty")
 	}
 
-	// Open database. busy_timeout rides in the DSN so ALL 10 pooled
-	// connections wait on lock contention instead of failing instantly with
-	// SQLITE_BUSY ("failed to create eval run" under concurrent writers).
-	db, err := sql.Open("sqlite3", sqlitedriver.DSN(dbPath, sqlitedriver.Options{BusyTimeoutMS: 5000}))
+	// Open the database in WAL mode with a busy timeout. Both settings ride
+	// in the DSN so they reach EVERY pooled connection: busy_timeout is a
+	// per-connection setting, so a post-open db.Exec configures only the one
+	// connection that happens to run it (see internal/sqlitedriver). No
+	// post-open "PRAGMA journal_mode" Exec is used here — journal_mode is a
+	// persistent database-level setting so either form works, but the DSN
+	// keeps the intent with the open call and covers a fresh database file
+	// without a follow-up statement.
+	//
+	// WAL is the structural half of the fix for issue #370. In SQLite's
+	// default rollback-journal mode every writer takes an EXCLUSIVE lock on
+	// the whole file across its fsync and readers block writers outright, so
+	// with 10 pooled connections all writing spans the lock is held
+	// essentially continuously under fleet load: writers burned the full 5s
+	// busy_timeout and still lost (~1,486 "failed to store eval run" in one
+	// 512-agent run). Under WAL, readers never block the writer and commits
+	// append to the -wal file, which collapses the write lock's duty cycle.
+	db, err := sql.Open("sqlite3", sqlitedriver.DSN(dbPath, sqlitedriver.Options{
+		BusyTimeoutMS: 5000,
+		WAL:           true,
+	}))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
 
 	// Configure connection pool.
 	//
-	// NOTE (follow-up): 10 concurrent connections all write to this database
-	// in rollback-journal mode, so writers serialize on the file lock and
-	// burn their busy_timeout waiting on each other. Enabling WAL and/or
-	// splitting the pool into one writer connection + N readers would cut
-	// contention structurally; kept as-is here to keep this change scoped to
-	// the busy_timeout fix.
+	// 10 connections stays right under WAL. SQLite allows exactly one writer
+	// at a time in any journal mode, so a narrower pool would not buy write
+	// throughput; what the extra connections buy is that the read path
+	// (CalculateEvalMetrics runs a full aggregate scan over eval_runs) runs
+	// concurrently with writers instead of blocking them, which is precisely
+	// what WAL enables and what rollback-journal mode did not. Serialising
+	// writers in Go instead (a write mutex or a 1-connection write pool) was
+	// considered and rejected: it trades SQLite's busy handler for a Go queue
+	// without changing write throughput, and TestSQLiteConcurrentWriters
+	// shows the busy handler no longer loses under WAL.
 	db.SetMaxOpenConns(10)
 	db.SetMaxIdleConns(5)
 	db.SetConnMaxLifetime(time.Hour)

--- a/pkg/observability/storage/sqlite_wal_test.go
+++ b/pkg/observability/storage/sqlite_wal_test.go
@@ -1,0 +1,286 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build fts5
+
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSQLiteStorageJournalModeIsWAL is the regression test for issue #370:
+// this store used to open in SQLite's default rollback-journal mode, where
+// every writer takes an EXCLUSIVE lock on the whole file and readers block
+// writers, so its 10 pooled connections serialised and exhausted their
+// busy_timeout under fleet load.
+//
+// journal_mode must be WAL on EVERY pooled connection, not just the one that
+// happened to run an Exec — the same defect PRAGMA busy_timeout had before
+// internal/sqlitedriver.DSN existed (see internal/sqlitedriver/dsn_test.go).
+// Connections are pinned with db.Conn and held so the pool is forced to open
+// fresh ones rather than hand back the same one.
+func TestSQLiteStorageJournalModeIsWAL(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "obs.db")
+
+	storage, err := NewSQLiteStorage(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storage.Close() })
+
+	const pinned = 6 // fewer than SetMaxOpenConns(10)
+	conns := make([]*sql.Conn, 0, pinned)
+	t.Cleanup(func() {
+		for _, c := range conns {
+			_ = c.Close()
+		}
+	})
+	for i := 0; i < pinned; i++ {
+		c, err := storage.db.Conn(context.Background())
+		require.NoError(t, err, "pin connection %d", i)
+		conns = append(conns, c)
+	}
+	require.Equal(t, pinned, storage.db.Stats().OpenConnections,
+		"connections must be distinct for this test to prove anything")
+
+	for i, c := range conns {
+		var journalMode string
+		require.NoError(t, c.QueryRowContext(context.Background(), "PRAGMA journal_mode").Scan(&journalMode))
+		assert.Equal(t, "wal", strings.ToLower(journalMode),
+			"conn %d: journal_mode must be WAL on every pooled connection", i)
+
+		var busyTimeout int
+		require.NoError(t, c.QueryRowContext(context.Background(), "PRAGMA busy_timeout").Scan(&busyTimeout))
+		assert.Equal(t, 5000, busyTimeout,
+			"conn %d: busy_timeout must be 5000 on every pooled connection", i)
+	}
+}
+
+// isLockError reports whether err is SQLite lock contention (SQLITE_BUSY /
+// SQLITE_LOCKED) or a write that ran out of time waiting for the lock.
+func isLockError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	for _, needle := range []string{"database is locked", "database table is locked", "sqlite_busy", "busy", "deadline exceeded"} {
+		if strings.Contains(s, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// seedContentionRows bulk-inserts n eval runs in one transaction so the
+// concurrency test starts from a table with real history in it rather than an
+// empty one.
+func seedContentionRows(t *testing.T, s *SQLiteStorage, evalID string, n int) {
+	t.Helper()
+	tx, err := s.db.Begin()
+	require.NoError(t, err)
+	stmt, err := tx.Prepare(`INSERT INTO eval_runs (
+		id, eval_id, query, model, configuration_json, response,
+		execution_time_ms, token_count, success, error_message,
+		session_id, timestamp
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	require.NoError(t, err)
+	for i := 0; i < n; i++ {
+		_, err := stmt.Exec(fmt.Sprintf("seed-%d", i), evalID, "seed query", "seed-model",
+			"{}", "seed response", int64(i), int32(i%1000), 1, "", "seed-session", time.Now().Unix())
+		require.NoError(t, err)
+	}
+	require.NoError(t, stmt.Close())
+	require.NoError(t, tx.Commit())
+}
+
+// holdingRead runs an aggregate over eval_runs inside a read transaction and
+// keeps that transaction open until ctx is cancelled, modelling a long
+// CalculateEvalMetrics scan over a fleet-sized table (or an operator's
+// sqlite3 session) running while spans are being written.
+//
+// Holding the read is what makes this test deterministic rather than a race
+// against the local disk. A long-running read is the invariant difference
+// between the two journal modes: under a rollback journal the reader holds
+// SHARED for the whole transaction and no writer can take the EXCLUSIVE lock
+// it needs to commit until every SHARED is released, so writers burn their
+// busy_timeout no matter how fast the hardware is. Under WAL the reader works
+// from a snapshot and never blocks the writer, no matter how slow the read is.
+func holdingRead(ctx context.Context, s *SQLiteStorage, evalID string, up chan<- struct{}) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// The read lock is taken by the first statement, not by BEGIN (SQLite
+	// transactions are deferred).
+	var runs int
+	var tokens int64
+	if err := tx.QueryRowContext(ctx,
+		"SELECT COUNT(*), COALESCE(SUM(token_count), 0) FROM eval_runs WHERE eval_id = ?",
+		evalID).Scan(&runs, &tokens); err != nil {
+		return err
+	}
+
+	up <- struct{}{}
+	<-ctx.Done()
+	return nil
+}
+
+// TestSQLiteConcurrentWriters is the contention regression for issue #370.
+//
+// It reproduces the shape of the fleet workload that dropped ~1,486 spans in
+// a single 512-agent run: many goroutines writing eval runs (EndSpan ->
+// CreateEvalRun is the hot path) while readers aggregate over the same table
+// (CalculateEvalMetrics does a full scan). In rollback-journal mode the
+// readers block the writers and the writers block each other on the
+// whole-file lock, so writes exhaust the 5s busy_timeout and are lost. Under
+// WAL readers never block the writer, so every write must land inside the
+// budget with no lock errors at all.
+//
+// Measured on this test with the store's pool unchanged (issue #370):
+//   - rollback journal (pre-fix): 480/480 writes failed with "database is
+//     locked", 0 rows landed, burst took 10.4s.
+//   - WAL (post-fix): 0 lock errors, 480/480 rows landed, burst took 112ms.
+func TestSQLiteConcurrentWriters(t *testing.T) {
+	const (
+		writers   = 8
+		perWriter = 60
+		readers   = 2
+		seedRows  = 5000
+
+		// The burst must finish well inside this. It is deliberately shorter
+		// than writeDeadline so a writer that ends up waiting on the store's
+		// 5s busy_timeout shows up as a lock error, not as a hang.
+		totalBudget   = 5 * time.Second
+		writeDeadline = 8 * time.Second
+	)
+
+	dbPath := filepath.Join(t.TempDir(), "contention.db")
+	storage, err := NewSQLiteStorage(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storage.Close() })
+
+	const evalID = "eval-contention"
+	require.NoError(t, storage.CreateEval(context.Background(), &Eval{
+		ID:     evalID,
+		Name:   "contention",
+		Suite:  "regression",
+		Status: "running",
+	}))
+
+	// Seed history so the readers are aggregating over real rows.
+	seedContentionRows(t, storage, evalID, seedRows)
+
+	ctx, cancel := context.WithTimeout(context.Background(), writeDeadline)
+	defer cancel()
+
+	// Readers aggregate over eval_runs and hold the read open for as long as
+	// the writers are working. Under a rollback journal these are what starve
+	// the writers; under WAL they are invisible to them.
+	readerCtx, stopReaders := context.WithCancel(context.Background())
+	defer stopReaders()
+	var readerWG sync.WaitGroup
+	var readErrs atomic.Int64
+	readersUp := make(chan struct{}, readers)
+	for r := 0; r < readers; r++ {
+		readerWG.Add(1)
+		go func() {
+			defer readerWG.Done()
+			if err := holdingRead(readerCtx, storage, evalID, readersUp); err != nil {
+				readErrs.Add(1)
+			}
+		}()
+	}
+	// Do not start writing until the readers actually hold their read locks,
+	// or the burst can finish before contention exists.
+	for r := 0; r < readers; r++ {
+		select {
+		case <-readersUp:
+		case <-time.After(totalBudget):
+			t.Fatal("reader did not acquire its read transaction")
+		}
+	}
+
+	start := time.Now()
+
+	var writerWG sync.WaitGroup
+	errCh := make(chan error, writers*perWriter)
+	for w := 0; w < writers; w++ {
+		writerWG.Add(1)
+		go func(writer int) {
+			defer writerWG.Done()
+			for seq := 0; seq < perWriter; seq++ {
+				run := &EvalRun{
+					ID:                fmt.Sprintf("span-%d-%d", writer, seq),
+					EvalID:            evalID,
+					Query:             "select 1",
+					Model:             "test-model",
+					ConfigurationJSON: `{"writer":true}`,
+					Response:          "ok",
+					ExecutionTimeMS:   int64(seq),
+					TokenCount:        int32(seq),
+					Success:           true,
+					SessionID:         fmt.Sprintf("session-%d", writer),
+					Timestamp:         time.Now().Unix(),
+				}
+				if err := storage.CreateEvalRun(ctx, run); err != nil {
+					errCh <- fmt.Errorf("writer %d seq %d: %w", writer, seq, err)
+				}
+			}
+		}(w)
+	}
+	writerWG.Wait()
+	elapsed := time.Since(start)
+
+	stopReaders()
+	readerWG.Wait()
+	close(errCh)
+
+	var lockErrs, otherErrs int
+	for err := range errCh {
+		if isLockError(err) {
+			lockErrs++
+			if lockErrs <= 3 {
+				t.Logf("lock error: %v", err)
+			}
+			continue
+		}
+		otherErrs++
+		t.Logf("write error: %v", err)
+	}
+
+	assert.Zero(t, lockErrs, "SQLITE_BUSY / lock-timeout writes must not happen under WAL (issue #370)")
+	assert.Zero(t, otherErrs, "no write may fail")
+	assert.Zero(t, readErrs.Load(), "concurrent readers must not fail either")
+
+	var stored int
+	require.NoError(t, storage.db.QueryRowContext(context.Background(),
+		"SELECT COUNT(*) FROM eval_runs WHERE eval_id = ? AND id LIKE 'span-%'", evalID).Scan(&stored))
+	assert.Equal(t, writers*perWriter, stored, "every eval run must land")
+
+	assert.Less(t, elapsed, totalBudget,
+		"writer burst must finish inside the budget (took %s)", elapsed)
+	t.Logf("%d writers x %d runs + %d readers: %d rows in %s", writers, perWriter, readers, stored, elapsed)
+}


### PR DESCRIPTION
Closes #370.

## The reported problem

After #366 gave every pooled connection a 5s `busy_timeout`, one failure class remained — and it was **every** remaining lock error in the system: `failed to store eval run`, 1,486 of them in a single 512-agent run. Cause: this store runs a 10-connection pool in **rollback-journal mode**, where a reader blocks the writer outright, so writers burned the full timeout and still lost. It also explains the long-standing "observability.db has no spans" symptom across the whole benchmark campaign.

**Fix:** open the store WAL via the existing helper. Pool stays at 10, with the reasoning recorded at the call site: SQLite permits one writer in *any* journal mode, so a narrower pool buys no write throughput — what the extra connections buy is `CalculateEvalMetrics`' full aggregate scan running concurrently with writers instead of blocking them, which is exactly what WAL enables. A Go-side write mutex was considered and rejected as swapping SQLite's busy handler for a queue without changing throughput.

### Contention evidence (8 writers × 60 eval runs, 2 readers holding open read transactions)

| | writes failed | rows landed | burst |
|---|---|---|---|
| rollback journal (pre-fix) | **480/480** `database is locked` | **0** | 10.4s |
| WAL (post-fix) | 0 | **480/480** | 112ms |

The reader deliberately *holds* its read transaction: volume-based load wasn't discriminating (rollback mode merely got 11–25× slower and still passed, making the test a race against local disk speed). A long-running read starves writers under a rollback journal on any hardware and never blocks them under WAL, so the assertion is hardware-independent in both directions.

## The bigger thing found while in here

The `PRAGMA key` hazard flagged in #366 is **not** unreachable — it was live and total. `OpenDB` never called `SetMaxOpenConns`, so encrypted stores ran on database/sql's *unlimited* default pool while the key was applied by a one-shot `Exec`. Probe against the pre-fix code:

```
conn 0: query err=<nil>
conn 1: acquire err: file is not a database
conn 2: acquire err: file is not a database
```

Encrypted session stores were broken at any concurrency — the first concurrent query lost. Fixed with a build-tagged `sqlitedriver.EncryptedDSN` so every pooled connection is keyed at open, rather than pinning the pool to 1 (which would also risk nested-query deadlock across `SessionStore`/`registry.go`).

Two details verified empirically rather than assumed: go-sqlcipher applies `_pragma_key` as `PRAGMA key = "<value>"` with **double** quotes, so a `"` in the key is escaped by doubling; and the rendering is wire-compatible with databases created by the old single-quoted `Exec` form (checked for plain, `"`, `&`/`=`/space and unicode keys, with a wrong key still rejected). Incidentally the old form hard-failed on keys containing `'`; the DSN form handles them. The nocgo stub returns an error rather than silently handing back an unkeyed DSN that would write plaintext.

## Not fixed here — filed separately

`pkg/storage/backend/sqlite_backend.go` opens the artifact store, HITL store and migrator against the same path with **no key even when `cfg.Encrypt` is true**, so the encrypted path is still broken end-to-end downstream of `OpenDB`.

Also corrected `docs/reference/sqlite-guidance.md`, which was still teaching the `db.Exec("PRAGMA busy_timeout = 5000")` pattern #366 removed — following it reintroduces the exact bug. Only the PRAGMA sections were audited.

## Validation

`gofmt`/`go vet` clean under both build tags; `go build -tags fts5 ./...` under CGO and `CGO_ENABLED=0`; `-race -count=2` on observability, storage and sqlitedriver plus the touched consumers; golangci-lint 0 issues. New tests fail on the pre-fix configuration (journal mode reports `delete` on all six pinned connections; encrypted conns 1..3 report `file is not a database`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)