### PR TITLE
fix(scheduler): aging advances a starvation tier, not a priority class

### DIFF
--- a/gen/go/loom/v1/llm_scheduler.pb.go
+++ b/gen/go/loom/v1/llm_scheduler.pb.go
@@ -40,7 +40,9 @@ const (
 	SlotPriorityClass_SLOT_PRIORITY_CLASS_IN_FLIGHT SlotPriorityClass = 2
 	// Conversation holding an external scarce resource (database session
 	// handle, MCP slot): priority inheritance — it is blocking other agents
-	// that are burning LLM budget trying to acquire what it holds.
+	// that are burning LLM budget trying to acquire what it holds. Reached
+	// ONLY by actually holding a lease; starvation aging never promotes a
+	// request into this class (see starvation_age_s).
 	SlotPriorityClass_SLOT_PRIORITY_CLASS_RESOURCE_HOLDER SlotPriorityClass = 3
 )
 
@@ -179,9 +181,13 @@ type LLMSchedulerConfig struct {
 	// The door gate is wired process-wide and configured at boot via looms
 	// config (llm.max_door_queue); this per-scope field is not yet read.
 	MaxDoorQueue int32 `protobuf:"varint,4,opt,name=max_door_queue,json=maxDoorQueue,proto3" json:"max_door_queue,omitempty"`
-	// Seconds after which a waiting slot request is promoted one priority
-	// class. Bounds starvation: any waiter reaches the top class in at most
-	// 2 * starvation_age_s.
+	// Seconds a request may wait before it earns starvation precedence, which
+	// puts it at the head of its band ahead of every non-starved request
+	// regardless of class (oldest starved first). Each further interval
+	// advances its tier. Bounds starvation without rewriting priority class:
+	// waiting longer does not make a request a lease holder, so the
+	// RESOURCE_HOLDER class keeps meaning what it says even in a scope that
+	// has been saturated for a long time.
 	StarvationAgeS int32 `protobuf:"varint,5,opt,name=starvation_age_s,json=starvationAgeS,proto3" json:"starvation_age_s,omitempty"`
 	// Target utilization of measured capacity, (0, 1]. 0 = default 0.8.
 	UtilizationTarget float32 `protobuf:"fixed32,6,opt,name=utilization_target,json=utilizationTarget,proto3" json:"utilization_target,omitempty"`

--- a/gen/openapiv2/loom/v1/llm_scheduler.swagger.json
+++ b/gen/openapiv2/loom/v1/llm_scheduler.swagger.json
@@ -83,7 +83,7 @@
         "starvationAgeS": {
           "type": "integer",
           "format": "int32",
-          "description": "Seconds after which a waiting slot request is promoted one priority\nclass. Bounds starvation: any waiter reaches the top class in at most\n2 * starvation_age_s."
+          "description": "Seconds a request may wait before it earns starvation precedence, which\nputs it at the head of its band ahead of every non-starved request\nregardless of class (oldest starved first). Each further interval\nadvances its tier. Bounds starvation without rewriting priority class:\nwaiting longer does not make a request a lease holder, so the\nRESOURCE_HOLDER class keeps meaning what it says even in a scope that\nhas been saturated for a long time."
         },
         "utilizationTarget": {
           "type": "number",
@@ -137,7 +137,7 @@
         "SLOT_PRIORITY_CLASS_RESOURCE_HOLDER"
       ],
       "default": "SLOT_PRIORITY_CLASS_UNSPECIFIED",
-      "description": "SlotPriorityClass orders slot requests. Higher classes are served first;\naging promotes a starved waiter one class (liveness, not throughput).\n\n - SLOT_PRIORITY_CLASS_NEW: First LLM call of a conversation: admitted as churn allows.\n - SLOT_PRIORITY_CLASS_IN_FLIGHT: Conversation mid-task: run-to-completion bias — finishing releases every\nresource the conversation holds.\n - SLOT_PRIORITY_CLASS_RESOURCE_HOLDER: Conversation holding an external scarce resource (database session\nhandle, MCP slot): priority inheritance — it is blocking other agents\nthat are burning LLM budget trying to acquire what it holds."
+      "description": "SlotPriorityClass orders slot requests. Higher classes are served first;\naging promotes a starved waiter one class (liveness, not throughput).\n\n - SLOT_PRIORITY_CLASS_NEW: First LLM call of a conversation: admitted as churn allows.\n - SLOT_PRIORITY_CLASS_IN_FLIGHT: Conversation mid-task: run-to-completion bias — finishing releases every\nresource the conversation holds.\n - SLOT_PRIORITY_CLASS_RESOURCE_HOLDER: Conversation holding an external scarce resource (database session\nhandle, MCP slot): priority inheritance — it is blocking other agents\nthat are burning LLM budget trying to acquire what it holds. Reached\nONLY by actually holding a lease; starvation aging never promotes a\nrequest into this class (see starvation_age_s)."
     },
     "v1SlotState": {
       "type": "object",

--- a/pkg/llm/scheduler/band_test.go
+++ b/pkg/llm/scheduler/band_test.go
@@ -79,8 +79,10 @@ func TestBatchCannotConsumeInteractiveHeadroom(t *testing.T) {
 	g2.Release(1)
 }
 
-// Aging must never promote a batch waiter into the interactive band: batch
-// liveness comes from its own budget share, not the human lane.
+// Aging must never move a batch waiter into the interactive band. The bands
+// are a hard ordering — interactive outranks batch entirely — so a batch
+// waiter's liveness comes from starvation precedence WITHIN its own band,
+// never from crossing into the human lane.
 func TestAgingStaysWithinBand(t *testing.T) {
 	s := newTest(t, Config{TokensPerMinute: 1000, StarvationAge: 500 * time.Millisecond})
 	hog, err := s.Acquire(context.Background(), Request{ReservationTokens: 600, Origin: originInteractive})
@@ -95,14 +97,16 @@ func TestAgingStaysWithinBand(t *testing.T) {
 		close(done)
 	}()
 
-	// Wait until aging has demonstrably promoted the batch waiter twice
-	// (NEW → IN_FLIGHT → RESOURCE_HOLDER within the batch band).
+	// Wait until aging has demonstrably advanced the batch waiter's
+	// starvation tier twice.
 	require.Eventually(t, func() bool {
 		return s.State().PromotionsTotal >= 2
 	}, 15*time.Second, 100*time.Millisecond)
 
 	ws := s.Waiters()
 	require.Len(t, ws, 1)
-	assert.Equal(t, originBatch, ws[0].Origin, "promotion must never change the band")
-	assert.Equal(t, classHolder, ws[0].Class, "waiter should have aged to the top of its own band")
+	assert.Equal(t, originBatch, ws[0].Origin, "aging must never change the band")
+	assert.Equal(t, classNew, ws[0].Class,
+		"aging advances the starvation tier without rewriting the class")
+	assert.GreaterOrEqual(t, ws[0].Promotions, int32(2))
 }

--- a/pkg/llm/scheduler/scheduler.go
+++ b/pkg/llm/scheduler/scheduler.go
@@ -12,6 +12,7 @@ package scheduler
 
 import (
 	"context"
+	"sort"
 	"sync"
 	"time"
 
@@ -600,32 +601,63 @@ func bandRank(o loomv1.SlotOrigin) int {
 // non-starved head, backfill continues (throughput).
 func (s *Scheduler) dispatchLocked() {
 	for _, band := range bandOrder {
+		// Build this band's dispatch order in one pass so a waiter can never
+		// be granted twice: starved waiters first (oldest first, across every
+		// class), then the ordinary class order with FIFO inside each class.
+		//
+		// Starvation precedence lives here rather than in the waiter's class,
+		// so "has waited too long" can outrank "holds a lease" for one
+		// dispatch without ever claiming to BE a lease holder. That keeps the
+		// proto's liveness bound — no waiter waits indefinitely behind a
+		// stream of higher classes — while leaving the class honest.
+		var starved, ordinary []*waiter
 		for _, class := range dispatchOrder {
-			q := s.queues[band][class]
-			var remaining []*waiter
-			var blockedOnStarvedHead bool
-			for i, w := range q {
+			for _, w := range s.queues[band][class] {
 				if w.cancelled {
 					continue
 				}
-				if !s.canGrantLocked(band, w.req.ReservationTokens) {
-					remaining = append(remaining, q[i:]...)
-					blockedOnStarvedHead = s.starvedAtTopLocked(w)
-					break
+				if hasStarvedLocked(w) {
+					starved = append(starved, w)
+					continue
 				}
-				w.ready <- s.grantLocked(w.req.ReservationTokens)
+				ordinary = append(ordinary, w)
 			}
-			// Filter any cancelled stragglers retained by the break above.
-			filtered := remaining[:0]
-			for _, w := range remaining {
-				if !w.cancelled {
-					filtered = append(filtered, w)
+		}
+		sort.SliceStable(starved, func(i, j int) bool {
+			return starved[i].since.Before(starved[j].since)
+		})
+
+		granted := make(map[*waiter]struct{})
+		blocked := false
+		for _, w := range append(starved, ordinary...) {
+			if !s.canGrantLocked(band, w.req.ReservationTokens) {
+				// The head that cannot fit is starved: hold the band rather
+				// than backfilling smaller requests past it, or it never
+				// accumulates the capacity it needs.
+				blocked = hasStarvedLocked(w)
+				break
+			}
+			w.ready <- s.grantLocked(w.req.ReservationTokens)
+			granted[w] = struct{}{}
+		}
+
+		// Rebuild each class queue from what remains, preserving FIFO.
+		for _, class := range dispatchOrder {
+			q := s.queues[band][class]
+			keep := q[:0]
+			for _, w := range q {
+				if w.cancelled {
+					continue
 				}
+				if _, done := granted[w]; done {
+					continue
+				}
+				keep = append(keep, w)
 			}
-			s.queues[band][class] = filtered
-			if blockedOnStarvedHead {
-				return
-			}
+			s.queues[band][class] = keep
+		}
+		if blocked {
+			return
 		}
 	}
 }
@@ -633,10 +665,23 @@ func (s *Scheduler) dispatchLocked() {
 // starvedAtTopLocked reports whether w has waited past its next aging point
 // while already at the top class of its band — the point where promotion can
 // no longer help it and admission liveness (backfill halt) must take over.
-func (s *Scheduler) starvedAtTopLocked(w *waiter) bool {
-	return w.class == loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_RESOURCE_HOLDER &&
-		time.Since(w.since) >= s.starvationAge*time.Duration(w.promoted+1)
+// agingDueLocked reports whether a waiter has waited past its CURRENT
+// starvation tier and should advance to the next one. The threshold escalates
+// with each tier, so this goes false immediately after a bump — which is why
+// dispatch precedence uses hasStarvedLocked instead of this.
+//
+// Class-independent by design: starvation is about elapsed time, not about
+// what the request is, and conflating the two is what let aging dilute the
+// RESOURCE_HOLDER class.
+func (s *Scheduler) agingDueLocked(w *waiter) bool {
+	return time.Since(w.since) >= s.starvationAge*time.Duration(w.promoted+1)
 }
+
+// hasStarvedLocked reports whether a waiter has crossed at least one
+// starvation threshold. Precedence is sticky on purpose: a waiter that has
+// starved keeps its head-of-band position until it is served, rather than
+// losing it the instant its tier advances.
+func hasStarvedLocked(w *waiter) bool { return w.promoted > 0 }
 
 // tick drives window rollover, Retry-After expiry, and starvation aging.
 func (s *Scheduler) tick() {
@@ -665,27 +710,28 @@ func (s *Scheduler) tick() {
 // only; batch regains admission when the interactive band goes quiet.
 func (s *Scheduler) ageLocked() {
 	for _, band := range bandOrder {
-		promote := func(from, to loomv1.SlotPriorityClass) {
-			var keep []*waiter
-			for _, w := range s.queues[band][from] {
+		for _, class := range dispatchOrder {
+			for _, w := range s.queues[band][class] {
 				if w.cancelled {
 					continue
 				}
-				if time.Since(w.since) >= s.starvationAge*time.Duration(w.promoted+1) {
+				if s.agingDueLocked(w) {
+					// Bump the starvation tier only. Aging deliberately does
+					// NOT move the waiter's class: class says what a request
+					// IS (a new turn, a turn mid-task, a turn holding a
+					// scarce backend lease), and waiting longer does not turn
+					// a request into a lease holder. Promoting across classes
+					// filled RESOURCE_HOLDER with non-holders under sustained
+					// saturation — measured on a 384-agent run, 382 of 383
+					// parked requests read as holders after 715 promotions,
+					// which erases the distinction priority inheritance
+					// depends on. Precedence for a starved waiter comes from
+					// dispatch instead (see dispatchLocked).
 					w.promoted++
-					w.class = to
 					s.promotionsTotal++
-					s.queues[band][to] = append(s.queues[band][to], w)
-					continue
 				}
-				keep = append(keep, w)
 			}
-			s.queues[band][from] = keep
 		}
-		promote(loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_IN_FLIGHT,
-			loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_RESOURCE_HOLDER)
-		promote(loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_NEW,
-			loomv1.SlotPriorityClass_SLOT_PRIORITY_CLASS_IN_FLIGHT)
 	}
 }
 

--- a/pkg/llm/scheduler/scheduler.go
+++ b/pkg/llm/scheduler/scheduler.go
@@ -610,8 +610,13 @@ func (s *Scheduler) dispatchLocked() {
 		// dispatch without ever claiming to BE a lease holder. That keeps the
 		// proto's liveness bound — no waiter waits indefinitely behind a
 		// stream of higher classes — while leaving the class honest.
-		var starved, ordinary []*waiter
-		for _, class := range dispatchOrder {
+		// ordinary stays grouped BY CLASS: an unfit non-starved head blocks
+		// only its own class, so the next class still gets a turn. Flattening
+		// it would make one stuck large reservation stall every cheaper
+		// waiter behind it in the whole band.
+		var starved []*waiter
+		ordinary := make([][]*waiter, len(dispatchOrder))
+		for ci, class := range dispatchOrder {
 			for _, w := range s.queues[band][class] {
 				if w.cancelled {
 					continue
@@ -620,7 +625,7 @@ func (s *Scheduler) dispatchLocked() {
 					starved = append(starved, w)
 					continue
 				}
-				ordinary = append(ordinary, w)
+				ordinary[ci] = append(ordinary[ci], w)
 			}
 		}
 		sort.SliceStable(starved, func(i, j int) bool {
@@ -629,16 +634,35 @@ func (s *Scheduler) dispatchLocked() {
 
 		granted := make(map[*waiter]struct{})
 		blocked := false
-		for _, w := range append(starved, ordinary...) {
+
+		// Starved waiters first, oldest first, across every class. A starved
+		// head that cannot fit HALTS the band: backfilling smaller requests
+		// past it is precisely how it never accumulates the capacity it
+		// needs, which is the starvation this ordering exists to end.
+		for _, w := range starved {
 			if !s.canGrantLocked(band, w.req.ReservationTokens) {
-				// The head that cannot fit is starved: hold the band rather
-				// than backfilling smaller requests past it, or it never
-				// accumulates the capacity it needs.
-				blocked = hasStarvedLocked(w)
+				blocked = true
 				break
 			}
 			w.ready <- s.grantLocked(w.req.ReservationTokens)
 			granted[w] = struct{}{}
+		}
+
+		// Then the ordinary class order, FIFO inside each class. An unfit
+		// head here stops ITS class and nothing else — it is not starved, so
+		// it has no claim on the band, and a large RESOURCE_HOLDER that
+		// cannot yet fit must not stall a burst of cheap NEW waiters that
+		// can. This is the backfill this function's contract promises.
+		if !blocked {
+			for ci := range dispatchOrder {
+				for _, w := range ordinary[ci] {
+					if !s.canGrantLocked(band, w.req.ReservationTokens) {
+						break // this class only; the next still gets a turn
+					}
+					w.ready <- s.grantLocked(w.req.ReservationTokens)
+					granted[w] = struct{}{}
+				}
+			}
 		}
 
 		// Rebuild each class queue from what remains, preserving FIFO.

--- a/pkg/llm/scheduler/scheduler_test.go
+++ b/pkg/llm/scheduler/scheduler_test.go
@@ -208,8 +208,63 @@ func TestAgingPromotesStarvedWaiters(t *testing.T) {
 
 	ws := s.Waiters()
 	require.Len(t, ws, 1)
-	assert.NotEqual(t, classNew, ws[0].Class, "waiter should have left NEW")
-	assert.GreaterOrEqual(t, ws[0].Promotions, int32(1))
+	assert.GreaterOrEqual(t, ws[0].Promotions, int32(1), "the starvation tier must advance")
+	assert.Equal(t, classNew, ws[0].Class,
+		"aging must NOT move the waiter's class: class says what a request is, "+
+			"and waiting longer does not turn a request into a lease holder — "+
+			"precedence for a starved waiter comes from dispatch")
+}
+
+// TestStarvedWaiterOutranksHolderWithoutBecomingOne is the liveness half of
+// that contract: a starved NEW waiter must still be served ahead of a
+// freshly-arrived RESOURCE_HOLDER, so removing the cross-class promotion
+// cannot starve lower classes behind a stream of holders.
+//
+// Reservations are sized so exactly ONE of the two waiters fits once the hog
+// releases (budget 800; two 500s cannot both be admitted) — otherwise both
+// are granted in the same dispatch pass and the assertion is a coin flip.
+func TestStarvedWaiterOutranksHolderWithoutBecomingOne(t *testing.T) {
+	s := newTest(t, Config{TokensPerMinute: 1000, StarvationAge: 300 * time.Millisecond, InteractiveHeadroom: -1})
+	hog, err := s.Acquire(context.Background(), Request{ReservationTokens: 700})
+	require.NoError(t, err)
+
+	// A NEW waiter parks first and ages past a starvation threshold.
+	newDone := make(chan struct{})
+	go func() {
+		g, err := s.Acquire(context.Background(), Request{ReservationTokens: 500, Class: classNew})
+		if err == nil {
+			g.Release(1)
+		}
+		close(newDone)
+	}()
+	require.Eventually(t, func() bool { return s.State().PromotionsTotal >= 1 },
+		5*time.Second, 20*time.Millisecond, "the NEW waiter must reach starvation")
+
+	// A holder arrives afterwards — higher class, but it has not starved.
+	holderDone := make(chan struct{})
+	go func() {
+		g, err := s.Acquire(context.Background(), Request{ReservationTokens: 500, Class: classHolder})
+		if err == nil {
+			g.Release(1)
+		}
+		close(holderDone)
+	}()
+	require.Eventually(t, func() bool { return s.State().ParkedRequests >= 2 },
+		5*time.Second, 20*time.Millisecond, "both must be parked")
+
+	// True up the hog's reservation (Release(0) would book the whole 700 and
+	// keep the window full until rollover), freeing room for exactly one.
+	hog.Release(1)
+
+	select {
+	case <-newDone:
+		// The starved waiter went first, without ever changing class.
+	case <-holderDone:
+		t.Fatal("the freshly-arrived holder was served before the starved waiter")
+	case <-time.After(5 * time.Second):
+		t.Fatal("neither waiter was served")
+	}
+	<-holderDone
 }
 
 func TestReservationTrueUpFreesBudget(t *testing.T) {

--- a/pkg/llm/scheduler/scheduler_test.go
+++ b/pkg/llm/scheduler/scheduler_test.go
@@ -470,8 +470,13 @@ func TestStarvedTopClassHeadHaltsBackfill(t *testing.T) {
 		require.NoError(t, gerr)
 		holderGranted <- g
 	}()
-	// ...and starves past its aging point at the top class.
-	time.Sleep(300 * time.Millisecond)
+	// ...and starves for real. Starvation is promoted > 0, and promoted is
+	// only bumped by ageLocked on the 1s tick — so sleeping past
+	// StarvationAge is NOT enough, and a short sleep here made this test
+	// assert the NON-starved path by accident (the old flattened dispatch
+	// halted the band for any unfit head, starved or not, so it passed for
+	// the wrong reason and left the starved case unexercised).
+	waitUntilStarved(t, s)
 
 	// A stream of small NEW arrivals that would individually fit.
 	smallGranted := make(chan *Grant, 2)
@@ -666,4 +671,85 @@ func TestListWaitersAllScopes(t *testing.T) {
 
 	cancel()
 	held.Release(0)
+}
+
+// The mirror of TestStarvedTopClassHeadHaltsBackfill: a NON-starved head that
+// cannot fit must block only its own class, not the whole band.
+//
+// Halting the band is correct for a STARVED head — that is how it finally
+// accumulates capacity. Applying the same halt to an ordinary head silently
+// converts one stuck large reservation into a stall for every cheaper waiter
+// behind it, for up to a full starvation_age. That is the throughput this
+// function's contract promises ("below a non-starved head, backfill
+// continues"), and only the starved case was pinned before.
+func TestNonStarvedHeadAllowsBackfill(t *testing.T) {
+	// StarvationAge far exceeds the test's lifetime, so nothing starves and
+	// the head below is unambiguously ordinary.
+	s := newTest(t, Config{TokensPerMinute: 1000, StarvationAge: time.Hour, InteractiveHeadroom: -1})
+
+	hog1, err := s.Acquire(context.Background(), Request{ReservationTokens: 500})
+	require.NoError(t, err)
+	hog2, err := s.Acquire(context.Background(), Request{ReservationTokens: 200})
+	require.NoError(t, err)
+
+	// A large RESOURCE_HOLDER parks: 500+200+400 > 800.
+	holderGranted := make(chan *Grant, 1)
+	go func() {
+		g, gerr := s.Acquire(context.Background(), Request{ReservationTokens: 400, Class: classHolder, ConversationID: "big-holder"})
+		require.NoError(t, gerr)
+		holderGranted <- g
+	}()
+	time.Sleep(100 * time.Millisecond) // park it, but nowhere near starving
+
+	// A cheap NEW arrival in a lower class, which fits once hog2 releases.
+	smallGranted := make(chan *Grant, 1)
+	go func() {
+		g, gerr := s.Acquire(context.Background(), Request{ReservationTokens: 100, Class: classNew})
+		require.NoError(t, gerr)
+		smallGranted <- g
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	// Free 200: the holder still does not fit (500+400 > 800), but the small
+	// one does (500+100 <= 800). Because the holder is NOT starved, it holds
+	// up only its own class and the small NEW waiter must be granted.
+	hog2.Release(1)
+
+	select {
+	case g := <-smallGranted:
+		g.Release(1)
+	case <-holderGranted:
+		t.Fatal("holder cannot fit while hog1 holds 500")
+	case <-time.After(2 * time.Second):
+		t.Fatal("a cheap NEW waiter was stalled behind an unfit but NON-starved holder; " +
+			"an ordinary head must block only its own class, not the band")
+	}
+
+	hog1.Release(1)
+	select {
+	case g := <-holderGranted:
+		g.Release(1)
+	case <-time.After(2 * time.Second):
+		t.Fatal("holder never admitted after capacity freed")
+	}
+}
+
+// waitUntilStarved blocks until some parked waiter has actually crossed a
+// starvation tier (promoted > 0), which only ageLocked's 1s tick can do.
+func waitUntilStarved(t *testing.T, s *Scheduler) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		for _, band := range bandOrder {
+			for _, class := range dispatchOrder {
+				for _, w := range s.queues[band][class] {
+					if !w.cancelled && hasStarvedLocked(w) {
+						return true
+					}
+				}
+			}
+		}
+		return false
+	}, 5*time.Second, 50*time.Millisecond, "no waiter ever crossed a starvation tier")
 }

--- a/proto/loom/v1/llm_scheduler.proto
+++ b/proto/loom/v1/llm_scheduler.proto
@@ -28,7 +28,9 @@ enum SlotPriorityClass {
   SLOT_PRIORITY_CLASS_IN_FLIGHT = 2;
   // Conversation holding an external scarce resource (database session
   // handle, MCP slot): priority inheritance — it is blocking other agents
-  // that are burning LLM budget trying to acquire what it holds.
+  // that are burning LLM budget trying to acquire what it holds. Reached
+  // ONLY by actually holding a lease; starvation aging never promotes a
+  // request into this class (see starvation_age_s).
   SLOT_PRIORITY_CLASS_RESOURCE_HOLDER = 3;
 }
 
@@ -84,9 +86,13 @@ message LLMSchedulerConfig {
   // config (llm.max_door_queue); this per-scope field is not yet read.
   int32 max_door_queue = 4;
 
-  // Seconds after which a waiting slot request is promoted one priority
-  // class. Bounds starvation: any waiter reaches the top class in at most
-  // 2 * starvation_age_s.
+  // Seconds a request may wait before it earns starvation precedence, which
+  // puts it at the head of its band ahead of every non-starved request
+  // regardless of class (oldest starved first). Each further interval
+  // advances its tier. Bounds starvation without rewriting priority class:
+  // waiting longer does not make a request a lease holder, so the
+  // RESOURCE_HOLDER class keeps meaning what it says even in a scope that
+  // has been saturated for a long time.
   int32 starvation_age_s = 5;
 
   // Target utilization of measured capacity, (0, 1]. 0 = default 0.8.


### PR DESCRIPTION
## Found by trying to measure the thing it broke

I set out to prove whether RESOURCE_HOLDER priority inheritance (#365/#369) actually helps. 384 agents, ceiling pinned below demand so admission genuinely queues, waiter classes sampled every 30s:

```
t+5m   382 holder    1 in-flight
t+10m  368 holder
t+15m  252 holder
t+20m  245 holder    2 in-flight
```

Essentially every parked request read as a holder, after **715 promotions**. Class ordering had degenerated to FIFO, so the mechanism could not be exercised at all — and a naive A/B would have reported "priority inheritance has no effect" for entirely the wrong reason.

**Cause:** aging promoted waiters up the *same ladder* priority inheritance orders (`NEW → IN_FLIGHT → RESOURCE_HOLDER`). A request holding nothing got relabelled a lease holder purely for having waited. The longer a scope stayed saturated, the less the class meant — so the dilution is worst exactly when scheduling matters most.

## The fix: two concerns, two mechanisms

- **Class says what a request IS.** `RESOURCE_HOLDER` is reachable only by actually holding a lease. Aging never writes it.
- **Starvation says how long it has WAITED.** Aging advances a tier (`promoted++`); dispatch serves waiters that have crossed a threshold ahead of every non-starved request in the band, oldest first.

Liveness is preserved rather than traded away: a starved `NEW` waiter is still served before a freshly-arrived holder. `dispatchLocked` now builds each band's order in a single pass (starved oldest-first, then class order, FIFO within class) and rebuilds the queues from what remains, so a waiter cannot be granted twice.

## One subtlety worth reviewing

Precedence is **sticky** (`promoted > 0`), not re-derived from the escalating threshold. My first draft used one predicate for both jobs, and because the threshold doubles per tier, a just-promoted waiter lost its precedence the instant it earned it — the new liveness test caught that, which is the main reason I trust it.

Two test expectations changed because they encoded the old ladder (`TestAgingPromotesStarvedWaiters`, `TestAgingStaysWithinBand`); both now assert the new contract, and the band test keeps its real subject — aging must never cross bands — which this change makes trivially true.

## Docs corrected

The proto promised "any waiter reaches the top class in at most 2 × starvation_age_s", which is no longer how liveness is delivered; `starvation_age_s` and the `RESOURCE_HOLDER` comment now describe the actual mechanism. Also fixed a stale claim in `band_test.go` that batch liveness comes from "its own budget share" — there is no such share; interactive outranks batch entirely.

## Validation

`gofmt`/`go vet` clean, `buf lint`/`generate` clean (comment-only proto diff), `go build -tags fts5 ./...`, scheduler suite `-race -count=3`, plus `-race` on pkg/agent, pkg/server, pkg/llm, cmd/loom, cmd/looms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)