### PR TITLE
HITL park-and-resume: a turn ends at a human decision and resumes on it

### DIFF
--- a/cmd/looms/cmd_hitl.go
+++ b/cmd/looms/cmd_hitl.go
@@ -511,6 +511,24 @@ func runHitlRespond(cmd *cobra.Command, args []string) {
 
 	span.SetAttribute("responded_by", respondedBy)
 
+	// A PARKED request cannot be answered by a store write. Every other HITL
+	// request has a waiter inside the turn polling for exactly this row, so
+	// writing the verdict is the whole handoff. A park has no waiter — its
+	// turn ENDED — and only Agent.ResumeChat can continue it. Deciding the row
+	// here would mark it answered while the approved actions never run, and
+	// the model would never learn what the human said.
+	if before, gerr := store.Get(ctx, requestID); gerr == nil && before != nil && before.RequestType == "parked" {
+		fmt.Fprintf(os.Stderr,
+			"Request %s is a PARKED turn: its decision must be applied through the agent's\n"+
+				"ResumeChat entry point, which re-enters the conversation. Responding here would\n"+
+				"close the request without ever running the actions or telling the model.\n\n"+
+				"Use the embedder that raised it (session %s) to deliver this decision.\n",
+			requestID, before.SessionID)
+		span.SetAttribute("success", false)
+		span.SetAttribute("refused", "parked")
+		os.Exit(1)
+	}
+
 	// Respond to request. The store's conditional write is a deliberate no-op
 	// for an already-decided or expired request, so success is judged by
 	// reading the row back — never by the write returning nil.

--- a/docs/architecture/hitl-park-and-resume.md
+++ b/docs/architecture/hitl-park-and-resume.md
@@ -176,6 +176,22 @@ must not kill a session.
   missing from the metrics backend.
 - 📋 Loop re-entry re-runs graph-memory context injection for the same turn,
   duplicating the injected block and paying a recall round-trip per resume.
-- 📋 `Chain.Preflight` re-evaluates every matching hook, so a stateful host
-  hook (a quota counter) sees each parked call twice.
 - 📋 No proto/gRPC surface for resume; park is a library API for embedders.
+  Whether loom should expose resume over gRPC is a product decision, not an
+  oversight — every other conversation entry point reaches clients through the
+  Weave surface, so the asymmetry is worth a deliberate answer.
+
+## 8. A note on hook evaluation count
+
+The pre-scan asks the admission chain the same question execution asks, so a
+call that parks and then runs evaluates every matching hook **twice** (three
+times for a `contact_human` re-classified at resume). This is safe because
+`Hook.Evaluate` is required to be side-effect free — now stated on the
+interface — with `PostToolHook` as the seam for anything that records. A host
+hook that counts inside `Evaluate` will over-count; that was true before park
+existed, but park is the first caller that makes it likely.
+
+Dynamic registration is not doubled: `tryDynamicRegistration` ends in
+`registry.Register`, so the pre-scan's registration is a hit for the later
+`Execute` rather than a second discovery round-trip. The cost moves earlier,
+it does not repeat.

--- a/docs/architecture/hitl-park-and-resume.md
+++ b/docs/architecture/hitl-park-and-resume.md
@@ -1,0 +1,181 @@
+# HITL Park-and-Resume: A Turn That Ends at a Human Decision
+
+**Status**: 🚧 In Development — PR #382 plus the review fixes on `fix/hitl-park-review`. The park pre-scan, `ResumeChat`, the request lifecycle, and the append-point guard are implemented with tests in `pkg/agent/hitl_park_test.go` and `pkg/agent/hitl_park_lifecycle_test.go`. Park is opt-in per agent (`WithHITLPark`) and is consumed by an embedder — loom itself ships no resume RPC.
+**Related**: PR #374 (in-turn hold heartbeat), PR #382 (park-and-resume)
+
+---
+
+## 1. Two ways to wait for a human
+
+Loom has two answers for a tool call that needs a person, and they are not
+alternatives so much as different scopes.
+
+| | In-turn hold (#374) | Park-and-resume (#382) |
+|---|---|---|
+| The turn | stays open, blocked inside the batch | **ends**, `TurnParkedError` |
+| The caller's stream | kept alive by a 30s heartbeat | closes; the resume is a new call |
+| Bounded by | the resolver's timeout | the request row's TTL (default 168h) |
+| Enabled by | an ask resolver on the chain | `WithHITLPark(store, ttl, notifier)` |
+| Good for | a decision measured in seconds | a decision measured in hours or days |
+
+A nil park store leaves the in-turn path exactly as it was. An agent that
+wires both keeps the hold as the fallback for any ask the pre-scan did not
+classify as a park item.
+
+### 1.1 What the progress stream shows
+
+`loom.proto`'s `WeaveProgress.hitl_request` distinguishes three shapes, and
+park adds a fourth case to the existing three:
+
+- **absent** — a hold heartbeat, liveness only, never a card;
+- **present, empty `request_id`** — the pre-creation ping, an unanswerable card;
+- **present, real `request_id`** — an answerable card;
+- **present, real `request_id`, then the stream ends** — a *park* card. The
+  turn is over; the answer arrives through `ResumeChat`, not through this
+  stream.
+
+A consumer written against the hold semantics will wait for heartbeats that
+never come. Treat the terminal card as the signal to close the run and hand
+the decision to whatever drives resume.
+
+## 2. The pre-scan
+
+`maybeParkBatch` runs *before anything in a batch executes*, after the
+assistant row carrying the tool calls is durable. Every call is preflighted
+through `Chain.Preflight` — the same hook combination `Admit` uses, with the
+blocking resolver never invoked.
+
+| Preflight verdict | Outcome |
+|---|---|
+| `Deny` | never a park item; falls to dispatch and denies as today |
+| `Ask` | **approval item** |
+| `contact_human`, registered, not denied | **question item** |
+| `contact_human`, unregistered | never an item; "tool not found" at execution |
+| `Allow` / `NoDecision` | never an item; dispatches normally at resume |
+
+One or more items parks the **whole batch**: a single grouped `human_requests`
+row whose `params` carry one descriptor per item keyed by `ToolCall.ID`, a
+durable tail of `…user, assistant(ToolCalls)` with no tool rows, and
+`TurnParkedError`.
+
+### 2.1 Durability is a precondition
+
+A request row must never outlive the batch it describes. Park therefore
+requires **both** that the assistant row's write succeeded and that a session
+store exists at all — `Memory.PersistMessage` returns `nil` when none is
+configured, so "persisted without error" is not the same as durable. Without a
+store the batch dispatches inline instead, where a governed call with no
+resolver fails closed.
+
+## 3. Resume
+
+`ResumeChat(ctx, sessionID, decision, progressCallback)` continues the parked
+turn. It appends **no** user message: resuming is not a new turn.
+
+### 3.1 The request row is the binding
+
+`ParkDecision.RequestID` names the row; the batch's item IDs come from **that
+row's params**, never from the caller's payload. `ParkDecision.ItemIDs` is an
+optional cross-check that must name exactly the row's items when supplied.
+
+This matters because a nested park chains — a resumed turn can park again, so
+one session can hold more than one row over its life. A decision bound by a
+caller-supplied list could be applied to a batch it never described simply by
+omitting the list. Binding through the row makes that unrepresentable.
+
+A row that is missing, already closed, or owned by another session is refused
+with `ErrUnknownRequest` before the session is touched — which also means a
+redelivered decision cannot re-execute its batch.
+
+### 3.2 Applying the decision
+
+| Call | Rejected | Approved |
+|---|---|---|
+| question item | `permission_denied`, human's reason verbatim | synthesized answer as the `contact_human` result |
+| approval item | `permission_denied` | dispatched under the `AskGrant` |
+| anything else in the batch | `permission_denied` | dispatched **ungranted** |
+
+The grant lifts `Ask` only — a `Deny` from any hook still dominates — and it
+covers **only the calls the card described**. An approval answers the question
+it was asked: a call that preflighted `Allow` at park time was never on the
+card, so if its verdict has since become `Ask` (a host gate tripping on budget,
+quota, or time of day while the human deliberated) it parks or fails closed
+like any fresh call, rather than borrowing an approval meant for something
+else.
+
+The grant lives only on the derived context handed to the parked batch's
+dispatch. The loop re-entry that follows runs ungranted, so a new ask in the
+continuation parks again.
+
+### 3.3 Closing the row
+
+The row is closed the instant its decision is applied, **before** the loop
+re-entry that may park a new one:
+
+- approved → `RespondToRequest(…, "approved", …)`
+- rejected → `RespondToRequest(…, "rejected", …)`
+- past `ExpiresAt` → `ExpireRequest(…, "system:expiry")`, and the decision is
+  applied as a refusal whatever it said — an approval must not execute on a
+  lapsed authorization.
+
+This is not bookkeeping. `guardParkedTail` refuses a new user turn while a
+parked row is pending, so a decided row left pending wedges the session for
+every later message. Expiry goes through `ExpireRequest` because the store's
+expiry guard is its own and no status payload lifts it.
+
+### 3.4 Terminals
+
+All are terminal — finish the request's lifecycle, never retry the resume.
+
+| Error | Meaning |
+|---|---|
+| `ErrParkDisabled` | the agent has no park wiring |
+| `ErrUnknownRequest` | no pending parked row with that ID owns this session |
+| `ErrStaleDecision` | supplied `ItemIDs` do not match the row's items |
+| `ErrNotParkedTail` | a user row of a later turn follows the batch |
+| `ErrNothingParked` | the turn already produced its final reply |
+
+`ErrNothingParked` covers a turn that ended with rowless calls behind it — the
+loop's `MaxToolExecutions` cap can end a turn that way, and those calls were
+declined, not deferred.
+
+## 4. Session handles across the gap
+
+MCP session handles are scoped to one `chat()` call by default. A parked turn
+spans two calls, so the parked half hands its `HandleCollector` to whoever
+resumes it (`mcpadapter.ContextWithHandleCollector`); a nested park re-parks
+it, and the call that actually ends the turn releases the handles once.
+Without this the park's deferred `ReleaseAll` kills handles the same turn is
+about to use.
+
+Only one parked turn per session can exist at a time — `guardParkedTail`
+enforces it — so one collector slot per session is the whole contract.
+
+## 5. The append-point guard
+
+A new user turn on a session holding a pending parked row is refused with
+`SessionParkedError`, raised at the append point rather than at admission:
+the embedder's admission-time probe races a park landing mid-turn, and the
+append point is the authoritative last moment. Store errors fail open with a
+warning — the embedder's own probe is the primary gate, and a store hiccup
+must not kill a session.
+
+## 6. What the embedder owns
+
+- Delivering the card to a human and collecting the verdict.
+- Calling `ResumeChat` with the row's `RequestID`.
+- Sweeping rows whose TTL lapsed with nobody deciding. Loom closes a row it is
+  handed a decision for; it runs no timer of its own, so an abandoned park
+  stays pending until a resume (with any decision) or an external sweep closes
+  it.
+
+## 7. Known gaps
+
+- 📋 A resumed turn does not record the six conversation metrics `chat()`
+  records, so resumed turns — the ones carrying human-approved actions — are
+  missing from the metrics backend.
+- 📋 Loop re-entry re-runs graph-memory context injection for the same turn,
+  duplicating the injected block and paying a recall round-trip per resume.
+- 📋 `Chain.Preflight` re-evaluates every matching hook, so a stateful host
+  hook (a quota counter) sees each parked call twice.
+- 📋 No proto/gRPC surface for resume; park is a library API for embedders.

--- a/docs/architecture/hitl-park-and-resume.md
+++ b/docs/architecture/hitl-park-and-resume.md
@@ -160,13 +160,19 @@ declined, not deferred.
 
 ## 4. Session handles across the gap
 
-MCP session handles stay scoped to one call, park exits included: `chat()`
-releases at the park, `ResumeChat` releases at every exit, and a resumed turn
-re-mints handles on demand. A collector carried across the gap would only be
-reachable when the same `Agent` instance serves both calls — in the pooled
-embedder lifecycle (a fresh `Agent` per call) it would leak the handles
-instead. Cross-call handle continuity is therefore an embedder-owned seam,
-alongside the resume transport itself (§6).
+MCP session handles are scoped to one call by default, but a parked turn
+spans two calls — so a park exit PARKS its `HandleCollector` (one slot per
+session; `chat()`'s first park and `ResumeChat`'s nested re-park alike), and
+a resume in the same process adopts it: handles minted before the park stay
+live through the gap and are released once, by the call that actually ends
+the turn.
+
+Adoption only works when one `Agent` instance serves both calls. A pooled
+embedder (a fresh `Agent` per call) adopts nothing, so it drains the slot at
+each park terminal via `Agent.ReleaseParkedHandles(sessionID)` — keeping its
+handles call-scoped with no leak; its resumed turns re-mint on demand. Both
+lifecycles are first-class: continuity for same-process embedders, an
+explicit release seam for pooled ones.
 
 Only one parked turn per session can exist at a time — `guardParkedTail`
 enforces it — so one collector slot per session is the whole contract.

--- a/docs/architecture/hitl-park-and-resume.md
+++ b/docs/architecture/hitl-park-and-resume.md
@@ -83,9 +83,20 @@ one session can hold more than one row over its life. A decision bound by a
 caller-supplied list could be applied to a batch it never described simply by
 omitting the list. Binding through the row makes that unrepresentable.
 
-A row that is missing, already closed, or owned by another session is refused
-with `ErrUnknownRequest` before the session is touched — which also means a
-redelivered decision cannot re-execute its batch.
+Two row states resume. A **pending** row is the standalone flow: `ResumeChat`
+is the decision channel and closes the row after applying (§3.3). A
+**decided** row (`approved`/`rejected`/`timeout`) is the embedder-recorded
+flow: the embedder's respond door decided the row first, under its own expiry
+CAS, and the resume applies that recorded verdict — the row's status is
+authoritative over the caller's payload, so a mismatched payload can never
+execute against a rejected row, and expiry is not re-judged at apply time (a
+decision recorded in time stands, however much later the resume runs). A row
+that is missing, owned by another session, or in any other state is refused
+with `ErrUnknownRequest` before the session is touched.
+
+Redelivery cannot re-execute a batch in either flow: the applied batch has
+its tool rows and final reply, so a replay lands in the tail-walk terminals
+(`ErrNothingParked`, or `ErrStaleDecision` when a nested park owns the tail).
 
 ### 3.2 Applying the decision
 
@@ -109,8 +120,10 @@ continuation parks again.
 
 ### 3.3 Closing the row
 
-The row is closed the instant its decision is applied, **before** the loop
-re-entry that may park a new one:
+In the standalone (pending-row) flow, the row is closed the instant its
+decision is applied, **before** the loop re-entry that may park a new one — a
+pre-decided row is already closed by the embedder's respond door and is left
+untouched:
 
 - approved → `RespondToRequest(…, "approved", …)`
 - rejected → `RespondToRequest(…, "rejected", …)`
@@ -141,12 +154,13 @@ declined, not deferred.
 
 ## 4. Session handles across the gap
 
-MCP session handles are scoped to one `chat()` call by default. A parked turn
-spans two calls, so the parked half hands its `HandleCollector` to whoever
-resumes it (`mcpadapter.ContextWithHandleCollector`); a nested park re-parks
-it, and the call that actually ends the turn releases the handles once.
-Without this the park's deferred `ReleaseAll` kills handles the same turn is
-about to use.
+MCP session handles stay scoped to one call, park exits included: `chat()`
+releases at the park, `ResumeChat` releases at every exit, and a resumed turn
+re-mints handles on demand. A collector carried across the gap would only be
+reachable when the same `Agent` instance serves both calls — in the pooled
+embedder lifecycle (a fresh `Agent` per call) it would leak the handles
+instead. Cross-call handle continuity is therefore an embedder-owned seam,
+alongside the resume transport itself (§6).
 
 Only one parked turn per session can exist at a time — `guardParkedTail`
 enforces it — so one collector slot per session is the whole contract.
@@ -171,11 +185,6 @@ must not kill a session.
 
 ## 7. Known gaps
 
-- 📋 A resumed turn does not record the six conversation metrics `chat()`
-  records, so resumed turns — the ones carrying human-approved actions — are
-  missing from the metrics backend.
-- 📋 Loop re-entry re-runs graph-memory context injection for the same turn,
-  duplicating the injected block and paying a recall round-trip per resume.
 - 📋 No proto/gRPC surface for resume; park is a library API for embedders.
   Whether loom should expose resume over gRPC is a product decision, not an
   oversight — every other conversation entry point reaches clients through the

--- a/docs/architecture/hitl-park-and-resume.md
+++ b/docs/architecture/hitl-park-and-resume.md
@@ -97,6 +97,12 @@ with `ErrUnknownRequest` before the session is touched.
 Redelivery cannot re-execute a batch in either flow: the applied batch has
 its tool rows and final reply, so a replay lands in the tail-walk terminals
 (`ErrNothingParked`, or `ErrStaleDecision` when a nested park owns the tail).
+The item binding is by CONTENT, not ID alone (`verifyItemBinding`):
+LLM-assigned call IDs can collide across batches (per-response counters), so
+each item's recorded tool and batch position must still describe the tail
+call it names. And an applied batch whose turn died before its final reply
+is NOT refused — the resume re-enters the loop (re-executing nothing) so the
+model sees the results and produces the answer.
 
 ### 3.2 Applying the decision
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1846,6 +1846,17 @@ func (a *Agent) chat(ctx context.Context, sessionID string, userMessage string, 
 	// it, so the ledger re-marks the fresh one the server installed.
 	a.seedLeaseHolding(ctx, sessionID)
 
+	// Append-point park guard: a pending parked decision owns the session
+	// tail, so a new user turn is refused BEFORE any turn-end side effect
+	// (payload drop, user append) can bury the parked batch. Sits behind the
+	// embedder's admission probe, which races a park landing mid-turn.
+	if err := a.guardParkedTail(ctx, sessionID); err != nil {
+		span.AddEvent("conversation.refused_parked", map[string]interface{}{
+			"session_id": sessionID,
+		})
+		return nil, err
+	}
+
 	// TURN END for the previous turn (HLD §1, §7.3): a new turn is starting —
 	// in-memory full payloads are replaced by their persisted-row form and the
 	// in-turn SQLite is dropped. Rows and summary versions are all that remains.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -2654,7 +2654,12 @@ func (a *Agent) runConversationLoop(ctx Context) (*Response, error) {
 		// turn HERE — before anything executes. A non-durable assistant row
 		// skips parking (a request row must never strand against a missing
 		// batch) and the batch dispatches inline, fail-closed.
-		if a.hitlPark != nil && assistantPersisted {
+		//
+		// Durable means BOTH: a store exists, and the write to it did not
+		// fail. PersistMessage returns nil when no store is configured, so
+		// assistantPersisted alone reports success for a batch that was never
+		// written anywhere — exactly the stranding this gate exists to stop.
+		if a.hitlPark != nil && assistantPersisted && a.memory.HasStore() {
 			if parkErr := a.maybeParkBatch(ctx, session, llmResp); parkErr != nil {
 				return nil, parkErr
 			}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -2024,7 +2024,20 @@ func (a *Agent) chat(ctx context.Context, sessionID string, userMessage string, 
 		"tokens":          response.Usage.TotalTokens,
 	})
 
-	// Emit metrics
+	a.recordConversationMetrics(sessionID, response, duration)
+
+	return response, nil
+}
+
+// recordConversationMetrics emits the six metrics that describe one completed
+// conversation. Shared by chat() and ResumeChat so a turn that ended at a
+// human decision and finished later is counted exactly like any other — those
+// are the turns carrying human-approved actions, so they are the last ones
+// that should be missing from the metrics backend.
+func (a *Agent) recordConversationMetrics(sessionID string, response *Response, duration time.Duration) {
+	turns, _ := response.Metadata["turns"].(int)
+	toolExecs, _ := response.Metadata["tool_executions"].(int)
+
 	a.tracer.RecordMetric(observability.MetricAgentConversations, 1, map[string]string{
 		observability.AttrSessionID: sessionID,
 		"status":                    "success",
@@ -2049,8 +2062,6 @@ func (a *Agent) chat(ctx context.Context, sessionID string, userMessage string, 
 	a.tracer.RecordMetric("agent.tokens.total", float64(response.Usage.TotalTokens), map[string]string{
 		observability.AttrSessionID: sessionID,
 	})
-
-	return response, nil
 }
 
 // appendMessage is the arrival seam (HLD §1): it stamps the message's turn,
@@ -2302,8 +2313,13 @@ func (a *Agent) runConversationLoop(ctx Context) (*Response, error) {
 		}
 	}
 
-	// Inject graph memory context (if enabled and available).
-	a.injectGraphMemoryContext(ctx, session)
+	// Inject graph memory context (if enabled and available). A resumed turn
+	// skips it: the loop is being RE-entered for a turn that already got its
+	// context block before it parked, so injecting again would duplicate the
+	// block in the prompt and pay a second recall round-trip per resume.
+	if !isResumedTurn(ctx) {
+		a.injectGraphMemoryContext(ctx, session)
+	}
 
 	// Conversation loop
 	for turnCount < a.config.MaxTurns && toolExecutionCount < a.config.MaxToolExecutions {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1795,9 +1795,16 @@ func (a *Agent) chat(ctx context.Context, sessionID string, userMessage string, 
 	// Session-handle lifecycle (issue #345): MCP tools that mint session
 	// handles get them auto-released when this conversation ends. Agent
 	// discretion doesn't work — in a 3×64-agent live study, zero agents
-	// released a handle — so the runtime owns the cleanup.
+	// released a handle — so the runtime owns the cleanup. A PARKED exit is
+	// the exception: the turn is unfinished, so its handles park with it for
+	// a same-process resume to adopt (pooled embedders drain the slot via
+	// ReleaseParkedHandles instead — see park.go).
 	ctx, handleCollector := mcpadapter.WithHandleCollector(ctx)
+	turnParkedExit := false
 	defer func() {
+		if turnParkedExit {
+			return
+		}
 		// The auto-release happens outside any tool result, so the ledger
 		// learns about it here instead of through applyLeaseEvents — without
 		// this the next turn would seed RESOURCE_HOLDER for handles this
@@ -1930,6 +1937,11 @@ func (a *Agent) chat(ctx context.Context, sessionID string, userMessage string, 
 		// the typed terminal unwrapped so embedders detect it with errors.As.
 		var parked *TurnParkedError
 		if errors.As(err, &parked) {
+			// The turn is unfinished — its handles park with it (see the
+			// collector setup above) instead of being released out from
+			// under the resume that will continue this same turn.
+			turnParkedExit = true
+			a.parkHandles(sessionID, handleCollector)
 			span.AddEvent("conversation.parked", map[string]interface{}{
 				"request_id":  parked.RequestID,
 				"duration_ms": duration.Milliseconds(),

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1869,7 +1869,7 @@ func (a *Agent) chat(ctx context.Context, sessionID string, userMessage string, 
 	// in the Timestamp field; per-turn temporal grounding ("today", "this month")
 	// is restored by rendering that Timestamp into the compiled view only
 	// (renderLocked), never into the stored body.
-	userMsg := a.appendMessage(ctx, session, Message{
+	userMsg, _ := a.appendMessage(ctx, session, Message{
 		Role:          "user",
 		Content:       userMessage,
 		ContentBlocks: p.contentBlocks,
@@ -1913,6 +1913,24 @@ func (a *Agent) chat(ctx context.Context, sessionID string, userMessage string, 
 	duration := time.Since(startTime)
 
 	if err != nil {
+		// A parked turn is a clean exit, not a failure: the batch's assistant
+		// row and the grouped human request are durable, nothing executed,
+		// and ResumeChat continues the turn when the decision arrives. Return
+		// the typed terminal unwrapped so embedders detect it with errors.As.
+		var parked *TurnParkedError
+		if errors.As(err, &parked) {
+			span.AddEvent("conversation.parked", map[string]interface{}{
+				"request_id":  parked.RequestID,
+				"duration_ms": duration.Milliseconds(),
+			})
+			if perr := a.memory.PersistSession(ctx, session); perr != nil {
+				zap.L().Warn("Failed to persist session at park",
+					zap.String("session_id", sessionID),
+					zap.Error(perr))
+			}
+			return nil, parked
+		}
+
 		span.Status = observability.Status{
 			Code:    observability.StatusError,
 			Message: err.Error(),
@@ -2030,7 +2048,7 @@ func (a *Agent) chat(ctx context.Context, sessionID string, userMessage string, 
 // full natural form. Nothing is examined, sized, flagged, or transformed at
 // arrival. turnStart is true only at the Chat() entry — the only
 // turn-incrementing event (HLD §4.5). Persist failures are logged, never fatal.
-func (a *Agent) appendMessage(ctx context.Context, session *Session, msg Message, turnStart bool) Message {
+func (a *Agent) appendMessage(ctx context.Context, session *Session, msg Message, turnStart bool) (Message, bool) {
 	// A replay/import override (WeaveRequest.occurred_at → WithOccurredAt)
 	// anchors every row persisted during the call at the conversation's
 	// historical time; without one, the caller-stamped wall clock stands.
@@ -2046,7 +2064,9 @@ func (a *Agent) appendMessage(ctx context.Context, session *Session, msg Message
 	}
 	msg.Turn = t
 
+	persisted := true
 	if err := a.memory.PersistMessage(ctx, session.ID, &msg, turnStart); err != nil {
+		persisted = false
 		zap.L().Warn("Failed to persist message",
 			zap.String("session_id", session.ID),
 			zap.String("role", msg.Role),
@@ -2054,7 +2074,7 @@ func (a *Agent) appendMessage(ctx context.Context, session *Session, msg Message
 	}
 
 	session.AddMessage(ctx, msg)
-	return msg
+	return msg, persisted
 }
 
 // Response represents the agent's response to a user message.
@@ -2608,7 +2628,7 @@ func (a *Agent) runConversationLoop(ctx Context) (*Response, error) {
 		}
 
 		// Add assistant message with tool calls to history FIRST (required by Anthropic API)
-		a.appendMessage(ctx, session, Message{
+		_, assistantPersisted := a.appendMessage(ctx, session, Message{
 			Role:       "assistant",
 			Content:    llmResp.Content,
 			ToolCalls:  llmResp.ToolCalls,
@@ -2618,285 +2638,53 @@ func (a *Agent) runConversationLoop(ctx Context) (*Response, error) {
 			Timestamp:  time.Now(),
 		}, false)
 
+		// HITL park pre-scan (park.go): with park enabled and the batch's
+		// assistant row durable, a batch needing a human decision ends the
+		// turn HERE — before anything executes. A non-durable assistant row
+		// skips parking (a request row must never strand against a missing
+		// batch) and the batch dispatches inline, fail-closed.
+		if a.hitlPark != nil && assistantPersisted {
+			if parkErr := a.maybeParkBatch(ctx, session, llmResp); parkErr != nil {
+				return nil, parkErr
+			}
+		}
+
 		// Execute tool calls with per-turn cap and deduplication.
 		// MaxIterations limits how many tool calls are executed from a single
 		// LLM response. Excess calls get "turn_limit_exceeded" error results.
 		// Identical calls (same name + input) within a turn reuse the first result.
+		//
+		// The per-call body lives in dispatchOneCall (shared verbatim with
+		// ResumeChat's parked-batch completion); batchState carries the
+		// loop-level counters it reads and writes.
 		maxPerTurn := a.config.MaxIterations
 		if maxPerTurn <= 0 {
 			maxPerTurn = 10 // default
 		}
-		turnToolCount := 0
-		turnDedup := make(map[string]*shuttle.Result) // dedup key → result
-
-		// pendingSidecars: text_body sidecar messages (e.g. skill body from
-		// manage_skills(load)) buffered across the whole tool batch. Draining
-		// them AFTER every tool_result in the batch has been appended keeps
-		// each tool_use adjacent to its tool_result — required by Anthropic's
-		// "tool_use ids must be followed by tool_result blocks" pairing rule
-		// when the model fires multiple tools in parallel.
-		var pendingSidecars []Message
+		st := &batchState{
+			span:               span,
+			turnCount:          turnCount,
+			batchLen:           len(llmResp.ToolCalls),
+			maxPerTurn:         maxPerTurn,
+			toolExecutionCount: &toolExecutionCount,
+			allToolExecutions:  &allToolExecutions,
+			tools:              &tools,
+			recovery:           recovery,
+			turnDedup:          make(map[string]*shuttle.Result),
+		}
 
 		for i, toolCall := range llmResp.ToolCalls {
 			if toolExecutionCount >= a.config.MaxToolExecutions {
 				break
 			}
-
-			// Per-turn cap: skip remaining calls with an error result
-			if turnToolCount >= maxPerTurn {
-				a.appendMessage(ctx, session, Message{
-					Role:      "tool",
-					Content:   fmt.Sprintf("turn_limit_exceeded — per-turn tool call limit (%d) reached. Synthesize a response from the results you have.", maxPerTurn),
-					ToolUseID: toolCall.ID,
-					ToolResult: &shuttle.Result{
-						Success: false,
-						Error: &shuttle.Error{
-							Code:    "turn_limit_exceeded",
-							Message: fmt.Sprintf("per-turn tool call limit (%d) reached — call %d of %d skipped", maxPerTurn, i+1, len(llmResp.ToolCalls)),
-						},
-					},
-					AgentID:   a.id,
-					Timestamp: time.Now(),
-				}, false)
-				toolExecutionCount++
-				continue
-			}
-
-			// Deduplication: compute canonical key from tool name + sorted JSON input
-			dedupKey := toolCall.Name + "|" + canonicalJSON(toolCall.Input)
-			if cachedResult, ok := turnDedup[dedupKey]; ok {
-				a.appendMessage(ctx, session, Message{
-					Role:       "tool",
-					Content:    a.formatToolResult(ctx, session.ID, toolCall.Name, cachedResult, nil) + "\n(deduplicated — reused result from identical call in this turn)",
-					ToolUseID:  toolCall.ID,
-					ToolResult: cachedResult,
-					AgentID:    a.id,
-					Timestamp:  time.Now(),
-				}, false)
-				allToolExecutions = append(allToolExecutions, ToolExecution{
-					ToolName: toolCall.Name,
-					Input:    toolCall.Input,
-					Result:   cachedResult,
-				})
-				toolExecutionCount++
-				turnToolCount++
-				continue
-			}
-
-			turnToolCount++
-			toolExecutionCount++
-
-			// Check if this is a HITL request (contact_human tool)
-			if toolCall.Name == "contact_human" {
-				// Extract HITL request details from tool input
-				hitlInfo := extractHITLInfo(toolCall.Input)
-
-				// Add instrumentation for HITL request
-				span.AddEvent("hitl.request_detected", map[string]interface{}{
-					"question":     hitlInfo.Question,
-					"request_type": hitlInfo.RequestType,
-					"priority":     hitlInfo.Priority,
-					"timeout":      hitlInfo.Timeout.String(),
-				})
-				span.SetAttribute("hitl.active", true)
-				span.SetAttribute("hitl.question", hitlInfo.Question)
-				span.SetAttribute("hitl.request_type", hitlInfo.RequestType)
-				span.SetAttribute("hitl.priority", hitlInfo.Priority)
-
-				// Emit HITL-specific progress event
-				emitProgressWithHITL(ctx, StageHumanInTheLoop, 50, "Waiting for human response", toolCall.Name, hitlInfo)
-			} else {
-				// Emit tool-started progress event
-				emitToolStarted(ctx, 50+clampInt32(toolExecutionCount*5), toolCall)
-			}
-
-			// Execute tool with tracing — always created
-			_, toolSpan := ctx.Tracer().StartSpan(ctx, "agent.tool_execution")
-			toolSpan.SetAttribute("tool_name", toolCall.Name)
-
-			// Execute with self-correction (circuit breaker + SQL correction)
-			result, err := a.executeToolWithSelfCorrection(ctx, toolCall.Name, toolCall.Input, session.ID)
-
-			// Tier 1: if tool CB fired, disable tool and inject synthetic result.
-			if err != nil && strings.Contains(err.Error(), "circuit breaker open") && recovery != nil {
-				_, syntheticResult := recovery.recoverToolCB(ctx, toolCall.Name, &tools)
-				result = syntheticResult
-				err = nil
-			}
-
-			// Record tool execution on conversation_loop span
-			{
-				toolSuccess := err == nil && (result == nil || result.Success)
-				toolEvent := map[string]interface{}{
-					"turn":      turnCount,
-					"tool_name": toolCall.Name,
-					"success":   toolSuccess,
-					"index":     i + 1,
-					"total":     len(llmResp.ToolCalls),
-				}
-				if err != nil {
-					toolEvent["error"] = err.Error()
-				} else if result != nil && !result.Success && result.Error != nil {
-					toolEvent["error"] = result.Error.Message
-				}
-				if result != nil {
-					toolEvent["execution_time_ms"] = result.ExecutionTimeMs
-				}
-				span.AddEvent("turn.tool_execution", toolEvent)
-			}
-
-			// Add instrumentation for HITL completion
-			if toolCall.Name == "contact_human" {
-				if err != nil {
-					span.AddEvent("hitl.request_failed", map[string]interface{}{
-						"error": err.Error(),
-					})
-				} else if result != nil {
-					// Extract response status from result
-					status := "unknown"
-					if result.Data != nil {
-						if dataMap, ok := result.Data.(map[string]interface{}); ok {
-							if s, ok := dataMap["status"].(string); ok {
-								status = s
-							}
-						}
-					}
-					span.AddEvent("hitl.request_completed", map[string]interface{}{
-						"status":            status,
-						"execution_time_ms": result.ExecutionTimeMs,
-					})
-					span.SetAttribute("hitl.status", status)
-				}
-			}
-
-			// Record tool execution results on span
-			{
-				success := err == nil && (result == nil || result.Success)
-
-				if err != nil {
-					toolSpan.RecordError(err)
-				} else if result != nil && !result.Success && result.Error != nil {
-					toolSpan.RecordError(fmt.Errorf("%s: %s", result.Error.Code, result.Error.Message))
-					toolSpan.SetAttribute("error.code", result.Error.Code)
-					toolSpan.SetAttribute("error.message", result.Error.Message)
-				}
-
-				toolSpan.SetAttribute("success", fmt.Sprintf("%t", success))
-				if result != nil {
-					toolSpan.SetAttribute("execution_time_ms", fmt.Sprintf("%d", result.ExecutionTimeMs))
-				}
-				ctx.Tracer().EndSpan(toolSpan)
-			}
-
-			// Record execution
-			execution := ToolExecution{
-				ToolName:          toolCall.Name,
-				Input:             toolCall.Input,
-				Result:            result,
-				Error:             err,
-				AdmissionDecision: admissionDecisionOf(result),
-			}
-			allToolExecutions = append(allToolExecutions, execution)
-
-			// Cache result for dedup (only cache successful results or tool errors —
-			// not Go-level errors which may be transient).
-			if result != nil {
-				turnDedup[dedupKey] = result
-			}
-
-			// Emit tool-completed progress event
-			emitToolCompleted(ctx, 50+clampInt32(toolExecutionCount*5), toolCall, result, err)
-
-			// Persist tool execution
-			if persistErr := a.memory.PersistToolExecution(ctx, session.ID, execution); persistErr != nil {
-				// Log but don't fail
-				toolSpan.RecordError(persistErr)
-			}
-
-			// === FEATURE INTEGRATION: Consecutive Failure Tracking ===
-			var escalationMsg string
-			if failureTracker, ok := session.FailureTracker.(*consecutiveFailureTracker); ok && failureTracker != nil && session.SegmentedMem != nil {
-				if err != nil {
-					// Track failure
-					errorType := extractErrorType(result)
-					if errorType == "" && result != nil && result.Error != nil && result.Error.Message != "" {
-						errorType = "execution_error"
-					} else if errorType == "" {
-						errorType = "unknown_error"
-					}
-
-					failureCount := failureTracker.record(toolCall.Name, toolCall.Input, errorType)
-					escalationMsg = failureTracker.getEscalationMessage(failureCount, 2)
-
-					if escalationMsg != "" {
-						span.AddEvent("failure.escalated", map[string]interface{}{
-							"tool":          toolCall.Name,
-							"failure_count": failureCount,
-						})
-					}
-				} else {
-					// Clear failures on success
-					failureTracker.clear(toolCall.Name, toolCall.Input)
-
-					span.AddEvent("failure.cleared", map[string]interface{}{
-						"tool": toolCall.Name,
-					})
-				}
-			}
-
-			// Format tool result with escalation if needed
-			formattedResult := a.formatToolResult(ctx, session.ID, toolCall.Name, result, err)
-			if escalationMsg != "" {
-				formattedResult = formatToolResultWithEscalation(formattedResult, err, escalationMsg)
-			}
-
-			// Add tool result to conversation
-			a.appendMessage(ctx, session, Message{
-				Role:       "tool",
-				Content:    formattedResult,
-				ToolUseID:  toolCall.ID, // Store ID for Bedrock/Anthropic format conversion
-				ToolResult: result,
-				AgentID:    a.id, // Track which agent executed this tool
-				Timestamp:  time.Now(),
-			}, false)
-
-			// If the tool signaled a text_body sidecar (e.g. manage_skills(load)
-			// — the skill body belongs under the user-instruction slot, not the
-			// tool-result data slot), BUFFER it. Sidecars from an entire tool
-			// batch are appended AFTER every tool_result in the batch, so
-			// tool_use↔tool_result adjacency is preserved (Anthropic pairing).
-			if result != nil && result.Metadata != nil {
-				if textBody, ok := result.Metadata["text_body"].(string); ok && textBody != "" {
-					pendingSidecars = append(pendingSidecars, Message{
-						Role:      "user",
-						Content:   textBody,
-						AgentID:   a.id,
-						Timestamp: time.Now(),
-					})
-				}
-			}
-
-			// === AUTOMATIC GRAPH MEMORY EXTRACTION ===
-			// After each tool execution, check if we should extract graph memories.
-			// Skip when the tool IS graph_memory — explicit use is higher quality.
-			if a.enableGraphMemoryExtraction && toolCall.Name != "graph_memory" {
-				a.graphToolExecutionsSinceExtraction++
-				if a.graphToolExecutionsSinceExtraction >= a.graphExtractionCadence {
-					a.graphExtractionWG.Add(1)
-					go func() {
-						defer a.graphExtractionWG.Done()
-						a.extractGraphMemoryAsync(ctx, session.ID)
-					}()
-					a.graphToolExecutionsSinceExtraction = 0
-				}
-			}
+			a.dispatchOneCall(ctx, session, toolCall, i, st)
 		}
 
 		// Drain buffered text_body sidecars from this batch AFTER every
 		// tool_result is in place. Order within the batch preserved so a
 		// multi-load turn (rare but possible) still stamps its bodies in
 		// call order.
-		for _, sidecar := range pendingSidecars {
+		for _, sidecar := range st.pendingSidecars {
 			// Sidecars never advance the turn and hold no special status beyond
 			// that (HLD §4.5).
 			a.appendMessage(ctx, session, sidecar, false)
@@ -2906,7 +2694,292 @@ func (a *Agent) runConversationLoop(ctx Context) (*Response, error) {
 	// If we hit max turns/executions, make one final LLM call to synthesize results
 	// This ensures the agent provides meaningful output instead of a generic error message
 	emitProgress(ctx, StageSynthesis, 90, "Synthesizing tool execution results", "")
+	return a.synthesizeFinalResponse(ctx, session, turnCount, toolExecutionCount, allToolExecutions)
+}
 
+// batchState carries the loop-level state the per-call dispatch body reads
+// and writes: whole-loop budgets and records by pointer, per-batch dedup,
+// per-batch sidecar buffer, and the span/counters the body's events cite.
+type batchState struct {
+	span       *observability.Span
+	turnCount  int
+	batchLen   int
+	maxPerTurn int
+
+	toolExecutionCount *int
+	allToolExecutions  *[]ToolExecution
+	tools              *[]shuttle.Tool
+	recovery           *recoveryOrchestrator
+
+	turnToolCount   int
+	turnDedup       map[string]*shuttle.Result
+	pendingSidecars []Message
+}
+
+// dispatchOneCall runs one call of a tool batch through the full per-call
+// ceremony — caps, dedup, progress emits, spans, execution with
+// self-correction, recovery, persistence, failure tracking, the tool row,
+// and sidecar buffering. The body is the conversation loop's original batch
+// body, moved verbatim; ResumeChat's parked-batch completion calls the same
+// function so the two paths cannot drift.
+func (a *Agent) dispatchOneCall(ctx Context, session *Session, toolCall ToolCall, i int, st *batchState) {
+	span := st.span
+
+	// Per-turn cap: skip remaining calls with an error result
+	if st.turnToolCount >= st.maxPerTurn {
+		a.appendMessage(ctx, session, Message{
+			Role:      "tool",
+			Content:   fmt.Sprintf("turn_limit_exceeded — per-turn tool call limit (%d) reached. Synthesize a response from the results you have.", st.maxPerTurn),
+			ToolUseID: toolCall.ID,
+			ToolResult: &shuttle.Result{
+				Success: false,
+				Error: &shuttle.Error{
+					Code:    "turn_limit_exceeded",
+					Message: fmt.Sprintf("per-turn tool call limit (%d) reached — call %d of %d skipped", st.maxPerTurn, i+1, st.batchLen),
+				},
+			},
+			AgentID:   a.id,
+			Timestamp: time.Now(),
+		}, false)
+		*st.toolExecutionCount++
+		return
+	}
+
+	// Deduplication: compute canonical key from tool name + sorted JSON input
+	dedupKey := toolCall.Name + "|" + canonicalJSON(toolCall.Input)
+	if cachedResult, ok := st.turnDedup[dedupKey]; ok {
+		a.appendMessage(ctx, session, Message{
+			Role:       "tool",
+			Content:    a.formatToolResult(ctx, session.ID, toolCall.Name, cachedResult, nil) + "\n(deduplicated — reused result from identical call in this turn)",
+			ToolUseID:  toolCall.ID,
+			ToolResult: cachedResult,
+			AgentID:    a.id,
+			Timestamp:  time.Now(),
+		}, false)
+		*st.allToolExecutions = append(*st.allToolExecutions, ToolExecution{
+			ToolName: toolCall.Name,
+			Input:    toolCall.Input,
+			Result:   cachedResult,
+		})
+		*st.toolExecutionCount++
+		st.turnToolCount++
+		return
+	}
+
+	st.turnToolCount++
+	*st.toolExecutionCount++
+
+	// Check if this is a HITL request (contact_human tool)
+	if toolCall.Name == "contact_human" {
+		// Extract HITL request details from tool input
+		hitlInfo := extractHITLInfo(toolCall.Input)
+
+		// Add instrumentation for HITL request
+		span.AddEvent("hitl.request_detected", map[string]interface{}{
+			"question":     hitlInfo.Question,
+			"request_type": hitlInfo.RequestType,
+			"priority":     hitlInfo.Priority,
+			"timeout":      hitlInfo.Timeout.String(),
+		})
+		span.SetAttribute("hitl.active", true)
+		span.SetAttribute("hitl.question", hitlInfo.Question)
+		span.SetAttribute("hitl.request_type", hitlInfo.RequestType)
+		span.SetAttribute("hitl.priority", hitlInfo.Priority)
+
+		// Emit HITL-specific progress event
+		emitProgressWithHITL(ctx, StageHumanInTheLoop, 50, "Waiting for human response", toolCall.Name, hitlInfo)
+	} else {
+		// Emit tool-started progress event
+		emitToolStarted(ctx, 50+clampInt32(*st.toolExecutionCount*5), toolCall)
+	}
+
+	// Execute tool with tracing — always created
+	_, toolSpan := ctx.Tracer().StartSpan(ctx, "agent.tool_execution")
+	toolSpan.SetAttribute("tool_name", toolCall.Name)
+
+	// Execute with self-correction (circuit breaker + SQL correction)
+	result, err := a.executeToolWithSelfCorrection(ctx, toolCall.Name, toolCall.Input, session.ID)
+
+	// Tier 1: if tool CB fired, disable tool and inject synthetic result.
+	if err != nil && strings.Contains(err.Error(), "circuit breaker open") && st.recovery != nil {
+		_, syntheticResult := st.recovery.recoverToolCB(ctx, toolCall.Name, st.tools)
+		result = syntheticResult
+		err = nil
+	}
+
+	// Record tool execution on conversation_loop span
+	{
+		toolSuccess := err == nil && (result == nil || result.Success)
+		toolEvent := map[string]interface{}{
+			"turn":      st.turnCount,
+			"tool_name": toolCall.Name,
+			"success":   toolSuccess,
+			"index":     i + 1,
+			"total":     st.batchLen,
+		}
+		if err != nil {
+			toolEvent["error"] = err.Error()
+		} else if result != nil && !result.Success && result.Error != nil {
+			toolEvent["error"] = result.Error.Message
+		}
+		if result != nil {
+			toolEvent["execution_time_ms"] = result.ExecutionTimeMs
+		}
+		span.AddEvent("turn.tool_execution", toolEvent)
+	}
+
+	// Add instrumentation for HITL completion
+	if toolCall.Name == "contact_human" {
+		if err != nil {
+			span.AddEvent("hitl.request_failed", map[string]interface{}{
+				"error": err.Error(),
+			})
+		} else if result != nil {
+			// Extract response status from result
+			status := "unknown"
+			if result.Data != nil {
+				if dataMap, ok := result.Data.(map[string]interface{}); ok {
+					if s, ok := dataMap["status"].(string); ok {
+						status = s
+					}
+				}
+			}
+			span.AddEvent("hitl.request_completed", map[string]interface{}{
+				"status":            status,
+				"execution_time_ms": result.ExecutionTimeMs,
+			})
+			span.SetAttribute("hitl.status", status)
+		}
+	}
+
+	// Record tool execution results on span
+	{
+		success := err == nil && (result == nil || result.Success)
+
+		if err != nil {
+			toolSpan.RecordError(err)
+		} else if result != nil && !result.Success && result.Error != nil {
+			toolSpan.RecordError(fmt.Errorf("%s: %s", result.Error.Code, result.Error.Message))
+			toolSpan.SetAttribute("error.code", result.Error.Code)
+			toolSpan.SetAttribute("error.message", result.Error.Message)
+		}
+
+		toolSpan.SetAttribute("success", fmt.Sprintf("%t", success))
+		if result != nil {
+			toolSpan.SetAttribute("execution_time_ms", fmt.Sprintf("%d", result.ExecutionTimeMs))
+		}
+		ctx.Tracer().EndSpan(toolSpan)
+	}
+
+	// Record execution
+	execution := ToolExecution{
+		ToolName:          toolCall.Name,
+		Input:             toolCall.Input,
+		Result:            result,
+		Error:             err,
+		AdmissionDecision: admissionDecisionOf(result),
+	}
+	*st.allToolExecutions = append(*st.allToolExecutions, execution)
+
+	// Cache result for dedup (only cache successful results or tool errors —
+	// not Go-level errors which may be transient).
+	if result != nil {
+		st.turnDedup[dedupKey] = result
+	}
+
+	// Emit tool-completed progress event
+	emitToolCompleted(ctx, 50+clampInt32(*st.toolExecutionCount*5), toolCall, result, err)
+
+	// Persist tool execution
+	if persistErr := a.memory.PersistToolExecution(ctx, session.ID, execution); persistErr != nil {
+		// Log but don't fail
+		toolSpan.RecordError(persistErr)
+	}
+
+	// === FEATURE INTEGRATION: Consecutive Failure Tracking ===
+	var escalationMsg string
+	if failureTracker, ok := session.FailureTracker.(*consecutiveFailureTracker); ok && failureTracker != nil && session.SegmentedMem != nil {
+		if err != nil {
+			// Track failure
+			errorType := extractErrorType(result)
+			if errorType == "" && result != nil && result.Error != nil && result.Error.Message != "" {
+				errorType = "execution_error"
+			} else if errorType == "" {
+				errorType = "unknown_error"
+			}
+
+			failureCount := failureTracker.record(toolCall.Name, toolCall.Input, errorType)
+			escalationMsg = failureTracker.getEscalationMessage(failureCount, 2)
+
+			if escalationMsg != "" {
+				span.AddEvent("failure.escalated", map[string]interface{}{
+					"tool":          toolCall.Name,
+					"failure_count": failureCount,
+				})
+			}
+		} else {
+			// Clear failures on success
+			failureTracker.clear(toolCall.Name, toolCall.Input)
+
+			span.AddEvent("failure.cleared", map[string]interface{}{
+				"tool": toolCall.Name,
+			})
+		}
+	}
+
+	// Format tool result with escalation if needed
+	formattedResult := a.formatToolResult(ctx, session.ID, toolCall.Name, result, err)
+	if escalationMsg != "" {
+		formattedResult = formatToolResultWithEscalation(formattedResult, err, escalationMsg)
+	}
+
+	// Add tool result to conversation
+	a.appendMessage(ctx, session, Message{
+		Role:       "tool",
+		Content:    formattedResult,
+		ToolUseID:  toolCall.ID, // Store ID for Bedrock/Anthropic format conversion
+		ToolResult: result,
+		AgentID:    a.id, // Track which agent executed this tool
+		Timestamp:  time.Now(),
+	}, false)
+
+	// If the tool signaled a text_body sidecar (e.g. manage_skills(load)
+	// — the skill body belongs under the user-instruction slot, not the
+	// tool-result data slot), BUFFER it. Sidecars from an entire tool
+	// batch are appended AFTER every tool_result in the batch, so
+	// tool_use↔tool_result adjacency is preserved (Anthropic pairing).
+	if result != nil && result.Metadata != nil {
+		if textBody, ok := result.Metadata["text_body"].(string); ok && textBody != "" {
+			st.pendingSidecars = append(st.pendingSidecars, Message{
+				Role:      "user",
+				Content:   textBody,
+				AgentID:   a.id,
+				Timestamp: time.Now(),
+			})
+		}
+	}
+
+	// === AUTOMATIC GRAPH MEMORY EXTRACTION ===
+	// After each tool execution, check if we should extract graph memories.
+	// Skip when the tool IS graph_memory — explicit use is higher quality.
+	if a.enableGraphMemoryExtraction && toolCall.Name != "graph_memory" {
+		a.graphToolExecutionsSinceExtraction++
+		if a.graphToolExecutionsSinceExtraction >= a.graphExtractionCadence {
+			a.graphExtractionWG.Add(1)
+			go func() {
+				defer a.graphExtractionWG.Done()
+				a.extractGraphMemoryAsync(ctx, session.ID)
+			}()
+			a.graphToolExecutionsSinceExtraction = 0
+		}
+	}
+}
+
+// synthesizeFinalResponse makes the final tool-free LLM call after the
+// conversation loop exhausts its turn/execution budget, so the agent yields
+// meaningful output instead of a generic limit error. Moved verbatim from
+// the loop tail when the batch body was extracted into dispatchOneCall.
+func (a *Agent) synthesizeFinalResponse(ctx Context, session *Session, turnCount, toolExecutionCount int, allToolExecutions []ToolExecution) (*Response, error) {
 	// Add a synthesis request to the conversation
 	// Include explicit format instructions since they may have been compressed in context
 	synthesisPrompt := "You must provide your final answer NOW with whatever information you have gathered so far. Summarize your findings: what actions were taken, what results were produced, and any remaining steps the user would need to complete manually. Be concise and actionable. You MUST respond with text — do not return an empty response."

--- a/pkg/agent/hitl_park_lifecycle_test.go
+++ b/pkg/agent/hitl_park_lifecycle_test.go
@@ -139,8 +139,12 @@ func TestPark_DecisionCannotBeReapplied(t *testing.T) {
 		t.Fatalf("export_csv ran %d times on the first resume, want 1", got)
 	}
 
-	if _, err := f.ag.ResumeChat(ctx, "s-once", decision, nil); !errors.Is(err, ErrUnknownRequest) {
-		t.Fatalf("replayed decision = %v, want ErrUnknownRequest", err)
+	// A decided row is still loadable (the embedder-recorded flow depends on
+	// it), so the replay guard is the tail walk: the applied batch has its
+	// rows and a final reply, and the replay lands in ErrNothingParked with
+	// nothing re-executed.
+	if _, err := f.ag.ResumeChat(ctx, "s-once", decision, nil); !errors.Is(err, ErrNothingParked) {
+		t.Fatalf("replayed decision = %v, want ErrNothingParked", err)
 	}
 	if got := f.tools["export_csv"].runs.Load(); got != 1 {
 		t.Fatalf("export_csv ran %d times after the replay, want 1", got)
@@ -187,9 +191,11 @@ func TestPark_UnboundDecisionCannotApproveANestedBatch(t *testing.T) {
 	}
 
 	// A's decision, redelivered with NO item ids, must not touch batch B.
+	// A's row is decided (loadable — the embedder-recorded flow depends on
+	// it), so the binding does the refusing: A's items are not in B's batch.
 	_, err = f.ag.ResumeChat(ctx, "s-bind", ParkDecision{RequestID: reqA, Approved: true}, nil)
-	if !errors.Is(err, ErrUnknownRequest) {
-		t.Fatalf("unbound stale decision = %v, want ErrUnknownRequest", err)
+	if !errors.Is(err, ErrStaleDecision) {
+		t.Fatalf("unbound stale decision = %v, want ErrStaleDecision", err)
 	}
 	if got := f.tools["drop_table"].runs.Load(); got != 0 {
 		t.Fatalf("drop_table ran %d times under request A's decision", got)
@@ -386,4 +392,68 @@ func TestPark_RequiresDurableSessionStore(t *testing.T) {
 	if got := write.runs.Load(); got != 0 {
 		t.Fatalf("export_csv ran %d times with no approval path", got)
 	}
+}
+
+// TestPark_EmbedderDecidedRowResumes pins the embedder-recorded flow: the
+// embedder's respond door decides the row FIRST (its own expiry CAS applies),
+// then resumes with a decision derived from the row. The decided row must
+// load, the row's status must be authoritative over the caller's payload, and
+// ResumeChat must not try to re-close a row that is already closed.
+func TestPark_EmbedderDecidedRowResumes(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("approved row executes the batch", func(t *testing.T) {
+		f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, twoCallBatch(),
+			"read_table", "export_csv")
+		_, err := f.ag.Chat(ctx, "s-embed-a", "go")
+		var parked *TurnParkedError
+		if !errors.As(err, &parked) {
+			t.Fatalf("expected park, got %v", err)
+		}
+		hr := f.pendingParked(t, "s-embed-a")
+		// The embedder decides the row before resuming — cloud's respond door.
+		if rerr := f.store.RespondToRequest(ctx, hr.ID, "approved", "", "user-1", nil); rerr != nil {
+			t.Fatalf("RespondToRequest: %v", rerr)
+		}
+		resp, err := f.ag.ResumeChat(ctx, "s-embed-a", ParkDecision{
+			RequestID: hr.ID, ItemIDs: paramKeys(hr), Approved: true,
+		}, nil)
+		if err != nil {
+			t.Fatalf("ResumeChat on decided row: %v", err)
+		}
+		if resp.Content != "continued" {
+			t.Fatalf("content = %q", resp.Content)
+		}
+		if got := f.tools["export_csv"].runs.Load(); got != 1 {
+			t.Fatalf("export_csv ran %d times, want 1", got)
+		}
+		// The row keeps the embedder's verdict — ResumeChat did not touch it.
+		after, _ := f.store.Get(ctx, hr.ID)
+		if after == nil || after.Status != "approved" {
+			t.Fatalf("row status after resume = %+v, want approved", after)
+		}
+	})
+
+	t.Run("rejected row refuses even an approving payload", func(t *testing.T) {
+		f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, twoCallBatch(),
+			"read_table", "export_csv")
+		_, err := f.ag.Chat(ctx, "s-embed-r", "go")
+		var parked *TurnParkedError
+		if !errors.As(err, &parked) {
+			t.Fatalf("expected park, got %v", err)
+		}
+		hr := f.pendingParked(t, "s-embed-r")
+		if rerr := f.store.RespondToRequest(ctx, hr.ID, "rejected", "wrong table", "user-1", nil); rerr != nil {
+			t.Fatalf("RespondToRequest: %v", rerr)
+		}
+		// Hostile/buggy caller says Approved — the row's verdict wins.
+		if _, err := f.ag.ResumeChat(ctx, "s-embed-r", ParkDecision{
+			RequestID: hr.ID, ItemIDs: paramKeys(hr), Approved: true,
+		}, nil); err != nil {
+			t.Fatalf("ResumeChat: %v", err)
+		}
+		if got := f.tools["export_csv"].runs.Load(); got != 0 {
+			t.Fatalf("export_csv ran %d times against a rejected row", got)
+		}
+	})
 }

--- a/pkg/agent/hitl_park_lifecycle_test.go
+++ b/pkg/agent/hitl_park_lifecycle_test.go
@@ -457,3 +457,97 @@ func TestPark_EmbedderDecidedRowResumes(t *testing.T) {
 		}
 	})
 }
+
+// TestPark_AppliedBatchWithoutFinalReplyResumesToCompletion — the crash
+// window between the batch's last tool row and the continuation's final
+// reply. All rows exist, no final reply: the retry must RE-ENTER the loop so
+// the model sees the results and finishes the turn — refusing it as
+// "already complete" would strand the turn's answer permanently — and must
+// not re-execute any tool body.
+func TestPark_AppliedBatchWithoutFinalReplyResumesToCompletion(t *testing.T) {
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, twoCallBatch(),
+		"read_table", "export_csv")
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-halfdone", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-halfdone")
+
+	// Simulate the crash window: every batch call already has its tool row
+	// (persisted before the death), but the continuation never ran.
+	sess := f.ag.memory.GetOrCreateSessionWithAgent(ctx, "s-halfdone", f.ag.config.Name, "")
+	for _, callID := range []string{"c-read", "c-write"} {
+		f.ag.appendMessage(ctx, sess, Message{
+			Role: "tool", Content: "ran", ToolUseID: callID,
+			ToolResult: &shuttle.Result{Success: true, Data: "ran"},
+			AgentID:    f.ag.id, Timestamp: time.Now(),
+		}, false)
+	}
+
+	resp, err := f.ag.ResumeChat(ctx, "s-halfdone", ParkDecision{
+		RequestID: hr.ID, ItemIDs: paramKeys(hr), Approved: true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("resume of an applied-but-unfinished turn refused: %v", err)
+	}
+	if resp.Content != "continued" {
+		t.Fatalf("content = %q, want the turn's answer", resp.Content)
+	}
+	// Recovery re-enters the loop; it never re-runs tool bodies.
+	if got := f.tools["export_csv"].runs.Load(); got != 0 {
+		t.Fatalf("export_csv re-ran %d times during recovery", got)
+	}
+	if got := f.tools["read_table"].runs.Load(); got != 0 {
+		t.Fatalf("read_table re-ran %d times during recovery", got)
+	}
+}
+
+// TestPark_CallIDCollisionCannotReplayAcrossBatches — LLM-assigned call IDs
+// can collide across batches (per-response counters). A redelivered decision
+// for request A whose item IDs happen to exist in nested batch B must be
+// refused by CONTENT binding (tool/seq), never applied by ID coincidence.
+func TestPark_CallIDCollisionCannotReplayAcrossBatches(t *testing.T) {
+	responses := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "call_0", Name: "export_csv", Input: map[string]interface{}{"v": "a"}},
+		}},
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "call_0", Name: "drop_table", Input: map[string]interface{}{"v": "b"}},
+		}},
+		{content: "done"},
+	}
+	f := newParkFixture(t,
+		[]shuttle.Hook{scopedAskHook{tool: "export_csv"}, scopedAskHook{tool: "drop_table"}},
+		responses, "export_csv", "drop_table")
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-collide", "go")
+	var parkedA *TurnParkedError
+	if !errors.As(err, &parkedA) {
+		t.Fatalf("expected park on batch A, got %v", err)
+	}
+	hrA := f.pendingParked(t, "s-collide")
+
+	_, err = f.ag.ResumeChat(ctx, "s-collide", ParkDecision{
+		RequestID: hrA.ID, ItemIDs: paramKeys(hrA), Approved: true,
+	}, nil)
+	var parkedB *TurnParkedError
+	if !errors.As(err, &parkedB) {
+		t.Fatalf("expected nested park on batch B, got %v", err)
+	}
+
+	// Redeliver A's decision: its item id "call_0" EXISTS in B's batch, but
+	// it describes export_csv — not B's drop_table.
+	_, err = f.ag.ResumeChat(ctx, "s-collide", ParkDecision{
+		RequestID: hrA.ID, ItemIDs: paramKeys(hrA), Approved: true,
+	}, nil)
+	if !errors.Is(err, ErrStaleDecision) {
+		t.Fatalf("colliding redelivery = %v, want ErrStaleDecision", err)
+	}
+	if got := f.tools["drop_table"].runs.Load(); got != 0 {
+		t.Fatalf("drop_table ran %d times under request A's redelivered decision", got)
+	}
+}

--- a/pkg/agent/hitl_park_lifecycle_test.go
+++ b/pkg/agent/hitl_park_lifecycle_test.go
@@ -551,3 +551,104 @@ func TestPark_CallIDCollisionCannotReplayAcrossBatches(t *testing.T) {
 		t.Fatalf("drop_table ran %d times under request A's redelivered decision", got)
 	}
 }
+
+// TestPark_HandleContinuityAcrossTheGap — same-process lifecycle: the parked
+// turn's handle collector survives the park (chat's first park AND a nested
+// re-park) and is adopted by the resume, so handles minted before the park
+// are never released mid-turn; the exit that finishes the turn drains the
+// slot. Pooled embedders instead drain explicitly via ReleaseParkedHandles.
+func TestPark_HandleContinuityAcrossTheGap(t *testing.T) {
+	ctx := context.Background()
+
+	parkedCollector := func(f *parkFixture, sessionID string) bool {
+		f.ag.parkedHandlesMu.Lock()
+		defer f.ag.parkedHandlesMu.Unlock()
+		return f.ag.parkedHandles[sessionID] != nil
+	}
+
+	t.Run("first park parks the collector; the finishing resume drains it", func(t *testing.T) {
+		f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, twoCallBatch(),
+			"read_table", "export_csv")
+		_, err := f.ag.Chat(ctx, "s-handles", "go")
+		var parked *TurnParkedError
+		if !errors.As(err, &parked) {
+			t.Fatalf("expected park, got %v", err)
+		}
+		if !parkedCollector(f, "s-handles") {
+			t.Fatalf("first park released the collector instead of parking it")
+		}
+		hr := f.pendingParked(t, "s-handles")
+		if _, err := f.ag.ResumeChat(ctx, "s-handles", ParkDecision{
+			RequestID: hr.ID, ItemIDs: paramKeys(hr), Approved: true,
+		}, nil); err != nil {
+			t.Fatalf("ResumeChat: %v", err)
+		}
+		if parkedCollector(f, "s-handles") {
+			t.Fatalf("finished turn left a parked collector behind")
+		}
+	})
+
+	t.Run("a nested re-park keeps the slot; the second resume drains it", func(t *testing.T) {
+		responses := []mockLLMResponse{
+			{content: "", toolCalls: []llmtypes.ToolCall{
+				{ID: "a-1", Name: "export_csv", Input: map[string]interface{}{"v": "a"}},
+			}},
+			{content: "", toolCalls: []llmtypes.ToolCall{
+				{ID: "b-1", Name: "drop_table", Input: map[string]interface{}{"v": "b"}},
+			}},
+			{content: "done"},
+		}
+		f := newParkFixture(t,
+			[]shuttle.Hook{scopedAskHook{tool: "export_csv"}, scopedAskHook{tool: "drop_table"}},
+			responses, "export_csv", "drop_table")
+		_, err := f.ag.Chat(ctx, "s-nested-h", "go")
+		var parkedA *TurnParkedError
+		if !errors.As(err, &parkedA) {
+			t.Fatalf("expected park A, got %v", err)
+		}
+		hrA := f.pendingParked(t, "s-nested-h")
+		_, err = f.ag.ResumeChat(ctx, "s-nested-h", ParkDecision{
+			RequestID: hrA.ID, ItemIDs: paramKeys(hrA), Approved: true,
+		}, nil)
+		var parkedB *TurnParkedError
+		if !errors.As(err, &parkedB) {
+			t.Fatalf("expected nested park B, got %v", err)
+		}
+		if !parkedCollector(f, "s-nested-h") {
+			t.Fatalf("nested re-park dropped the collector")
+		}
+		hrB := f.pendingParked(t, "s-nested-h")
+		if _, err := f.ag.ResumeChat(ctx, "s-nested-h", ParkDecision{
+			RequestID: hrB.ID, ItemIDs: paramKeys(hrB), Approved: true,
+		}, nil); err != nil {
+			t.Fatalf("resume B: %v", err)
+		}
+		if parkedCollector(f, "s-nested-h") {
+			t.Fatalf("finished turn left a parked collector behind")
+		}
+	})
+
+	t.Run("ReleaseParkedHandles drains the slot for pooled embedders", func(t *testing.T) {
+		f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, twoCallBatch(),
+			"read_table", "export_csv")
+		if _, err := f.ag.Chat(ctx, "s-pooled", "go"); err == nil {
+			t.Fatalf("expected park")
+		}
+		if !parkedCollector(f, "s-pooled") {
+			t.Fatalf("park did not park the collector")
+		}
+		f.ag.ReleaseParkedHandles("s-pooled")
+		if parkedCollector(f, "s-pooled") {
+			t.Fatalf("ReleaseParkedHandles left the slot occupied")
+		}
+		// Idempotent: draining an empty slot is a no-op.
+		f.ag.ReleaseParkedHandles("s-pooled")
+		// The resume still works with a fresh collector.
+		hr := f.pendingParked(t, "s-pooled")
+		if _, err := f.ag.ResumeChat(ctx, "s-pooled", ParkDecision{
+			RequestID: hr.ID, ItemIDs: paramKeys(hr), Approved: true,
+		}, nil); err != nil {
+			t.Fatalf("ResumeChat after explicit drain: %v", err)
+		}
+	})
+}

--- a/pkg/agent/hitl_park_lifecycle_test.go
+++ b/pkg/agent/hitl_park_lifecycle_test.go
@@ -1,0 +1,389 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package agent
+
+// The parked request's lifecycle, and the reach of the decision that closes
+// it. Three properties, each of which failed before the review fixes:
+//
+//   - a decided row is CLOSED, so the session keeps taking turns;
+//   - the request row — not the caller's payload — binds the decision to a
+//     batch, so an unbound decision cannot approve a batch nobody saw;
+//   - the grant reaches only the items the human's card described.
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+)
+
+// TestPark_DecidedRequestIsClosedAndSessionContinues pins the property the
+// whole feature rests on: after a decision is applied, the next user message
+// is accepted. guardParkedTail refuses a new turn while a parked row is
+// pending, so a row left pending by the resume wedges the session forever.
+func TestPark_DecidedRequestIsClosedAndSessionContinues(t *testing.T) {
+	responses := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "c-write", Name: "export_csv", Input: map[string]interface{}{"v": "w"}},
+		}},
+		{content: "first turn done"},
+		{content: "second turn done"},
+	}
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, responses, "export_csv")
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-life", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-life")
+
+	resp, err := f.ag.ResumeChat(ctx, "s-life", ParkDecision{
+		RequestID: hr.ID, ItemIDs: paramKeys(hr), Approved: true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("ResumeChat: %v", err)
+	}
+	if resp.Content != "first turn done" {
+		t.Fatalf("resume content = %q", resp.Content)
+	}
+
+	// The row is terminally closed, carrying the verdict.
+	after, err := f.store.Get(ctx, hr.ID)
+	if err != nil || after == nil {
+		t.Fatalf("Get after resume: %v", err)
+	}
+	if after.Status != "approved" {
+		t.Fatalf("request status = %q, want approved", after.Status)
+	}
+
+	// And the session takes its next turn.
+	next, err := f.ag.Chat(ctx, "s-life", "now the next thing")
+	if err != nil {
+		t.Fatalf("turn after resume refused: %v", err)
+	}
+	if next.Content != "second turn done" {
+		t.Fatalf("next turn content = %q", next.Content)
+	}
+}
+
+// TestPark_RejectedRequestIsClosedToo — the refusal path closes the row on the
+// same contract; a rejected batch must not wedge the session either.
+func TestPark_RejectedRequestIsClosedToo(t *testing.T) {
+	responses := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "c-write", Name: "export_csv", Input: map[string]interface{}{"v": "w"}},
+		}},
+		{content: "replanned"},
+		{content: "next turn"},
+	}
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, responses, "export_csv")
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-rej", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-rej")
+
+	if _, err := f.ag.ResumeChat(ctx, "s-rej", ParkDecision{
+		RequestID: hr.ID, Approved: false, Reason: "rejected by user: not on prod",
+	}, nil); err != nil {
+		t.Fatalf("ResumeChat: %v", err)
+	}
+	after, _ := f.store.Get(ctx, hr.ID)
+	if after == nil || after.Status != "rejected" {
+		t.Fatalf("request status = %v, want rejected", after)
+	}
+	if _, err := f.ag.Chat(ctx, "s-rej", "carry on"); err != nil {
+		t.Fatalf("turn after rejected resume refused: %v", err)
+	}
+}
+
+// TestPark_DecisionCannotBeReapplied — a closed row is no longer resumable, so
+// a redelivered decision cannot double-execute its batch.
+func TestPark_DecisionCannotBeReapplied(t *testing.T) {
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, twoCallBatch(),
+		"read_table", "export_csv")
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-once", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-once")
+	decision := ParkDecision{RequestID: hr.ID, ItemIDs: paramKeys(hr), Approved: true}
+
+	if _, err := f.ag.ResumeChat(ctx, "s-once", decision, nil); err != nil {
+		t.Fatalf("ResumeChat: %v", err)
+	}
+	if got := f.tools["export_csv"].runs.Load(); got != 1 {
+		t.Fatalf("export_csv ran %d times on the first resume, want 1", got)
+	}
+
+	if _, err := f.ag.ResumeChat(ctx, "s-once", decision, nil); !errors.Is(err, ErrUnknownRequest) {
+		t.Fatalf("replayed decision = %v, want ErrUnknownRequest", err)
+	}
+	if got := f.tools["export_csv"].runs.Load(); got != 1 {
+		t.Fatalf("export_csv ran %d times after the replay, want 1", got)
+	}
+}
+
+// TestPark_UnboundDecisionCannotApproveANestedBatch is the binding proof. A
+// nested park chains, so two requests can exist for one session; a decision
+// that names request A must never be applied to batch B — including when the
+// caller supplies no ItemIDs at all, which is exactly when a payload-derived
+// binding would check nothing.
+func TestPark_UnboundDecisionCannotApproveANestedBatch(t *testing.T) {
+	responses := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "a-write", Name: "export_csv", Input: map[string]interface{}{"v": "a"}},
+		}},
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "b-drop", Name: "drop_table", Input: map[string]interface{}{"v": "b"}},
+		}},
+		{content: "done"},
+	}
+	f := newParkFixture(t,
+		[]shuttle.Hook{scopedAskHook{tool: "export_csv"}, scopedAskHook{tool: "drop_table"}},
+		responses, "export_csv", "drop_table")
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-bind", "go")
+	var parkedA *TurnParkedError
+	if !errors.As(err, &parkedA) {
+		t.Fatalf("expected park on batch A, got %v", err)
+	}
+	reqA := parkedA.RequestID
+
+	// Approve A; the continuation parks again on batch B.
+	_, err = f.ag.ResumeChat(ctx, "s-bind", ParkDecision{
+		RequestID: reqA, ItemIDs: []string{"a-write"}, Approved: true,
+	}, nil)
+	var parkedB *TurnParkedError
+	if !errors.As(err, &parkedB) {
+		t.Fatalf("expected nested park on batch B, got %v", err)
+	}
+	if parkedB.RequestID == reqA {
+		t.Fatalf("nested park reused request A's id")
+	}
+
+	// A's decision, redelivered with NO item ids, must not touch batch B.
+	_, err = f.ag.ResumeChat(ctx, "s-bind", ParkDecision{RequestID: reqA, Approved: true}, nil)
+	if !errors.Is(err, ErrUnknownRequest) {
+		t.Fatalf("unbound stale decision = %v, want ErrUnknownRequest", err)
+	}
+	if got := f.tools["drop_table"].runs.Load(); got != 0 {
+		t.Fatalf("drop_table ran %d times under request A's decision", got)
+	}
+
+	// B's own decision still works.
+	if _, err := f.ag.ResumeChat(ctx, "s-bind", ParkDecision{
+		RequestID: parkedB.RequestID, ItemIDs: []string{"b-drop"}, Approved: true,
+	}, nil); err != nil {
+		t.Fatalf("resume B: %v", err)
+	}
+	if got := f.tools["drop_table"].runs.Load(); got != 1 {
+		t.Fatalf("drop_table ran %d times under its OWN decision, want 1", got)
+	}
+}
+
+// TestPark_MismatchedItemIDsRefused — when a caller DOES supply item ids they
+// are honored as a cross-check: a list that does not name exactly the row's
+// items is refused rather than silently ignored.
+func TestPark_MismatchedItemIDsRefused(t *testing.T) {
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, twoCallBatch(),
+		"read_table", "export_csv")
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-xcheck", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-xcheck")
+
+	// The row's single item is c-write; a list naming a real-but-different
+	// call of the same batch is still the wrong decision.
+	_, err = f.ag.ResumeChat(ctx, "s-xcheck", ParkDecision{
+		RequestID: hr.ID, ItemIDs: []string{"c-read"}, Approved: true,
+	}, nil)
+	if !errors.Is(err, ErrStaleDecision) {
+		t.Fatalf("mismatched item ids = %v, want ErrStaleDecision", err)
+	}
+	if got := f.tools["export_csv"].runs.Load(); got != 0 {
+		t.Fatalf("export_csv ran under a mismatched decision")
+	}
+}
+
+// driftHook governs one tool: Allow until armed, Ask afterwards — a host gate
+// that trips on budget, quota, or time of day while the turn waits. The
+// library's own hooks are deterministic; the Hook interface is public and a
+// host's need not be.
+type driftHook struct {
+	tool  string
+	armed atomic.Bool
+}
+
+func (h *driftHook) Matches(r shuttle.AdmissionRequest) bool { return r.ToolName == h.tool }
+func (h *driftHook) Evaluate(shuttle.AdmissionRequest) shuttle.Decision {
+	if h.armed.Load() {
+		return shuttle.Decision{Kind: shuttle.Ask}
+	}
+	return shuttle.Decision{Kind: shuttle.Allow}
+}
+
+// TestPark_GrantDoesNotReachCallsOffTheCard pins the grant's blast radius. An
+// approval answers the question it was asked: a call that was not a park item
+// never appeared on the human's card, so it may not borrow that approval when
+// its own verdict has since become Ask.
+func TestPark_GrantDoesNotReachCallsOffTheCard(t *testing.T) {
+	drift := &driftHook{tool: "read_table"}
+	f := newParkFixture(t,
+		[]shuttle.Hook{scopedAskHook{tool: "export_csv"}, drift},
+		twoCallBatch(), "read_table", "export_csv")
+	ctx := context.Background()
+
+	// read_table preflights Allow, so only export_csv is a card item.
+	_, err := f.ag.Chat(ctx, "s-drift", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-drift")
+	items := paramKeys(hr)
+	if len(items) != 1 || items[0] != "c-write" {
+		t.Fatalf("card items = %v, want only [c-write]", items)
+	}
+
+	// The gate trips while the human deliberates.
+	drift.armed.Store(true)
+
+	if _, err := f.ag.ResumeChat(ctx, "s-drift", ParkDecision{
+		RequestID: hr.ID, ItemIDs: items, Approved: true,
+	}, nil); err != nil {
+		t.Fatalf("ResumeChat: %v", err)
+	}
+
+	if got := f.tools["read_table"].runs.Load(); got != 0 {
+		t.Errorf("read_table now requires its own approval and was never on the card, "+
+			"yet it ran %d time(s) under the batch grant", got)
+	}
+	if got := f.tools["export_csv"].runs.Load(); got != 1 {
+		t.Errorf("export_csv (the approved item) ran %d times, want 1", got)
+	}
+}
+
+// TestPark_ExpiredDecisionIsRefusedNotExecuted — an approval that lands after
+// the row's window has closed is applied as a refusal, and the row is closed
+// through the one path allowed to close past expiry, so the session survives.
+func TestPark_ExpiredDecisionIsRefusedNotExecuted(t *testing.T) {
+	responses := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "c-write", Name: "export_csv", Input: map[string]interface{}{"v": "w"}},
+		}},
+		{content: "replanned after timeout"},
+		{content: "later turn"},
+	}
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, responses, "export_csv")
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-exp", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-exp")
+
+	// Backdate the window: the human took too long.
+	hr.ExpiresAt = time.Now().Add(-time.Minute)
+	if err := f.store.Update(ctx, hr); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if _, err := f.ag.ResumeChat(ctx, "s-exp", ParkDecision{
+		RequestID: hr.ID, ItemIDs: paramKeys(hr), Approved: true,
+	}, nil); err != nil {
+		t.Fatalf("ResumeChat: %v", err)
+	}
+	if got := f.tools["export_csv"].runs.Load(); got != 0 {
+		t.Fatalf("export_csv ran %d times on a lapsed approval", got)
+	}
+	after, _ := f.store.Get(ctx, hr.ID)
+	if after == nil || after.Status != "timeout" {
+		t.Fatalf("expired request status = %v, want timeout", after)
+	}
+	if _, err := f.ag.Chat(ctx, "s-exp", "carry on"); err != nil {
+		t.Fatalf("turn after an expired park refused: %v", err)
+	}
+}
+
+// TestResumeChat_RefusedWithoutParkWiring — the entry point is closed on an
+// agent that never enabled park, so it can never complete a rowless batch
+// under a grant and bypass whatever approval path that agent does have.
+func TestResumeChat_RefusedWithoutParkWiring(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.PatternConfig = DefaultPatternConfig()
+	cfg.PatternConfig.UseLLMClassifier = false
+	ag := NewAgent(&mockBackend{}, &mockToolCallingLLM{responses: []mockLLMResponse{{content: "hi"}}},
+		WithConfig(cfg))
+
+	if _, err := ag.ResumeChat(context.Background(), "s-nopark",
+		ParkDecision{RequestID: "x", Approved: true}, nil); !errors.Is(err, ErrParkDisabled) {
+		t.Fatalf("ResumeChat without park = %v, want ErrParkDisabled", err)
+	}
+}
+
+// TestPark_RequiresDurableSessionStore — Memory's Persist* methods are silent
+// no-ops without a store, so "persisted without error" is not the same as
+// durable. Park must not raise a durable request row against a batch that
+// lives only in RAM; without a store the batch dispatches inline instead,
+// where a govened call fails closed with no resolver wired.
+func TestPark_RequiresDurableSessionStore(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.PatternConfig = DefaultPatternConfig()
+	cfg.PatternConfig.UseLLMClassifier = false
+
+	store := shuttle.NewInMemoryHumanRequestStore()
+	ag := NewAgent(&mockBackend{}, &mockToolCallingLLM{responses: twoCallBatch()},
+		WithConfig(cfg),
+		WithHITLPark(store, 0, NewProgressNotifier()),
+		WithAdmissionHooks(shuttle.NewChain([]shuttle.Hook{scopedAskHook{tool: "export_csv"}}, nil, nil)),
+	) // NOTE: no WithMemory(NewMemoryWithStore(...)) — storeless on purpose.
+	read := &countingTool{name: "read_table"}
+	write := &countingTool{name: "export_csv"}
+	ag.RegisterTool(read)
+	ag.RegisterTool(write)
+
+	ctx := context.Background()
+	_, err := ag.Chat(ctx, "s-nostore", "go")
+	var parked *TurnParkedError
+	if errors.As(err, &parked) {
+		t.Fatalf("parked against a non-durable batch")
+	}
+	if reqs, _ := store.ListBySession(ctx, "s-nostore"); len(reqs) != 0 {
+		t.Fatalf("raised %d request row(s) for a batch that was never stored", len(reqs))
+	}
+	// Fail-closed inline: the ask has no resolver, so the body never runs.
+	if got := write.runs.Load(); got != 0 {
+		t.Fatalf("export_csv ran %d times with no approval path", got)
+	}
+}

