### PR TITLE
fix(hitl): heartbeat a pending hold, wire it into serve, and gate the card on a request id

### DIFF
--- a/cmd/looms/cmd_serve.go
+++ b/cmd/looms/cmd_serve.go
@@ -1688,7 +1688,7 @@ func runServe(cmd *cobra.Command, args []string) {
 		hitlStore,
 		askTimeout,
 		time.Second,
-		nil,
+		hitlNotifier(),
 	)
 	admissionChain, err := createAdmissionChain(config, shuttle.ChainDeps{Perm: permissionChecker, Ask: askResolver, Custom: shuttle.ProcessCustomHookRegistry()}, logger)
 	if err != nil {
@@ -2078,9 +2078,10 @@ func runServe(cmd *cobra.Command, args []string) {
 					for _, toolName := range cfg.Tools.Builtin {
 						if toolName == "contact_human" {
 							humanTool := shuttle.NewContactHumanTool(shuttle.ContactHumanConfig{
-								Store:  hitlStore,
-								Tracer: tracer,
-								Logger: logger,
+								Store:    hitlStore,
+								Notifier: hitlNotifier(),
+								Tracer:   tracer,
+								Logger:   logger,
 							})
 							ag.RegisterTool(humanTool)
 							logger.Info("    Auto-registered contact_human tool (shared HITL store)",
@@ -3328,9 +3329,10 @@ func runServe(cmd *cobra.Command, args []string) {
 				for _, toolName := range agentConfig.Tools.Builtin {
 					if toolName == "contact_human" {
 						humanTool := shuttle.NewContactHumanTool(shuttle.ContactHumanConfig{
-							Store:  hitlStore,
-							Tracer: tracer,
-							Logger: logger,
+							Store:    hitlStore,
+							Notifier: hitlNotifier(),
+							Tracer:   tracer,
+							Logger:   logger,
 						})
 						newAgent.RegisterTool(humanTool)
 						logger.Info("  Auto-registered contact_human tool (shared HITL store)",

--- a/cmd/looms/hitl_wiring.go
+++ b/cmd/looms/hitl_wiring.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"github.com/teradata-labs/loom/pkg/agent"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+)
+
+// hitlNotifier returns the notifier EVERY HITL hold origin in serve is wired
+// with — the ask resolver and both contact_human registration paths (cold start
+// and hot reload). One function so the origins cannot drift, and so the wiring
+// is reachable from a test: a nil notifier here is silent in exactly the way a
+// held turn cannot afford, costing the pending card AND the heartbeats that
+// keep the caller's stream alive for the length of the hold.
+//
+// The bridge it returns also implements shuttle.Heartbeater, which the waiters
+// discover by interface assertion; hitlNotifierBeats pins that so the
+// capability cannot be lost by swapping in a plain Notifier.
+func hitlNotifier() shuttle.Notifier { return agent.NewProgressNotifier() }

--- a/cmd/looms/hitl_wiring_test.go
+++ b/cmd/looms/hitl_wiring_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+)
+
+// serve must hand its HITL origins a real notifier. A nil one is silent in
+// exactly the way a held turn cannot afford: no pending card reaches the
+// caller, and no heartbeat keeps the stream alive for the length of the hold.
+func TestHITLNotifier_IsWiredAndNotNil(t *testing.T) {
+	n := hitlNotifier()
+	require.NotNil(t, n, "serve must wire a real notifier into every HITL hold origin")
+}
+
+// The waiters reach the heartbeat only through an interface assertion, so a
+// notifier that stops advertising the capability would silently return every
+// hold to being byte-silent — with nothing failing to say so.
+func TestHITLNotifier_AdvertisesHeartbeater(t *testing.T) {
+	_, ok := hitlNotifier().(shuttle.Heartbeater)
+	require.True(t, ok, "serve's HITL notifier must implement shuttle.Heartbeater")
+}
+
+// Guards the wiring itself: every HITL hold origin in serve must be handed
+// hitlNotifier(), never a nil literal. This is a source check because the
+// origins are built deep inside serve's startup path, and the failure it
+// catches is invisible at runtime — a nil notifier does not error, it just
+// never emits.
+func TestServe_AllHITLOriginsUseTheSharedNotifier(t *testing.T) {
+	src, err := os.ReadFile(filepath.Join(".", "cmd_serve.go"))
+	require.NoError(t, err)
+	text := string(src)
+
+	askResolver := regexp.MustCompile(`(?s)shuttle\.NewHITLAskResolver\((.*?)\n\t*\)`)
+	asks := askResolver.FindAllStringSubmatch(text, -1)
+	require.NotEmpty(t, asks, "expected serve to build an ask resolver")
+	for _, m := range asks {
+		require.Contains(t, m[1], "hitlNotifier()",
+			"the ask resolver must be wired with hitlNotifier(); a nil notifier drops the card AND the heartbeats")
+	}
+
+	contactHuman := regexp.MustCompile(`(?s)shuttle\.ContactHumanConfig\{(.*?)\}`)
+	contacts := contactHuman.FindAllStringSubmatch(text, -1)
+	require.NotEmpty(t, contacts, "expected serve to register contact_human")
+	for _, m := range contacts {
+		require.Contains(t, m[1], "Notifier: hitlNotifier()",
+			"every contact_human registration (cold start AND hot reload) must be wired with hitlNotifier()")
+	}
+	require.GreaterOrEqual(t, len(contacts), 2,
+		"both the cold-start and hot-reload registration paths must be covered")
+}
+
+// The notifier bridge lives in pkg/agent because pkg/shuttle cannot import it;
+// this pins that serve reaches it through the one intended entry point rather
+// than re-deriving a second bridge that could drift.
+func TestHITLNotifier_ComesFromTheAgentBridge(t *testing.T) {
+	src, err := os.ReadFile(filepath.Join(".", "hitl_wiring.go"))
+	require.NoError(t, err)
+	require.True(t, strings.Contains(string(src), "agent.NewProgressNotifier()"),
+		"hitlNotifier must return the pkg/agent progress bridge")
+}

--- a/docs/guides/human-in-the-loop.md
+++ b/docs/guides/human-in-the-loop.md
@@ -9,6 +9,8 @@
 - [Prerequisites](#prerequisites)
 - [Quick Start](#quick-start)
 - [Configuration](#configuration)
+  - [Keeping a Held Stream Alive](#keeping-a-held-stream-alive)
+  - [Which Progress Event Is an Answerable Card](#which-progress-event-is-an-answerable-card)
 - [Common Tasks](#common-tasks)
   - [Request Approval Before Actions](#request-approval-before-actions)
   - [Request User Input](#request-user-input)
@@ -19,6 +21,7 @@
   - [Example 2: Multi-Choice Decision](#example-2-multi-choice-decision)
 - [Workflow HITL Gates (Durable Checkpoint/Resume)](#workflow-hitl-gates-durable-checkpointresume)
 - [Troubleshooting](#troubleshooting)
+  - [The Turn Hangs After a Human Approves](#the-turn-hangs-after-a-human-approves)
 - [Next Steps](#next-steps)
 
 
@@ -77,6 +80,76 @@ type ContactHumanConfig struct {
     Logger       *zap.Logger          // Logger for structured logging (default: NoOp logger)
 }
 ```
+
+### Keeping a Held Stream Alive
+
+✅ Available
+
+> **Note:** Added after v1.4.0 — available in the next release, not in v1.4.0
+> itself.
+
+A hold blocks the turn until a human answers, and emits nothing in between. A
+streaming caller therefore sees no bytes for the whole window — up to 300s for
+an approval hold, up to your configured `Timeout` for `contact_human` — which
+can be long enough for a load balancer or proxy to trip its idle timeout and
+drop the stream the decision has to come back on.
+
+Under `looms serve` this is handled for you: every hold emits a keep-alive on
+the progress stream every 30s, with no configuration.
+
+When you supply your own `Notifier`, opt in by also implementing `Heartbeater`:
+
+```go
+type webhookNotifier struct{ url string }
+
+func (n *webhookNotifier) Notify(ctx context.Context, req *shuttle.HumanRequest) error {
+    return postJSON(ctx, n.url, req) // the card a human acts on
+}
+
+// Heartbeat is called every 30s while the request is still pending.
+func (n *webhookNotifier) Heartbeat(ctx context.Context) error {
+    return pingKeepAlive(ctx, n.url) // no payload — just traffic
+}
+```
+
+Both hold types — an `ask` admission verdict and `contact_human` — use it on the
+same terms:
+
+- **Opt in, or nothing changes.** A `Notifier` without `Heartbeat` is never
+  called and behaves exactly as before.
+- **Never affects the outcome.** An error returned from `Heartbeat` is ignored,
+  and a heartbeat never delays a decision.
+- **Keep it quick and non-blocking.** `Heartbeat` is called from the waiting
+  turn. An implementation that blocks stalls the hold, so use a timeout and
+  return — never wait on a slow endpoint.
+
+### Which Progress Event Is an Answerable Card
+
+✅ Available
+
+If you are building a client that renders HITL prompts, gate on a **non-empty
+`hitl_request.request_id`**. That id is what
+`AnswerClarificationQuestion` submits against. Three shapes arrive on
+`EXECUTION_STAGE_HUMAN_IN_THE_LOOP` and only one is answerable:
+
+| `hitl_request` | `request_id` | What it is | Show a prompt? |
+|----------------|--------------|------------|----------------|
+| absent | — | Keep-alive; carries no state and may be dropped under load | No |
+| present | empty | Early "a hold is coming" hint, sent before the request is stored | No |
+| present | non-empty | The answerable card | Yes |
+
+```go
+// Correct: only an id-bearing event can accept an answer.
+if p.GetStage() == loomv1.ExecutionStage_EXECUTION_STAGE_HUMAN_IN_THE_LOOP &&
+    p.GetHitlRequest().GetRequestId() != "" {
+    showPrompt(p.GetHitlRequest())
+}
+```
+
+Prompting on either of the other two gives the human a box with no id to submit
+against: the answer goes nowhere and the hold sits pending until it times out.
+Loom's TUI gates on the id; a client written against `hitl_request != nil` needs
+updating.
 
 ### Request Types
 
@@ -355,7 +428,8 @@ result, _ := tool.Execute(ctx, map[string]interface{}{
 
 ### No Notification Received
 
-The default notifier is no-op. Configure a webhook notifier:
+Under `looms serve` the progress-stream bridge is wired for you. When embedding
+the tool directly the default notifier is no-op — configure one:
 
 ```go
 notifier := shuttle.NewJSONNotifier("https://myapp.com/webhook/hitl")
@@ -363,6 +437,22 @@ tool := shuttle.NewContactHumanTool(shuttle.ContactHumanConfig{
     Notifier: notifier,
 })
 ```
+
+### The Turn Hangs After a Human Approves
+
+Two causes, both fixed but worth recognising in an older client or a custom
+consumer:
+
+1. **The stream was dropped during the hold.** A hold that emits nothing for its
+   whole window can trip a proxy or load balancer idle timeout, so the approval
+   comes back to a stream that no longer exists. Use a notifier that implements
+   [`Heartbeater`](#keeping-a-held-stream-alive) — `looms serve` already does.
+2. **The prompt had no request id.** A client that shows its dialog for any
+   HITL-stage event also shows one for a keep-alive or the early hint, and that
+   dialog has no id to submit against — the human answers, the answer goes
+   nowhere, and the hold times out. Gate on a non-empty
+   `hitl_request.request_id`; see
+   [which one is answerable](#which-progress-event-is-an-answerable-card).
 
 ### Request Not Found After Restart
 

--- a/gen/go/loom/v1/loom.pb.go
+++ b/gen/go/loom/v1/loom.pb.go
@@ -556,7 +556,26 @@ type WeaveProgress struct {
 	Timestamp int64 `protobuf:"varint,5,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	// Partial result (available at certain stages)
 	PartialResult *ExecutionResult `protobuf:"bytes,6,opt,name=partial_result,json=partialResult,proto3" json:"partial_result,omitempty"`
-	// HITL request info (only when stage == EXECUTION_STAGE_HUMAN_IN_THE_LOOP)
+	// HITL request info (only when stage == EXECUTION_STAGE_HUMAN_IN_THE_LOOP).
+	//
+	// A non-empty hitl_request.request_id is what makes a message an ANSWERABLE
+	// card. Consumers MUST key the human-facing prompt off that id, because it is
+	// the handle AnswerClarificationQuestion / RespondToRequest take; a prompt
+	// raised without one cannot deliver its answer, and the hold behind it stays
+	// pending until it times out. Two other shapes ride the same stage and MUST
+	// NOT raise a prompt:
+	//
+	//   - hitl_request ABSENT — a hold heartbeat. A hold is otherwise byte-silent
+	//     on this stream for its whole window (up to 300s for an approval hold),
+	//     long enough for an intermediary to trip an inactivity timeout and tear
+	//     down the stream the decision has to travel back on. These messages
+	//     exist only to produce traffic and carry no state; they may also be
+	//     dropped under backpressure, so consumers must not count on receiving
+	//     every one.
+	//   - hitl_request PRESENT with an empty request_id — the pre-creation ping
+	//     the conversation loop emits off a contact_human call before the store
+	//     row exists. Useful as an early "a hold is coming" hint; the answerable
+	//     card follows once the row is written.
 	HitlRequest *HITLRequestInfo `protobuf:"bytes,7,opt,name=hitl_request,json=hitlRequest,proto3" json:"hitl_request,omitempty"`
 	// Token streaming fields
 	// Accumulated content so far (for streaming responses)

--- a/gen/openapiv2/loom/v1/loom.swagger.json
+++ b/gen/openapiv2/loom/v1/loom.swagger.json
@@ -9997,7 +9997,7 @@
         },
         "hitlRequest": {
           "$ref": "#/definitions/v1HITLRequestInfo",
-          "title": "HITL request info (only when stage == EXECUTION_STAGE_HUMAN_IN_THE_LOOP)"
+          "description": "HITL request info (only when stage == EXECUTION_STAGE_HUMAN_IN_THE_LOOP).\n\nA non-empty hitl_request.request_id is what makes a message an ANSWERABLE\ncard. Consumers MUST key the human-facing prompt off that id, because it is\nthe handle AnswerClarificationQuestion / RespondToRequest take; a prompt\nraised without one cannot deliver its answer, and the hold behind it stays\npending until it times out. Two other shapes ride the same stage and MUST\nNOT raise a prompt:\n\n  - hitl_request ABSENT — a hold heartbeat. A hold is otherwise byte-silent\n    on this stream for its whole window (up to 300s for an approval hold),\n    long enough for an intermediary to trip an inactivity timeout and tear\n    down the stream the decision has to travel back on. These messages\n    exist only to produce traffic and carry no state; they may also be\n    dropped under backpressure, so consumers must not count on receiving\n    every one.\n  - hitl_request PRESENT with an empty request_id — the pre-creation ping\n    the conversation loop emits off a contact_human call before the store\n    row exists. Useful as an early \"a hold is coming\" hint; the answerable\n    card follows once the row is written."
         },
         "partialContent": {
           "type": "string",

--- a/internal/tui/adapter/coordinator.go
+++ b/internal/tui/adapter/coordinator.go
@@ -218,8 +218,10 @@ func (c *CoordinatorAdapter) Run(ctx context.Context, sessionID, prompt string, 
 				lastContent = progress.PartialContent
 			}
 
-			// Check for HITL (Human-In-The-Loop) request and emit clarification question
-			if progress.Stage == loomv1.ExecutionStage_EXECUTION_STAGE_HUMAN_IN_THE_LOOP && progress.HitlRequest != nil {
+			// Check for HITL (Human-In-The-Loop) request and emit clarification
+			// question. Heartbeats and the pre-creation ping ride this same
+			// stage and must not raise a dialog — see IsAnswerableHITLCard.
+			if IsAnswerableHITLCard(progress) {
 				// Convert HITLRequestInfo to metaagent.Question
 				question := &metaagent.Question{
 					ID:      progress.HitlRequest.RequestId,

--- a/internal/tui/adapter/events.go
+++ b/internal/tui/adapter/events.go
@@ -321,6 +321,29 @@ func formatStageName(stage loomv1.ExecutionStage) string {
 	}
 }
 
+// IsAnswerableHITLCard reports whether a progress message should raise the
+// human-facing clarification dialog.
+//
+// A NON-EMPTY hitl_request.request_id is what makes a message a card, because
+// that id is the handle the answer travels back on
+// (AnswerClarificationQuestion). Two other shapes ride the same stage and must
+// not raise a dialog:
+//
+//   - hitl_request absent — a hold heartbeat, liveness traffic only, emitted so
+//     a byte-silent hold cannot trip an intermediary's inactivity timeout.
+//   - hitl_request present with an empty request_id — the conversation loop's
+//     pre-creation ping, raised off a contact_human call before the store row
+//     exists.
+//
+// Raising a dialog on either one gives the human a box whose answer has nowhere
+// to go: the RPC path is skipped for an empty id and there is no AnswerChan on
+// a server-driven question, so it dead-ends on "no communication channel
+// available" while the hold behind it sits pending until it times out.
+func IsAnswerableHITLCard(progress *loomv1.WeaveProgress) bool {
+	return progress.GetStage() == loomv1.ExecutionStage_EXECUTION_STAGE_HUMAN_IN_THE_LOOP &&
+		progress.GetHitlRequest().GetRequestId() != ""
+}
+
 // HITLRequestToPermission converts a HITL request to a permission.PermissionRequest.
 func HITLRequestToPermission(hitl *loomv1.HITLRequestInfo) permission.PermissionRequest {
 	return permission.PermissionRequest{

--- a/internal/tui/adapter/hitl_card_gate_test.go
+++ b/internal/tui/adapter/hitl_card_gate_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package adapter
+
+import (
+	"testing"
+
+	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
+)
+
+// Only an ANSWERABLE card raises the dialog. The two other shapes that ride the
+// HITL stage — a hold heartbeat and the pre-creation ping — must not, because a
+// dialog without a request_id cannot deliver its answer: it dead-ends on "no
+// communication channel available" while the hold behind it sits pending until
+// it times out.
+func TestIsAnswerableHITLCard(t *testing.T) {
+	tests := []struct {
+		name     string
+		progress *loomv1.WeaveProgress
+		want     bool
+	}{
+		{
+			name: "card with a request id is answerable",
+			progress: &loomv1.WeaveProgress{
+				Stage:       loomv1.ExecutionStage_EXECUTION_STAGE_HUMAN_IN_THE_LOOP,
+				HitlRequest: &loomv1.HITLRequestInfo{RequestId: "req-1", Question: "Approve?"},
+			},
+			want: true,
+		},
+		{
+			name: "heartbeat carries no request at all",
+			progress: &loomv1.WeaveProgress{
+				Stage:   loomv1.ExecutionStage_EXECUTION_STAGE_HUMAN_IN_THE_LOOP,
+				Message: "Still waiting for human response",
+			},
+			want: false,
+		},
+		{
+			name: "pre-creation ping carries a request with an empty id",
+			progress: &loomv1.WeaveProgress{
+				Stage:       loomv1.ExecutionStage_EXECUTION_STAGE_HUMAN_IN_THE_LOOP,
+				HitlRequest: &loomv1.HITLRequestInfo{Question: "Approve?", RequestType: "approval"},
+			},
+			want: false,
+		},
+		{
+			name: "an id on another stage is not a HITL card",
+			progress: &loomv1.WeaveProgress{
+				Stage:       loomv1.ExecutionStage_EXECUTION_STAGE_TOOL_EXECUTION,
+				HitlRequest: &loomv1.HITLRequestInfo{RequestId: "req-1"},
+			},
+			want: false,
+		},
+		{
+			name:     "nil progress does not panic",
+			progress: nil,
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsAnswerableHITLCard(tt.progress); got != tt.want {
+				t.Errorf("IsAnswerableHITLCard() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -2704,7 +2704,7 @@ func (a *Agent) runConversationLoop(ctx Context) (*Response, error) {
 				span.SetAttribute("hitl.priority", hitlInfo.Priority)
 
 				// Emit HITL-specific progress event
-				emitProgressWithHITL(ctx, StageHumanInTheLoop, 50, "Waiting for human response", toolCall.Name, hitlInfo)
+				emitProgressWithHITL(ctx, StageHumanInTheLoop, hitlStageProgress, "Waiting for human response", toolCall.Name, hitlInfo)
 			} else {
 				// Emit tool-started progress event
 				emitToolStarted(ctx, 50+clampInt32(toolExecutionCount*5), toolCall)

--- a/pkg/agent/hitl_heartbeat_emit_test.go
+++ b/pkg/agent/hitl_heartbeat_emit_test.go
@@ -56,9 +56,48 @@ func TestHeartbeatEmit_EmitsIDLessHITLStageEvent(t *testing.T) {
 	require.Equal(t, agent.StageHumanInTheLoop, got.Stage,
 		"the heartbeat rides the HITL stage so consumers can scope it to a hold")
 	require.Nil(t, got.HITLRequest,
-		"a heartbeat must carry no request payload — an id-bearing event is a card")
+		"a heartbeat must carry no request payload at all — absent payload is the "+
+			"contract, which is STRICTER than an empty request id (the pre-creation "+
+			"ping carries a payload with an empty id and IS a card)")
 	require.NotEmpty(t, got.Message)
 	require.False(t, got.Timestamp.IsZero())
+	require.True(t, got.Droppable,
+		"a heartbeat must be droppable — it emits from the turn goroutine parked in "+
+			"the hold's poll loop, so a blocking send on a wedged consumer would stall "+
+			"the poll that reads the human's decision")
+}
+
+// The card and the heartbeats that follow it must carry the SAME progress
+// percentage. A consumer renders a percentage only while it is in (0, 100), so
+// a heartbeat at a different value makes the indicator flicker for the whole
+// length of a hold.
+func TestHeartbeatEmit_ProgressMatchesTheCard(t *testing.T) {
+	var mu sync.Mutex
+	var events []types.ProgressEvent
+
+	ctx := agent.ContextWithProgressCallback(context.Background(), func(e types.ProgressEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		events = append(events, e)
+	})
+
+	n := agent.NewProgressNotifier()
+	require.NoError(t, n.Notify(ctx, &shuttle.HumanRequest{ID: "req-1", Kind: "approval"}))
+
+	hb, ok := n.(shuttle.Heartbeater)
+	require.True(t, ok)
+	require.NoError(t, hb.Heartbeat(ctx))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, events, 2)
+
+	card, beat := events[0], events[1]
+	require.NotNil(t, card.HITLRequest, "the first emit is the card")
+	require.Nil(t, beat.HITLRequest, "the second emit is the heartbeat")
+	require.Equal(t, card.Progress, beat.Progress,
+		"a heartbeat must not move the progress indicator the card set")
+	require.False(t, card.Droppable, "a card carries state and must never be dropped")
 }
 
 // Fail-open: with no progress callback installed there is nothing to emit on,

--- a/pkg/agent/hitl_heartbeat_emit_test.go
+++ b/pkg/agent/hitl_heartbeat_emit_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package agent_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/teradata-labs/loom/pkg/agent"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+	"github.com/teradata-labs/loom/pkg/types"
+)
+
+// The progress bridge must advertise the heartbeat capability, or the ask
+// resolver's interface assertion silently skips it and holds stay silent.
+func TestHeartbeatEmit_BridgeImplementsHeartbeater(t *testing.T) {
+	_, ok := agent.NewProgressNotifier().(shuttle.Heartbeater)
+	require.True(t, ok, "the progress notifier must implement shuttle.Heartbeater")
+}
+
+// A heartbeat produces traffic on the run's progress stream, and does so
+// WITHOUT a HITLRequest payload — that is what keeps it from being mistaken for
+// a second approval card by any consumer that keys off the id-bearing event.
+func TestHeartbeatEmit_EmitsIDLessHITLStageEvent(t *testing.T) {
+	var mu sync.Mutex
+	var events []types.ProgressEvent
+
+	ctx := agent.ContextWithProgressCallback(context.Background(), func(e types.ProgressEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		events = append(events, e)
+	})
+
+	hb, ok := agent.NewProgressNotifier().(shuttle.Heartbeater)
+	require.True(t, ok)
+	require.NoError(t, hb.Heartbeat(ctx))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, events, 1, "a heartbeat must produce exactly one progress event")
+
+	got := events[0]
+	require.Equal(t, agent.StageHumanInTheLoop, got.Stage,
+		"the heartbeat rides the HITL stage so consumers can scope it to a hold")
+	require.Nil(t, got.HITLRequest,
+		"a heartbeat must carry no request payload — an id-bearing event is a card")
+	require.NotEmpty(t, got.Message)
+	require.False(t, got.Timestamp.IsZero())
+}
+
+// Fail-open: with no progress callback installed there is nothing to emit on,
+// and a heartbeat must stay a silent no-op rather than erroring or panicking —
+// a missing progress stream may never affect a hold.
+func TestHeartbeatEmit_NoCallbackIsNoOp(t *testing.T) {
+	hb, ok := agent.NewProgressNotifier().(shuttle.Heartbeater)
+	require.True(t, ok)
+	require.NotPanics(t, func() {
+		require.NoError(t, hb.Heartbeat(context.Background()))
+	})
+}

--- a/pkg/agent/progress_notifier.go
+++ b/pkg/agent/progress_notifier.go
@@ -29,6 +29,13 @@ import (
 // stream in one shape.
 type progressNotifier struct{}
 
+// hitlStageProgress is the completion percentage every StageHumanInTheLoop
+// event carries — the pre-creation ping, the card, and the heartbeats between
+// the card and the human's decision. One value for the whole stage because a
+// consumer renders a percentage only while it is in (0, 100), so a heartbeat at
+// a different value would make the indicator flicker for the length of a hold.
+const hitlStageProgress int32 = 50
+
 // NewProgressNotifier returns the bridge that converts a pending HumanRequest
 // into a StageHumanInTheLoop ProgressEvent delivered on the run's installed
 // ProgressCallback.
@@ -51,6 +58,10 @@ func (progressNotifier) Notify(ctx context.Context, req *shuttle.HumanRequest) e
 	}
 	cb(types.ProgressEvent{
 		Stage: StageHumanInTheLoop,
+		// Matches the HITL-stage progress the conversation loop emits for a
+		// contact_human call, so a consumer rendering a percentage does not
+		// see it flip between the card and the heartbeats that follow.
+		Progress: hitlStageProgress,
 		HITLRequest: &types.HITLRequestInfo{
 			RequestID:       req.ID,
 			Kind:            req.Kind,
@@ -68,15 +79,23 @@ func (progressNotifier) Notify(ctx context.Context, req *shuttle.HumanRequest) e
 	return nil
 }
 
-// Heartbeat delivers an id-less StageHumanInTheLoop ProgressEvent on the
+// Heartbeat delivers a payload-less StageHumanInTheLoop ProgressEvent on the
 // callback carried in ctx, so a hold that is otherwise byte-silent for its whole
 // window keeps the run's progress stream producing traffic.
 //
-// It deliberately carries NO HITLRequest. A consumer keys the human-facing card
-// off the id-bearing event (an id-less event is already the documented
-// pre-creation ping and is ignored), so a heartbeat cannot duplicate a card —
-// including on a consumer built before heartbeats existed, which simply drops
-// it. Fail-open like Notify: with no callback installed this is a no-op, and a
+// It deliberately carries NO HITLRequest at all. That is the contract a
+// consumer keys the human-facing card off (proto: WeaveProgress.hitl_request —
+// a HITL-stage message that OMITS it is liveness only, never a card), so a
+// heartbeat cannot raise or duplicate a card, including on a consumer built
+// before heartbeats existed. Note this is a stricter shape than an EMPTY
+// request_id, which the conversation loop already emits ahead of a
+// contact_human row and which IS a card — an unanswerable one until the row
+// exists. Absent payload and empty id are different things; only the former is
+// a heartbeat.
+//
+// The event is marked Droppable: a transport under backpressure discards it
+// rather than block this goroutine, which is the hold's own poll loop.
+// Fail-open like Notify: with no callback installed this is a no-op, and a
 // missing progress stream never blocks or fails the hold.
 func (progressNotifier) Heartbeat(ctx context.Context) error {
 	cb := ProgressCallbackFromContext(ctx)
@@ -85,8 +104,10 @@ func (progressNotifier) Heartbeat(ctx context.Context) error {
 	}
 	cb(types.ProgressEvent{
 		Stage:     StageHumanInTheLoop,
+		Progress:  hitlStageProgress,
 		Message:   "Still waiting for human response",
 		Timestamp: time.Now(),
+		Droppable: true,
 	})
 	return nil
 }

--- a/pkg/agent/progress_notifier.go
+++ b/pkg/agent/progress_notifier.go
@@ -34,6 +34,11 @@ type progressNotifier struct{}
 // ProgressCallback.
 func NewProgressNotifier() shuttle.Notifier { return progressNotifier{} }
 
+// The bridge is also a Heartbeater: the ask resolver's waiter pokes it while a
+// hold is still pending. Asserted here so the capability cannot be lost silently
+// (it is reached only through an interface assertion at the call site).
+var _ shuttle.Heartbeater = progressNotifier{}
+
 // Notify delivers the pending request as a StageHumanInTheLoop ProgressEvent on
 // the callback carried in ctx. The callback is read from ctx (not captured at
 // build time) because it enters ctx only at run start, after the agent is
@@ -58,6 +63,29 @@ func (progressNotifier) Notify(ctx context.Context, req *shuttle.HumanRequest) e
 			Question:        req.Question,
 		},
 		Message:   "Waiting for human response",
+		Timestamp: time.Now(),
+	})
+	return nil
+}
+
+// Heartbeat delivers an id-less StageHumanInTheLoop ProgressEvent on the
+// callback carried in ctx, so a hold that is otherwise byte-silent for its whole
+// window keeps the run's progress stream producing traffic.
+//
+// It deliberately carries NO HITLRequest. A consumer keys the human-facing card
+// off the id-bearing event (an id-less event is already the documented
+// pre-creation ping and is ignored), so a heartbeat cannot duplicate a card —
+// including on a consumer built before heartbeats existed, which simply drops
+// it. Fail-open like Notify: with no callback installed this is a no-op, and a
+// missing progress stream never blocks or fails the hold.
+func (progressNotifier) Heartbeat(ctx context.Context) error {
+	cb := ProgressCallbackFromContext(ctx)
+	if cb == nil {
+		return nil
+	}
+	cb(types.ProgressEvent{
+		Stage:     StageHumanInTheLoop,
+		Message:   "Still waiting for human response",
 		Timestamp: time.Now(),
 	})
 	return nil

--- a/pkg/server/multi_agent.go
+++ b/pkg/server/multi_agent.go
@@ -1181,13 +1181,7 @@ func (s *MultiAgentServer) StreamWeave(req *loomv1.WeaveRequest, stream loomv1.L
 	progressChan := make(chan agent.ProgressEvent, 10)
 
 	// Create progress callback that sends events to channel
-	progressCallback := func(event agent.ProgressEvent) {
-		select {
-		case progressChan <- event:
-		case <-stream.Context().Done():
-			// Context cancelled, stop sending
-		}
-	}
+	progressCallback := newProgressSender(progressChan, stream.Context().Done())
 
 	// Execute agent with progress callback
 	go func() {

--- a/pkg/server/progress_sender.go
+++ b/pkg/server/progress_sender.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package server
+
+import (
+	"github.com/teradata-labs/loom/pkg/agent"
+)
+
+// newProgressSender returns the ProgressCallback a streaming RPC installs on a
+// turn: it hands each event to the sending goroutine over out, and gives up
+// when done closes. Shared by every streaming entry point so the two cannot
+// drift on backpressure semantics.
+//
+// A state-bearing event blocks until the sender takes it — a dropped token
+// chunk, HITL card, or tool lifecycle event is a hole the consumer cannot
+// reconstruct, so the turn waits.
+//
+// A DROPPABLE event is discarded instead when out is full. This is what keeps a
+// HITL hold heartbeat from deepening the hang it exists to prevent. A hold
+// emits from the turn goroutine while blocked in its poll loop, and the sending
+// goroutine can be wedged indefinitely in stream.Send against a client that is
+// gone but whose context has not been canceled — an intermediary dropping the
+// connection half-open, which no gRPC keepalive is configured to detect. Once
+// out fills, a blocking send would stall the poll loop that reads the human's
+// decision, and the hold would never resolve OR expire. Losing a heartbeat
+// costs nothing: the next one is 30s away, and the only job of any of them is
+// to produce bytes.
+func newProgressSender(out chan<- agent.ProgressEvent, done <-chan struct{}) agent.ProgressCallback {
+	return func(event agent.ProgressEvent) {
+		if event.Droppable {
+			select {
+			case out <- event:
+			default:
+				// Consumer is behind; this event carries no state to lose.
+			}
+			return
+		}
+		select {
+		case out <- event:
+		case <-done:
+			// Context cancelled, stop sending
+		}
+	}
+}

--- a/pkg/server/progress_sender_test.go
+++ b/pkg/server/progress_sender_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/teradata-labs/loom/pkg/agent"
+)
+
+// A droppable event must never block the emitting goroutine. This is the
+// property that keeps a HITL hold heartbeat from deepening the hang it exists
+// to prevent: the hold emits from the turn goroutine while parked in its poll
+// loop, so a blocking send on a wedged consumer would stall the poll that reads
+// the human's decision — and the hold would then neither resolve nor expire.
+func TestProgressSender_DroppableEventDoesNotBlockOnFullChannel(t *testing.T) {
+	out := make(chan agent.ProgressEvent, 1)
+	never := make(chan struct{}) // consumer alive, but wedged: never cancelled
+	send := newProgressSender(out, never)
+
+	send(agent.ProgressEvent{Message: "fills the buffer"})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// Several beats' worth, all onto a channel that is already full.
+		for i := 0; i < 5; i++ {
+			send(agent.ProgressEvent{Message: "heartbeat", Droppable: true})
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a droppable event blocked on a full channel — a held turn would wedge here")
+	}
+
+	require.Len(t, out, 1, "the buffered state-bearing event is still the only one queued")
+	require.Equal(t, "fills the buffer", (<-out).Message)
+}
+
+// A droppable event is still delivered when there is room — dropping is a
+// backpressure release valve, not the normal path.
+func TestProgressSender_DroppableEventDeliveredWhenThereIsRoom(t *testing.T) {
+	out := make(chan agent.ProgressEvent, 2)
+	send := newProgressSender(out, make(chan struct{}))
+
+	send(agent.ProgressEvent{Message: "heartbeat", Droppable: true})
+
+	require.Len(t, out, 1)
+	got := <-out
+	require.Equal(t, "heartbeat", got.Message)
+	require.True(t, got.Droppable)
+}
+
+// A state-bearing event must NOT be dropped: a lost token chunk, HITL card, or
+// tool lifecycle event is a hole the consumer cannot reconstruct, so the
+// emitting turn waits for the sender to take it.
+func TestProgressSender_StateBearingEventWaitsForTheSender(t *testing.T) {
+	out := make(chan agent.ProgressEvent, 1)
+	send := newProgressSender(out, make(chan struct{}))
+
+	send(agent.ProgressEvent{Message: "first"})
+
+	blocked := make(chan struct{})
+	go func() {
+		defer close(blocked)
+		send(agent.ProgressEvent{Message: "second"})
+	}()
+
+	select {
+	case <-blocked:
+		t.Fatal("a state-bearing event was dropped instead of waiting")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	require.Equal(t, "first", (<-out).Message) // drain, making room
+
+	select {
+	case <-blocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the state-bearing event never landed after room was made")
+	}
+	require.Equal(t, "second", (<-out).Message)
+}
+
+// A state-bearing event gives up when the stream's context is done, so a turn
+// outliving its client cannot wedge on a consumer that will never read again.
+func TestProgressSender_StateBearingEventGivesUpWhenDone(t *testing.T) {
+	out := make(chan agent.ProgressEvent, 1)
+	done := make(chan struct{})
+	send := newProgressSender(out, done)
+
+	send(agent.ProgressEvent{Message: "fills the buffer"})
+
+	released := make(chan struct{})
+	go func() {
+		defer close(released)
+		send(agent.ProgressEvent{Message: "abandoned"})
+	}()
+
+	close(done)
+
+	select {
+	case <-released:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a state-bearing event did not give up after the stream was done")
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -242,13 +242,7 @@ func (s *Server) StreamWeave(req *loomv1.WeaveRequest, stream loomv1.LoomService
 	progressChan := make(chan agent.ProgressEvent, DefaultProgressBufferSize)
 
 	// Create progress callback that sends events to channel
-	progressCallback := func(event agent.ProgressEvent) {
-		select {
-		case progressChan <- event:
-		case <-stream.Context().Done():
-			// Context cancelled, stop sending
-		}
-	}
+	progressCallback := newProgressSender(progressChan, stream.Context().Done())
 
 	// Execute agent with progress callback
 	go func() {

--- a/pkg/shuttle/admission_ask.go
+++ b/pkg/shuttle/admission_ask.go
@@ -130,9 +130,9 @@ type hitlAskResolver struct {
 // store poll interval (default 1s, mirroring ContactHumanConfig). notifier is
 // fired once the pending request is stored so the hold surfaces on the progress
 // stream; a nil notifier disables the emit (the hold is unaffected). A notifier
-// that also implements Heartbeater is poked every askHeartbeatInterval while the
-// hold is still pending, so a byte-silent hold cannot trip a proxy's inactivity
-// timeout; one that does not is never heartbeaten.
+// that also implements Heartbeater is poked every holdHeartbeatInterval while
+// the hold is still pending, so a byte-silent hold cannot trip a proxy's
+// inactivity timeout; one that does not is never heartbeaten.
 func NewHITLAskResolver(store HumanRequestStore, timeout, poll time.Duration, notifier Notifier) AskResolver {
 	if timeout <= 0 {
 		timeout = 300 * time.Second
@@ -145,7 +145,7 @@ func NewHITLAskResolver(store HumanRequestStore, timeout, poll time.Duration, no
 		timeout:   timeout,
 		poll:      poll,
 		notifier:  notifier,
-		heartbeat: askHeartbeatInterval,
+		heartbeat: holdHeartbeatInterval,
 	}
 }
 
@@ -235,14 +235,6 @@ const askDeadlineMargin = 2 * time.Second
 // waiter abandons on context cancellation.
 const abandonWriteTimeout = 5 * time.Second
 
-// askHeartbeatInterval is how often a still-pending hold pokes a Heartbeater
-// notifier. A hold is otherwise byte-silent on the caller's stream for its whole
-// window (up to the 300s default), which is long enough to trip a proxy's
-// inactivity timeout and tear down the very stream the decision must travel
-// back on. 30s sits comfortably inside common proxy read timeouts while costing
-// at most ~10 events over a default-length hold.
-const askHeartbeatInterval = 30 * time.Second
-
 // wait polls the store until the request is resolved, the stored expiry passes,
 // or the context is canceled. ONE clock judges the hold: the row's ExpiresAt —
 // the same instant the store's resolve CAS enforces — so a resolution landing in
@@ -264,12 +256,10 @@ func (r *hitlAskResolver) wait(ctx context.Context, requestID string, expiresAt 
 	ticker := time.NewTicker(r.poll)
 	defer ticker.Stop()
 
-	// Heartbeating is opt-in by capability: a notifier that does not implement
-	// Heartbeater (or no notifier at all) leaves hb nil and the hold stays
-	// exactly as silent as it was before. Asserting a nil interface yields
-	// ok=false, so the nil-notifier case needs no separate guard.
-	hb, _ := r.notifier.(Heartbeater)
-	lastBeat := time.Now()
+	// Heartbeating is opt-in by capability — see holdBeater. A notifier that
+	// does not implement Heartbeater (or no notifier at all) yields a beater
+	// that never beats, and the hold stays exactly as silent as it was before.
+	beater := newHoldBeater(r.notifier, r.heartbeat)
 
 	missing := 0
 	for {
@@ -294,6 +284,9 @@ func (r *hitlAskResolver) wait(ctx context.Context, requestID string, expiresAt 
 				if missing >= missingRowDenyAfter {
 					return Decision{Kind: Deny, Reason: "approval request no longer exists"}
 				}
+				// The beat still runs on the way out: an unreadable row is
+				// not a reason to let the caller's stream go silent.
+				beater.beat(ctx)
 				continue
 			case err == nil:
 				missing = 0
@@ -310,10 +303,7 @@ func (r *hitlAskResolver) wait(ctx context.Context, requestID string, expiresAt 
 			// Still pending: keep the caller's stream alive. Best-effort and
 			// last — the heartbeat must never delay a resolution the poll above
 			// already saw, and a notifier error never changes the outcome.
-			if hb != nil && r.heartbeat > 0 && time.Since(lastBeat) >= r.heartbeat {
-				lastBeat = time.Now()
-				_ = hb.Heartbeat(ctx)
-			}
+			beater.beat(ctx)
 		}
 	}
 }

--- a/pkg/shuttle/admission_ask.go
+++ b/pkg/shuttle/admission_ask.go
@@ -120,13 +120,19 @@ type hitlAskResolver struct {
 	timeout  time.Duration // how long to block before failing closed
 	poll     time.Duration // store poll interval
 	notifier Notifier      // pending-emit collaborator; nil disables the emit
+	// heartbeat is how often a still-pending hold pokes the notifier when it
+	// implements Heartbeater. Zero disables heartbeating.
+	heartbeat time.Duration
 }
 
 // NewHITLAskResolver builds the Ask resolver wired into ChainDeps.Ask. timeout
 // bounds the turn-blocking wait (default 300s when non-positive); poll is the
 // store poll interval (default 1s, mirroring ContactHumanConfig). notifier is
 // fired once the pending request is stored so the hold surfaces on the progress
-// stream; a nil notifier disables the emit (the hold is unaffected).
+// stream; a nil notifier disables the emit (the hold is unaffected). A notifier
+// that also implements Heartbeater is poked every askHeartbeatInterval while the
+// hold is still pending, so a byte-silent hold cannot trip a proxy's inactivity
+// timeout; one that does not is never heartbeaten.
 func NewHITLAskResolver(store HumanRequestStore, timeout, poll time.Duration, notifier Notifier) AskResolver {
 	if timeout <= 0 {
 		timeout = 300 * time.Second
@@ -134,7 +140,13 @@ func NewHITLAskResolver(store HumanRequestStore, timeout, poll time.Duration, no
 	if poll <= 0 {
 		poll = 1 * time.Second
 	}
-	return &hitlAskResolver{store: store, timeout: timeout, poll: poll, notifier: notifier}
+	return &hitlAskResolver{
+		store:     store,
+		timeout:   timeout,
+		poll:      poll,
+		notifier:  notifier,
+		heartbeat: askHeartbeatInterval,
+	}
 }
 
 // Resolve creates a pending "approval" HumanRequest scoped to the call's session
@@ -223,6 +235,14 @@ const askDeadlineMargin = 2 * time.Second
 // waiter abandons on context cancellation.
 const abandonWriteTimeout = 5 * time.Second
 
+// askHeartbeatInterval is how often a still-pending hold pokes a Heartbeater
+// notifier. A hold is otherwise byte-silent on the caller's stream for its whole
+// window (up to the 300s default), which is long enough to trip a proxy's
+// inactivity timeout and tear down the very stream the decision must travel
+// back on. 30s sits comfortably inside common proxy read timeouts while costing
+// at most ~10 events over a default-length hold.
+const askHeartbeatInterval = 30 * time.Second
+
 // wait polls the store until the request is resolved, the stored expiry passes,
 // or the context is canceled. ONE clock judges the hold: the row's ExpiresAt —
 // the same instant the store's resolve CAS enforces — so a resolution landing in
@@ -243,6 +263,13 @@ func (r *hitlAskResolver) wait(ctx context.Context, requestID string, expiresAt 
 	}
 	ticker := time.NewTicker(r.poll)
 	defer ticker.Stop()
+
+	// Heartbeating is opt-in by capability: a notifier that does not implement
+	// Heartbeater (or no notifier at all) leaves hb nil and the hold stays
+	// exactly as silent as it was before. Asserting a nil interface yields
+	// ok=false, so the nil-notifier case needs no separate guard.
+	hb, _ := r.notifier.(Heartbeater)
+	lastBeat := time.Now()
 
 	missing := 0
 	for {
@@ -279,6 +306,13 @@ func (r *hitlAskResolver) wait(ctx context.Context, requestID string, expiresAt 
 			}
 			if time.Now().After(deadline) {
 				return r.expire(ctx, requestID)
+			}
+			// Still pending: keep the caller's stream alive. Best-effort and
+			// last — the heartbeat must never delay a resolution the poll above
+			// already saw, and a notifier error never changes the outcome.
+			if hb != nil && r.heartbeat > 0 && time.Since(lastBeat) >= r.heartbeat {
+				lastBeat = time.Now()
+				_ = hb.Heartbeat(ctx)
 			}
 		}
 	}

--- a/pkg/shuttle/admission_ask_heartbeat_test.go
+++ b/pkg/shuttle/admission_ask_heartbeat_test.go
@@ -1,0 +1,254 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package shuttle
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// plainNotifier implements only Notifier — the pre-heartbeat shape. Used to
+// prove a notifier without the capability is never heartbeaten and keeps
+// behaving exactly as before.
+type plainNotifier struct {
+	mu       sync.Mutex
+	notifies int
+}
+
+func (n *plainNotifier) Notify(context.Context, *HumanRequest) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.notifies++
+	return nil
+}
+
+func (n *plainNotifier) count() int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.notifies
+}
+
+// beatingNotifier implements Notifier AND Heartbeater, recording both.
+type beatingNotifier struct {
+	mu         sync.Mutex
+	notifies   int
+	heartbeats int
+	err        error // returned by Heartbeat, to prove errors are ignored
+}
+
+func (n *beatingNotifier) Notify(context.Context, *HumanRequest) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.notifies++
+	return nil
+}
+
+func (n *beatingNotifier) Heartbeat(context.Context) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.heartbeats++
+	return n.err
+}
+
+func (n *beatingNotifier) beats() int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.heartbeats
+}
+
+func (n *beatingNotifier) notifyCount() int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.notifies
+}
+
+// askReq builds a minimal Ask request for the resolver under test.
+func askReq(ctx context.Context) AdmissionRequest {
+	return AdmissionRequest{
+		Ctx:       ctx,
+		ToolName:  "write_table",
+		Params:    map[string]interface{}{"table": "sales"},
+		UserID:    "user-1",
+		SessionID: "sess-1",
+	}
+}
+
+// resolveAsync runs Resolve on its own goroutine (it blocks) and returns a
+// channel carrying the decision.
+func resolveAsync(r *hitlAskResolver, ctx context.Context) <-chan Decision {
+	out := make(chan Decision, 1)
+	go func() { out <- r.Resolve(askReq(ctx), Decision{Kind: Ask, Reason: "approval required"}) }()
+	return out
+}
+
+// TestAskResolver_HeartbeatsWhilePending is the core guarantee: a hold that is
+// waiting on a human keeps poking a Heartbeater, so the caller's stream never
+// goes silent for the whole window.
+func TestAskResolver_HeartbeatsWhilePending(t *testing.T) {
+	store := NewInMemoryHumanRequestStore()
+	notifier := &beatingNotifier{}
+	r := &hitlAskResolver{
+		store:     store,
+		timeout:   5 * time.Second,
+		poll:      2 * time.Millisecond,
+		notifier:  notifier,
+		heartbeat: 15 * time.Millisecond,
+	}
+
+	decision := resolveAsync(r, context.Background())
+
+	// Let the hold sit pending across several heartbeat intervals.
+	require.Eventually(t, func() bool { return notifier.beats() >= 3 }, 2*time.Second, 5*time.Millisecond,
+		"a pending hold must keep heartbeating")
+
+	// The pending card itself is emitted exactly once, no matter how many
+	// heartbeats follow — heartbeats must never re-raise the card.
+	require.Equal(t, 1, notifier.notifyCount())
+
+	respondOncePending(store, "approved")
+	select {
+	case d := <-decision:
+		require.Equal(t, Allow, d.Kind)
+	case <-time.After(3 * time.Second):
+		t.Fatal("resolver did not return after approval")
+	}
+}
+
+// TestAskResolver_HeartbeatStopsWhenHoldResolves proves the beat is bounded by
+// the hold: once the decision lands, nothing further is emitted.
+func TestAskResolver_HeartbeatStopsWhenHoldResolves(t *testing.T) {
+	store := NewInMemoryHumanRequestStore()
+	notifier := &beatingNotifier{}
+	r := &hitlAskResolver{
+		store:     store,
+		timeout:   5 * time.Second,
+		poll:      2 * time.Millisecond,
+		notifier:  notifier,
+		heartbeat: 10 * time.Millisecond,
+	}
+
+	decision := resolveAsync(r, context.Background())
+	require.Eventually(t, func() bool { return notifier.beats() >= 1 }, 2*time.Second, 5*time.Millisecond)
+
+	respondOncePending(store, "approved")
+	select {
+	case d := <-decision:
+		require.Equal(t, Allow, d.Kind)
+	case <-time.After(3 * time.Second):
+		t.Fatal("resolver did not return after approval")
+	}
+
+	settled := notifier.beats()
+	time.Sleep(50 * time.Millisecond) // several heartbeat intervals
+	require.Equal(t, settled, notifier.beats(), "no heartbeat may fire after the hold resolved")
+}
+
+// TestAskResolver_HeartbeatOptInAndErrorsIgnored is table-driven over the
+// notifier shapes: only a Heartbeater is beaten, a zero interval disables the
+// beat entirely, and a Heartbeat that errors never changes the outcome.
+func TestAskResolver_HeartbeatOptInAndErrorsIgnored(t *testing.T) {
+	tests := []struct {
+		name        string
+		heartbeat   time.Duration
+		errOnBeat   error
+		wantBeats   bool
+		plainNotify bool
+	}{
+		{name: "heartbeater is beaten", heartbeat: 10 * time.Millisecond, wantBeats: true},
+		{name: "beat errors are ignored", heartbeat: 10 * time.Millisecond, errOnBeat: context.DeadlineExceeded, wantBeats: true},
+		{name: "zero interval disables beating", heartbeat: 0, wantBeats: false},
+		{name: "plain notifier is never beaten", heartbeat: 10 * time.Millisecond, plainNotify: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewInMemoryHumanRequestStore()
+			beating := &beatingNotifier{err: tt.errOnBeat}
+			plain := &plainNotifier{}
+
+			var n Notifier = beating
+			if tt.plainNotify {
+				n = plain
+			}
+			r := &hitlAskResolver{
+				store:     store,
+				timeout:   5 * time.Second,
+				poll:      2 * time.Millisecond,
+				notifier:  n,
+				heartbeat: tt.heartbeat,
+			}
+
+			decision := resolveAsync(r, context.Background())
+			waitForPending(t, store)
+			time.Sleep(60 * time.Millisecond) // several intervals
+
+			if tt.wantBeats {
+				require.GreaterOrEqual(t, beating.beats(), 1, "expected the hold to heartbeat")
+			} else {
+				require.Zero(t, beating.beats(), "expected no heartbeat")
+			}
+			if tt.plainNotify {
+				require.Equal(t, 1, plain.count(), "the pending card is still emitted once")
+			}
+
+			// The hold still resolves normally in every shape.
+			respondOncePending(store, "approved")
+			select {
+			case d := <-decision:
+				require.Equal(t, Allow, d.Kind)
+			case <-time.After(3 * time.Second):
+				t.Fatal("resolver did not return after approval")
+			}
+		})
+	}
+}
+
+// TestAskResolver_NilNotifierWithHeartbeatDoesNotPanic covers the nil-interface
+// assertion path: a nil notifier must stay a silent, working hold.
+func TestAskResolver_NilNotifierWithHeartbeatDoesNotPanic(t *testing.T) {
+	store := NewInMemoryHumanRequestStore()
+	r := &hitlAskResolver{
+		store:     store,
+		timeout:   5 * time.Second,
+		poll:      2 * time.Millisecond,
+		notifier:  nil,
+		heartbeat: 5 * time.Millisecond,
+	}
+
+	decision := resolveAsync(r, context.Background())
+	waitForPending(t, store)
+	time.Sleep(30 * time.Millisecond)
+	respondOncePending(store, "approved")
+
+	select {
+	case d := <-decision:
+		require.Equal(t, Allow, d.Kind)
+	case <-time.After(3 * time.Second):
+		t.Fatal("resolver did not return after approval")
+	}
+}
+
+// TestNewHITLAskResolver_DefaultsHeartbeatInterval pins the constructor default
+// so the production path is beaten without any caller opt-in.
+func TestNewHITLAskResolver_DefaultsHeartbeatInterval(t *testing.T) {
+	r, ok := NewHITLAskResolver(NewInMemoryHumanRequestStore(), 0, 0, nil).(*hitlAskResolver)
+	require.True(t, ok)
+	require.Equal(t, askHeartbeatInterval, r.heartbeat)
+	require.Equal(t, 300*time.Second, r.timeout)
+	require.Equal(t, time.Second, r.poll)
+}

--- a/pkg/shuttle/admission_ask_heartbeat_test.go
+++ b/pkg/shuttle/admission_ask_heartbeat_test.go
@@ -197,13 +197,17 @@ func TestAskResolver_HeartbeatOptInAndErrorsIgnored(t *testing.T) {
 			waitForPending(t, store)
 			time.Sleep(60 * time.Millisecond) // several intervals
 
-			if tt.wantBeats {
+			// Every assertion is made against the notifier the resolver
+			// ACTUALLY holds — counting beats on an uninstalled notifier
+			// would pass no matter what the resolver did.
+			if tt.plainNotify {
+				_, isBeater := n.(Heartbeater)
+				require.False(t, isBeater, "a plain notifier must not advertise the capability")
+				require.Equal(t, 1, plain.count(), "the pending card is still emitted once")
+			} else if tt.wantBeats {
 				require.GreaterOrEqual(t, beating.beats(), 1, "expected the hold to heartbeat")
 			} else {
 				require.Zero(t, beating.beats(), "expected no heartbeat")
-			}
-			if tt.plainNotify {
-				require.Equal(t, 1, plain.count(), "the pending card is still emitted once")
 			}
 
 			// The hold still resolves normally in every shape.
@@ -248,7 +252,7 @@ func TestAskResolver_NilNotifierWithHeartbeatDoesNotPanic(t *testing.T) {
 func TestNewHITLAskResolver_DefaultsHeartbeatInterval(t *testing.T) {
 	r, ok := NewHITLAskResolver(NewInMemoryHumanRequestStore(), 0, 0, nil).(*hitlAskResolver)
 	require.True(t, ok)
-	require.Equal(t, askHeartbeatInterval, r.heartbeat)
+	require.Equal(t, holdHeartbeatInterval, r.heartbeat)
 	require.Equal(t, 300*time.Second, r.timeout)
 	require.Equal(t, time.Second, r.poll)
 }

--- a/pkg/shuttle/hold_heartbeat.go
+++ b/pkg/shuttle/hold_heartbeat.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package shuttle
+
+import (
+	"context"
+	"time"
+)
+
+// Heartbeater is an OPTIONAL capability a Notifier may implement. A notifier
+// that implements it is poked periodically for as long as a hold is still
+// waiting on a human, so a transport that would otherwise go byte-silent for
+// the whole hold can keep its stream alive.
+//
+// A hold blocks the turn goroutine inside its poll loop and emits nothing
+// between the pending notification and the human's decision. On a streaming
+// transport that is silence for the whole hold window — up to 300s for an ask
+// hold, up to the configured ceiling for contact_human — which is long enough
+// for an intermediary to trip its inactivity timeout and tear down the very
+// stream the decision has to travel back on.
+//
+// It is deliberately a separate optional interface rather than a method on
+// Notifier: a Notifier that does not implement it is never heartbeaten and
+// behaves exactly as before.
+type Heartbeater interface {
+	// Heartbeat signals that a hold is still pending. It carries no request
+	// payload — its only job is to produce traffic. Implementations must be
+	// cheap, best-effort, and non-blocking: a heartbeat that blocks stalls the
+	// turn goroutine mid-hold and stops the poll that would see the human's
+	// decision. The returned error never changes a hold's outcome.
+	Heartbeat(ctx context.Context) error
+}
+
+// holdHeartbeatInterval is how often a still-pending hold pokes a Heartbeater
+// notifier. Shared by both hold origins — the ask resolver and contact_human —
+// so the two cannot drift. 30s sits comfortably inside common proxy read
+// timeouts while costing at most ~10 events over a default-length hold.
+const holdHeartbeatInterval = 30 * time.Second
+
+// holdBeater is the per-hold heartbeat bookkeeping shared by both waiters. It
+// is owned by the single goroutine running the hold — the turn's — and carries
+// no locking, which is deliberate: the beat is emitted on that goroutine so a
+// downstream consumer still receives progress events serially (a background
+// ticker would have broken that invariant and forced a mutex into every
+// consumer, e.g. grpc.ServerStream.Send is not concurrency-safe).
+type holdBeater struct {
+	hb       Heartbeater
+	interval time.Duration
+	last     time.Time
+}
+
+// newHoldBeater derives the beater for a hold. Heartbeating is opt-in BY
+// CAPABILITY: a notifier that does not implement Heartbeater — or no notifier
+// at all — yields a beater that never beats, so the hold stays exactly as
+// silent as it was before. Asserting a nil interface yields ok=false, so the
+// nil-notifier case needs no separate guard. A non-positive interval disables
+// beating.
+func newHoldBeater(n Notifier, interval time.Duration) *holdBeater {
+	hb, _ := n.(Heartbeater)
+	return &holdBeater{hb: hb, interval: interval, last: time.Now()}
+}
+
+// beat pokes the notifier when the interval has elapsed since the last poke,
+// and is a no-op otherwise. Best-effort throughout: callers invoke it only
+// AFTER the resolution poll — so it can never delay a decision the poll already
+// saw — and a Heartbeat error never changes a hold's outcome.
+func (b *holdBeater) beat(ctx context.Context) {
+	if b == nil || b.hb == nil || b.interval <= 0 {
+		return
+	}
+	if time.Since(b.last) < b.interval {
+		return
+	}
+	b.last = time.Now()
+	_ = b.hb.Heartbeat(ctx)
+}

--- a/pkg/shuttle/human_tool.go
+++ b/pkg/shuttle/human_tool.go
@@ -34,6 +34,9 @@ type ContactHumanTool struct {
 	pollInterval time.Duration
 	tracer       observability.Tracer
 	logger       *zap.Logger
+	// heartbeat is how often a still-pending question pokes the notifier when
+	// it implements Heartbeater. Zero disables heartbeating.
+	heartbeat time.Duration
 
 	// For testing - allows mocking time
 	now func() time.Time
@@ -115,26 +118,8 @@ type Notifier interface {
 	Notify(ctx context.Context, req *HumanRequest) error
 }
 
-// Heartbeater is an OPTIONAL capability a Notifier may implement. A notifier
-// that implements it is poked periodically for as long as a hold is still
-// waiting on a human, so a transport that would otherwise go byte-silent for
-// the whole hold can keep its stream alive.
-//
-// A hold blocks the turn goroutine inside the waiter's poll loop and emits
-// nothing between the pending notification and the human's decision. On a
-// streaming transport behind a proxy that is silence long enough to trip an
-// inactivity timeout and tear the stream down, so the decision — when it
-// finally arrives — has nowhere to go.
-//
-// It is deliberately a separate optional interface rather than a method on
-// Notifier: a Notifier that does not implement it is never heartbeaten and
-// behaves exactly as before.
-type Heartbeater interface {
-	// Heartbeat signals that a hold is still pending. It carries no request
-	// payload — its only job is to produce traffic. Implementations must be
-	// cheap and best-effort; the returned error never changes a hold's outcome.
-	Heartbeat(ctx context.Context) error
-}
+// Heartbeater — the optional keep-the-stream-alive capability a Notifier may
+// implement — lives in hold_heartbeat.go, shared by both hold origins.
 
 // ContactHumanConfig configures the ContactHumanTool.
 type ContactHumanConfig struct {
@@ -174,6 +159,7 @@ func NewContactHumanTool(config ContactHumanConfig) *ContactHumanTool {
 		pollInterval: config.PollInterval,
 		tracer:       config.Tracer,
 		logger:       config.Logger,
+		heartbeat:    holdHeartbeatInterval,
 		now:          time.Now,
 	}
 }
@@ -464,6 +450,12 @@ func (t *ContactHumanTool) waitForResponse(ctx context.Context, requestID string
 	ticker := time.NewTicker(t.pollInterval)
 	defer ticker.Stop()
 
+	// A question hold is byte-silent on the caller's stream for its whole
+	// window exactly like an ask hold, so it beats on the same terms (see
+	// holdBeater): opt-in by capability, best-effort, and emitted on this
+	// goroutine after the resolution poll.
+	beater := newHoldBeater(t.notifier, t.heartbeat)
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -493,13 +485,21 @@ func (t *ContactHumanTool) waitForResponse(ctx context.Context, requestID string
 			// sweep may legitimately retire the row under a live waiter.
 			req, err := t.store.Get(ctx, requestID)
 			if err != nil || req == nil {
-				continue // Retry on error or absent row until the deadline
+				// Retry on error or absent row until the deadline. The beat
+				// still runs: an unreadable row is not a reason to let the
+				// caller's stream go silent.
+				beater.beat(ctx)
+				continue
 			}
 
 			// Check if human has responded
 			if req.Status != "pending" {
 				return req, false
 			}
+
+			// Still pending: keep the caller's stream alive. Last, so it can
+			// never delay a response the poll above already saw.
+			beater.beat(ctx)
 		}
 	}
 }

--- a/pkg/shuttle/human_tool.go
+++ b/pkg/shuttle/human_tool.go
@@ -115,6 +115,27 @@ type Notifier interface {
 	Notify(ctx context.Context, req *HumanRequest) error
 }
 
+// Heartbeater is an OPTIONAL capability a Notifier may implement. A notifier
+// that implements it is poked periodically for as long as a hold is still
+// waiting on a human, so a transport that would otherwise go byte-silent for
+// the whole hold can keep its stream alive.
+//
+// A hold blocks the turn goroutine inside the waiter's poll loop and emits
+// nothing between the pending notification and the human's decision. On a
+// streaming transport behind a proxy that is silence long enough to trip an
+// inactivity timeout and tear the stream down, so the decision — when it
+// finally arrives — has nowhere to go.
+//
+// It is deliberately a separate optional interface rather than a method on
+// Notifier: a Notifier that does not implement it is never heartbeaten and
+// behaves exactly as before.
+type Heartbeater interface {
+	// Heartbeat signals that a hold is still pending. It carries no request
+	// payload — its only job is to produce traffic. Implementations must be
+	// cheap and best-effort; the returned error never changes a hold's outcome.
+	Heartbeat(ctx context.Context) error
+}
+
 // ContactHumanConfig configures the ContactHumanTool.
 type ContactHumanConfig struct {
 	Store        HumanRequestStore

--- a/pkg/shuttle/human_tool_heartbeat_test.go
+++ b/pkg/shuttle/human_tool_heartbeat_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package shuttle
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// contactHumanUnderTest builds a contact_human tool over a real in-memory store
+// with test-scale poll and heartbeat intervals.
+func contactHumanUnderTest(n Notifier, heartbeat time.Duration) (*ContactHumanTool, *InMemoryHumanRequestStore) {
+	store := NewInMemoryHumanRequestStore()
+	tool := NewContactHumanTool(ContactHumanConfig{
+		Store:        store,
+		Notifier:     n,
+		Timeout:      5 * time.Second,
+		PollInterval: 2 * time.Millisecond,
+	})
+	tool.heartbeat = heartbeat
+	return tool, store
+}
+
+// askQuestionAsync runs a contact_human call on its own goroutine (it blocks)
+// and returns a channel carrying the result.
+func askQuestionAsync(t *ContactHumanTool, ctx context.Context) <-chan *Result {
+	out := make(chan *Result, 1)
+	go func() {
+		res, _ := t.Execute(ctx, map[string]interface{}{
+			"question":        "Proceed?",
+			"timeout_seconds": float64(5),
+		})
+		out <- res
+	}()
+	return out
+}
+
+// A question hold is byte-silent for its whole window exactly like an approval
+// hold — up to the configured ceiling, and the model may ask for minutes — so
+// it must heartbeat on the same terms.
+func TestContactHuman_HeartbeatsWhilePending(t *testing.T) {
+	notifier := &beatingNotifier{}
+	tool, store := contactHumanUnderTest(notifier, 15*time.Millisecond)
+
+	result := askQuestionAsync(tool, context.Background())
+
+	require.Eventually(t, func() bool { return notifier.beats() >= 3 }, 2*time.Second, 5*time.Millisecond,
+		"a pending question must keep heartbeating")
+
+	// The card itself is emitted exactly once no matter how many beats follow.
+	require.Equal(t, 1, notifier.notifyCount())
+
+	respondOncePending(store, "approved")
+	select {
+	case res := <-result:
+		require.True(t, res.Success)
+	case <-time.After(3 * time.Second):
+		t.Fatal("contact_human did not return after the human responded")
+	}
+}
+
+// The beat is bounded by the hold: once the human answers, nothing further is
+// emitted.
+func TestContactHuman_HeartbeatStopsWhenAnswered(t *testing.T) {
+	notifier := &beatingNotifier{}
+	tool, store := contactHumanUnderTest(notifier, 10*time.Millisecond)
+
+	result := askQuestionAsync(tool, context.Background())
+	require.Eventually(t, func() bool { return notifier.beats() >= 1 }, 2*time.Second, 5*time.Millisecond)
+
+	respondOncePending(store, "approved")
+	select {
+	case res := <-result:
+		require.True(t, res.Success)
+	case <-time.After(3 * time.Second):
+		t.Fatal("contact_human did not return after the human responded")
+	}
+
+	settled := notifier.beats()
+	time.Sleep(50 * time.Millisecond) // several heartbeat intervals
+	require.Equal(t, settled, notifier.beats(), "no heartbeat may fire after the question was answered")
+}
+
+// Opt-in by capability, same as the ask hold: a plain Notifier is never beaten
+// and keeps behaving exactly as before, and the default notifier (NoOpNotifier,
+// installed when a caller supplies none) is safe to beat against.
+func TestContactHuman_HeartbeatIsOptInByCapability(t *testing.T) {
+	t.Run("plain notifier is never beaten", func(t *testing.T) {
+		plain := &plainNotifier{}
+		tool, store := contactHumanUnderTest(plain, 5*time.Millisecond)
+
+		result := askQuestionAsync(tool, context.Background())
+		waitForPending(t, store)
+		time.Sleep(40 * time.Millisecond) // several intervals
+
+		_, isBeater := Notifier(plain).(Heartbeater)
+		require.False(t, isBeater, "a plain notifier must not advertise the capability")
+		require.Equal(t, 1, plain.count(), "the card is still emitted once")
+
+		respondOncePending(store, "approved")
+		select {
+		case res := <-result:
+			require.True(t, res.Success)
+		case <-time.After(3 * time.Second):
+			t.Fatal("contact_human did not return after the human responded")
+		}
+	})
+
+	t.Run("default no-op notifier is safe", func(t *testing.T) {
+		tool, store := contactHumanUnderTest(nil, 5*time.Millisecond)
+
+		result := askQuestionAsync(tool, context.Background())
+		waitForPending(t, store)
+		time.Sleep(30 * time.Millisecond)
+		respondOncePending(store, "approved")
+
+		select {
+		case res := <-result:
+			require.True(t, res.Success)
+		case <-time.After(3 * time.Second):
+			t.Fatal("contact_human did not return after the human responded")
+		}
+	})
+}
+
+// The constructor defaults the interval, so the production path beats without
+// any caller opt-in — and shares ONE constant with the ask hold so the two
+// origins cannot drift.
+func TestNewContactHumanTool_DefaultsHeartbeatInterval(t *testing.T) {
+	tool := NewContactHumanTool(ContactHumanConfig{})
+	require.Equal(t, holdHeartbeatInterval, tool.heartbeat)
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -443,6 +443,18 @@ type ProgressEvent struct {
 	// HITLRequest contains HITL request details (only when Stage == StageHumanInTheLoop)
 	HITLRequest *HITLRequestInfo
 
+	// Droppable marks an event whose ONLY purpose is to produce traffic — a
+	// HITL hold heartbeat. A transport under backpressure may discard it
+	// rather than block the emitting goroutine: losing one is harmless,
+	// unlike a card, a token chunk, or a tool lifecycle event, all of which
+	// carry state the consumer cannot reconstruct.
+	//
+	// This is what keeps a heartbeat from deepening the very hang it exists to
+	// prevent. A hold emits from the turn goroutine, so a blocking send on a
+	// wedged consumer stalls the poll loop that would otherwise see the human's
+	// decision. Never set this on an event carrying state.
+	Droppable bool
+
 	// Token streaming fields (for real-time LLM response rendering)
 
 	// PartialContent is the accumulated content so far during streaming

--- a/proto/loom/v1/loom.proto
+++ b/proto/loom/v1/loom.proto
@@ -746,7 +746,26 @@ message WeaveProgress {
   // Partial result (available at certain stages)
   ExecutionResult partial_result = 6;
 
-  // HITL request info (only when stage == EXECUTION_STAGE_HUMAN_IN_THE_LOOP)
+  // HITL request info (only when stage == EXECUTION_STAGE_HUMAN_IN_THE_LOOP).
+  //
+  // A non-empty hitl_request.request_id is what makes a message an ANSWERABLE
+  // card. Consumers MUST key the human-facing prompt off that id, because it is
+  // the handle AnswerClarificationQuestion / RespondToRequest take; a prompt
+  // raised without one cannot deliver its answer, and the hold behind it stays
+  // pending until it times out. Two other shapes ride the same stage and MUST
+  // NOT raise a prompt:
+  //
+  //   - hitl_request ABSENT — a hold heartbeat. A hold is otherwise byte-silent
+  //     on this stream for its whole window (up to 300s for an approval hold),
+  //     long enough for an intermediary to trip an inactivity timeout and tear
+  //     down the stream the decision has to travel back on. These messages
+  //     exist only to produce traffic and carry no state; they may also be
+  //     dropped under backpressure, so consumers must not count on receiving
+  //     every one.
+  //   - hitl_request PRESENT with an empty request_id — the pre-creation ping
+  //     the conversation loop emits off a contact_human call before the store
+  //     row exists. Useful as an early "a hold is coming" hint; the answerable
+  //     card follows once the row is written.
   HITLRequestInfo hitl_request = 7;
 
   // Token streaming fields


### PR DESCRIPTION
## Problem

A HITL hold blocks the turn goroutine and emits **nothing** between the pending card and the human's decision.

On a streaming transport that is silence for the whole hold window — up to 300s for an approval hold, up to the configured ceiling for `contact_human` — which is long enough for a proxy to trip its inactivity timeout and tear down the very stream the decision has to travel back on. The human approves, the resolver returns `Allow`, the tool runs… and the result has nowhere to go. The turn appears to hang forever.

Found while investigating a live preprod report of "an HITL request causes tool calls to hang after approving". Review then turned up a **second, independent cause of the same symptom** (see *The card gate* below), and a way the first fix could deepen the hang it was meant to cure (see *Not wedging the hold*).

## Fix

### 1. Heartbeat a pending hold

An optional `Heartbeater` capability on `Notifier`:

```go
type Heartbeater interface {
	Heartbeat(ctx context.Context) error
}
```

While a hold is pending, the waiter pokes a notifier that implements it every 30s. A notifier that does **not** implement it is never poked, so **every existing `Notifier` behaves exactly as before** — opt-in by capability, no signature change to `NewHITLAskResolver`.

Both hold origins beat, through one shared `holdBeater` and one interval constant so they cannot drift: the ask resolver **and** `contact_human`, whose `waitForResponse` is byte-silent on identical terms. The beat also runs on the absent-row path, since an unreadable row is not a reason to let the stream go quiet.

### 2. Actually wire it

`cmd_serve` passed a **nil** notifier to `NewHITLAskResolver` and left `ContactHumanConfig.Notifier` unset at both registration sites, so `agent.NewProgressNotifier()` had **zero non-test callers**. Neither the pending card nor any heartbeat reached a caller of the shipped binary — the bridge from TER-710 was never connected.

All three origins now share `hitlNotifier()`, and a source-level test fails if any regresses to nil. That failure is otherwise invisible at runtime: a nil notifier does not error, it just never emits.

### 3. Not wedging the hold

The heartbeat emits from the turn goroutine parked in the hold's poll loop, onto a 10-slot channel whose sender can block indefinitely in `stream.Send` against a client that is gone but whose context was never cancelled — a connection dropped half-open, which no gRPC keepalive is configured to detect.

Ten beats fill that buffer inside one default hold window. The eleventh would block the poll loop that reads the human's decision, and the hold would then **neither resolve nor expire** — a worse hang than the one being fixed, in exactly the scenario that motivates the fix.

`ProgressEvent.Droppable` marks liveness-only events, and the now-shared progress sender (one implementation for both streaming RPCs) discards them under backpressure rather than blocking. State-bearing events — token chunks, cards, tool lifecycle — still wait, because a hole in those is not reconstructable.

### 4. The card gate

Three shapes ride `EXECUTION_STAGE_HUMAN_IN_THE_LOOP`, and only one is answerable:

| `hitl_request` | `request_id` | What it is | Card? |
|---|---|---|---|
| absent | — | heartbeat; liveness only, droppable | No |
| present | empty | pre-creation ping, emitted before the store row exists | No |
| present | non-empty | answerable card | **Yes** |

An earlier revision of this PR justified the heartbeat by claiming an id-less event was "already the documented pre-creation ping, and is ignored." Neither half held. The proto documented no such thing, and the real ping carries a payload with an **empty `request_id`** — which the TUI **did** raise a dialog for, gating on `hitl_request != nil`. That dialog has no id to submit against, so `sendAnswerViaRPC` is skipped and there is no `AnswerChan`: the human answers into a dead box that reports "no communication channel available" while the hold sits pending until it times out.

That is a second, independent path to "hangs after approving", and it is fixed here. The contract now lives on `WeaveProgress.hitl_request` where downstream consumers actually read it, and the TUI gates on a non-empty `request_id` via `IsAnswerableHITLCard`.

The heartbeat's safety comes from carrying **no payload at all** — strictly narrower than an empty id — so it cannot raise a card even on a consumer that gates the old way.

## Design notes

- **The emit stays on the turn goroutine.** No new goroutine, no locking. Downstream consumers rely on loom delivering progress events on a single goroutine (`grpc.ServerStream.Send` is not concurrency-safe); a background ticker would have broken that invariant and forced a mutex into every consumer.
- **Best-effort throughout.** The beat is evaluated *after* the resolution poll so it can never delay a decision the poll already saw, and a `Heartbeat` error never changes a hold's outcome.
- `heartbeat: 0` disables beating; a nil notifier is safe (asserting a nil interface yields `ok=false`).
- Every HITL-stage event now carries the same progress percentage, so the indicator no longer flickers between the card and the beats that follow it.

## Tests

- `pkg/shuttle/admission_ask_heartbeat_test.go` — beats while pending; stops once resolved; the card is emitted exactly once no matter how many beats follow; table-driven over notifier shapes, each row asserting against the notifier the resolver actually holds; nil-notifier; constructor defaults.
- `pkg/shuttle/human_tool_heartbeat_test.go` — the same guarantees for `contact_human`, plus one shared interval constant.
- `pkg/server/progress_sender_test.go` — a droppable event never blocks on a full channel; is still delivered when there is room; a state-bearing event waits for the sender and gives up when the stream is done.
- `pkg/agent/hitl_heartbeat_emit_test.go` — the bridge advertises the capability; the event is HITL-stage, payload-less, droppable, and carries the card's progress value.
- `internal/tui/adapter/hitl_card_gate_test.go` — only an id-bearing card raises a dialog; heartbeat, ping, wrong-stage, and nil are all rejected.
- `cmd/looms/hitl_wiring_test.go` — serve wires a real, heartbeating notifier into every HITL origin.

`just check` green (proto lint/format/gen, fmt, vet, lint, full suite with `-race` under `-tags fts5`, build, gosec, interop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