--- a/pkg/agent/hitl_park_noop_test.go
+++ b/pkg/agent/hitl_park_noop_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+// Park no-op proofs. The park pre-scan sits on the hottest path in the product
+// (every tool batch of every turn), and the dispatchOneCall extraction moves
+// the batch loop body verbatim. These tests pin both claims:
+//
+//   - golden: an ungoverned two-tool turn produces exactly this message
+//     sequence (roles, tool pairing, contents). Written against the
+//     pre-extraction loop; the extraction must keep it green unchanged.
+//   - differential: enabling park on an ungoverned agent changes nothing —
+//     the message sequences of a park-enabled and a park-disabled run of the
+//     same script are identical.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+)
+
+// parkEchoTool is a trivial ungoverned tool: echoes its "v" param.
+type parkEchoTool struct{ name string }
+
+func (t *parkEchoTool) Name() string        { return t.name }
+func (t *parkEchoTool) Description() string { return "echoes v" }
+func (t *parkEchoTool) InputSchema() *shuttle.JSONSchema {
+	return &shuttle.JSONSchema{
+		Type:       "object",
+		Properties: map[string]*shuttle.JSONSchema{"v": {Type: "string"}},
+	}
+}
+func (t *parkEchoTool) Execute(ctx context.Context, params map[string]interface{}) (*shuttle.Result, error) {
+	v, _ := params["v"].(string)
+	return &shuttle.Result{Success: true, Data: "echo:" + v}, nil
+}
+func (t *parkEchoTool) Backend() string { return "" }
+
+// startParkNoopAgent builds an ungoverned agent (no admission chain) with two
+// echo tools and a scripted two-call batch followed by a final text turn.
+func startParkNoopAgent(t *testing.T, parkEnabled bool) *Agent {
+	t.Helper()
+	cfg := DefaultConfig()
+	cfg.PatternConfig = DefaultPatternConfig()
+	cfg.PatternConfig.UseLLMClassifier = false
+
+	llm := &mockToolCallingLLM{responses: []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "call-a", Name: "echo_a", Input: map[string]interface{}{"v": "one"}},
+			{ID: "call-b", Name: "echo_b", Input: map[string]interface{}{"v": "two"}},
+		}},
+		{content: "all done"},
+	}}
+
+	opts := []Option{WithConfig(cfg)}
+	if parkEnabled {
+		opts = append(opts, WithHITLPark(shuttle.NewInMemoryHumanRequestStore(), 0, nil))
+	}
+	ag := NewAgent(&mockBackend{}, llm, opts...)
+	ag.RegisterTool(&parkEchoTool{name: "echo_a"})
+	ag.RegisterTool(&parkEchoTool{name: "echo_b"})
+	return ag
+}
+
+// messageTrace renders the session's conversational rows (system rows excluded)
+// as one comparable line per row: role, tool-use id, and content.
+func messageTrace(t *testing.T, ag *Agent, ctx context.Context, sessionID string) []string {
+	t.Helper()
+	sess := ag.memory.GetOrCreateSessionWithAgent(ctx, sessionID, ag.config.Name, "")
+	var out []string
+	for _, m := range sess.GetMessages() {
+		if m.Role == "system" {
+			continue
+		}
+		content := m.Content
+		// The compiled view prepends a rendered "[<timestamp>] " prefix to
+		// user rows (renderLocked temporal grounding) — normalize it away so
+		// the trace pins conversational content, not the wall clock.
+		if m.Role == "user" && strings.HasPrefix(content, "[") {
+			if end := strings.Index(content, "] "); end > 0 {
+				content = content[end+2:]
+			}
+		}
+		out = append(out, fmt.Sprintf("%s|%s|%s", m.Role, m.ToolUseID, content))
+	}
+	return out
+}
+
+func TestParkNoop_GoldenUngovernedBatchSequence(t *testing.T) {
+	ag := startParkNoopAgent(t, false)
+	ctx := context.Background()
+	resp, err := ag.Chat(ctx, "park-noop-golden", "run both")
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Content != "all done" {
+		t.Fatalf("final content = %q, want %q", resp.Content, "all done")
+	}
+	if len(resp.ToolExecutions) != 2 {
+		t.Fatalf("tool executions = %d, want 2", len(resp.ToolExecutions))
+	}
+
+	trace := messageTrace(t, ag, ctx, "park-noop-golden")
+	want := []string{
+		"user||run both",
+		"assistant||",
+		"tool|call-a|echo:one",
+		"tool|call-b|echo:two",
+		"assistant||all done",
+	}
+	if len(trace) != len(want) {
+		t.Fatalf("trace length = %d, want %d\ntrace: %#v", len(trace), len(want), trace)
+	}
+	for i := range want {
+		if trace[i] != want[i] {
+			t.Fatalf("trace[%d] = %q, want %q\nfull: %#v", i, trace[i], want[i], trace)
+		}
+	}
+}
+
+func TestParkNoop_ParkEnabledUngovernedRunIsIdentical(t *testing.T) {
+	ctx := context.Background()
+
+	agOff := startParkNoopAgent(t, false)
+	respOff, err := agOff.Chat(ctx, "park-noop-off", "run both")
+	if err != nil {
+		t.Fatalf("Chat (park off): %v", err)
+	}
+	agOn := startParkNoopAgent(t, true)
+	respOn, err := agOn.Chat(ctx, "park-noop-on", "run both")
+	if err != nil {
+		t.Fatalf("Chat (park on): %v", err)
+	}
+
+	if respOff.Content != respOn.Content {
+		t.Fatalf("content diverged: off=%q on=%q", respOff.Content, respOn.Content)
+	}
+	if len(respOff.ToolExecutions) != len(respOn.ToolExecutions) {
+		t.Fatalf("tool executions diverged: off=%d on=%d",
+			len(respOff.ToolExecutions), len(respOn.ToolExecutions))
+	}
+
+	traceOff := messageTrace(t, agOff, ctx, "park-noop-off")
+	traceOn := messageTrace(t, agOn, ctx, "park-noop-on")
+	if len(traceOff) != len(traceOn) {
+		t.Fatalf("trace lengths diverged: off=%d on=%d\noff: %#v\non: %#v",
+			len(traceOff), len(traceOn), traceOff, traceOn)
+	}
+	for i := range traceOff {
+		if traceOff[i] != traceOn[i] {
+			t.Fatalf("trace[%d] diverged:\noff: %q\non:  %q", i, traceOff[i], traceOn[i])
+		}
+	}
+}

--- a/pkg/agent/hitl_park_test.go
+++ b/pkg/agent/hitl_park_test.go
@@ -23,11 +23,13 @@ package agent
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
 
 	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+	"github.com/teradata-labs/loom/pkg/observability"
 	"github.com/teradata-labs/loom/pkg/shuttle"
 )
 
@@ -78,15 +80,27 @@ type parkFixture struct {
 // newParkFixture builds a park-enabled agent: hooks govern via the given
 // chain hooks (no blocking resolver — park mode never wires one), and the
 // scripted LLM issues the given batches then a final text.
+//
+// A real session store is wired because park REQUIRES one: a request row may
+// only be raised against a batch that survives a restart, and Memory's
+// Persist* methods are silent no-ops without a store. A storeless fixture
+// would exercise the feature with its central precondition switched off.
 func newParkFixture(t *testing.T, hooks []shuttle.Hook, responses []mockLLMResponse, toolNames ...string) *parkFixture {
 	t.Helper()
 	cfg := DefaultConfig()
 	cfg.PatternConfig = DefaultPatternConfig()
 	cfg.PatternConfig.UseLLMClassifier = false
 
+	sessions, err := NewSessionStore(filepath.Join(t.TempDir(), "park.db"), observability.NewNoOpTracer())
+	if err != nil {
+		t.Fatalf("session store: %v", err)
+	}
+	t.Cleanup(func() { _ = sessions.Close() })
+
 	store := shuttle.NewInMemoryHumanRequestStore()
 	opts := []Option{
 		WithConfig(cfg),
+		WithMemory(NewMemoryWithStore(sessions)),
 		WithHITLPark(store, 0, NewProgressNotifier()),
 	}
 	if len(hooks) > 0 {
@@ -394,14 +408,35 @@ func TestPark_ResumeTerminals(t *testing.T) {
 		t.Fatalf("moved-on resume = %v, want ErrNotParkedTail", err)
 	}
 
-	// A fully completed turn has nothing parked.
+	// A request ID that names no pending parked row of this session is
+	// refused before the session is touched at all.
 	done := newParkFixture(t, nil, []mockLLMResponse{{content: "hi"}})
 	if _, err := done.ag.Chat(ctx, "s-done", "hello"); err != nil {
 		t.Fatalf("Chat: %v", err)
 	}
 	_, err = done.ag.ResumeChat(ctx, "s-done", ParkDecision{RequestID: "x", Approved: true}, nil)
+	if !errors.Is(err, ErrUnknownRequest) {
+		t.Fatalf("unknown-request resume = %v, want ErrUnknownRequest", err)
+	}
+
+	// A pending row whose turn has ALREADY produced its final assistant reply
+	// has nothing left to finish — even though the batch left rowless calls
+	// behind (the loop's own caps can end a turn that way). Completing them
+	// now would run bodies the finished turn declined to run.
+	fin := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, twoCallBatch(),
+		"read_table", "export_csv")
+	if _, err := fin.ag.Chat(ctx, "s-fin", "go"); !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	finHR := fin.pendingParked(t, "s-fin")
+	finSess := fin.ag.memory.GetOrCreateSessionWithAgent(ctx, "s-fin", fin.ag.config.Name, "")
+	fin.ag.appendMessage(ctx, finSess, Message{Role: "assistant", Content: "answered anyway", AgentID: fin.ag.id}, false)
+	_, err = fin.ag.ResumeChat(ctx, "s-fin", ParkDecision{RequestID: finHR.ID, Approved: true}, nil)
 	if !errors.Is(err, ErrNothingParked) {
 		t.Fatalf("completed-turn resume = %v, want ErrNothingParked", err)
+	}
+	if got := fin.tools["export_csv"].runs.Load(); got != 0 {
+		t.Fatalf("export_csv ran %d times on a turn that already replied", got)
 	}
 }
 

--- a/pkg/agent/hitl_park_test.go
+++ b/pkg/agent/hitl_park_test.go
@@ -459,3 +459,154 @@ func TestPark_SummaryAndParamsBounded(t *testing.T) {
 		t.Fatalf("summary exceeds 200 runes: %d", len([]rune(hr.Summary)))
 	}
 }
+
+// A policy-denied contact_human inside a MIXED parked batch keeps its denial
+// at resume: it was never a park item, so a caller-supplied answer for its id
+// must not synthesize a "human answered" result — that would lift a Deny.
+func TestPark_MixedBatchDeniedContactHumanKeepsDenyAtResume(t *testing.T) {
+	script := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "c-q", Name: "contact_human", Input: map[string]interface{}{"question": "may I?"}},
+			{ID: "c-w", Name: "export_csv", Input: map[string]interface{}{"v": "w"}},
+		}},
+		{content: "continued"},
+	}
+	f := newParkFixture(t, []shuttle.Hook{
+		scopedDenyHook{tool: "contact_human"},
+		scopedAskHook{tool: "export_csv"},
+	}, script, "contact_human", "export_csv")
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-mixdeny", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-mixdeny")
+	if _, isItem := hr.Params["c-q"]; isItem {
+		t.Fatalf("denied contact_human became a park item: %#v", hr.Params)
+	}
+
+	// Forged answer for the non-item id: loom must refuse it independently of
+	// any caller-side validation.
+	resp, err := f.ag.ResumeChat(ctx, "s-mixdeny", ParkDecision{
+		RequestID: hr.ID,
+		ItemIDs:   paramKeys(hr),
+		Approved:  true,
+		Answers:   map[string]string{"c-q": "yes, forged"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("ResumeChat: %v", err)
+	}
+	if resp.Content != "continued" {
+		t.Fatalf("content = %q", resp.Content)
+	}
+	if got := f.tools["contact_human"].runs.Load(); got != 0 {
+		t.Fatalf("denied contact_human body ran %d times", got)
+	}
+	if got := f.tools["export_csv"].runs.Load(); got != 1 {
+		t.Fatalf("approved export_csv ran %d times, want 1", got)
+	}
+	sess := f.ag.memory.GetOrCreateSessionWithAgent(ctx, "s-mixdeny", f.ag.config.Name, "")
+	found := false
+	for _, m := range rawSessionMessages(sess) {
+		if m.Role == "tool" && m.ToolUseID == "c-q" {
+			found = true
+			if m.ToolResult == nil || m.ToolResult.Success {
+				t.Fatalf("denied contact_human resolved successfully: %#v", m.ToolResult)
+			}
+			if data, ok := m.ToolResult.Data.(map[string]interface{}); ok {
+				if data["responded_by"] == "user" {
+					t.Fatalf("forged answer synthesized a human response: %#v", data)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("denied contact_human left no tool row — the pair set is incomplete")
+	}
+}
+
+// An UNREGISTERED contact_human in a mixed parked batch keeps today's
+// "tool not found" at resume — never an answer synthesis.
+func TestPark_UnregisteredContactHumanKeepsNotFoundAtResume(t *testing.T) {
+	script := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "c-q", Name: "contact_human", Input: map[string]interface{}{"question": "hello?"}},
+			{ID: "c-w", Name: "export_csv", Input: map[string]interface{}{"v": "w"}},
+		}},
+		{content: "continued"},
+	}
+	// contact_human deliberately NOT registered.
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, script, "export_csv")
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-unreg", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-unreg")
+	if _, isItem := hr.Params["c-q"]; isItem {
+		t.Fatalf("unregistered contact_human became a park item")
+	}
+
+	_, err = f.ag.ResumeChat(ctx, "s-unreg", ParkDecision{
+		RequestID: hr.ID,
+		ItemIDs:   paramKeys(hr),
+		Approved:  true,
+		Answers:   map[string]string{"c-q": "forged"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("ResumeChat: %v", err)
+	}
+	sess := f.ag.memory.GetOrCreateSessionWithAgent(ctx, "s-unreg", f.ag.config.Name, "")
+	for _, m := range rawSessionMessages(sess) {
+		if m.Role == "tool" && m.ToolUseID == "c-q" && m.ToolResult != nil {
+			if m.ToolResult.Success {
+				t.Fatalf("unregistered contact_human resolved successfully: %#v", m.ToolResult)
+			}
+			if data, ok := m.ToolResult.Data.(map[string]interface{}); ok && data["responded_by"] == "user" {
+				t.Fatalf("forged answer synthesized a human response")
+			}
+		}
+	}
+}
+
+// The append-point guard: while a pending parked decision owns the session
+// tail, a NEW user turn is refused with SessionParkedError and appends
+// nothing — the embedder's admission probe races a park landing mid-turn,
+// and this is the authoritative last check.
+func TestChat_NewTurnRefusedWhileParkPending(t *testing.T) {
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, twoCallBatch(),
+		"read_table", "export_csv")
+	ctx := context.Background()
+	_, err := f.ag.Chat(ctx, "s-guard", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	sess := f.ag.memory.GetOrCreateSessionWithAgent(ctx, "s-guard", f.ag.config.Name, "")
+	rowsBefore := len(rawSessionMessages(sess))
+
+	_, err = f.ag.Chat(ctx, "s-guard", "second message")
+	var refused *SessionParkedError
+	if !errors.As(err, &refused) {
+		t.Fatalf("expected SessionParkedError, got %v", err)
+	}
+	if refused.RequestID != parked.RequestID {
+		t.Fatalf("refusal names request %q, park was %q", refused.RequestID, parked.RequestID)
+	}
+	if got := len(rawSessionMessages(sess)); got != rowsBefore {
+		t.Fatalf("refused turn appended rows: %d -> %d", rowsBefore, got)
+	}
+
+	// A session with no pending park admits normally.
+	done := newParkFixture(t, nil, []mockLLMResponse{{content: "hi"}, {content: "again"}})
+	if _, err := done.ag.Chat(ctx, "s-open", "hello"); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if _, err := done.ag.Chat(ctx, "s-open", "hello again"); err != nil {
+		t.Fatalf("second turn on an unparked session refused: %v", err)
+	}
+}

--- a/pkg/agent/hitl_park_test.go
+++ b/pkg/agent/hitl_park_test.go
@@ -1,0 +1,461 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package agent
+
+// Park-and-resume behavior through the real conversation loop: the pre-scan
+// parks a batch with an ask before anything executes, the grouped request
+// binds the batch by item IDs, and ResumeChat completes the turn under the
+// human's decision — approve executes under a batch-scoped grant, reject
+// synthesizes uniform refusals and the model re-plans, question items carry
+// the human's answer. The typed terminals refuse stale or moved-on decisions.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+)
+
+// countingTool records how many times its body actually ran — the block-all
+// proof reads this.
+type countingTool struct {
+	name string
+	runs atomic.Int64
+}
+
+func (t *countingTool) Name() string        { return t.name }
+func (t *countingTool) Description() string { return "counting tool" }
+func (t *countingTool) InputSchema() *shuttle.JSONSchema {
+	return &shuttle.JSONSchema{
+		Type:       "object",
+		Properties: map[string]*shuttle.JSONSchema{"v": {Type: "string"}, "question": {Type: "string"}},
+	}
+}
+func (t *countingTool) Execute(ctx context.Context, params map[string]interface{}) (*shuttle.Result, error) {
+	t.runs.Add(1)
+	v, _ := params["v"].(string)
+	return &shuttle.Result{Success: true, Data: "ran:" + v}, nil
+}
+func (t *countingTool) Backend() string { return "" }
+
+// scopedAskHook asks for approval on exactly one tool name.
+type scopedAskHook struct{ tool string }
+
+func (h scopedAskHook) Matches(r shuttle.AdmissionRequest) bool { return r.ToolName == h.tool }
+func (h scopedAskHook) Evaluate(shuttle.AdmissionRequest) shuttle.Decision {
+	return shuttle.Decision{Kind: shuttle.Ask}
+}
+
+// scopedDenyHook denies exactly one tool name.
+type scopedDenyHook struct{ tool string }
+
+func (h scopedDenyHook) Matches(r shuttle.AdmissionRequest) bool { return r.ToolName == h.tool }
+func (h scopedDenyHook) Evaluate(shuttle.AdmissionRequest) shuttle.Decision {
+	return shuttle.Decision{Kind: shuttle.Deny, Reason: "denied by policy"}
+}
+
+type parkFixture struct {
+	ag    *Agent
+	store *shuttle.InMemoryHumanRequestStore
+	tools map[string]*countingTool
+}
+
+// newParkFixture builds a park-enabled agent: hooks govern via the given
+// chain hooks (no blocking resolver — park mode never wires one), and the
+// scripted LLM issues the given batches then a final text.
+func newParkFixture(t *testing.T, hooks []shuttle.Hook, responses []mockLLMResponse, toolNames ...string) *parkFixture {
+	t.Helper()
+	cfg := DefaultConfig()
+	cfg.PatternConfig = DefaultPatternConfig()
+	cfg.PatternConfig.UseLLMClassifier = false
+
+	store := shuttle.NewInMemoryHumanRequestStore()
+	opts := []Option{
+		WithConfig(cfg),
+		WithHITLPark(store, 0, NewProgressNotifier()),
+	}
+	if len(hooks) > 0 {
+		opts = append(opts, WithAdmissionHooks(shuttle.NewChain(hooks, nil, nil)))
+	}
+	llm := &mockToolCallingLLM{responses: responses}
+	ag := NewAgent(&mockBackend{}, llm, opts...)
+	tools := make(map[string]*countingTool, len(toolNames))
+	for _, n := range toolNames {
+		ct := &countingTool{name: n}
+		ag.RegisterTool(ct)
+		tools[n] = ct
+	}
+	return &parkFixture{ag: ag, store: store, tools: tools}
+}
+
+// pendingParked returns the single pending parked request for the session.
+func (f *parkFixture) pendingParked(t *testing.T, sessionID string) *shuttle.HumanRequest {
+	t.Helper()
+	reqs, err := f.store.ListBySession(context.Background(), sessionID)
+	if err != nil {
+		t.Fatalf("ListBySession: %v", err)
+	}
+	var out *shuttle.HumanRequest
+	for _, r := range reqs {
+		if r.Status == "pending" && r.RequestType == "parked" {
+			if out != nil {
+				t.Fatalf("more than one pending parked request")
+			}
+			out = r
+		}
+	}
+	if out == nil {
+		t.Fatalf("no pending parked request for %s", sessionID)
+	}
+	return out
+}
+
+func paramKeys(hr *shuttle.HumanRequest) []string {
+	keys := make([]string, 0, len(hr.Params))
+	for k := range hr.Params {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// twoCallBatch scripts [read (ungoverned), write (ask)] then a final text.
+func twoCallBatch() []mockLLMResponse {
+	return []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "c-read", Name: "read_table", Input: map[string]interface{}{"v": "r"}},
+			{ID: "c-write", Name: "export_csv", Input: map[string]interface{}{"v": "w"}},
+		}},
+		{content: "continued"},
+	}
+}
+
+func TestPark_AskBatchParksBeforeAnythingExecutes(t *testing.T) {
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, twoCallBatch(),
+		"read_table", "export_csv")
+
+	_, err := f.ag.Chat(context.Background(), "s-park", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("Chat error = %v, want *TurnParkedError", err)
+	}
+	if parked.SessionID != "s-park" || parked.RequestID == "" {
+		t.Fatalf("parked terminal incomplete: %+v", parked)
+	}
+	if parked.Usage.InputTokens == 0 && parked.Usage.OutputTokens == 0 {
+		t.Fatalf("parked terminal carries no usage")
+	}
+
+	// Block-all: nothing executed, including the ungoverned sibling.
+	if got := f.tools["read_table"].runs.Load(); got != 0 {
+		t.Fatalf("read_table ran %d times before the decision", got)
+	}
+	if got := f.tools["export_csv"].runs.Load(); got != 0 {
+		t.Fatalf("export_csv ran %d times before the decision", got)
+	}
+
+	hr := f.pendingParked(t, "s-park")
+	if hr.ID != parked.RequestID || hr.Kind != "approval" || hr.RequestType != "parked" {
+		t.Fatalf("request shape wrong: %+v", hr)
+	}
+	// The ask item — and only the ask item — is bound into the request.
+	keys := paramKeys(hr)
+	if len(keys) != 1 || keys[0] != "c-write" {
+		t.Fatalf("params keys = %v, want [c-write]", keys)
+	}
+
+	// The durable tail is assistant(ToolCalls) with no tool rows.
+	msgs := rawSessionMessages(f.ag.memory.GetOrCreateSessionWithAgent(context.Background(), "s-park", f.ag.config.Name, ""))
+	last := msgs[len(msgs)-1]
+	if last.Role != "assistant" || len(last.ToolCalls) != 2 {
+		t.Fatalf("tail = %s with %d calls, want parked assistant batch", last.Role, len(last.ToolCalls))
+	}
+}
+
+func TestPark_ApproveResumeExecutesBatchAndContinues(t *testing.T) {
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, twoCallBatch(),
+		"read_table", "export_csv")
+	_, err := f.ag.Chat(context.Background(), "s-approve", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-approve")
+
+	resp, err := f.ag.ResumeChat(context.Background(), "s-approve", ParkDecision{
+		RequestID: hr.ID,
+		ItemIDs:   paramKeys(hr),
+		Approved:  true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("ResumeChat: %v", err)
+	}
+	if resp.Content != "continued" {
+		t.Fatalf("resume content = %q, want %q", resp.Content, "continued")
+	}
+	if got := f.tools["read_table"].runs.Load(); got != 1 {
+		t.Fatalf("read_table ran %d times, want 1", got)
+	}
+	if got := f.tools["export_csv"].runs.Load(); got != 1 {
+		t.Fatalf("export_csv ran %d times, want 1 (grant lifts the ask)", got)
+	}
+
+	// Pair atomicity restored with REAL rows, on the parked turn.
+	sess := f.ag.memory.GetOrCreateSessionWithAgent(context.Background(), "s-approve", f.ag.config.Name, "")
+	msgs := rawSessionMessages(sess)
+	var parkedTurn int64 = -1
+	rows := map[string]bool{}
+	for _, m := range msgs {
+		if m.Role == "assistant" && len(m.ToolCalls) == 2 {
+			parkedTurn = m.Turn
+		}
+		if m.Role == "tool" {
+			rows[m.ToolUseID] = true
+			if parkedTurn >= 0 && m.Turn != parkedTurn {
+				t.Fatalf("tool row %s landed on turn %d, want parked turn %d", m.ToolUseID, m.Turn, parkedTurn)
+			}
+		}
+	}
+	if !rows["c-read"] || !rows["c-write"] {
+		t.Fatalf("missing tool rows: %v", rows)
+	}
+}
+
+func TestPark_RejectResumeRefusesWholeBatchAndReplans(t *testing.T) {
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, twoCallBatch(),
+		"read_table", "export_csv")
+	_, err := f.ag.Chat(context.Background(), "s-reject", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-reject")
+
+	resp, err := f.ag.ResumeChat(context.Background(), "s-reject", ParkDecision{
+		RequestID: hr.ID,
+		ItemIDs:   paramKeys(hr),
+		Approved:  false,
+		Reason:    "rejected by user: wrong table",
+	}, nil)
+	if err != nil {
+		t.Fatalf("ResumeChat: %v", err)
+	}
+	if resp.Content != "continued" {
+		t.Fatalf("resume content = %q", resp.Content)
+	}
+	// Block-all covers the refusal: NO body ran, allow-classified included.
+	if got := f.tools["read_table"].runs.Load(); got != 0 {
+		t.Fatalf("read_table ran %d times on a rejected batch", got)
+	}
+	if got := f.tools["export_csv"].runs.Load(); got != 0 {
+		t.Fatalf("export_csv ran %d times on a rejected batch", got)
+	}
+	// Every call's row is the synthesized refusal with the verbatim reason.
+	sess := f.ag.memory.GetOrCreateSessionWithAgent(context.Background(), "s-reject", f.ag.config.Name, "")
+	refusals := 0
+	for _, m := range rawSessionMessages(sess) {
+		if m.Role == "tool" && m.ToolResult != nil && !m.ToolResult.Success &&
+			m.ToolResult.Error != nil && m.ToolResult.Error.Code == "permission_denied" {
+			if m.ToolResult.Error.Message != "rejected by user: wrong table" {
+				t.Fatalf("refusal reason = %q", m.ToolResult.Error.Message)
+			}
+			refusals++
+		}
+	}
+	if refusals != 2 {
+		t.Fatalf("refusal rows = %d, want 2", refusals)
+	}
+}
+
+func TestPark_QuestionItemCarriesAnswer(t *testing.T) {
+	script := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "c-q", Name: "contact_human", Input: map[string]interface{}{"question": "prod or staging?"}},
+		}},
+		{content: "using staging"},
+	}
+	// No hooks at all: a hooks-less agent with contact_human still parks.
+	f := newParkFixture(t, nil, script, "contact_human")
+
+	_, err := f.ag.Chat(context.Background(), "s-question", "deploy it")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-question")
+	desc, ok := hr.Params["c-q"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("question item descriptor missing: %#v", hr.Params)
+	}
+	if desc["kind"] != "question" || desc["question"] != "prod or staging?" {
+		t.Fatalf("descriptor = %#v", desc)
+	}
+	// contact_human's body never ran.
+	if got := f.tools["contact_human"].runs.Load(); got != 0 {
+		t.Fatalf("contact_human body ran %d times", got)
+	}
+
+	resp, err := f.ag.ResumeChat(context.Background(), "s-question", ParkDecision{
+		RequestID: hr.ID,
+		ItemIDs:   paramKeys(hr),
+		Approved:  true,
+		Answers:   map[string]string{"c-q": "staging"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("ResumeChat: %v", err)
+	}
+	if resp.Content != "using staging" {
+		t.Fatalf("content = %q", resp.Content)
+	}
+	sess := f.ag.memory.GetOrCreateSessionWithAgent(context.Background(), "s-question", f.ag.config.Name, "")
+	found := false
+	for _, m := range rawSessionMessages(sess) {
+		if m.Role == "tool" && m.ToolUseID == "c-q" {
+			found = true
+			data, _ := m.ToolResult.Data.(map[string]interface{})
+			if data["response"] != "staging" || data["responded_by"] != "user" {
+				t.Fatalf("answer row = %#v", data)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("no synthesized answer row")
+	}
+}
+
+func TestPark_DeniedContactHumanIsNotLifted(t *testing.T) {
+	script := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "c-q", Name: "contact_human", Input: map[string]interface{}{"question": "may I?"}},
+		}},
+		{content: "done without asking"},
+	}
+	f := newParkFixture(t, []shuttle.Hook{scopedDenyHook{tool: "contact_human"}}, script, "contact_human")
+
+	resp, err := f.ag.Chat(context.Background(), "s-denyq", "go")
+	if err != nil {
+		t.Fatalf("Chat: %v (a denied contact_human must not park)", err)
+	}
+	if resp.Content != "done without asking" {
+		t.Fatalf("content = %q", resp.Content)
+	}
+	if got := f.tools["contact_human"].runs.Load(); got != 0 {
+		t.Fatalf("denied contact_human body ran %d times", got)
+	}
+	// No request row was ever raised.
+	reqs, _ := f.store.ListBySession(context.Background(), "s-denyq")
+	if len(reqs) != 0 {
+		t.Fatalf("requests raised for a denied question: %d", len(reqs))
+	}
+}
+
+func TestPark_ResumeTerminals(t *testing.T) {
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, twoCallBatch(),
+		"read_table", "export_csv")
+	ctx := context.Background()
+	_, err := f.ag.Chat(ctx, "s-term", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-term")
+	sess := f.ag.memory.GetOrCreateSessionWithAgent(ctx, "s-term", f.ag.config.Name, "")
+
+	// Stale: item IDs not in the tail batch.
+	_, err = f.ag.ResumeChat(ctx, "s-term", ParkDecision{RequestID: hr.ID, ItemIDs: []string{"bogus"}, Approved: true}, nil)
+	if !errors.Is(err, ErrStaleDecision) {
+		t.Fatalf("stale resume = %v, want ErrStaleDecision", err)
+	}
+
+	// Same-turn user rows (in-turn machinery) do NOT refuse the resume.
+	f.ag.appendMessage(ctx, sess, Message{Role: "user", Content: "sidecar body", AgentID: f.ag.id}, false)
+	if _, _, lerr := locateParkedBatch(sess, paramKeys(hr)); lerr != nil {
+		t.Fatalf("same-turn user row refused resume: %v", lerr)
+	}
+
+	// A user row of a LATER turn means history moved on.
+	f.ag.appendMessage(ctx, sess, Message{Role: "user", Content: "new message", AgentID: f.ag.id}, true)
+	_, err = f.ag.ResumeChat(ctx, "s-term", ParkDecision{RequestID: hr.ID, ItemIDs: paramKeys(hr), Approved: true}, nil)
+	if !errors.Is(err, ErrNotParkedTail) {
+		t.Fatalf("moved-on resume = %v, want ErrNotParkedTail", err)
+	}
+
+	// A fully completed turn has nothing parked.
+	done := newParkFixture(t, nil, []mockLLMResponse{{content: "hi"}})
+	if _, err := done.ag.Chat(ctx, "s-done", "hello"); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	_, err = done.ag.ResumeChat(ctx, "s-done", ParkDecision{RequestID: "x", Approved: true}, nil)
+	if !errors.Is(err, ErrNothingParked) {
+		t.Fatalf("completed-turn resume = %v, want ErrNothingParked", err)
+	}
+}
+
+func TestPark_MissingAnswerSynthesizesFailure(t *testing.T) {
+	script := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "c-q", Name: "contact_human", Input: map[string]interface{}{"question": "which env?"}},
+		}},
+		{content: "recovered"},
+	}
+	f := newParkFixture(t, nil, script, "contact_human")
+	ctx := context.Background()
+	if _, err := f.ag.Chat(ctx, "s-noanswer", "go"); err == nil {
+		t.Fatalf("expected park")
+	}
+	hr := f.pendingParked(t, "s-noanswer")
+	if _, err := f.ag.ResumeChat(ctx, "s-noanswer", ParkDecision{
+		RequestID: hr.ID, ItemIDs: paramKeys(hr), Approved: true, Answers: nil,
+	}, nil); err != nil {
+		t.Fatalf("ResumeChat: %v", err)
+	}
+	sess := f.ag.memory.GetOrCreateSessionWithAgent(ctx, "s-noanswer", f.ag.config.Name, "")
+	for _, m := range rawSessionMessages(sess) {
+		if m.Role == "tool" && m.ToolUseID == "c-q" {
+			if m.ToolResult.Success || m.ToolResult.Error == nil || m.ToolResult.Error.Code != "MISSING_ANSWER" {
+				t.Fatalf("row = %#v, want MISSING_ANSWER failure", m.ToolResult)
+			}
+			return
+		}
+	}
+	t.Fatalf("no row for the unanswered question")
+}
+
+func TestPark_SummaryAndParamsBounded(t *testing.T) {
+	big := strings.Repeat("x", 10000)
+	script := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "c-big", Name: "export_csv", Input: map[string]interface{}{"v": big}},
+		}},
+		{content: "done"},
+	}
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, script, "export_csv")
+	if _, err := f.ag.Chat(context.Background(), "s-big", "go"); err == nil {
+		t.Fatalf("expected park")
+	}
+	hr := f.pendingParked(t, "s-big")
+	if !hr.ParamsTruncated {
+		t.Fatalf("oversized item did not set ParamsTruncated")
+	}
+	desc, _ := hr.Params["c-big"].(map[string]interface{})
+	if desc == nil || desc["tool"] != "export_csv" {
+		t.Fatalf("oversized item dropped from params: %#v", hr.Params)
+	}
+	if len([]rune(hr.Summary)) > 200 {
+		t.Fatalf("summary exceeds 200 runes: %d", len([]rune(hr.Summary)))
+	}
+}

--- a/pkg/agent/memory.go
+++ b/pkg/agent/memory.go
@@ -685,6 +685,14 @@ func (m *Memory) ClearAll() {
 	m.sessions = make(map[string]*Session)
 }
 
+// HasStore reports whether a persistent session store is configured. Every
+// Persist* method is a silent no-op returning nil without one, so a caller
+// that needs a message to be DURABLE — not merely "persisted without error" —
+// has to ask this separately. The HITL park pre-scan is the case: it may only
+// raise a durable request row for a batch that will still exist after a
+// restart.
+func (m *Memory) HasStore() bool { return m.store != nil }
+
 // PersistSession saves a session to persistent storage if configured.
 func (m *Memory) PersistSession(ctx context.Context, session *Session) error {
 	if m.store == nil {

--- a/pkg/agent/park.go
+++ b/pkg/agent/park.go
@@ -101,8 +101,8 @@ func (e *SessionParkedError) Error() string {
 	return fmt.Sprintf("session is waiting for a human decision (request %s)", e.RequestID)
 }
 
-// Typed terminals for ResumeChat callers. All three are terminal: the caller
-// must finish the request's lifecycle and never retry the resume.
+// Typed terminals for ResumeChat callers. All are terminal: the caller must
+// finish the request's lifecycle and never retry the resume.
 var (
 	// ErrNothingParked: the tail turn is fully complete — there is no batch to
 	// finish and no loop to re-enter.
@@ -113,20 +113,113 @@ var (
 	// ErrStaleDecision: the decision's item IDs do not all appear in the tail
 	// batch — it belongs to a batch that is no longer the tail.
 	ErrStaleDecision = errors.New("decision does not match the parked batch")
+	// ErrParkDisabled: ResumeChat was called on an agent with no park wiring.
+	// Completing a rowless tail batch under a grant would bypass whatever
+	// approval path that agent DOES have, so the entry point is closed.
+	ErrParkDisabled = errors.New("park is not enabled on this agent")
+	// ErrUnknownRequest: no pending parked request with that ID owns this
+	// session. Covers a missing row, a row from another session, and a
+	// non-parked request type — all indistinguishable to a caller by design.
+	ErrUnknownRequest = errors.New("no pending parked request for this session")
 )
 
-// ParkDecision is the human's verdict for one parked batch. ItemIDs are the
-// request's params keys — the ToolCall.IDs of the items the human saw;
-// ResumeChat refuses to apply the decision to any other batch. Reason is used
-// VERBATIM as the refusal text on every synthesized denial (the caller
-// composes it: "rejected by user: …", "approval timed out"). Answers maps
-// question-item ToolCall.IDs to answer text.
+// ParkDecision is the human's verdict for one parked batch.
+//
+// RequestID is the binding: ResumeChat loads that row and takes the batch's
+// item IDs from ITS params — a decision can only ever describe the batch its
+// request describes. ItemIDs is an OPTIONAL cross-check; when non-empty it
+// must name exactly the row's items or the resume is refused. It is never the
+// authority, because an empty or partial list would otherwise widen the
+// decision to calls the human never saw.
+//
+// Reason is used VERBATIM as the refusal text on every synthesized denial
+// (the caller composes it: "rejected by user: …"). Answers maps question-item
+// ToolCall.IDs to answer text.
 type ParkDecision struct {
 	RequestID string
 	ItemIDs   []string
 	Approved  bool
 	Reason    string
 	Answers   map[string]string
+}
+
+// loadParkedRequest resolves the decision's request to a pending parked row
+// that belongs to this session. Absence and mismatch collapse to one error:
+// a caller holding a wrong ID learns nothing about other sessions' requests.
+// Both a nil request and an error mean possibly-absent (the store interface's
+// documented contract — the postgres store returns (nil, nil) for a miss).
+func (a *Agent) loadParkedRequest(ctx context.Context, sessionID, requestID string) (*shuttle.HumanRequest, error) {
+	if requestID == "" {
+		return nil, ErrUnknownRequest
+	}
+	hr, err := a.hitlPark.store.Get(ctx, requestID)
+	if err != nil || hr == nil {
+		return nil, ErrUnknownRequest
+	}
+	if hr.SessionID != sessionID || hr.RequestType != "parked" {
+		return nil, ErrUnknownRequest
+	}
+	if hr.Status != "pending" {
+		// Already decided or closed: its batch has been completed once and
+		// re-applying would double-execute it.
+		return nil, ErrUnknownRequest
+	}
+	return hr, nil
+}
+
+// parkedItemIDs returns the request's item IDs — its params keys, which
+// buildParkParams writes one per park item, keyed by ToolCall.ID.
+func parkedItemIDs(hr *shuttle.HumanRequest) []string {
+	out := make([]string, 0, len(hr.Params))
+	for k := range hr.Params {
+		out = append(out, k)
+	}
+	return out
+}
+
+// sameIDSet reports whether two id lists describe the same set.
+func sameIDSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := make(map[string]bool, len(a))
+	for _, id := range a {
+		seen[id] = true
+	}
+	for _, id := range b {
+		if !seen[id] {
+			return false
+		}
+	}
+	return true
+}
+
+// closeParkedRequest terminally closes the row whose decision was just
+// applied. This is what keeps a session usable: guardParkedTail refuses a new
+// turn while a parked row is pending, so a decided batch whose row stays
+// pending would wedge the session for every later message.
+//
+// An expired row cannot be resolved — the store's expiry guard is its own and
+// no status payload lifts it — so it is closed through ExpireRequest, the one
+// path allowed to close past expiry. Close failures are logged, not returned:
+// the human's decision has already been applied to the batch, and failing the
+// resume would strand the turn it just completed.
+func (a *Agent) closeParkedRequest(ctx context.Context, hr *shuttle.HumanRequest, decision ParkDecision, expired bool) {
+	var err error
+	switch {
+	case expired:
+		err = a.hitlPark.store.ExpireRequest(ctx, hr.ID, "system:expiry")
+	case decision.Approved:
+		err = a.hitlPark.store.RespondToRequest(ctx, hr.ID, "approved", decision.Reason, "human", nil)
+	default:
+		err = a.hitlPark.store.RespondToRequest(ctx, hr.ID, "rejected", decision.Reason, "human", nil)
+	}
+	if err != nil {
+		zap.L().Error("parked request could not be closed; the session will refuse new turns until it is",
+			zap.String("session_id", hr.SessionID),
+			zap.String("request_id", hr.ID),
+			zap.Error(err))
+	}
 }
 
 // guardParkedTail refuses a new user turn while the session holds a PENDING
@@ -149,6 +242,43 @@ func (a *Agent) guardParkedTail(ctx context.Context, sessionID string) error {
 		}
 	}
 	return nil
+}
+
+// parkHandles hands the unfinished turn's session handles to whoever resumes
+// it. A parked turn spans two Go calls, but MCP session handles are scoped to
+// one call (pkg/mcp/adapter: "handles live for exactly one agent message
+// exchange"), so releasing at the park would kill handles the SAME turn is
+// still going to use after the human decides. Storing the live collector
+// keeps that scope honest across the gap. Only one turn per session can be
+// parked at a time — guardParkedTail enforces it — so one slot per session is
+// the whole contract.
+func (a *Agent) parkHandles(sessionID string, c *mcpadapter.HandleCollector) {
+	a.parkedHandlesMu.Lock()
+	defer a.parkedHandlesMu.Unlock()
+	if a.parkedHandles == nil {
+		a.parkedHandles = make(map[string]*mcpadapter.HandleCollector)
+	}
+	// A collector already parked for this session belongs to the same turn
+	// (the resume adopted it and is re-parking it); replacing it is a no-op
+	// in that case and never strands a second one.
+	a.parkedHandles[sessionID] = c
+}
+
+// adoptParkedHandles installs the parked turn's collector on ctx when one is
+// waiting, so handles minted before the park stay live through the resume and
+// are released once, at the end of the turn that actually finishes. With none
+// waiting it plants a fresh collector — a resume of a turn that minted no
+// handles behaves exactly like chat().
+func (a *Agent) adoptParkedHandles(ctx context.Context, sessionID string) (context.Context, *mcpadapter.HandleCollector) {
+	a.parkedHandlesMu.Lock()
+	c := a.parkedHandles[sessionID]
+	delete(a.parkedHandles, sessionID)
+	a.parkedHandlesMu.Unlock()
+
+	if c == nil {
+		return mcpadapter.WithHandleCollector(ctx)
+	}
+	return mcpadapter.ContextWithHandleCollector(ctx, c), c
 }
 
 // isParkQuestion reproduces the pre-scan's question classification at
@@ -209,15 +339,16 @@ func (a *Agent) maybeParkBatch(ctx Context, sess *Session, llmResp *LLMResponse)
 
 	now := time.Now()
 	params, truncated := buildParkParams(items)
+	kind, question := parkKindAndQuestion(items)
 	hr := &shuttle.HumanRequest{
 		ID:              uuid.New().String(),
 		AgentID:         a.id,
 		SessionID:       sess.ID,
-		Question:        fmt.Sprintf("Approve %d pending action(s)?", len(items)),
+		Question:        question,
 		Context:         map[string]interface{}{"kind": "parked"},
 		RequestType:     "parked",
 		Priority:        "normal",
-		Kind:            "approval",
+		Kind:            kind,
 		Summary:         parkSummary(items),
 		Timeout:         a.hitlPark.ttl,
 		CreatedAt:       now,
@@ -239,6 +370,27 @@ func (a *Agent) maybeParkBatch(ctx Context, sess *Session, llmResp *LLMResponse)
 		ExpiresAt: hr.ExpiresAt,
 		Usage:     llmResp.Usage,
 	}
+}
+
+// parkKindAndQuestion renders the card's Kind and headline. A card renderer
+// keys its shape off Kind, so a park whose items are ALL questions must not
+// arrive as an approval prompt — the human would be asked to approve/reject
+// where the model asked them something. A single question card carries the
+// model's own question verbatim; anything mixed is an approval over the batch.
+func parkKindAndQuestion(items []parkItem) (kind, question string) {
+	questions := 0
+	for _, it := range items {
+		if it.kind == "question" {
+			questions++
+		}
+	}
+	if questions == len(items) {
+		if len(items) == 1 && items[0].question != "" {
+			return "question", items[0].question
+		}
+		return "question", fmt.Sprintf("Answer %d pending question(s)", len(items))
+	}
+	return "approval", fmt.Sprintf("Approve %d pending action(s)?", len(items))
 }
 
 // parkParamsMaxBytes bounds the whole grouped-request params map. Per-item
@@ -317,12 +469,21 @@ func parkSummary(items []parkItem) string {
 // post-resume loop only — the parked batch's executions are authoritative in
 // the persisted tool rows and tool-execution records.
 func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkDecision, progressCallback types.ProgressCallback) (*Response, error) {
+	if a.hitlPark == nil {
+		return nil, ErrParkDisabled
+	}
 	ctx = session.WithSessionID(ctx, sessionID)
 
-	// Session-handle lifecycle: same ownership as chat() — handles minted
-	// during the resumed turn are auto-released when it ends.
-	ctx, handleCollector := mcpadapter.WithHandleCollector(ctx)
+	// Session-handle lifecycle: the resumed turn ADOPTS the handles its parked
+	// half minted, so a handle the model is about to use is still live. A
+	// nested park re-parks them (parkedHandles below); any other exit releases
+	// them, closing out the whole turn's handles exactly once.
+	ctx, handleCollector := a.adoptParkedHandles(ctx, sessionID)
+	parkedAgain := false
 	defer func() {
+		if parkedAgain {
+			return
+		}
 		a.leases.apply(sessionID, handleCollector.ReleaseAll(zap.L()), nil)
 	}()
 
@@ -350,15 +511,47 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 		progressCallback: progressCallback,
 	}
 
-	batch, rowless, err := locateParkedBatch(sess, decision.ItemIDs)
+	// The request row — not the caller's payload — is the batch binding. Its
+	// params keys ARE the items the human saw; a caller-supplied ItemIDs list
+	// is honored only as a cross-check.
+	hr, err := a.loadParkedRequest(ctx, sessionID, decision.RequestID)
+	if err != nil {
+		span.AddEvent("resume.refused", map[string]interface{}{"reason": err.Error()})
+		return nil, err
+	}
+	itemIDs := parkedItemIDs(hr)
+	if len(decision.ItemIDs) > 0 && !sameIDSet(decision.ItemIDs, itemIDs) {
+		span.AddEvent("resume.refused", map[string]interface{}{"reason": ErrStaleDecision.Error()})
+		return nil, ErrStaleDecision
+	}
+
+	// A decision that arrives past the row's expiry is applied as a refusal
+	// whatever it says: the window the human was granted has closed, and an
+	// approval must never execute on a lapsed authorization.
+	expired := !hr.ExpiresAt.IsZero() && time.Now().After(hr.ExpiresAt)
+	effective := decision
+	if expired {
+		effective.Approved = false
+		if effective.Reason == "" {
+			effective.Reason = "approval timed out"
+		}
+	}
+	span.SetAttribute("resume.expired", expired)
+
+	batch, rowless, err := locateParkedBatch(sess, itemIDs)
 	if err != nil {
 		span.AddEvent("resume.refused", map[string]interface{}{"reason": err.Error()})
 		return nil, err
 	}
 
 	if len(rowless) > 0 {
-		a.completeParkedBatch(agentCtx, sess, batch, rowless, decision)
+		a.completeParkedBatch(agentCtx, sess, batch, rowless, effective, itemIDs)
 	}
+
+	// Close the row the moment its decision has been applied — before the
+	// loop re-entry that may park a NEW request. A row left pending here
+	// wedges every later turn at guardParkedTail.
+	a.closeParkedRequest(ctx, hr, effective, expired)
 
 	response, err := a.runConversationLoop(agentCtx)
 
@@ -367,7 +560,10 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 		var parked *TurnParkedError
 		if errors.As(err, &parked) {
 			// A nested park is a clean exit, not a failure (same contract as
-			// chat()).
+			// chat()). The turn is still unfinished, so its handles are parked
+			// with it rather than released out from under the next resume.
+			parkedAgain = true
+			a.parkHandles(sessionID, handleCollector)
 			span.AddEvent("conversation.parked", map[string]interface{}{
 				"request_id":  parked.RequestID,
 				"duration_ms": duration.Milliseconds(),
@@ -413,12 +609,17 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 	return response, nil
 }
 
-// rawSessionMessages returns the session's L1 rows in append order — the
-// segmented store's raw view when configured, else the flat message list.
+// rawSessionMessages returns the session's L1 rows in append order.
+//
+// It reaches past types.Session.GetMessages on purpose: that one delegates to
+// GetMessagesForLLM when segmented memory is configured, which RENDERS the
+// context window (folding, pair synthesis). The tail walk must see the rows
+// as appended — a synthesized pair would read as a tool row that no call
+// actually produced. SegmentedMemory's own GetMessages is that raw view.
 func rawSessionMessages(sess *Session) []Message {
 	if sess.SegmentedMem != nil {
 		if sm, ok := sess.SegmentedMem.(*SegmentedMemory); ok && sm != nil {
-			return sm.RawMessages()
+			return sm.GetMessages()
 		}
 	}
 	return sess.GetMessages()
@@ -474,13 +675,23 @@ func locateParkedBatch(sess *Session, itemIDs []string) (Message, []ToolCall, er
 		}
 	}
 
+	// A final assistant reply means the turn ALREADY ended and the user has
+	// its answer — whether or not every call left a row. The loop can finish a
+	// turn with rowless calls (the MaxToolExecutions break stops dispatching
+	// without appending rows), and those calls were deliberately skipped:
+	// executing them now, under a grant, would run tool bodies the finished
+	// turn declined to run.
+	if finalReply {
+		return Message{}, nil, ErrNothingParked
+	}
+
 	var rowless []ToolCall
 	for _, c := range msgs[k].ToolCalls {
 		if !seenRows[c.ID] {
 			rowless = append(rowless, c)
 		}
 	}
-	if len(rowless) == 0 && finalReply {
+	if len(rowless) == 0 {
 		return Message{}, nil, ErrNothingParked
 	}
 	return msgs[k], rowless, nil
@@ -491,10 +702,15 @@ func locateParkedBatch(sess *Session, itemIDs []string) (Message, []ToolCall, er
 // permission_denied carrying the human's reason — no tool bodies run,
 // allow-classified calls included (block-all covers the refusal). Approved:
 // question items synthesize the human's answer as the contact_human result;
-// every other call executes through the normal dispatch ceremony under an
-// AskGrant scoped to this batch only — asks resolve to Allow, hard denials
-// still deny.
-func (a *Agent) completeParkedBatch(ctx Context, sess *Session, batch Message, rowless []ToolCall, decision ParkDecision) {
+// every other call executes through the normal dispatch ceremony.
+//
+// itemIDs are the calls the human's card actually described. ONLY those run
+// under the AskGrant: an approval answers the question it was asked, so a
+// call that was not on the card cannot borrow it. Calls outside the set
+// dispatch ungranted, so an ask that appeared while the turn waited — a host
+// gate that trips on budget, quota, or time of day — parks or fails closed
+// exactly as it would in a fresh turn instead of being silently admitted.
+func (a *Agent) completeParkedBatch(ctx Context, sess *Session, batch Message, rowless []ToolCall, decision ParkDecision, itemIDs []string) {
 	maxPerTurn := a.config.MaxIterations
 	if maxPerTurn <= 0 {
 		maxPerTurn = 10
@@ -534,6 +750,10 @@ func (a *Agent) completeParkedBatch(ctx Context, sess *Session, batch Message, r
 		tracer:           ctx.Tracer(),
 		progressCallback: ctx.ProgressCallback(),
 	}
+	granted := make(map[string]bool, len(itemIDs))
+	for _, id := range itemIDs {
+		granted[id] = true
+	}
 
 	for _, call := range rowless {
 		switch {
@@ -563,8 +783,10 @@ func (a *Agent) completeParkedBatch(ctx Context, sess *Session, batch Message, r
 					"status":       "responded",
 				},
 			}, st)
-		default:
+		case granted[call.ID]:
 			a.dispatchOneCall(grantCtx, sess, call, seqOf[call.ID], st)
+		default:
+			a.dispatchOneCall(ctx, sess, call, seqOf[call.ID], st)
 		}
 	}
 

--- a/pkg/agent/park.go
+++ b/pkg/agent/park.go
@@ -143,28 +143,39 @@ type ParkDecision struct {
 	Answers   map[string]string
 }
 
-// loadParkedRequest resolves the decision's request to a pending parked row
-// that belongs to this session. Absence and mismatch collapse to one error:
-// a caller holding a wrong ID learns nothing about other sessions' requests.
+// loadParkedRequest resolves the decision's request to a parked row that
+// belongs to this session. Absence and mismatch collapse to one error: a
+// caller holding a wrong ID learns nothing about other sessions' requests.
 // Both a nil request and an error mean possibly-absent (the store interface's
 // documented contract — the postgres store returns (nil, nil) for a miss).
-func (a *Agent) loadParkedRequest(ctx context.Context, sessionID, requestID string) (*shuttle.HumanRequest, error) {
+//
+// Two row states resume. A PENDING row is the standalone flow: ResumeChat is
+// the decision channel and closes the row after applying. A DECIDED row
+// (approved/rejected/timeout) is the embedder-recorded flow: the embedder's
+// respond door decided the row first — under its own expiry CAS — and the
+// resume applies that recorded verdict. Double-application is not guarded
+// here for either state; the tail walk is the guard (an applied batch has its
+// tool rows, so a replay lands in ErrNothingParked/ErrStaleDecision).
+func (a *Agent) loadParkedRequest(ctx context.Context, sessionID, requestID string) (hr *shuttle.HumanRequest, preDecided bool, err error) {
 	if requestID == "" {
-		return nil, ErrUnknownRequest
+		return nil, false, ErrUnknownRequest
 	}
-	hr, err := a.hitlPark.store.Get(ctx, requestID)
-	if err != nil || hr == nil {
-		return nil, ErrUnknownRequest
+	hr, gerr := a.hitlPark.store.Get(ctx, requestID)
+	if gerr != nil || hr == nil {
+		return nil, false, ErrUnknownRequest
 	}
 	if hr.SessionID != sessionID || hr.RequestType != "parked" {
-		return nil, ErrUnknownRequest
+		return nil, false, ErrUnknownRequest
 	}
-	if hr.Status != "pending" {
-		// Already decided or closed: its batch has been completed once and
-		// re-applying would double-execute it.
-		return nil, ErrUnknownRequest
+	switch hr.Status {
+	case "pending":
+		return hr, false, nil
+	case "approved", "rejected", "timeout":
+		return hr, true, nil
+	default:
+		// "responded" or anything else is not a park verdict.
+		return nil, false, ErrUnknownRequest
 	}
-	return hr, nil
 }
 
 // parkedItemIDs returns the request's item IDs — its params keys, which
@@ -259,43 +270,6 @@ func contextWithResumedTurn(ctx context.Context) context.Context {
 func isResumedTurn(ctx context.Context) bool {
 	v, _ := ctx.Value(resumedTurnKey{}).(bool)
 	return v
-}
-
-// parkHandles hands the unfinished turn's session handles to whoever resumes
-// it. A parked turn spans two Go calls, but MCP session handles are scoped to
-// one call (pkg/mcp/adapter: "handles live for exactly one agent message
-// exchange"), so releasing at the park would kill handles the SAME turn is
-// still going to use after the human decides. Storing the live collector
-// keeps that scope honest across the gap. Only one turn per session can be
-// parked at a time — guardParkedTail enforces it — so one slot per session is
-// the whole contract.
-func (a *Agent) parkHandles(sessionID string, c *mcpadapter.HandleCollector) {
-	a.parkedHandlesMu.Lock()
-	defer a.parkedHandlesMu.Unlock()
-	if a.parkedHandles == nil {
-		a.parkedHandles = make(map[string]*mcpadapter.HandleCollector)
-	}
-	// A collector already parked for this session belongs to the same turn
-	// (the resume adopted it and is re-parking it); replacing it is a no-op
-	// in that case and never strands a second one.
-	a.parkedHandles[sessionID] = c
-}
-
-// adoptParkedHandles installs the parked turn's collector on ctx when one is
-// waiting, so handles minted before the park stay live through the resume and
-// are released once, at the end of the turn that actually finishes. With none
-// waiting it plants a fresh collector — a resume of a turn that minted no
-// handles behaves exactly like chat().
-func (a *Agent) adoptParkedHandles(ctx context.Context, sessionID string) (context.Context, *mcpadapter.HandleCollector) {
-	a.parkedHandlesMu.Lock()
-	c := a.parkedHandles[sessionID]
-	delete(a.parkedHandles, sessionID)
-	a.parkedHandlesMu.Unlock()
-
-	if c == nil {
-		return mcpadapter.WithHandleCollector(ctx)
-	}
-	return mcpadapter.ContextWithHandleCollector(ctx, c), c
 }
 
 // isParkQuestion reproduces the pre-scan's question classification at
@@ -491,16 +465,15 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 	}
 	ctx = session.WithSessionID(ctx, sessionID)
 
-	// Session-handle lifecycle: the resumed turn ADOPTS the handles its parked
-	// half minted, so a handle the model is about to use is still live. A
-	// nested park re-parks them (parkedHandles below); any other exit releases
-	// them, closing out the whole turn's handles exactly once.
-	ctx, handleCollector := a.adoptParkedHandles(ctx, sessionID)
-	parkedAgain := false
+	// Session-handle lifecycle: same per-call ownership as chat() — handles
+	// minted during this call are released when it ends, park exits included.
+	// A parked turn spans calls, and in the pooled-embedder lifecycle (a
+	// fresh Agent per call) a collector carried across the gap would be
+	// unreachable by the next call — a leak, not a continuity. Handles are
+	// therefore scoped to the call everywhere, and a resumed turn re-mints on
+	// demand; cross-call handle continuity is an embedder-owned seam.
+	ctx, handleCollector := mcpadapter.WithHandleCollector(ctx)
 	defer func() {
-		if parkedAgain {
-			return
-		}
 		a.leases.apply(sessionID, handleCollector.ReleaseAll(zap.L()), nil)
 	}()
 
@@ -532,7 +505,7 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 	// The request row — not the caller's payload — is the batch binding. Its
 	// params keys ARE the items the human saw; a caller-supplied ItemIDs list
 	// is honored only as a cross-check.
-	hr, err := a.loadParkedRequest(ctx, sessionID, decision.RequestID)
+	hr, preDecided, err := a.loadParkedRequest(ctx, sessionID, decision.RequestID)
 	if err != nil {
 		span.AddEvent("resume.refused", map[string]interface{}{"reason": err.Error()})
 		return nil, err
@@ -543,18 +516,38 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 		return nil, ErrStaleDecision
 	}
 
-	// A decision that arrives past the row's expiry is applied as a refusal
-	// whatever it says: the window the human was granted has closed, and an
-	// approval must never execute on a lapsed authorization.
-	expired := !hr.ExpiresAt.IsZero() && time.Now().After(hr.ExpiresAt)
 	effective := decision
-	if expired {
-		effective.Approved = false
-		if effective.Reason == "" {
-			effective.Reason = "approval timed out"
+	expired := false
+	if preDecided {
+		// Embedder-recorded flow: the row IS the decision record — its status
+		// overrides the caller's payload, so a mismatched payload can never
+		// execute against a rejected row. Expiry was already judged by the
+		// respond door's decide-time CAS; a decision recorded in time is not
+		// re-judged at apply time, however much later the resume runs.
+		effective.Approved = hr.Status == "approved"
+		if !effective.Approved && effective.Reason == "" {
+			if hr.Status == "timeout" {
+				effective.Reason = "approval timed out"
+			} else {
+				effective.Reason = "rejected by user"
+			}
+		}
+	} else {
+		// Standalone flow: the decision arrives NOW, so apply time is decide
+		// time — one that arrives past the row's expiry is applied as a
+		// refusal whatever it says: the window the human was granted has
+		// closed, and an approval must never execute on a lapsed
+		// authorization.
+		expired = !hr.ExpiresAt.IsZero() && time.Now().After(hr.ExpiresAt)
+		if expired {
+			effective.Approved = false
+			if effective.Reason == "" {
+				effective.Reason = "approval timed out"
+			}
 		}
 	}
 	span.SetAttribute("resume.expired", expired)
+	span.SetAttribute("resume.pre_decided", preDecided)
 
 	batch, rowless, err := locateParkedBatch(sess, itemIDs)
 	if err != nil {
@@ -568,8 +561,11 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 
 	// Close the row the moment its decision has been applied — before the
 	// loop re-entry that may park a NEW request. A row left pending here
-	// wedges every later turn at guardParkedTail.
-	a.closeParkedRequest(ctx, hr, effective, expired)
+	// wedges every later turn at guardParkedTail. A pre-decided row is
+	// already closed (the embedder's respond door decided it).
+	if !preDecided {
+		a.closeParkedRequest(ctx, hr, effective, expired)
+	}
 
 	response, err := a.runConversationLoop(agentCtx)
 
@@ -578,10 +574,7 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 		var parked *TurnParkedError
 		if errors.As(err, &parked) {
 			// A nested park is a clean exit, not a failure (same contract as
-			// chat()). The turn is still unfinished, so its handles are parked
-			// with it rather than released out from under the next resume.
-			parkedAgain = true
-			a.parkHandles(sessionID, handleCollector)
+			// chat()).
 			span.AddEvent("conversation.parked", map[string]interface{}{
 				"request_id":  parked.RequestID,
 				"duration_ms": duration.Milliseconds(),

--- a/pkg/agent/park.go
+++ b/pkg/agent/park.go
@@ -188,6 +188,42 @@ func parkedItemIDs(hr *shuttle.HumanRequest) []string {
 	return out
 }
 
+// verifyItemBinding checks that every request item still DESCRIBES the tail
+// call it names: same tool, and same batch position when the descriptor
+// carries one. The subset check upstream only proves the IDs exist in the
+// batch — with per-response counter IDs two different batches can share IDs,
+// and an old decision must never execute a new batch's calls by collision.
+func verifyItemBinding(hr *shuttle.HumanRequest, batch Message) error {
+	byID := make(map[string]int, len(batch.ToolCalls))
+	for i, c := range batch.ToolCalls {
+		byID[c.ID] = i
+	}
+	for id, raw := range hr.Params {
+		desc, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		idx, inBatch := byID[id]
+		if !inBatch {
+			continue // subset check upstream already refused if required
+		}
+		if tool, _ := desc["tool"].(string); tool != "" && tool != batch.ToolCalls[idx].Name {
+			return ErrStaleDecision
+		}
+		switch seq := desc["seq"].(type) {
+		case int:
+			if seq != idx {
+				return ErrStaleDecision
+			}
+		case float64: // JSON round-trip through a persistent store
+			if int(seq) != idx {
+				return ErrStaleDecision
+			}
+		}
+	}
+	return nil
+}
+
 // sameIDSet reports whether two id lists describe the same set.
 func sameIDSet(a, b []string) bool {
 	if len(a) != len(b) {
@@ -554,6 +590,15 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 		span.AddEvent("resume.refused", map[string]interface{}{"reason": err.Error()})
 		return nil, err
 	}
+	// Content binding, not ID binding alone: LLM-assigned call IDs can
+	// collide across batches (per-response counters), so an old request's
+	// item could name a NEW batch's call by accident. Each item's recorded
+	// tool (and seq, when present) must match the tail call it names, or the
+	// decision belongs to a different batch.
+	if bindErr := verifyItemBinding(hr, batch); bindErr != nil {
+		span.AddEvent("resume.refused", map[string]interface{}{"reason": bindErr.Error()})
+		return nil, bindErr
+	}
 
 	if len(rowless) > 0 {
 		a.completeParkedBatch(agentCtx, sess, batch, rowless, effective, itemIDs)
@@ -704,9 +749,11 @@ func locateParkedBatch(sess *Session, itemIDs []string) (Message, []ToolCall, er
 			rowless = append(rowless, c)
 		}
 	}
-	if len(rowless) == 0 {
-		return Message{}, nil, ErrNothingParked
-	}
+	// Every row present but NO final reply: the batch was applied and the
+	// turn died before its continuation (LLM outage, crash). Nothing to
+	// complete — but this is not "already complete": the loop must re-enter
+	// so the model sees the results and produces the turn's answer. Refusing
+	// here would strand the turn's answer permanently.
 	return msgs[k], rowless, nil
 }
 

--- a/pkg/agent/park.go
+++ b/pkg/agent/park.go
@@ -1,0 +1,550 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package agent
+
+// HITL park-and-resume. A tool batch that needs a human decision ends the
+// turn instead of holding it open: the pre-scan (maybeParkBatch) runs before
+// anything in the batch executes, persists ONE grouped human request for the
+// whole batch, and returns TurnParkedError. The turn's durable tail is then
+// …, user, assistant(ToolCalls) with no tool rows for the parked batch.
+// ResumeChat is the missing entry point that continues that turn without
+// appending a user message: it completes (or refuses) the parked batch under
+// the human's decision and re-enters the conversation loop.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	mcpadapter "github.com/teradata-labs/loom/pkg/mcp/adapter"
+	"github.com/teradata-labs/loom/pkg/observability"
+	"github.com/teradata-labs/loom/pkg/session"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+	"github.com/teradata-labs/loom/pkg/types"
+)
+
+// hitlParkConfig is the park wiring an embedder installs via WithHITLPark.
+type hitlParkConfig struct {
+	store    shuttle.HumanRequestStore
+	ttl      time.Duration
+	notifier shuttle.Notifier
+}
+
+// defaultParkTTL bounds how long a parked request may wait for a decision
+// when the embedder passes a non-positive ttl. A zero-expiry pending row is
+// uninsertable and undecidable at the stores' guards, so "no expiry" is not
+// offered.
+const defaultParkTTL = 168 * time.Hour
+
+// WithHITLPark enables park-and-resume for governed calls and contact_human.
+// store persists the grouped request; ttl bounds how long a parked request
+// may wait for a decision (non-positive → 168h); notifier emits the pending
+// event. A nil store leaves park disabled and the legacy in-turn resolver
+// path intact.
+func WithHITLPark(store shuttle.HumanRequestStore, ttl time.Duration, notifier shuttle.Notifier) Option {
+	return func(a *Agent) {
+		if store == nil {
+			return
+		}
+		if ttl <= 0 {
+			ttl = defaultParkTTL
+		}
+		a.hitlPark = &hitlParkConfig{store: store, ttl: ttl, notifier: notifier}
+	}
+}
+
+// TurnParkedError ends a turn that needs a human decision. The turn's tail in
+// the session store is …, user, assistant(ToolCalls) — no tool rows for the
+// parked batch. ResumeChat completes the pair set and continues the loop.
+// Usage carries the parking LLM response's usage (the same last-response
+// semantics Response.Usage has) so the embedder can complete its execution
+// accounting.
+type TurnParkedError struct {
+	RequestID string
+	SessionID string
+	ExpiresAt time.Time
+	Usage     Usage
+}
+
+func (e *TurnParkedError) Error() string {
+	return fmt.Sprintf("turn parked awaiting human decision (request %s)", e.RequestID)
+}
+
+// Typed terminals for ResumeChat callers. All three are terminal: the caller
+// must finish the request's lifecycle and never retry the resume.
+var (
+	// ErrNothingParked: the tail turn is fully complete — there is no batch to
+	// finish and no loop to re-enter.
+	ErrNothingParked = errors.New("nothing parked: the turn is already complete")
+	// ErrNotParkedTail: a user message of a later turn follows the parked
+	// batch — history moved on and the decision can no longer be applied.
+	ErrNotParkedTail = errors.New("parked batch is no longer the session tail")
+	// ErrStaleDecision: the decision's item IDs do not all appear in the tail
+	// batch — it belongs to a batch that is no longer the tail.
+	ErrStaleDecision = errors.New("decision does not match the parked batch")
+)
+
+// ParkDecision is the human's verdict for one parked batch. ItemIDs are the
+// request's params keys — the ToolCall.IDs of the items the human saw;
+// ResumeChat refuses to apply the decision to any other batch. Reason is used
+// VERBATIM as the refusal text on every synthesized denial (the caller
+// composes it: "rejected by user: …", "approval timed out"). Answers maps
+// question-item ToolCall.IDs to answer text.
+type ParkDecision struct {
+	RequestID string
+	ItemIDs   []string
+	Approved  bool
+	Reason    string
+	Answers   map[string]string
+}
+
+// parkItem is one batch call needing a human: an approval-gated call or a
+// contact_human question.
+type parkItem struct {
+	call     ToolCall
+	seq      int
+	kind     string // "approval" | "question"
+	question string
+}
+
+// maybeParkBatch is the pre-scan: every call of the batch — contact_human
+// included — is preflighted; a Deny is never lifted (the call falls to the
+// dispatch loop and denies as today), a contact_human survives as a question
+// item, an Ask as an approval item. With no items it returns nil and the
+// serial dispatch loop runs exactly as today. With items it persists ONE
+// grouped request and ends the turn with TurnParkedError.
+func (a *Agent) maybeParkBatch(ctx Context, sess *Session, llmResp *LLMResponse) error {
+	var items []parkItem
+	for i, call := range llmResp.ToolCalls {
+		d := a.executor.Preflight(ctx, call.Name, call.Input)
+		if d.Kind == shuttle.Deny {
+			continue
+		}
+		if call.Name == "contact_human" {
+			// Unregistered contact_human keeps today's "tool not found" at
+			// execution.
+			if _, ok := a.tools.Get("contact_human"); !ok {
+				continue
+			}
+			info := extractHITLInfo(call.Input)
+			items = append(items, parkItem{call: call, seq: i, kind: "question", question: info.Question})
+			continue
+		}
+		if d.Kind == shuttle.Ask {
+			items = append(items, parkItem{call: call, seq: i, kind: "approval"})
+		}
+	}
+	if len(items) == 0 {
+		return nil
+	}
+
+	now := time.Now()
+	params, truncated := buildParkParams(items)
+	hr := &shuttle.HumanRequest{
+		ID:              uuid.New().String(),
+		AgentID:         a.id,
+		SessionID:       sess.ID,
+		Question:        fmt.Sprintf("Approve %d pending action(s)?", len(items)),
+		Context:         map[string]interface{}{"kind": "parked"},
+		RequestType:     "parked",
+		Priority:        "normal",
+		Kind:            "approval",
+		Summary:         parkSummary(items),
+		Timeout:         a.hitlPark.ttl,
+		CreatedAt:       now,
+		ExpiresAt:       now.Add(a.hitlPark.ttl),
+		Params:          params,
+		ParamsTruncated: truncated,
+		Status:          "pending",
+	}
+	if err := a.hitlPark.store.Store(ctx, hr); err != nil {
+		// A park that isn't durable must not pretend to park.
+		return fmt.Errorf("parking turn: persisting human request: %w", err)
+	}
+	if a.hitlPark.notifier != nil {
+		_ = a.hitlPark.notifier.Notify(ctx, hr)
+	}
+	return &TurnParkedError{
+		RequestID: hr.ID,
+		SessionID: sess.ID,
+		ExpiresAt: hr.ExpiresAt,
+		Usage:     llmResp.Usage,
+	}
+}
+
+// parkParamsMaxBytes bounds the whole grouped-request params map. Per-item
+// bodies are bounded at shuttle's per-call 8 KB first; items are never
+// dropped — an over-budget item degrades to its display digest.
+const parkParamsMaxBytes = 65536
+
+// buildParkParams renders one descriptor per item, keyed by the item's
+// ToolCall.ID — the batch↔request binding the resume validates.
+func buildParkParams(items []parkItem) (map[string]interface{}, bool) {
+	truncated := false
+	out := make(map[string]interface{}, len(items))
+	for _, it := range items {
+		desc := map[string]interface{}{
+			"seq":  it.seq,
+			"kind": it.kind,
+			"tool": it.call.Name,
+		}
+		bp, cut := shuttle.BoundParams(it.call.Input)
+		if cut {
+			truncated = true
+			desc["params"] = shuttle.SummarizeCall(it.call.Name, it.call.Input)
+			desc["params_truncated"] = true
+		} else {
+			desc["params"] = bp
+		}
+		if it.kind == "question" {
+			desc["question"] = it.question
+		}
+		out[it.call.ID] = desc
+	}
+	if enc, err := json.Marshal(out); err == nil && len(enc) <= parkParamsMaxBytes {
+		return out, truncated
+	}
+	// Whole-map overflow: degrade item bodies to digests in batch order until
+	// the map fits. Items are never dropped — the card must show every action.
+	for _, it := range items {
+		desc, ok := out[it.call.ID].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if _, alreadyDigest := desc["params"].(string); alreadyDigest {
+			continue
+		}
+		desc["params"] = shuttle.SummarizeCall(it.call.Name, it.call.Input)
+		desc["params_truncated"] = true
+		truncated = true
+		if enc, err := json.Marshal(out); err == nil && len(enc) <= parkParamsMaxBytes {
+			break
+		}
+	}
+	return out, truncated
+}
+
+// parkSummary renders the ordered "tool: digest" list, bounded to the same
+// 200-rune display cap the single-call resolver uses.
+func parkSummary(items []parkItem) string {
+	s := ""
+	for i, it := range items {
+		if i > 0 {
+			s += "; "
+		}
+		s += shuttle.SummarizeCall(it.call.Name, it.call.Input)
+	}
+	r := []rune(s)
+	if len(r) > 200 {
+		return string(r[:200])
+	}
+	return s
+}
+
+// ResumeChat continues a parked turn: executes (or refuses) the parked batch
+// under decision, then re-enters the conversation loop. It appends NO user
+// message; the loop budget restarts (caps bound runaway model loops, not
+// human patience). Response.ToolExecutions on a resumed turn covers the
+// post-resume loop only — the parked batch's executions are authoritative in
+// the persisted tool rows and tool-execution records.
+func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkDecision, progressCallback types.ProgressCallback) (*Response, error) {
+	ctx = session.WithSessionID(ctx, sessionID)
+
+	// Session-handle lifecycle: same ownership as chat() — handles minted
+	// during the resumed turn are auto-released when it ends.
+	ctx, handleCollector := mcpadapter.WithHandleCollector(ctx)
+	defer func() {
+		a.leases.apply(sessionID, handleCollector.ReleaseAll(zap.L()), nil)
+	}()
+
+	startTime := time.Now()
+	ctx, span := a.tracer.StartSpan(ctx, "agent.conversation.resume")
+	defer a.tracer.EndSpan(span)
+	span.SetAttribute(observability.AttrSessionID, sessionID)
+	span.SetAttribute("resume.request_id", decision.RequestID)
+	span.SetAttribute("resume.approved", decision.Approved)
+
+	sess := a.memory.GetOrCreateSessionWithAgent(ctx, sessionID, a.config.Name, "")
+	a.seedLeaseHolding(ctx, sessionID)
+
+	// NO DropTurnPayloads / dropInTurnSQLite — the parked turn is still the
+	// current turn. NO user append — resuming is not a new turn. NO graph
+	// extraction goroutine — there is no new user message to extract from.
+
+	if progressCallback != nil {
+		ctx = ContextWithProgressCallback(ctx, progressCallback)
+	}
+	agentCtx := &agentContext{
+		Context:          ctx,
+		session:          sess,
+		tracer:           a.tracer,
+		progressCallback: progressCallback,
+	}
+
+	batch, rowless, err := locateParkedBatch(sess, decision.ItemIDs)
+	if err != nil {
+		span.AddEvent("resume.refused", map[string]interface{}{"reason": err.Error()})
+		return nil, err
+	}
+
+	if len(rowless) > 0 {
+		a.completeParkedBatch(agentCtx, sess, batch, rowless, decision)
+	}
+
+	response, err := a.runConversationLoop(agentCtx)
+
+	duration := time.Since(startTime)
+	if err != nil {
+		var parked *TurnParkedError
+		if errors.As(err, &parked) {
+			// A nested park is a clean exit, not a failure (same contract as
+			// chat()).
+			span.AddEvent("conversation.parked", map[string]interface{}{
+				"request_id":  parked.RequestID,
+				"duration_ms": duration.Milliseconds(),
+			})
+			if perr := a.memory.PersistSession(ctx, sess); perr != nil {
+				zap.L().Warn("Failed to persist session at park",
+					zap.String("session_id", sessionID), zap.Error(perr))
+			}
+			return nil, parked
+		}
+		span.Status = observability.Status{Code: observability.StatusError, Message: err.Error()}
+		span.AddEvent("conversation.failed", map[string]interface{}{
+			"error":       err.Error(),
+			"duration_ms": duration.Milliseconds(),
+		})
+		if progressCallback != nil {
+			progressCallback(ProgressEvent{
+				Stage:     StageFailed,
+				Progress:  0,
+				Message:   fmt.Sprintf("Execution failed: %v", err),
+				Timestamp: time.Now(),
+			})
+		}
+		return nil, fmt.Errorf("conversation loop failed: %w", err)
+	}
+
+	a.appendMessage(ctx, sess, Message{
+		Role:       "assistant",
+		Content:    response.Content,
+		AgentID:    a.id,
+		Timestamp:  time.Now(),
+		TokenCount: response.Usage.TotalTokens,
+		CostUSD:    response.Usage.CostUSD,
+	}, false)
+
+	if err := a.memory.PersistSession(ctx, sess); err != nil {
+		zap.L().Warn("Failed to persist session",
+			zap.String("session_id", sessionID), zap.Error(err))
+		span.RecordError(err)
+	}
+
+	span.SetAttribute("conversation.duration_ms", duration.Milliseconds())
+	return response, nil
+}
+
+// rawSessionMessages returns the session's L1 rows in append order — the
+// segmented store's raw view when configured, else the flat message list.
+func rawSessionMessages(sess *Session) []Message {
+	if sess.SegmentedMem != nil {
+		if sm, ok := sess.SegmentedMem.(*SegmentedMemory); ok && sm != nil {
+			return sm.RawMessages()
+		}
+	}
+	return sess.GetMessages()
+}
+
+// locateParkedBatch finds the tail tool batch and validates the decision
+// against it. The walk is turn-aware: the loop itself appends user-role rows
+// WITHIN a turn (sidecar drain, empty-response nudge, hygiene fixup,
+// synthesis prompt), all stamped with the current turn; only a user row of a
+// LATER turn — the sole turn-incrementing append — means history moved on.
+func locateParkedBatch(sess *Session, itemIDs []string) (Message, []ToolCall, error) {
+	msgs := rawSessionMessages(sess)
+
+	k := -1
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role == "assistant" && len(msgs[i].ToolCalls) > 0 {
+			k = i
+			break
+		}
+	}
+	if k < 0 {
+		return Message{}, nil, ErrNothingParked
+	}
+	parkedTurn := msgs[k].Turn
+
+	seenRows := make(map[string]bool)
+	finalReply := false
+	for _, m := range msgs[k+1:] {
+		switch m.Role {
+		case "user":
+			if m.Turn > parkedTurn {
+				return Message{}, nil, ErrNotParkedTail
+			}
+			// Same-turn user rows are in-turn machinery — skip.
+		case "tool":
+			if m.ToolUseID != "" {
+				seenRows[m.ToolUseID] = true
+			}
+		case "assistant":
+			if len(m.ToolCalls) == 0 {
+				finalReply = true
+			}
+		}
+	}
+
+	callIDs := make(map[string]bool, len(msgs[k].ToolCalls))
+	for _, c := range msgs[k].ToolCalls {
+		callIDs[c.ID] = true
+	}
+	for _, id := range itemIDs {
+		if !callIDs[id] {
+			return Message{}, nil, ErrStaleDecision
+		}
+	}
+
+	var rowless []ToolCall
+	for _, c := range msgs[k].ToolCalls {
+		if !seenRows[c.ID] {
+			rowless = append(rowless, c)
+		}
+	}
+	if len(rowless) == 0 && finalReply {
+		return Message{}, nil, ErrNothingParked
+	}
+	return msgs[k], rowless, nil
+}
+
+// completeParkedBatch finishes the parked batch's tool_use↔tool_result pairs
+// in original batch order. Rejected: every rowless call gets a synthesized
+// permission_denied carrying the human's reason — no tool bodies run,
+// allow-classified calls included (block-all covers the refusal). Approved:
+// question items synthesize the human's answer as the contact_human result;
+// every other call executes through the normal dispatch ceremony under an
+// AskGrant scoped to this batch only — asks resolve to Allow, hard denials
+// still deny.
+func (a *Agent) completeParkedBatch(ctx Context, sess *Session, batch Message, rowless []ToolCall, decision ParkDecision) {
+	maxPerTurn := a.config.MaxIterations
+	if maxPerTurn <= 0 {
+		maxPerTurn = 10
+	}
+	resumeExecCount := 0
+	var resumeExecs []ToolExecution
+	tools := a.advertisedTools(sess)
+	var recovery *recoveryOrchestrator
+	_, span := ctx.Tracer().StartSpan(ctx, "agent.resume_batch")
+	defer ctx.Tracer().EndSpan(span)
+	if a.config.EnableSelfHealing {
+		recovery = newRecoveryOrchestrator(a.config.RecoveryConfig, span)
+	}
+	st := &batchState{
+		span:               span,
+		turnCount:          0,
+		batchLen:           len(batch.ToolCalls),
+		maxPerTurn:         maxPerTurn,
+		toolExecutionCount: &resumeExecCount,
+		allToolExecutions:  &resumeExecs,
+		tools:              &tools,
+		recovery:           recovery,
+		turnDedup:          make(map[string]*shuttle.Result),
+	}
+
+	seqOf := make(map[string]int, len(batch.ToolCalls))
+	for i, c := range batch.ToolCalls {
+		seqOf[c.ID] = i
+	}
+
+	// The grant lives only on this derived context — step 4's loop re-entry
+	// runs on the original ctx, so a NEW ask in the continuation parks again
+	// instead of inheriting the old approval.
+	grantCtx := &agentContext{
+		Context:          shuttle.ContextWithAskGrant(ctx, &shuttle.AskGrant{Approved: true}),
+		session:          sess,
+		tracer:           ctx.Tracer(),
+		progressCallback: ctx.ProgressCallback(),
+	}
+
+	for _, call := range rowless {
+		switch {
+		case !decision.Approved:
+			reason := decision.Reason
+			if reason == "" {
+				reason = "rejected by user"
+			}
+			a.synthesizeParkedResult(ctx, sess, call, &shuttle.Result{
+				Success: false,
+				Error:   &shuttle.Error{Code: "permission_denied", Message: reason, Retryable: false},
+			}, st)
+		case call.Name == "contact_human":
+			answer, ok := decision.Answers[call.ID]
+			if !ok || answer == "" {
+				a.synthesizeParkedResult(ctx, sess, call, &shuttle.Result{
+					Success: false,
+					Error:   &shuttle.Error{Code: "MISSING_ANSWER", Message: "no answer was provided for this question", Retryable: false},
+				}, st)
+				continue
+			}
+			a.synthesizeParkedResult(ctx, sess, call, &shuttle.Result{
+				Success: true,
+				Data: map[string]interface{}{
+					"response":     answer,
+					"responded_by": "user",
+					"status":       "responded",
+				},
+			}, st)
+		default:
+			a.dispatchOneCall(grantCtx, sess, call, seqOf[call.ID], st)
+		}
+	}
+
+	// Drain buffered text_body sidecars AFTER every tool_result of the batch
+	// is in place — the same pairing rule the loop's drain protects.
+	for _, sidecar := range st.pendingSidecars {
+		a.appendMessage(ctx, sess, sidecar, false)
+	}
+}
+
+// synthesizeParkedResult appends a decision-synthesized result as the call's
+// tool row with the normal persistence and progress ceremony, without running
+// any tool body.
+func (a *Agent) synthesizeParkedResult(ctx Context, sess *Session, call ToolCall, res *shuttle.Result, st *batchState) {
+	execution := ToolExecution{
+		ToolName: call.Name,
+		Input:    call.Input,
+		Result:   res,
+	}
+	*st.allToolExecutions = append(*st.allToolExecutions, execution)
+	emitToolCompleted(ctx, 60, call, res, nil)
+	if persistErr := a.memory.PersistToolExecution(ctx, sess.ID, execution); persistErr != nil {
+		zap.L().Warn("Failed to persist synthesized tool execution",
+			zap.String("session_id", sess.ID),
+			zap.String("tool", call.Name),
+			zap.Error(persistErr))
+	}
+	a.appendMessage(ctx, sess, Message{
+		Role:       "tool",
+		Content:    a.formatToolResult(ctx, sess.ID, call.Name, res, nil),
+		ToolUseID:  call.ID,
+		ToolResult: res,
+		AgentID:    a.id,
+		Timestamp:  time.Now(),
+	}, false)
+}

--- a/pkg/agent/park.go
+++ b/pkg/agent/park.go
@@ -86,6 +86,21 @@ func (e *TurnParkedError) Error() string {
 	return fmt.Sprintf("turn parked awaiting human decision (request %s)", e.RequestID)
 }
 
+// SessionParkedError refuses a NEW user turn while a pending parked decision
+// owns the session tail. Appending the turn would bury the parked batch and
+// the decision could never be applied. Raised at the append point — the
+// authoritative last moment — because the embedder's admission-time probe
+// races the park row, which is written mid-turn.
+type SessionParkedError struct {
+	RequestID string
+	SessionID string
+	ExpiresAt time.Time
+}
+
+func (e *SessionParkedError) Error() string {
+	return fmt.Sprintf("session is waiting for a human decision (request %s)", e.RequestID)
+}
+
 // Typed terminals for ResumeChat callers. All three are terminal: the caller
 // must finish the request's lifecycle and never retry the resume.
 var (
@@ -112,6 +127,44 @@ type ParkDecision struct {
 	Approved  bool
 	Reason    string
 	Answers   map[string]string
+}
+
+// guardParkedTail refuses a new user turn while the session holds a PENDING
+// parked request. Store errors fail open with a warn — the embedder's own
+// admission probe is the primary gate; this guard closes its race with a park
+// landing mid-turn, and must not turn a store hiccup into a dead session.
+func (a *Agent) guardParkedTail(ctx context.Context, sessionID string) error {
+	if a.hitlPark == nil {
+		return nil
+	}
+	reqs, err := a.hitlPark.store.ListBySession(ctx, sessionID)
+	if err != nil {
+		zap.L().Warn("parked-tail guard: listing session requests failed; admitting turn",
+			zap.String("session_id", sessionID), zap.Error(err))
+		return nil
+	}
+	for _, r := range reqs {
+		if r != nil && r.RequestType == "parked" && r.Status == "pending" {
+			return &SessionParkedError{RequestID: r.ID, SessionID: sessionID, ExpiresAt: r.ExpiresAt}
+		}
+	}
+	return nil
+}
+
+// isParkQuestion reproduces the pre-scan's question classification at
+// completion time: a registered contact_human whose preflight verdict is not
+// Deny. A contact_human that fails this — policy-denied, or unregistered —
+// was deliberately NOT a park item and must complete through the normal
+// dispatch ceremony (policy denial, "tool not found"), never through answer
+// synthesis: a caller-supplied answer for it would lift a Deny.
+func (a *Agent) isParkQuestion(ctx Context, call ToolCall) bool {
+	if call.Name != "contact_human" {
+		return false
+	}
+	if _, ok := a.tools.Get("contact_human"); !ok {
+		return false
+	}
+	return a.executor.Preflight(ctx, call.Name, call.Input).Kind != shuttle.Deny
 }
 
 // parkItem is one batch call needing a human: an approval-gated call or a
@@ -493,7 +546,7 @@ func (a *Agent) completeParkedBatch(ctx Context, sess *Session, batch Message, r
 				Success: false,
 				Error:   &shuttle.Error{Code: "permission_denied", Message: reason, Retryable: false},
 			}, st)
-		case call.Name == "contact_human":
+		case a.isParkQuestion(ctx, call):
 			answer, ok := decision.Answers[call.ID]
 			if !ok || answer == "" {
 				a.synthesizeParkedResult(ctx, sess, call, &shuttle.Result{

--- a/pkg/agent/park.go
+++ b/pkg/agent/park.go
@@ -308,6 +308,53 @@ func isResumedTurn(ctx context.Context) bool {
 	return v
 }
 
+// parkHandles hands the unfinished turn's session handles to whoever resumes
+// it in this process. A parked turn spans two Go calls, and releasing at the
+// park would kill handles the SAME turn is still going to use after the
+// human decides. One slot per session — guardParkedTail admits one parked
+// turn at a time; a re-park by a resume replaces its own adopted collector.
+func (a *Agent) parkHandles(sessionID string, c *mcpadapter.HandleCollector) {
+	a.parkedHandlesMu.Lock()
+	defer a.parkedHandlesMu.Unlock()
+	if a.parkedHandles == nil {
+		a.parkedHandles = make(map[string]*mcpadapter.HandleCollector)
+	}
+	a.parkedHandles[sessionID] = c
+}
+
+// adoptParkedHandles installs the parked turn's collector on ctx when one is
+// waiting, so handles minted before the park stay live through the resume and
+// are released once, at the end of the turn that actually finishes. With none
+// waiting it plants a fresh collector — a resume in a fresh Agent (pooled
+// embedder) or of a turn that minted no handles behaves exactly like chat().
+func (a *Agent) adoptParkedHandles(ctx context.Context, sessionID string) (context.Context, *mcpadapter.HandleCollector) {
+	a.parkedHandlesMu.Lock()
+	c := a.parkedHandles[sessionID]
+	delete(a.parkedHandles, sessionID)
+	a.parkedHandlesMu.Unlock()
+
+	if c == nil {
+		return mcpadapter.WithHandleCollector(ctx)
+	}
+	return mcpadapter.ContextWithHandleCollector(ctx, c), c
+}
+
+// ReleaseParkedHandles is the pooled-embedder seam: an embedder whose Agent
+// instances do not outlive the call adopts nothing at resume, so a parked
+// collector would be unreachable and its handles would leak. Such an embedder
+// calls this at each park terminal to keep handles call-scoped (the resumed
+// turn re-mints on demand). Same-process embedders never call it and keep
+// handle continuity across the gap. No-op when nothing is parked.
+func (a *Agent) ReleaseParkedHandles(sessionID string) {
+	a.parkedHandlesMu.Lock()
+	c := a.parkedHandles[sessionID]
+	delete(a.parkedHandles, sessionID)
+	a.parkedHandlesMu.Unlock()
+	if c != nil {
+		a.leases.apply(sessionID, c.ReleaseAll(zap.L()), nil)
+	}
+}
+
 // isParkQuestion reproduces the pre-scan's question classification at
 // completion time: a registered contact_human whose preflight verdict is not
 // Deny. A contact_human that fails this — policy-denied, or unregistered —
@@ -501,15 +548,18 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 	}
 	ctx = session.WithSessionID(ctx, sessionID)
 
-	// Session-handle lifecycle: same per-call ownership as chat() — handles
-	// minted during this call are released when it ends, park exits included.
-	// A parked turn spans calls, and in the pooled-embedder lifecycle (a
-	// fresh Agent per call) a collector carried across the gap would be
-	// unreachable by the next call — a leak, not a continuity. Handles are
-	// therefore scoped to the call everywhere, and a resumed turn re-mints on
-	// demand; cross-call handle continuity is an embedder-owned seam.
-	ctx, handleCollector := mcpadapter.WithHandleCollector(ctx)
+	// Session-handle lifecycle: the resumed turn ADOPTS the handles its parked
+	// half minted (same-process embedders), so a handle the model is about to
+	// use is still live. A nested park re-parks them; any other exit releases
+	// them, closing out the whole turn's handles exactly once. Pooled
+	// embedders adopt nothing (fresh Agent) and drain each park's slot via
+	// ReleaseParkedHandles instead.
+	ctx, handleCollector := a.adoptParkedHandles(ctx, sessionID)
+	parkedAgain := false
 	defer func() {
+		if parkedAgain {
+			return
+		}
 		a.leases.apply(sessionID, handleCollector.ReleaseAll(zap.L()), nil)
 	}()
 
@@ -619,7 +669,10 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 		var parked *TurnParkedError
 		if errors.As(err, &parked) {
 			// A nested park is a clean exit, not a failure (same contract as
-			// chat()).
+			// chat()). The turn is still unfinished — its handles park with
+			// it rather than being released out from under the next resume.
+			parkedAgain = true
+			a.parkHandles(sessionID, handleCollector)
 			span.AddEvent("conversation.parked", map[string]interface{}{
 				"request_id":  parked.RequestID,
 				"duration_ms": duration.Milliseconds(),

--- a/pkg/agent/park.go
+++ b/pkg/agent/park.go
@@ -244,6 +244,23 @@ func (a *Agent) guardParkedTail(ctx context.Context, sessionID string) error {
 	return nil
 }
 
+// resumedTurnKey marks a context as continuing a turn that already ran the
+// loop's entry work once, before it parked.
+type resumedTurnKey struct{}
+
+// contextWithResumedTurn marks ctx as a resume. Per-TURN entry work in
+// runConversationLoop — graph-memory context injection — must not run twice
+// for one turn just because the loop is entered twice.
+func contextWithResumedTurn(ctx context.Context) context.Context {
+	return context.WithValue(ctx, resumedTurnKey{}, true)
+}
+
+// isResumedTurn reports whether this loop entry is continuing a parked turn.
+func isResumedTurn(ctx context.Context) bool {
+	v, _ := ctx.Value(resumedTurnKey{}).(bool)
+	return v
+}
+
 // parkHandles hands the unfinished turn's session handles to whoever resumes
 // it. A parked turn spans two Go calls, but MCP session handles are scoped to
 // one call (pkg/mcp/adapter: "handles live for exactly one agent message
@@ -504,6 +521,7 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 	if progressCallback != nil {
 		ctx = ContextWithProgressCallback(ctx, progressCallback)
 	}
+	ctx = contextWithResumedTurn(ctx)
 	agentCtx := &agentContext{
 		Context:          ctx,
 		session:          sess,
@@ -606,6 +624,8 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 	}
 
 	span.SetAttribute("conversation.duration_ms", duration.Milliseconds())
+	span.Status = observability.Status{Code: observability.StatusOK}
+	a.recordConversationMetrics(sessionID, response, duration)
 	return response, nil
 }
 

--- a/pkg/agent/segmented_memory.go
+++ b/pkg/agent/segmented_memory.go
@@ -493,6 +493,17 @@ func (sm *SegmentedMemory) ReplayMessages(ctx context.Context, messages []Messag
 }
 
 // GetMessages returns all L1 messages for building conversation context.
+// RawMessages returns a copy of the L1 rows in append order — the same
+// traversal compileLocked renders from — with no rendering, no folding, and
+// no pair synthesis. Read-only view for the park resume walk.
+func (sm *SegmentedMemory) RawMessages() []Message {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	out := make([]Message, len(sm.contextMessages))
+	copy(out, sm.contextMessages)
+	return out
+}
+
 func (sm *SegmentedMemory) GetMessages() []Message {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()

--- a/pkg/agent/segmented_memory.go
+++ b/pkg/agent/segmented_memory.go
@@ -493,17 +493,10 @@ func (sm *SegmentedMemory) ReplayMessages(ctx context.Context, messages []Messag
 }
 
 // GetMessages returns all L1 messages for building conversation context.
-// RawMessages returns a copy of the L1 rows in append order — the same
-// traversal compileLocked renders from — with no rendering, no folding, and
-// no pair synthesis. Read-only view for the park resume walk.
-func (sm *SegmentedMemory) RawMessages() []Message {
-	sm.mu.RLock()
-	defer sm.mu.RUnlock()
-	out := make([]Message, len(sm.contextMessages))
-	copy(out, sm.contextMessages)
-	return out
-}
-
+// This is the RAW view: the rows in append order, with no rendering, no
+// folding, and no pair synthesis (that is GetMessagesForLLM/compileLocked,
+// which is what types.Session.GetMessages delegates to when segmented memory
+// is configured).
 func (sm *SegmentedMemory) GetMessages() []Message {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -23,7 +23,6 @@ import (
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
 	"github.com/teradata-labs/loom/pkg/communication"
 	"github.com/teradata-labs/loom/pkg/fabric"
-	mcpadapter "github.com/teradata-labs/loom/pkg/mcp/adapter"
 	"github.com/teradata-labs/loom/pkg/memory"
 	"github.com/teradata-labs/loom/pkg/observability"
 	"github.com/teradata-labs/loom/pkg/patterns"
@@ -80,13 +79,6 @@ type Agent struct {
 	// hitlPark, when non-nil, enables HITL park-and-resume: a batch needing a
 	// human decision ends the turn (TurnParkedError) instead of holding it.
 	hitlPark *hitlParkConfig
-
-	// parkedHandles holds the MCP session-handle collector of each session's
-	// parked turn, so the resume that finishes that turn adopts its handles
-	// instead of finding them released. One slot per session: guardParkedTail
-	// admits only one parked turn at a time.
-	parkedHandlesMu sync.Mutex
-	parkedHandles   map[string]*mcpadapter.HandleCollector
 
 	// Resolves the caller identity (AdmissionRequest.UserID) from the call
 	// context; injected here because pkg/shuttle cannot import the storage

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -23,6 +23,7 @@ import (
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
 	"github.com/teradata-labs/loom/pkg/communication"
 	"github.com/teradata-labs/loom/pkg/fabric"
+	mcpadapter "github.com/teradata-labs/loom/pkg/mcp/adapter"
 	"github.com/teradata-labs/loom/pkg/memory"
 	"github.com/teradata-labs/loom/pkg/observability"
 	"github.com/teradata-labs/loom/pkg/patterns"
@@ -79,6 +80,13 @@ type Agent struct {
 	// hitlPark, when non-nil, enables HITL park-and-resume: a batch needing a
 	// human decision ends the turn (TurnParkedError) instead of holding it.
 	hitlPark *hitlParkConfig
+
+	// parkedHandles holds the MCP session-handle collector of each session's
+	// parked turn, so the resume that finishes that turn adopts its handles
+	// instead of finding them released. One slot per session: guardParkedTail
+	// admits only one parked turn at a time.
+	parkedHandlesMu sync.Mutex
+	parkedHandles   map[string]*mcpadapter.HandleCollector
 
 	// Resolves the caller identity (AdmissionRequest.UserID) from the call
 	// context; injected here because pkg/shuttle cannot import the storage

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -23,6 +23,7 @@ import (
 	loomv1 "github.com/teradata-labs/loom/gen/go/loom/v1"
 	"github.com/teradata-labs/loom/pkg/communication"
 	"github.com/teradata-labs/loom/pkg/fabric"
+	mcpadapter "github.com/teradata-labs/loom/pkg/mcp/adapter"
 	"github.com/teradata-labs/loom/pkg/memory"
 	"github.com/teradata-labs/loom/pkg/observability"
 	"github.com/teradata-labs/loom/pkg/patterns"
@@ -79,6 +80,15 @@ type Agent struct {
 	// hitlPark, when non-nil, enables HITL park-and-resume: a batch needing a
 	// human decision ends the turn (TurnParkedError) instead of holding it.
 	hitlPark *hitlParkConfig
+
+	// parkedHandles holds the MCP session-handle collector of each session's
+	// parked turn, so a same-process resume adopts its handles instead of
+	// finding them released. One slot per session (guardParkedTail admits one
+	// parked turn at a time). Pooled embedders — a fresh Agent per call, where
+	// adoption can never happen — drain the slot explicitly at each park via
+	// ReleaseParkedHandles, keeping call-scoped semantics with no leak.
+	parkedHandlesMu sync.Mutex
+	parkedHandles   map[string]*mcpadapter.HandleCollector
 
 	// Resolves the caller identity (AdmissionRequest.UserID) from the call
 	// context; injected here because pkg/shuttle cannot import the storage

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -76,6 +76,10 @@ type Agent struct {
 	// Admission hook chain consulted before every tool body runs
 	admissionChain *shuttle.Chain
 
+	// hitlPark, when non-nil, enables HITL park-and-resume: a batch needing a
+	// human decision ends the turn (TurnParkedError) instead of holding it.
+	hitlPark *hitlParkConfig
+
 	// Resolves the caller identity (AdmissionRequest.UserID) from the call
 	// context; injected here because pkg/shuttle cannot import the storage
 	// layer that owns the user-id context key without a cycle

--- a/pkg/mcp/adapter/session_handles.go
+++ b/pkg/mcp/adapter/session_handles.go
@@ -79,6 +79,19 @@ func WithHandleCollector(ctx context.Context) (context.Context, *HandleCollector
 	return context.WithValue(ctx, handleCollectorKey{}, c), c
 }
 
+// ContextWithHandleCollector installs an EXISTING collector on ctx, so a turn
+// that spans more than one call — a HITL park and the resume that finishes it
+// — keeps one collector for its whole life. Its handles then stay live across
+// the gap and are released once, by whichever call actually ends the turn.
+// The per-call scope in the type comment above is the default, not a limit:
+// the owner is whoever planted the collector.
+func ContextWithHandleCollector(ctx context.Context, c *HandleCollector) context.Context {
+	if c == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, handleCollectorKey{}, c)
+}
+
 // collectorFrom returns the conversation's collector, or nil when the caller
 // did not opt in (workflows, direct executor use).
 func collectorFrom(ctx context.Context) *HandleCollector {

--- a/pkg/mcp/adapter/session_handles.go
+++ b/pkg/mcp/adapter/session_handles.go
@@ -79,19 +79,6 @@ func WithHandleCollector(ctx context.Context) (context.Context, *HandleCollector
 	return context.WithValue(ctx, handleCollectorKey{}, c), c
 }
 
-// ContextWithHandleCollector installs an EXISTING collector on ctx, so a turn
-// that spans more than one call — a HITL park and the resume that finishes it
-// — keeps one collector for its whole life. Its handles then stay live across
-// the gap and are released once, by whichever call actually ends the turn.
-// The per-call scope in the type comment above is the default, not a limit:
-// the owner is whoever planted the collector.
-func ContextWithHandleCollector(ctx context.Context, c *HandleCollector) context.Context {
-	if c == nil {
-		return ctx
-	}
-	return context.WithValue(ctx, handleCollectorKey{}, c)
-}
-
 // collectorFrom returns the conversation's collector, or nil when the caller
 // did not opt in (workflows, direct executor use).
 func collectorFrom(ctx context.Context) *HandleCollector {

--- a/pkg/shuttle/admission_chain.go
+++ b/pkg/shuttle/admission_chain.go
@@ -70,23 +70,12 @@ func (c *Chain) Admit(req AdmissionRequest) AdmissionResult {
 		return AdmissionResult{Decision: Decision{Kind: NoDecision}}
 	}
 
-	final := Decision{Kind: NoDecision}
-	matched := make([]Hook, 0, len(c.hooks))
-
-	for _, h := range c.hooks {
-		if h == nil {
-			continue
-		}
-		ok, d := evalHook(h, req)
-		if !ok {
-			continue
-		}
-		matched = append(matched, h)
-		final = moreRestrictive(final, d)
-	}
+	final, matched := c.combine(req)
 
 	if final.Kind == Ask {
-		if c.askResolver != nil {
+		if granted, ok := applyAskGrant(req, final); ok {
+			final = granted
+		} else if c.askResolver != nil {
 			final = resolveAsk(c.askResolver, req, final)
 		} else {
 			final = Decision{Kind: Deny, Reason: "tool call requires approval but no approval resolver is configured"}
@@ -103,6 +92,58 @@ func (c *Chain) Admit(req AdmissionRequest) AdmissionResult {
 	}
 
 	return AdmissionResult{Decision: final, AuditDecision: auditDecision}
+}
+
+// Preflight combines hook verdicts exactly as Admit does and resolves an Ask
+// ONLY from a context AskGrant (deterministic, non-blocking); with no grant
+// the Ask is returned as Ask. The blocking resolver is never invoked and no
+// audit decision is computed — audit stamps belong to the real execution
+// pass. Used by the park pre-scan to learn whether a call would hold, without
+// side effects. Nil chain → NoDecision.
+func (c *Chain) Preflight(req AdmissionRequest) Decision {
+	if c == nil {
+		return Decision{Kind: NoDecision}
+	}
+	final, _ := c.combine(req)
+	if final.Kind == Ask {
+		if granted, ok := applyAskGrant(req, final); ok {
+			final = granted
+		}
+	}
+	return final
+}
+
+// combine evaluates every matching hook and folds their verdicts under
+// Deny > Ask > Allow > NoDecision — the shared first half of Admit and
+// Preflight, so the two can never drift.
+func (c *Chain) combine(req AdmissionRequest) (Decision, []Hook) {
+	final := Decision{Kind: NoDecision}
+	matched := make([]Hook, 0, len(c.hooks))
+
+	for _, h := range c.hooks {
+		if h == nil {
+			continue
+		}
+		ok, d := evalHook(h, req)
+		if !ok {
+			continue
+		}
+		matched = append(matched, h)
+		final = moreRestrictive(final, d)
+	}
+	return final, matched
+}
+
+// applyAskGrant resolves an Ask from a context AskGrant when one is installed.
+// The grant lifts only the Ask — combine has already let any Deny dominate.
+func applyAskGrant(req AdmissionRequest, d Decision) (Decision, bool) {
+	if d.Kind != Ask || req.Ctx == nil {
+		return d, false
+	}
+	if g := AskGrantFromContext(req.Ctx); g != nil {
+		return g.Decide(), true
+	}
+	return d, false
 }
 
 // Observe fans a completed tool call out to every post-tool hook. A nil chain

--- a/pkg/shuttle/admission_hook.go
+++ b/pkg/shuttle/admission_hook.go
@@ -52,6 +52,17 @@ type AdmissionRequest struct {
 
 // Hook is a single admission policy: it decides whether it applies to a request
 // (Matches) and, when it does, returns its verdict (Evaluate).
+//
+// Both methods MUST be side-effect free, and both may be called MORE THAN ONCE
+// for a single tool call: Preflight asks the same question Admit does without
+// executing anything, so a call that is preflighted and then executed
+// evaluates every matching hook twice (three times for a contact_human that a
+// park re-classifies at resume). A hook that counts, meters, or records inside
+// Evaluate will therefore over-count. Observation has its own seam — see
+// PostToolHook, which runs exactly once, after the body.
+//
+// Reading mutable state is fine (the gated allowlist reads the approved set);
+// WRITING it from Evaluate is not.
 type Hook interface {
 	Matches(req AdmissionRequest) bool
 	Evaluate(req AdmissionRequest) Decision

--- a/pkg/shuttle/ask_grant.go
+++ b/pkg/shuttle/ask_grant.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package shuttle
+
+import "context"
+
+// AskGrant resolves Ask decisions from a decision a human (or the session
+// override) already made. Installed on the context only around a parked
+// batch's re-execution, or around a whole overridden turn. Blanket by design:
+// the human approved or rejected the batch as one unit. A grant lifts only an
+// Ask — a Deny from any hook still dominates in the chain's combination.
+type AskGrant struct {
+	Approved bool
+	Reason   string // human's note; verbatim deny reason when !Approved
+}
+
+// Decide renders the grant as a terminal admission decision for one Ask.
+func (g *AskGrant) Decide() Decision {
+	if g.Approved {
+		return Decision{Kind: Allow}
+	}
+	reason := g.Reason
+	if reason == "" {
+		reason = "rejected by user"
+	}
+	return Decision{Kind: Deny, Reason: reason}
+}
+
+type askGrantKey struct{}
+
+// ContextWithAskGrant installs g on ctx. The chain reads it per call, so the
+// caller controls the grant's scope by controlling which calls run under the
+// derived context.
+func ContextWithAskGrant(ctx context.Context, g *AskGrant) context.Context {
+	return context.WithValue(ctx, askGrantKey{}, g)
+}
+
+// AskGrantFromContext returns the grant installed on ctx, or nil.
+func AskGrantFromContext(ctx context.Context) *AskGrant {
+	if g, ok := ctx.Value(askGrantKey{}).(*AskGrant); ok {
+		return g
+	}
+	return nil
+}
+
+// SummarizeCall renders the deterministic one-line display digest for a tool
+// call — the same digest the ask resolver stamps on a held call's request row.
+// Exported for the park pre-scan, which builds one grouped request per batch.
+func SummarizeCall(toolName string, params map[string]interface{}) string {
+	return summarizeCall(toolName, params)
+}
+
+// BoundParams caps the JSON-encoded size of params at the resolver's per-call
+// bound (8 KB), reporting whether whole pairs were cut. Exported for the park
+// pre-scan's per-item descriptor bounding.
+func BoundParams(params map[string]interface{}) (map[string]interface{}, bool) {
+	return boundParams(params)
+}

--- a/pkg/shuttle/executor.go
+++ b/pkg/shuttle/executor.go
@@ -246,15 +246,12 @@ func (e *Executor) Preflight(ctx context.Context, toolName string, params map[st
 		return Decision{Kind: NoDecision}
 	}
 
-	if e.permissionChecker != nil {
-		if err := e.permissionChecker.CheckPermission(ctx, toolName, params); err != nil {
-			return Decision{Kind: Deny, Reason: err.Error()}
-		}
-	}
-	if e.admissionChain == nil {
-		return Decision{Kind: NoDecision}
-	}
-
+	// Same order as Execute: acquire the tool, normalize, THEN gate. Both
+	// gates must judge the exact params the tool would receive — Execute's own
+	// note: "the matcher must judge the exact params the tool would receive,
+	// or the caller's key spelling would decide whether a binding matches."
+	// Checking raw params here would let Preflight and Execute reach opposite
+	// verdicts on one call, which is precisely what the pre-scan may not do.
 	tool, ok := e.registry.Get(toolName)
 	if !ok {
 		dynamicTool, err := e.tryDynamicRegistration(ctx, toolName)
@@ -265,6 +262,15 @@ func (e *Executor) Preflight(ctx context.Context, toolName string, params map[st
 	}
 
 	normalizedParams := normalizeParametersToSchema(tool, params)
+
+	if e.permissionChecker != nil {
+		if err := e.permissionChecker.CheckPermission(ctx, toolName, normalizedParams); err != nil {
+			return Decision{Kind: Deny, Reason: err.Error()}
+		}
+	}
+	if e.admissionChain == nil {
+		return Decision{Kind: NoDecision}
+	}
 
 	userID := ""
 	if e.identityResolver != nil {

--- a/pkg/shuttle/executor.go
+++ b/pkg/shuttle/executor.go
@@ -231,6 +231,56 @@ func stampAdmissionDecision(result *Result, auditDecision string) {
 	result.Metadata["admission.decision"] = auditDecision
 }
 
+// Preflight reports the admission decision a call would receive, without
+// executing the tool body. With no admission chain AND no permission checker
+// it returns NoDecision immediately — before any registry work — so an
+// ungoverned agent's pre-scan stays a pure pass. Otherwise params are
+// normalized with the same normalizeParametersToSchema call Execute uses; a
+// registry miss attempts tryDynamicRegistration exactly as Execute does —
+// registration is an execution-required side effect that merely happens
+// earlier — and a failed registration returns NoDecision, leaving execution
+// to surface the real error later. An Ask is resolved only by a context
+// AskGrant; without one it is reported as Ask.
+func (e *Executor) Preflight(ctx context.Context, toolName string, params map[string]interface{}) Decision {
+	if e.admissionChain == nil && e.permissionChecker == nil {
+		return Decision{Kind: NoDecision}
+	}
+
+	if e.permissionChecker != nil {
+		if err := e.permissionChecker.CheckPermission(ctx, toolName, params); err != nil {
+			return Decision{Kind: Deny, Reason: err.Error()}
+		}
+	}
+	if e.admissionChain == nil {
+		return Decision{Kind: NoDecision}
+	}
+
+	tool, ok := e.registry.Get(toolName)
+	if !ok {
+		dynamicTool, err := e.tryDynamicRegistration(ctx, toolName)
+		if err != nil || dynamicTool == nil {
+			return Decision{Kind: NoDecision}
+		}
+		tool = dynamicTool
+	}
+
+	normalizedParams := normalizeParametersToSchema(tool, params)
+
+	userID := ""
+	if e.identityResolver != nil {
+		userID = e.identityResolver(ctx)
+	}
+	req := AdmissionRequest{
+		Ctx:       ctx,
+		ToolName:  toolName,
+		Params:    normalizedParams,
+		UserID:    userID,
+		SessionID: session.SessionIDFromContext(ctx),
+		State:     e.approvedSet,
+	}
+	return e.admissionChain.Preflight(req)
+}
+
 // Execute executes a tool by name with the given parameters.
 func (e *Executor) Execute(ctx context.Context, toolName string, params map[string]interface{}) (result *Result, err error) {
 	tool, ok := e.registry.Get(toolName)

--- a/pkg/shuttle/preflight_grant_test.go
+++ b/pkg/shuttle/preflight_grant_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package shuttle
+
+// Preflight/Admit parity and the AskGrant contract. Preflight must agree with
+// Admit on every verdict except Ask resolution (Preflight reports Ask, Admit
+// resolves it), and a grant lifts ONLY an Ask — a Deny from any hook
+// dominates in both entry points.
+
+import (
+	"context"
+	"testing"
+)
+
+type verdictHook struct{ d Decision }
+
+func (h verdictHook) Matches(AdmissionRequest) bool      { return true }
+func (h verdictHook) Evaluate(AdmissionRequest) Decision { return h.d }
+
+func req(ctx context.Context) AdmissionRequest {
+	return AdmissionRequest{Ctx: ctx, ToolName: "t", Params: map[string]interface{}{}}
+}
+
+func TestPreflightAdmitParity(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name          string
+		hooks         []Hook
+		wantPreflight DecisionKind
+		wantAdmit     DecisionKind // with no resolver
+	}{
+		{"no hooks", nil, NoDecision, NoDecision},
+		{"allow", []Hook{verdictHook{Decision{Kind: Allow}}}, Allow, Allow},
+		{"deny", []Hook{verdictHook{Decision{Kind: Deny, Reason: "no"}}}, Deny, Deny},
+		{"ask", []Hook{verdictHook{Decision{Kind: Ask}}}, Ask, Deny}, // Admit fails closed without resolver
+		{"ask+deny", []Hook{verdictHook{Decision{Kind: Ask}}, verdictHook{Decision{Kind: Deny, Reason: "hard"}}}, Deny, Deny},
+		{"ask+allow", []Hook{verdictHook{Decision{Kind: Ask}}, verdictHook{Decision{Kind: Allow}}}, Ask, Deny},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			chain := NewChain(tc.hooks, nil, nil)
+			if got := chain.Preflight(req(ctx)); got.Kind != tc.wantPreflight {
+				t.Fatalf("Preflight = %v, want %v", got.Kind, tc.wantPreflight)
+			}
+			if got := chain.Admit(req(ctx)); got.Decision.Kind != tc.wantAdmit {
+				t.Fatalf("Admit = %v, want %v", got.Decision.Kind, tc.wantAdmit)
+			}
+		})
+	}
+}
+
+func TestAskGrantLiftsOnlyAsk(t *testing.T) {
+	approve := ContextWithAskGrant(context.Background(), &AskGrant{Approved: true})
+	reject := ContextWithAskGrant(context.Background(), &AskGrant{Approved: false, Reason: "nope"})
+
+	askChain := NewChain([]Hook{verdictHook{Decision{Kind: Ask}}}, nil, nil)
+	if got := askChain.Preflight(req(approve)); got.Kind != Allow {
+		t.Fatalf("Preflight ask+approve grant = %v, want Allow", got.Kind)
+	}
+	if got := askChain.Admit(req(approve)); got.Decision.Kind != Allow {
+		t.Fatalf("Admit ask+approve grant = %v, want Allow", got.Decision.Kind)
+	}
+	if got := askChain.Admit(req(reject)); got.Decision.Kind != Deny || got.Decision.Reason != "nope" {
+		t.Fatalf("Admit ask+reject grant = %v (%q), want Deny with verbatim reason", got.Decision.Kind, got.Decision.Reason)
+	}
+
+	// A Deny is never lifted by a grant — combination lets Deny dominate.
+	denyChain := NewChain([]Hook{verdictHook{Decision{Kind: Ask}}, verdictHook{Decision{Kind: Deny, Reason: "hard"}}}, nil, nil)
+	if got := denyChain.Preflight(req(approve)); got.Kind != Deny {
+		t.Fatalf("Preflight deny+grant = %v, want Deny", got.Kind)
+	}
+	if got := denyChain.Admit(req(approve)); got.Decision.Kind != Deny || got.Decision.Reason != "hard" {
+		t.Fatalf("Admit deny+grant = %v (%q), want the hook's Deny", got.Decision.Kind, got.Decision.Reason)
+	}
+
+	// A grant leaves Allow / NoDecision untouched.
+	allowChain := NewChain([]Hook{verdictHook{Decision{Kind: Allow}}}, nil, nil)
+	if got := allowChain.Preflight(req(approve)); got.Kind != Allow {
+		t.Fatalf("Preflight allow+grant = %v, want Allow", got.Kind)
+	}
+	empty := NewChain(nil, nil, nil)
+	if got := empty.Preflight(req(reject)); got.Kind != NoDecision {
+		t.Fatalf("Preflight empty+grant = %v, want NoDecision", got.Kind)
+	}
+}
+
+func TestExecutorPreflight(t *testing.T) {
+	ctx := context.Background()
+
+	// Short-circuit: no chain, no permission checker → NoDecision, no
+	// registry work (an unregistered name must not error or register).
+	bare := NewExecutor(NewRegistry())
+	if got := bare.Preflight(ctx, "unknown_tool", nil); got.Kind != NoDecision {
+		t.Fatalf("bare Preflight = %v, want NoDecision", got.Kind)
+	}
+
+	// Governed executor: registered tool preflights through the chain.
+	reg := NewRegistry()
+	reg.Register(&MockTool{MockName: "governed"})
+	exec := NewExecutor(reg)
+	exec.SetAdmissionChain(NewChain([]Hook{verdictHook{Decision{Kind: Ask}}}, nil, nil))
+	if got := exec.Preflight(ctx, "governed", map[string]interface{}{"x": 1}); got.Kind != Ask {
+		t.Fatalf("governed Preflight = %v, want Ask", got.Kind)
+	}
+	// With a grant on ctx the same call preflights Allow (no park under
+	// override).
+	granted := ContextWithAskGrant(ctx, &AskGrant{Approved: true})
+	if got := exec.Preflight(granted, "governed", map[string]interface{}{"x": 1}); got.Kind != Allow {
+		t.Fatalf("governed Preflight with grant = %v, want Allow", got.Kind)
+	}
+	// Unknown tool on a governed executor: dynamic registration cannot
+	// succeed here → NoDecision, execution will surface the real error.
+	if got := exec.Preflight(ctx, "never_registered", nil); got.Kind != NoDecision {
+		t.Fatalf("unknown-tool Preflight = %v, want NoDecision", got.Kind)
+	}
+}


### PR DESCRIPTION
## What

Park-and-resume for HITL: a tool batch that needs a human decision no longer blocks inside the turn — the turn ENDS cleanly and resumes when the decision arrives, however much later.

- **Pre-scan admission** (`maybeParkBatch`): before anything in a batch executes, every call is preflighted (`Chain.Preflight` — same verdict surface as execution admission, side-effect free). Any Ask or registered `contact_human` question parks the WHOLE batch: one grouped `human_requests` row (per-call descriptors keyed by ToolCall.ID), durable tail `…user, assistant(ToolCalls)` with no tool rows, typed `TurnParkedError` terminal. A Deny is never lifted and never parks.
- **`ResumeChat`**: continues the parked turn without appending a user message. Turn-aware tail walk binds the decision to its exact batch (`ErrNothingParked` / `ErrNotParkedTail` / `ErrStaleDecision` typed terminals); rejected → uniform `permission_denied` with the human's verbatim reason; approved → question items synthesize the human's answer, everything else dispatches under a batch-scoped `AskGrant` (lifts Ask only — Deny still dominates, re-verified per call at completion time via the pre-scan's own classification). Loop then re-enters normally; a nested park chains.
- **Append-point guard**: a new user turn on a session with a pending parked decision is refused with the typed `SessionParkedError` before any turn-end side effect — closes the race between an embedder's admission-time probe and a park landing mid-turn.
- **`dispatchOneCall` extraction**: the conversation loop's dispatch body extracted verbatim (shared by the loop and resume completion); golden/differential tests pin identical behavior with the feature off, for ungoverned agents, and for ask-free batches.
- `shuttle`: `Preflight` on Executor/Chain, `AskGrant` context (batch-scoped Ask lift), `SummarizeCall`/`BoundParams` exports.

Embedder contract: `WithHITLPark(store, ttl, notifier)` — nil store leaves the legacy in-turn resolver path fully intact.

## Testing

`go test -tags fts5 ./...` green (the sole failure, `pkg/orchestration TestPipeline_PartialResultsCostAndDuration`, is a pre-existing timing flake present on main). Park behavior suite covers: pre-scan ordering/durability, block-all, question answers, deny-never-lifted (pure and mixed batches, forged-answer refusal), resume terminals, tail walk across in-turn user rows, the append-point guard, params bounding, and the no-op proofs. Proven live end-to-end (with the loom-cloud embedder) under real LLM traffic: approve / reject-and-replan / question-answers / janitor-driven resume with no client. Mixed multi-item batches are covered by the behavior suite and verified manually through the product UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
