### PR TITLE
fix(hitl): claim a parked decision, and bind it to what the human approved

### DIFF
--- a/cmd/looms/cmd_hitl.go
+++ b/cmd/looms/cmd_hitl.go
@@ -517,7 +517,21 @@ func runHitlRespond(cmd *cobra.Command, args []string) {
 	// turn ENDED — and only Agent.ResumeChat can continue it. Deciding the row
 	// here would mark it answered while the approved actions never run, and
 	// the model would never learn what the human said.
-	if before, gerr := store.Get(ctx, requestID); gerr == nil && before != nil && before.RequestType == "parked" {
+	// Fail CLOSED: the sqlite and in-memory stores return an error for both
+	// absence and store failure, so a Get hiccup must not skip this guard and
+	// decide a parked row anyway — that is the exact silent wrong outcome the
+	// guard exists to stop.
+	before, gerr := store.Get(ctx, requestID)
+	if gerr != nil || before == nil {
+		fmt.Fprintf(os.Stderr,
+			"Cannot read request %s to check whether it is a parked turn (%v).\n"+
+				"Refusing rather than risk deciding a park the agent must resume.\n",
+			requestID, gerr)
+		span.SetAttribute("success", false)
+		span.SetAttribute("refused", "unverifiable")
+		os.Exit(1)
+	}
+	if before.RequestType == "parked" {
 		fmt.Fprintf(os.Stderr,
 			"Request %s is a PARKED turn: its decision must be applied through the agent's\n"+
 				"ResumeChat entry point, which re-enters the conversation. Responding here would\n"+

--- a/cmd/looms/cmd_hitl.go
+++ b/cmd/looms/cmd_hitl.go
@@ -423,6 +423,21 @@ func runHitlExpire(cmd *cobra.Command, args []string) {
 	if operator == "" {
 		operator = "operator"
 	}
+
+	// Expiring a PARKED row is legitimate — it is the retirement route for a
+	// stranded park — but it does not finish the turn. The batch keeps its
+	// unpaired tool calls, and the model is later shown "the call did not
+	// complete" for actions a human may well have approved. Say so, rather
+	// than printing an unqualified success.
+	if before, gerr := store.Get(ctx, requestID); gerr == nil && before != nil && before.RequestType == "parked" {
+		fmt.Fprintf(os.Stderr,
+			"Note: %s is a PARKED turn. Expiring it releases the session, but does NOT\n"+
+				"complete the turn — its tool calls stay unanswered and the agent will report\n"+
+				"them as never completed. Prefer resuming through the embedder that raised\n"+
+				"it (session %s) when that is still possible.\n\n",
+			requestID, before.SessionID)
+	}
+
 	if err := store.ExpireRequest(ctx, requestID, "operator:"+operator); err != nil {
 		span.RecordError(err)
 		span.SetAttribute("success", false)

--- a/docs/architecture/hitl-park-and-resume.md
+++ b/docs/architecture/hitl-park-and-resume.md
@@ -124,12 +124,10 @@ The grant lives only on the derived context handed to the parked batch's
 dispatch. The loop re-entry that follows runs ungranted, so a new ask in the
 continuation parks again.
 
-### 3.3 Closing the row
+### 3.3 Claiming the decision
 
-In the standalone (pending-row) flow, the row is closed the instant its
-decision is applied, **before** the loop re-entry that may park a new one — a
-pre-decided row is already closed by the embedder's respond door and is left
-untouched:
+In the standalone (pending-row) flow the row is closed **before the batch
+runs** — it is a claim, not bookkeeping:
 
 - approved → `RespondToRequest(…, "approved", …)`
 - rejected → `RespondToRequest(…, "rejected", …)`
@@ -137,22 +135,61 @@ untouched:
   applied as a refusal whatever it said — an approval must not execute on a
   lapsed authorization.
 
-This is not bookkeeping. `guardParkedTail` refuses a new user turn while a
-parked row is pending, so a decided row left pending wedges the session for
-every later message. Expiry goes through `ExpireRequest` because the store's
-expiry guard is its own and no status payload lifts it.
+The tail walk cannot be the double-application guard on its own. It reads the
+batch's rowless calls *before* any of them execute, so two overlapping resumes
+of one decision both see work to do and both do it — the approved bodies run
+twice, both callers get `nil`, and two tool rows land for one `tool_use_id`,
+which puts duplicate `tool_result` blocks in the next provider request.
+
+Two things make the close a real claim.
+
+**It is judged by reading the row back.** Both store writes are documented
+no-ops that return `nil` when the row is no longer claimable — already
+decided, or expired since it was read. A close judged by its error therefore
+succeeds silently while doing nothing, and since `guardParkedTail` refuses a
+new user turn while a parked row is pending, that wedges the session for every
+later message. If the read-back still shows `pending`, the row lapsed
+mid-flight and is closed through `ExpireRequest` — the one path allowed past
+the store's own expiry guard.
+
+**It carries a claim token.** "No longer pending" does not identify *who*
+closed it: the store admits exactly one claimant and silently no-ops the rest,
+and every loser reads back a non-pending row. Each resume stamps a token into
+`response_data` and proceeds only if the token it reads back is its own.
+
+Claiming first also makes a parked batch **at-most-once**: a crash mid-batch
+leaves the row closed and the remainder unrun. For actions a human gated, not
+running is the safe direction.
+
+**The embedder-recorded flow cannot claim** — its row is already decided by the
+respond door, so there is nothing left to take. A per-session lock is its
+guarantee inside one process; a pooled embedder spreading resumes across
+processes must deliver an already-decided resume at most once itself.
+
+Refusals never damage a live park: handle adoption happens *after* the claim,
+because adopting removes the collector from the parked slot, and a resume
+refused with a bad request id must not release the handles of a turn that is
+still parked.
 
 ### 3.4 Terminals
 
-All are terminal — finish the request's lifecycle, never retry the resume.
+Most are terminal — finish the request's lifecycle and never retry.
+`ErrClaimNotConfirmed` is the exception.
 
-| Error | Meaning |
-|---|---|
-| `ErrParkDisabled` | the agent has no park wiring |
-| `ErrUnknownRequest` | no pending parked row with that ID owns this session |
-| `ErrStaleDecision` | supplied `ItemIDs` do not match the row's items |
-| `ErrNotParkedTail` | a user row of a later turn follows the batch |
-| `ErrNothingParked` | the turn already produced its final reply |
+| Error | Retry? | Meaning |
+|---|---|---|
+| `ErrParkDisabled` | no | the agent has no park wiring |
+| `ErrUnknownRequest` | no | no pending parked row with that ID owns this session — including one another resume already claimed |
+| `ErrStaleDecision` | no | supplied `ItemIDs` do not match the row's items |
+| `ErrNotParkedTail` | no | a user row of a later turn follows the batch |
+| `ErrNothingParked` | no | the turn already produced its final reply |
+| `ErrDecisionExpired` | no | the row lapsed before the decision could be claimed; nothing ran |
+| `ErrClaimNotConfirmed` | **yes** | the claim neither landed nor was confirmed as someone else's; nothing ran |
+
+The two turn-is-dead refusals — `ErrNotParkedTail`, `ErrNothingParked` — close
+a still-pending row on the way out. An unresumable turn whose row stays pending
+holds its session at `guardParkedTail` against a decision that can never be
+applied.
 
 `ErrNothingParked` covers a turn that ended with rowless calls behind it — the
 loop's `MaxToolExecutions` cap can end a turn that way, and those calls were
@@ -193,10 +230,35 @@ must not kill a session.
 - Sweeping rows whose TTL lapsed with nobody deciding. Loom closes a row it is
   handed a decision for; it runs no timer of its own, so an abandoned park
   stays pending until a resume (with any decision) or an external sweep closes
-  it.
+  it. It no longer *holds the session* though — `guardParkedTail` ignores
+  lapsed rows, since nothing sweeps them and a park nobody decided would
+  otherwise refuse every future turn on that session permanently.
+- Delivering an already-decided resume at most once across processes. The
+  standalone flow claims its own row, so it is safe however many times the
+  decision arrives; the embedder-recorded flow has no row left to claim, and
+  loom's per-session lock only spans one process.
 
 ## 7. Known gaps
 
+- 📋 **Abandoned parks are never reclaimed.** A park nobody decides keeps its
+  row (past TTL, `pending`) and its MCP handle collector until something calls
+  `ResumeChat` or an operator runs `looms hitl expire`. The session keeps
+  working; the row and handles leak.
+- 📋 **No restart coverage.** Every test resumes on the same in-process agent,
+  which hits the session cache and never rehydrates from SQLite — so the
+  feature's central premise, that a parked turn survives a restart, is
+  unverified. `locateParkedBatch` depends on a reloaded session reproducing
+  `Turn` stamps, the assistant row's `ToolCalls`, and each tool row's
+  `ToolUseID` exactly.
+- 📋 **The durable row is not the authorization record in the standalone
+  flow.** `ResumeChat` takes `Approved` as a parameter and writes the verdict;
+  the approver is the literal string `"human"`, so nothing records *who*
+  approved. (The embedder-recorded flow does not have this problem — there the
+  row is decided first and its status overrides the payload.)
+- 📋 **`AskGrant` is a blanket context value.** It lifts any `Ask` downstream of
+  the granted call's context, not just that call. No in-tree tool re-enters the
+  executor, so it is unreachable today — but a code-mode or agent-delegation
+  tool would inherit approve-all under one approval.
 - 📋 No proto/gRPC surface for resume; park is a library API for embedders.
   Whether loom should expose resume over gRPC is a product decision, not an
   oversight — every other conversation entry point reaches clients through the

--- a/docs/architecture/hitl-park-and-resume.md
+++ b/docs/architecture/hitl-park-and-resume.md
@@ -223,6 +223,18 @@ append point is the authoritative last moment. Store errors fail open with a
 warning — the embedder's own probe is the primary gate, and a store hiccup
 must not kill a session.
 
+A **decided but unapplied** row still holds it. The embedder-recorded flow
+decides the row before calling `ResumeChat`, so between those two moments the
+batch is unapplied while the row is no longer `pending`; matching on status
+alone admitted a new user turn that buried it — silently discarding the
+approval and leaving the history asserting the call never completed. The guard
+asks the tail as well: an assistant batch still missing tool rows is an
+unapplied park whatever the row says.
+
+A **lapsed** row does not hold it. Nothing sweeps parked rows — a park has no
+waiter by design — so matching on `pending` alone let a park nobody ever
+decided refuse every future turn on that session, permanently.
+
 ## 6. What the embedder owns
 
 - Delivering the card to a human and collecting the verdict.
@@ -238,7 +250,27 @@ must not kill a session.
   decision arrives; the embedder-recorded flow has no row left to claim, and
   loom's per-session lock only spans one process.
 
-## 7. Known gaps
+## 7. Binding an approval to what the human saw
+
+`verifyItemBinding` compares each request item against the tail call it names:
+tool, batch position, **and arguments**. The arguments matter most, because the
+other two can carry no information at all — on Gemini `ToolCall.ID` *is* the
+function name (`pkg/llm/gemini/client.go`: "Gemini doesn't provide call IDs"),
+so for a single-call batch the id, the tool name and the seq collapse into one
+fact and every same-tool batch looks identical.
+
+Without the argument check a spent decision — which still loads, since the
+embedder-recorded flow accepts a decided row — re-binds to a LATER batch of the
+same tool and executes arguments nobody approved.
+
+A batch whose call IDs cannot name their calls does not park at all: a
+duplicate ID would collapse two calls into one card descriptor (the human
+approves one action, two run), and an empty ID can never be matched back.
+Providers produce both — Ollama can omit the id, Gemini reuses the function
+name. Such a batch dispatches inline, where an Ask with no resolver fails
+closed.
+
+## 8. Known gaps
 
 - 📋 **Abandoned parks are never reclaimed.** A park nobody decides keeps its
   row (past TTL, `pending`) and its MCP handle collector until something calls
@@ -264,7 +296,7 @@ must not kill a session.
   oversight — every other conversation entry point reaches clients through the
   Weave surface, so the asymmetry is worth a deliberate answer.
 
-## 8. A note on hook evaluation count
+## 9. A note on hook evaluation count
 
 The pre-scan asks the admission chain the same question execution asks, so a
 call that parks and then runs evaluates every matching hook **twice** (three

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -2329,7 +2329,12 @@ func (a *Agent) runConversationLoop(ctx Context) (*Response, error) {
 	// skips it: the loop is being RE-entered for a turn that already got its
 	// context block before it parked, so injecting again would duplicate the
 	// block in the prompt and pay a second recall round-trip per resume.
-	if !isResumedTurn(ctx) {
+	// A resumed turn already ran this once — but only if the block SURVIVED.
+	// injectGraphMemoryContext appends through Session.AddMessage, which is
+	// in-memory only and never persisted, so a resume in a fresh process finds
+	// nothing there. Suppressing on "is a resume" alone would leave exactly
+	// the turn carrying the human-approved action with no recall at all.
+	if !isResumedTurn(ctx) || !hasGraphMemoryContext(session) {
 		a.injectGraphMemoryContext(ctx, session)
 	}
 
@@ -3273,6 +3278,22 @@ func (a *Agent) FlushGraphMemoryExtraction() {
 	a.graphExtractionWG.Wait()
 }
 
+// graphMemoryContextMarker opens the injected graph-memory block, and is how a
+// resumed turn tells "already injected" from "injected in a process that is
+// gone" — the block lives only in memory (Session.AddMessage is not persisted).
+const graphMemoryContextMarker = "[Graph Memory Context]"
+
+// hasGraphMemoryContext reports whether this session still carries an injected
+// graph-memory block.
+func hasGraphMemoryContext(session *types.Session) bool {
+	for _, m := range session.GetMessages() {
+		if strings.HasPrefix(m.Content, graphMemoryContextMarker) {
+			return true
+		}
+	}
+	return false
+}
+
 // injectGraphMemoryContext queries graph memory for the current topic and injects
 // relevant context into the conversation as a system message.
 func (a *Agent) injectGraphMemoryContext(ctx context.Context, session *types.Session) {
@@ -3427,7 +3448,7 @@ func (a *Agent) injectGraphMemoryContext(ctx context.Context, session *types.Ses
 
 	session.AddMessage(ctx, types.Message{
 		Role:    "system",
-		Content: "[Graph Memory Context]\n" + sb.String(),
+		Content: graphMemoryContextMarker + "\n" + sb.String(),
 	})
 	outcome = "injected"
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1857,7 +1857,7 @@ func (a *Agent) chat(ctx context.Context, sessionID string, userMessage string, 
 	// tail, so a new user turn is refused BEFORE any turn-end side effect
 	// (payload drop, user append) can bury the parked batch. Sits behind the
 	// embedder's admission probe, which races a park landing mid-turn.
-	if err := a.guardParkedTail(ctx, sessionID); err != nil {
+	if err := a.guardParkedTail(ctx, sessionID, session); err != nil {
 		span.AddEvent("conversation.refused_parked", map[string]interface{}{
 			"session_id": sessionID,
 		})

--- a/pkg/agent/hitl_park_claim_test.go
+++ b/pkg/agent/hitl_park_claim_test.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package agent
+
+// claimParkedRequest is the serialization point of the whole feature: exactly
+// one resume may take ownership of a decision, and only the owner executes the
+// batch. Driving it directly is deliberate — through ResumeChat the claim
+// happens microseconds after the row is read, so goroutine jitter alone
+// decides whether two resumes ever collide, and an end-to-end test passes
+// whether or not the mechanism works. These hit the mechanism itself.
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+)
+
+// newClaimFixture builds a park-enabled agent and one pending parked row.
+func newClaimFixture(t *testing.T, ttl time.Duration) (*Agent, *shuttle.InMemoryHumanRequestStore, *shuttle.HumanRequest) {
+	t.Helper()
+	store := shuttle.NewInMemoryHumanRequestStore()
+	cfg := DefaultConfig()
+	cfg.PatternConfig = DefaultPatternConfig()
+	cfg.PatternConfig.UseLLMClassifier = false
+	ag := NewAgent(&mockBackend{}, &mockToolCallingLLM{responses: []mockLLMResponse{{content: "x"}}},
+		WithConfig(cfg), WithHITLPark(store, ttl, nil))
+
+	now := time.Now()
+	hr := &shuttle.HumanRequest{
+		ID:          uuid.New().String(),
+		AgentID:     ag.id,
+		SessionID:   "s-claim-unit",
+		RequestType: "parked",
+		Kind:        "approval",
+		Status:      "pending",
+		CreatedAt:   now,
+		ExpiresAt:   now.Add(ttl),
+		Params:      map[string]interface{}{"c-1": map[string]interface{}{"kind": "approval"}},
+	}
+	if err := store.Store(context.Background(), hr); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	return ag, store, hr
+}
+
+// TestClaimParkedRequest_ExactlyOneWinner is the at-most-once proof. Every
+// claimant's store write returns nil — the winner's because it landed, the
+// losers' because the store's conditional write refused them as a deliberate
+// no-op — and every claimant then reads back a non-pending row. Only the
+// token distinguishes them. Without that check every loser would take the
+// winner's close for its own and run the approved batch again.
+func TestClaimParkedRequest_ExactlyOneWinner(t *testing.T) {
+	const claimants = 8
+	ag, store, hr := newClaimFixture(t, time.Hour)
+	ctx := context.Background()
+	decision := ParkDecision{RequestID: hr.ID, Approved: true, Reason: "ok"}
+
+	var wg sync.WaitGroup
+	results := make([]error, claimants)
+	start := make(chan struct{})
+	for i := 0; i < claimants; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start // release together, into the same window
+			results[i] = ag.claimParkedRequest(ctx, hr, decision, false)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	winners := 0
+	for i, err := range results {
+		switch {
+		case err == nil:
+			winners++
+		case errors.Is(err, ErrUnknownRequest):
+			// correct loser: someone else owns this decision
+		default:
+			t.Errorf("claimant %d got %v, want nil or ErrUnknownRequest", i, err)
+		}
+	}
+	if winners != 1 {
+		t.Errorf("%d claimants won the decision, want exactly 1 — every extra winner "+
+			"executes the human-approved batch again", winners)
+	}
+
+	after, err := store.Get(ctx, hr.ID)
+	if err != nil || after == nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if after.Status != "approved" {
+		t.Errorf("row status = %q, want approved", after.Status)
+	}
+}
+
+// TestClaimParkedRequest_LapsedRowIsClosedNotSilentlyLeftPending — the row
+// expires between the resume reading it and claiming it. RespondToRequest
+// refuses to write past expiry and returns nil, so a claim judged by that
+// error would proceed to execute against a row still marked pending, leaving
+// the session refused at guardParkedTail forever.
+func TestClaimParkedRequest_LapsedRowIsClosedNotSilentlyLeftPending(t *testing.T) {
+	ag, store, hr := newClaimFixture(t, 80*time.Millisecond)
+	ctx := context.Background()
+
+	// The window closes while the caller is still deciding what to do.
+	time.Sleep(150 * time.Millisecond)
+
+	// expired=false is the point: the resume checked expiry BEFORE the lapse,
+	// exactly as ResumeChat does, and only the read-back can catch it.
+	err := ag.claimParkedRequest(ctx, hr, ParkDecision{RequestID: hr.ID, Approved: true}, false)
+	if !errors.Is(err, ErrDecisionExpired) {
+		t.Fatalf("claim of a lapsed row = %v, want ErrDecisionExpired", err)
+	}
+
+	after, gerr := store.Get(ctx, hr.ID)
+	if gerr != nil || after == nil {
+		t.Fatalf("Get: %v", gerr)
+	}
+	if after.Status == "pending" {
+		t.Errorf("lapsed row left pending; guardParkedTail will refuse every later turn")
+	}
+}
+
+// TestClaimParkedRequest_RejectionClaimsToo — the refusal path takes ownership
+// on the same terms, so a rejected batch cannot be refused twice and cannot
+// leave its row open.
+func TestClaimParkedRequest_RejectionClaimsToo(t *testing.T) {
+	ag, store, hr := newClaimFixture(t, time.Hour)
+	ctx := context.Background()
+	decision := ParkDecision{RequestID: hr.ID, Approved: false, Reason: "rejected by user: no"}
+
+	if err := ag.claimParkedRequest(ctx, hr, decision, false); err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	if err := ag.claimParkedRequest(ctx, hr, decision, false); !errors.Is(err, ErrUnknownRequest) {
+		t.Errorf("second claim = %v, want ErrUnknownRequest", err)
+	}
+
+	after, _ := store.Get(ctx, hr.ID)
+	if after == nil || after.Status != "rejected" {
+		t.Fatalf("row status = %v, want rejected", after)
+	}
+	if after.Response != decision.Reason {
+		t.Errorf("row response = %q, want the human's verbatim reason %q", after.Response, decision.Reason)
+	}
+}

--- a/pkg/agent/hitl_park_concurrency_test.go
+++ b/pkg/agent/hitl_park_concurrency_test.go
@@ -1,0 +1,326 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package agent
+
+// Concurrency and claim-order properties of ResumeChat. One human decision
+// authorizes one execution of its batch — no matter how many times, or how
+// simultaneously, that decision is delivered.
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+)
+
+// slowTool holds the batch open long enough for a second resume to overlap
+// the first — the window between the row's pending check and its close.
+type slowTool struct {
+	name string
+	runs atomic.Int64
+	wait time.Duration
+}
+
+func (t *slowTool) Name() string        { return t.name }
+func (t *slowTool) Description() string { return "slow tool" }
+func (t *slowTool) InputSchema() *shuttle.JSONSchema {
+	return &shuttle.JSONSchema{
+		Type:       "object",
+		Properties: map[string]*shuttle.JSONSchema{"v": {Type: "string"}},
+	}
+}
+func (t *slowTool) Execute(ctx context.Context, params map[string]interface{}) (*shuttle.Result, error) {
+	t.runs.Add(1)
+	time.Sleep(t.wait)
+	return &shuttle.Result{Success: true, Data: "slow-ok"}, nil
+}
+func (t *slowTool) Backend() string { return "" }
+
+// TestPark_ConcurrentResumesExecuteTheBatchOnce drives two resumes of ONE
+// decision through the whole entry point and asserts the batch runs once,
+// exactly one caller reports success, and one tool row lands per tool_use_id
+// (duplicates would put two tool_result blocks for one id in the next
+// provider request).
+//
+// It is a smoke test, NOT the proof of the claim mechanism. Because the claim
+// now happens microseconds after the row is read, goroutine scheduling alone
+// usually decides the winner here — the loser is typically refused at
+// loadParkedRequest, before the claim is ever contended. Deleting the claim
+// token check does not fail this test. The mechanism itself is pinned by
+// TestClaimParkedRequest_ExactlyOneWinner, which contends the claim directly.
+func TestPark_ConcurrentResumesExecuteTheBatchOnce(t *testing.T) {
+	responses := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "c-slow", Name: "slow_write", Input: map[string]interface{}{"v": "w"}},
+		}},
+		{content: "done"},
+		{content: "done again"},
+	}
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "slow_write"}}, responses)
+	slow := &slowTool{name: "slow_write", wait: 300 * time.Millisecond}
+	f.ag.RegisterTool(slow)
+
+	ctx := context.Background()
+	_, err := f.ag.Chat(ctx, "s-conc", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-conc")
+	decision := ParkDecision{RequestID: hr.ID, ItemIDs: paramKeys(hr), Approved: true}
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = f.ag.ResumeChat(ctx, "s-conc", decision, nil)
+		}(i)
+	}
+	wg.Wait()
+
+	if got := slow.runs.Load(); got != 1 {
+		t.Errorf("approved tool body ran %d times for ONE human approval, want 1", got)
+	}
+
+	// Exactly one resume may succeed; the other must say so rather than
+	// silently returning success for work it did not do. Which terminal the
+	// loser gets depends on where it lost — refused at the claim
+	// (ErrUnknownRequest), or arriving after the winner finished the turn
+	// (ErrNothingParked). Both are correct refusals; silence is not.
+	succeeded := 0
+	for i, e := range errs {
+		if e == nil {
+			succeeded++
+			continue
+		}
+		if !errors.Is(e, ErrUnknownRequest) && !errors.Is(e, ErrNothingParked) {
+			t.Errorf("resume %d failed with %v, want nil or a terminal refusal", i, e)
+		}
+	}
+	if succeeded != 1 {
+		t.Errorf("%d resumes reported success, want exactly 1 (errors: %v)", succeeded, errs)
+	}
+
+	// One tool row for the call — duplicates break tool_use/tool_result pairing.
+	sess := f.ag.memory.GetOrCreateSessionWithAgent(ctx, "s-conc", f.ag.config.Name, "")
+	rows := 0
+	for _, m := range rawSessionMessages(sess) {
+		if m.Role == "tool" && m.ToolUseID == "c-slow" {
+			rows++
+		}
+	}
+	if rows != 1 {
+		t.Errorf("%d tool rows for tool_use_id c-slow, want 1", rows)
+	}
+}
+
+// TestPark_ClaimPrecedesExecution pins the ordering the at-most-once
+// guarantee rests on: by the time any tool body runs, the row is already
+// closed. If execution came first, a crash — or an expiry crossing mid-batch
+// — would leave a decided batch with a pending row, and the session wedged.
+func TestPark_ClaimPrecedesExecution(t *testing.T) {
+	responses := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "c-obs", Name: "observer", Input: map[string]interface{}{"v": "w"}},
+		}},
+		{content: "done"},
+	}
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "observer"}}, responses)
+
+	var statusAtRun string
+	obs := &funcTool{
+		name: "observer",
+		run: func(ctx context.Context, _ map[string]interface{}) (*shuttle.Result, error) {
+			if reqs, err := f.store.ListBySession(ctx, "s-claim"); err == nil {
+				for _, r := range reqs {
+					if r.RequestType == "parked" {
+						statusAtRun = r.Status
+					}
+				}
+			}
+			return &shuttle.Result{Success: true, Data: "ok"}, nil
+		},
+	}
+	f.ag.RegisterTool(obs)
+
+	ctx := context.Background()
+	_, err := f.ag.Chat(ctx, "s-claim", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-claim")
+
+	if _, err := f.ag.ResumeChat(ctx, "s-claim", ParkDecision{
+		RequestID: hr.ID, ItemIDs: paramKeys(hr), Approved: true,
+	}, nil); err != nil {
+		t.Fatalf("ResumeChat: %v", err)
+	}
+	if statusAtRun != "approved" {
+		t.Errorf("row status while the approved body ran = %q, want \"approved\" "+
+			"(the decision must be claimed before anything executes)", statusAtRun)
+	}
+}
+
+// TestPark_ExpiryCrossingDuringTheBatchDoesNotWedge — the TTL lapses while
+// the approved batch is still running. This cannot wedge the session BY
+// CONSTRUCTION: the decision is claimed and the row closed before any tool
+// body starts, so a lapse during the batch finds an already-closed row. The
+// test pins that construction end to end — moving the claim back after the
+// batch fails it, because then the close would meet an expired row,
+// RespondToRequest would refuse it while returning nil, and the row would be
+// left pending forever.
+//
+// The read-back that catches a refused write is pinned directly by
+// TestClaimParkedRequest_LapsedRowIsClosedNotSilentlyLeftPending.
+func TestPark_ExpiryCrossingDuringTheBatchDoesNotWedge(t *testing.T) {
+	responses := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "c-slow", Name: "slow_write", Input: map[string]interface{}{"v": "w"}},
+		}},
+		{content: "done"},
+		{content: "next turn"},
+	}
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "slow_write"}}, responses)
+	f.ag.RegisterTool(&slowTool{name: "slow_write", wait: 400 * time.Millisecond})
+
+	ctx := context.Background()
+	_, err := f.ag.Chat(ctx, "s-cross", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-cross")
+
+	// Expire shortly after the resume starts, while the tool is still running.
+	hr.ExpiresAt = time.Now().Add(150 * time.Millisecond)
+	if err := f.store.Update(ctx, hr); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	_, _ = f.ag.ResumeChat(ctx, "s-cross", ParkDecision{
+		RequestID: hr.ID, ItemIDs: paramKeys(hr), Approved: true,
+	}, nil)
+
+	after, _ := f.store.Get(ctx, hr.ID)
+	if after != nil && after.Status == "pending" {
+		t.Errorf("row left pending after the resume; the session is wedged")
+	}
+	if _, err := f.ag.Chat(ctx, "s-cross", "carry on"); err != nil {
+		t.Errorf("turn after an expiry-crossing resume refused: %v", err)
+	}
+}
+
+// TestPark_AbandonedParkStopsHoldingTheSessionOnceLapsed — nothing sweeps
+// parked rows, so guardParkedTail must not treat a lapsed one as holding the
+// session. Otherwise a park nobody ever decides kills the session forever.
+func TestPark_AbandonedParkStopsHoldingTheSessionOnceLapsed(t *testing.T) {
+	responses := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "c-write", Name: "export_csv", Input: map[string]interface{}{"v": "w"}},
+		}},
+		{content: "unreachable"},
+		{content: "later turn"},
+	}
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, responses, "export_csv")
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-aband", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-aband")
+
+	// While the window is open the session IS held.
+	if _, err := f.ag.Chat(ctx, "s-aband", "too soon"); !errors.As(err, new(*SessionParkedError)) {
+		t.Fatalf("turn during an open park = %v, want SessionParkedError", err)
+	}
+
+	// Nobody ever decides; the window lapses.
+	hr.ExpiresAt = time.Now().Add(-time.Minute)
+	if err := f.store.Update(ctx, hr); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if _, err := f.ag.Chat(ctx, "s-aband", "much later"); err != nil {
+		t.Errorf("turn after an abandoned park lapsed was refused: %v", err)
+	}
+}
+
+// funcTool is a tool whose body is supplied per test.
+type funcTool struct {
+	name string
+	run  func(context.Context, map[string]interface{}) (*shuttle.Result, error)
+}
+
+func (t *funcTool) Name() string        { return t.name }
+func (t *funcTool) Description() string { return "func tool" }
+func (t *funcTool) InputSchema() *shuttle.JSONSchema {
+	return &shuttle.JSONSchema{
+		Type:       "object",
+		Properties: map[string]*shuttle.JSONSchema{"v": {Type: "string"}},
+	}
+}
+func (t *funcTool) Execute(ctx context.Context, p map[string]interface{}) (*shuttle.Result, error) {
+	return t.run(ctx, p)
+}
+func (t *funcTool) Backend() string { return "" }
+
+// TestPark_UnresumableTurnReleasesTheSession — when the tail has moved on, the
+// decision can never be applied, but the row is still PENDING. Left that way
+// it holds the session at guardParkedTail forever, so an unresumable turn must
+// close its own row on the way out.
+func TestPark_UnresumableTurnReleasesTheSession(t *testing.T) {
+	responses := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "c-write", Name: "export_csv", Input: map[string]interface{}{"v": "w"}},
+		}},
+		{content: "unreachable"},
+		{content: "later turn"},
+	}
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, responses, "export_csv")
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-unres", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-unres")
+
+	// History moves on: a user row of a LATER turn lands after the batch.
+	sess := f.ag.memory.GetOrCreateSessionWithAgent(ctx, "s-unres", f.ag.config.Name, "")
+	f.ag.appendMessage(ctx, sess, Message{Role: "user", Content: "new message", AgentID: f.ag.id}, true)
+
+	if _, err := f.ag.ResumeChat(ctx, "s-unres", ParkDecision{
+		RequestID: hr.ID, ItemIDs: paramKeys(hr), Approved: true,
+	}, nil); !errors.Is(err, ErrNotParkedTail) {
+		t.Fatalf("resume of a moved-on turn = %v, want ErrNotParkedTail", err)
+	}
+
+	after, _ := f.store.Get(ctx, hr.ID)
+	if after == nil || after.Status == "pending" {
+		t.Errorf("unresumable row left pending (%v); the session is wedged at guardParkedTail", after)
+	}
+	if err := f.ag.guardParkedTail(ctx, "s-unres"); err != nil {
+		t.Errorf("session still held after the park became unresumable: %v", err)
+	}
+}

--- a/pkg/agent/hitl_park_concurrency_test.go
+++ b/pkg/agent/hitl_park_concurrency_test.go
@@ -324,3 +324,48 @@ func TestPark_UnresumableTurnReleasesTheSession(t *testing.T) {
 		t.Errorf("session still held after the park became unresumable: %v", err)
 	}
 }
+
+// TestPark_UnloadableSessionDoesNotDestroyTheApproval is the destructive-path
+// guard. locateParkedBatch returns ErrNothingParked both for a turn that truly
+// finished AND for a session with no assistant batch at all — and an empty
+// session is reachable with the park perfectly intact, because
+// GetOrCreateSessionWithAgent fails OPEN (a load error yields a fresh empty
+// session under the same ID) and LoadSession is user-scoped. Closing the row
+// on that signal erases the human's decision record for good.
+//
+// Simulated here by resuming a session id that holds a valid row but has no
+// conversation: the refusal must be read-only.
+func TestPark_UnloadableSessionDoesNotDestroyTheApproval(t *testing.T) {
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, twoCallBatch(),
+		"read_table", "export_csv")
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-lost", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-lost")
+
+	// Re-point the row at a session with no history at all, standing in for a
+	// session the resume could not load.
+	hr.SessionID = "s-lost-empty"
+	if err := f.store.Update(ctx, hr); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if _, err := f.ag.ResumeChat(ctx, "s-lost-empty", ParkDecision{
+		RequestID: hr.ID, ItemIDs: paramKeys(hr), Approved: true,
+	}, nil); !errors.Is(err, ErrNothingParked) {
+		t.Fatalf("resume against an empty session = %v, want ErrNothingParked", err)
+	}
+
+	after, gerr := f.store.Get(ctx, hr.ID)
+	if gerr != nil || after == nil {
+		t.Fatalf("Get: %v", gerr)
+	}
+	if after.Status != "pending" {
+		t.Errorf("APPROVAL DESTROYED: row status = %q after a refusal that proved nothing "+
+			"about the turn; a correctly-scoped resume can never complete it now", after.Status)
+	}
+}

--- a/pkg/agent/hitl_park_concurrency_test.go
+++ b/pkg/agent/hitl_park_concurrency_test.go
@@ -369,3 +369,62 @@ func TestPark_UnloadableSessionDoesNotDestroyTheApproval(t *testing.T) {
 			"about the turn; a correctly-scoped resume can never complete it now", after.Status)
 	}
 }
+
+// TestPark_SpentDecisionCannotBindALaterBatchOfTheSameTool is the
+// approval-bypass proof. A decided row still LOADS (the embedder-recorded flow
+// needs that), so a redelivered decision is refused only by the item binding —
+// and tool name plus batch position can carry no information at all: on Gemini
+// ToolCall.ID IS the function name, so for a single-call batch id, tool and
+// seq are one fact and every same-tool batch looks identical. The arguments
+// the human actually saw are the only thing that separates them.
+func TestPark_SpentDecisionCannotBindALaterBatchOfTheSameTool(t *testing.T) {
+	// Gemini-shaped: ID == tool name, so the ids collide across turns.
+	responses := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "export_csv", Name: "export_csv", Input: map[string]interface{}{"v": "customers_sample"}},
+		}},
+		{content: "first turn done"},
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "export_csv", Name: "export_csv", Input: map[string]interface{}{"v": "ALL_CUSTOMERS_PII"}},
+		}},
+		{content: "second turn done"},
+	}
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, responses)
+	exp := &countingTool{name: "export_csv"}
+	f.ag.RegisterTool(exp)
+	ctx := context.Background()
+
+	// Turn 1: parks, human approves the SAMPLE export, it runs.
+	_, err := f.ag.Chat(ctx, "s-spent", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr1 := f.pendingParked(t, "s-spent")
+	spent := ParkDecision{RequestID: hr1.ID, ItemIDs: paramKeys(hr1), Approved: true}
+	if _, err := f.ag.ResumeChat(ctx, "s-spent", spent, nil); err != nil {
+		t.Fatalf("resume 1: %v", err)
+	}
+	if got := exp.runs.Load(); got != 1 {
+		t.Fatalf("approved sample export ran %d times, want 1", got)
+	}
+
+	// Turn 2: parks the PII export. Nobody has seen this card.
+	_, err = f.ag.Chat(ctx, "s-spent", "again")
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected second park, got %v", err)
+	}
+
+	// Turn 1's spent decision is redelivered — a retry, a stale Approve click,
+	// an at-least-once queue. It must not authorize turn 2's arguments.
+	_, err = f.ag.ResumeChat(ctx, "s-spent", spent, nil)
+	if err == nil {
+		t.Errorf("APPROVAL BYPASS: a spent decision for {v:customers_sample} was accepted " +
+			"for a batch running {v:ALL_CUSTOMERS_PII}")
+	} else if !errors.Is(err, ErrStaleDecision) {
+		t.Logf("refused with %v", err)
+	}
+	if got := exp.runs.Load(); got != 1 {
+		t.Errorf("APPROVAL BYPASS: export_csv ran %d times; the unapproved PII export executed", got)
+	}
+}

--- a/pkg/agent/hitl_park_concurrency_test.go
+++ b/pkg/agent/hitl_park_concurrency_test.go
@@ -594,3 +594,36 @@ func (r *recordingExecStore) saved() []ToolExecution {
 	defer r.mu.Unlock()
 	return append([]ToolExecution(nil), r.execs...)
 }
+
+// TestPark_OperatorRetirementReleasesTheSession — `looms hitl expire` is the
+// operator's one recovery route for a stranded park, and it writes "timeout".
+// The unapplied-tail guard must not hold on that: a timeout is a closure, not
+// a verdict awaiting application, and nobody is coming to apply it. Holding
+// would make the recovery route do nothing.
+func TestPark_OperatorRetirementReleasesTheSession(t *testing.T) {
+	responses := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "c-write", Name: "export_csv", Input: map[string]interface{}{"v": "w"}},
+		}},
+		{content: "unreachable"},
+		{content: "after retirement"},
+	}
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, responses, "export_csv")
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-retire", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-retire")
+
+	// The operator retires it. The batch stays rowless — that is the point.
+	if err := f.store.ExpireRequest(ctx, hr.ID, "operator:someone"); err != nil {
+		t.Fatalf("ExpireRequest: %v", err)
+	}
+
+	if _, err := f.ag.Chat(ctx, "s-retire", "carry on"); err != nil {
+		t.Errorf("session still held after the operator retired the park: %v", err)
+	}
+}

--- a/pkg/agent/hitl_park_concurrency_test.go
+++ b/pkg/agent/hitl_park_concurrency_test.go
@@ -320,7 +320,7 @@ func TestPark_UnresumableTurnReleasesTheSession(t *testing.T) {
 	if after == nil || after.Status == "pending" {
 		t.Errorf("unresumable row left pending (%v); the session is wedged at guardParkedTail", after)
 	}
-	if err := f.ag.guardParkedTail(ctx, "s-unres"); err != nil {
+	if err := f.ag.guardParkedTail(ctx, "s-unres", sess); err != nil {
 		t.Errorf("session still held after the park became unresumable: %v", err)
 	}
 }
@@ -427,4 +427,170 @@ func TestPark_SpentDecisionCannotBindALaterBatchOfTheSameTool(t *testing.T) {
 	if got := exp.runs.Load(); got != 1 {
 		t.Errorf("APPROVAL BYPASS: export_csv ran %d times; the unapproved PII export executed", got)
 	}
+}
+
+// TestPark_DecidedButUnappliedParkStillHoldsTheSession — the embedder-recorded
+// flow decides the row BEFORE calling ResumeChat, so between those moments the
+// batch is unapplied while the row is no longer "pending". Matching on status
+// alone admitted a new user turn that buried the batch: the human's approval
+// was silently discarded and the history told the model the call never ran.
+func TestPark_DecidedButUnappliedParkStillHoldsTheSession(t *testing.T) {
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, twoCallBatch(),
+		"read_table", "export_csv")
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-decided", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-decided")
+
+	// The embedder's respond door decides the row; ResumeChat has NOT run.
+	if err := f.store.RespondToRequest(ctx, hr.ID, "approved", "ok", "human", nil); err != nil {
+		t.Fatalf("RespondToRequest: %v", err)
+	}
+
+	if _, err := f.ag.Chat(ctx, "s-decided", "sneak a new turn in"); !errors.As(err, new(*SessionParkedError)) {
+		t.Errorf("a new turn was admitted over a decided-but-unapplied park (%v); "+
+			"the batch is buried and the approval silently discarded", err)
+	}
+}
+
+// TestPark_QuestionParkAnsweredAsRespondedResumes — "responded" is the
+// documented status for an input/decision request and the natural one for a
+// question card. Refusing it stranded the turn behind a terminal error.
+func TestPark_QuestionParkAnsweredAsRespondedResumes(t *testing.T) {
+	script := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "c-q", Name: "contact_human", Input: map[string]interface{}{"question": "which env?"}},
+		}},
+		{content: "done"},
+	}
+	f := newParkFixture(t, nil, script, "contact_human")
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-resp", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-resp")
+	if hr.Kind != "question" {
+		t.Fatalf("card Kind = %q, want question", hr.Kind)
+	}
+	if err := f.store.RespondToRequest(ctx, hr.ID, "responded", "staging", "human", nil); err != nil {
+		t.Fatalf("RespondToRequest: %v", err)
+	}
+
+	if _, err := f.ag.ResumeChat(ctx, "s-resp", ParkDecision{
+		RequestID: hr.ID, ItemIDs: paramKeys(hr), Approved: true,
+		Answers: map[string]string{"c-q": "staging"},
+	}, nil); err != nil {
+		t.Fatalf("resume of a responded question park = %v, want success", err)
+	}
+}
+
+// TestPark_UnbindableCallIDsDoNotPark — the card is keyed by ToolCall.ID, so
+// duplicate IDs collapse two calls into ONE descriptor (the human approves one
+// action, two run) and an empty ID can never be matched back. Providers really
+// do produce both. Such a batch must not park; it dispatches inline, where an
+// Ask with no resolver fails closed.
+func TestPark_UnbindableCallIDsDoNotPark(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		id1  string
+		id2  string
+	}{
+		{"duplicate ids", "dup", "dup"},
+		{"empty id", "", "c-2"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			script := []mockLLMResponse{
+				{content: "", toolCalls: []llmtypes.ToolCall{
+					{ID: tc.id1, Name: "export_csv", Input: map[string]interface{}{"v": "a"}},
+					{ID: tc.id2, Name: "export_csv", Input: map[string]interface{}{"v": "b"}},
+				}},
+				{content: "done"},
+			}
+			f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, script)
+			exp := &countingTool{name: "export_csv"}
+			f.ag.RegisterTool(exp)
+			ctx := context.Background()
+
+			sid := "s-unbindable-" + tc.name
+			_, err := f.ag.Chat(ctx, sid, "go")
+			if errors.As(err, new(*TurnParkedError)) {
+				t.Fatalf("parked a batch whose call IDs cannot bind a decision")
+			}
+			if reqs, _ := f.store.ListBySession(ctx, sid); len(reqs) != 0 {
+				t.Errorf("raised %d card(s) for an unbindable batch", len(reqs))
+			}
+			// Fail-closed inline: no resolver, so the governed body never runs.
+			if got := exp.runs.Load(); got != 0 {
+				t.Errorf("export_csv ran %d times with no approval path", got)
+			}
+		})
+	}
+}
+
+// TestPark_SynthesizedRefusalCarriesItsAuditVerdict — a deny must ride every
+// deny. These rows never pass through Executor.Execute, so nothing else stamps
+// them, and a NULL verdict is miscounted by analytics keying on
+// admission_decision IS NULL.
+func TestPark_SynthesizedRefusalCarriesItsAuditVerdict(t *testing.T) {
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, twoCallBatch(),
+		"read_table", "export_csv")
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-audit", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-audit")
+
+	// A resumed turn's Response.ToolExecutions covers the post-resume loop
+	// only; the parked batch's are authoritative in the PERSISTED records, so
+	// observe those.
+	rec := &recordingExecStore{SessionStorage: f.sessions}
+	f.ag.memory = NewMemoryWithStore(rec)
+
+	if _, err := f.ag.ResumeChat(ctx, "s-audit", ParkDecision{
+		RequestID: hr.ID, ItemIDs: paramKeys(hr), Approved: false,
+		Reason: "rejected by user: not on prod",
+	}, nil); err != nil {
+		t.Fatalf("ResumeChat: %v", err)
+	}
+
+	saved := rec.saved()
+	if len(saved) == 0 {
+		t.Fatal("no tool executions persisted for the refused batch")
+	}
+	for _, e := range saved {
+		if e.Result != nil && !e.Result.Success && e.AdmissionDecision != "deny" {
+			t.Errorf("persisted refusal of %s carries AdmissionDecision %q, want \"deny\"",
+				e.ToolName, e.AdmissionDecision)
+		}
+	}
+}
+
+// recordingExecStore captures what actually reaches durable storage.
+type recordingExecStore struct {
+	SessionStorage
+	mu    sync.Mutex
+	execs []ToolExecution
+}
+
+func (r *recordingExecStore) SaveToolExecution(ctx context.Context, sessionID string, exec ToolExecution) error {
+	r.mu.Lock()
+	r.execs = append(r.execs, exec)
+	r.mu.Unlock()
+	return r.SessionStorage.SaveToolExecution(ctx, sessionID, exec)
+}
+
+func (r *recordingExecStore) saved() []ToolExecution {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]ToolExecution(nil), r.execs...)
 }

--- a/pkg/agent/hitl_park_noop_test.go
+++ b/pkg/agent/hitl_park_noop_test.go
@@ -28,10 +28,12 @@ package agent
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+	"github.com/teradata-labs/loom/pkg/observability"
 	"github.com/teradata-labs/loom/pkg/shuttle"
 )
 
@@ -68,7 +70,17 @@ func startParkNoopAgent(t *testing.T, parkEnabled bool) *Agent {
 		{content: "all done"},
 	}}
 
-	opts := []Option{WithConfig(cfg)}
+	// A session store on BOTH arms. Park's pre-scan gate requires one (a
+	// request row may not outlive its batch), so a storeless "park enabled"
+	// arm silently runs with the pre-scan off and the differential compares
+	// park-off against park-off — proving nothing.
+	sessions, err := NewSessionStore(filepath.Join(t.TempDir(), "noop.db"), observability.NewNoOpTracer())
+	if err != nil {
+		t.Fatalf("session store: %v", err)
+	}
+	t.Cleanup(func() { _ = sessions.Close() })
+
+	opts := []Option{WithConfig(cfg), WithMemory(NewMemoryWithStore(sessions))}
 	if parkEnabled {
 		opts = append(opts, WithHITLPark(shuttle.NewInMemoryHumanRequestStore(), 0, nil))
 	}

--- a/pkg/agent/hitl_park_resume_effects_test.go
+++ b/pkg/agent/hitl_park_resume_effects_test.go
@@ -1,0 +1,205 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package agent
+
+// Per-TURN work must happen once per turn, not once per loop entry — a parked
+// turn enters the loop twice. And the card the human is shown must describe
+// what the model actually asked for. Each test here was written against a
+// deletion that the suite previously accepted in silence.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+	"github.com/teradata-labs/loom/pkg/observability"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+)
+
+// metricRecorder wraps a tracer and remembers the metric names it recorded.
+// The package's other recording tracer lives in package agent_test and so is
+// not reachable from here.
+type metricRecorder struct {
+	observability.Tracer
+	mu    sync.Mutex
+	names []string
+}
+
+func (m *metricRecorder) RecordMetric(name string, value float64, labels map[string]string) {
+	m.mu.Lock()
+	m.names = append(m.names, name)
+	m.mu.Unlock()
+	m.Tracer.RecordMetric(name, value, labels)
+}
+
+func (m *metricRecorder) count() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.names)
+}
+
+func (m *metricRecorder) namesAfter(n int) map[string]bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := map[string]bool{}
+	for _, name := range m.names[n:] {
+		out[name] = true
+	}
+	return out
+}
+
+// TestPark_ResumeDoesNotReinjectGraphMemoryContext — the loop injects graph
+// memory context at ENTRY, and a resumed turn enters it a second time for the
+// same turn. Without a resume marker the block is injected twice, duplicating
+// memory text in the prompt and paying a second recall round-trip per resume.
+func TestPark_ResumeDoesNotReinjectGraphMemoryContext(t *testing.T) {
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, twoCallBatch(),
+		"read_table", "export_csv")
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-graph", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-graph")
+
+	countBlocks := func() int {
+		sess := f.ag.memory.GetOrCreateSessionWithAgent(ctx, "s-graph", f.ag.config.Name, "")
+		n := 0
+		for _, m := range rawSessionMessages(sess) {
+			if strings.Contains(m.Content, "[Graph Memory Context]") {
+				n++
+			}
+		}
+		return n
+	}
+	before := countBlocks()
+
+	if _, err := f.ag.ResumeChat(ctx, "s-graph", ParkDecision{
+		RequestID: hr.ID, ItemIDs: paramKeys(hr), Approved: true,
+	}, nil); err != nil {
+		t.Fatalf("ResumeChat: %v", err)
+	}
+
+	if after := countBlocks(); after != before {
+		t.Errorf("graph memory context blocks went %d → %d across a resume; "+
+			"per-turn entry work ran twice for one turn", before, after)
+	}
+	if !isResumedTurn(contextWithResumedTurn(ctx)) {
+		t.Error("contextWithResumedTurn/isResumedTurn do not round-trip")
+	}
+}
+
+// TestPark_ResumedTurnIsCounted — a resumed turn is the one carrying the
+// human-approved actions. If it records none of the conversation metrics,
+// exactly the highest-risk turns go missing from the metrics backend.
+func TestPark_ResumedTurnIsCounted(t *testing.T) {
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, twoCallBatch(),
+		"read_table", "export_csv")
+	tracer := &metricRecorder{Tracer: f.ag.tracer}
+	f.ag.tracer = tracer
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-metrics", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-metrics")
+
+	// The park exit records nothing (the turn has not completed), so anything
+	// seen after this point belongs to the resume.
+	beforeResume := tracer.count()
+
+	if _, err := f.ag.ResumeChat(ctx, "s-metrics", ParkDecision{
+		RequestID: hr.ID, ItemIDs: paramKeys(hr), Approved: true,
+	}, nil); err != nil {
+		t.Fatalf("ResumeChat: %v", err)
+	}
+
+	seen := tracer.namesAfter(beforeResume)
+	for _, want := range []string{
+		"agent.turns.total",
+		"agent.tool_executions.total",
+		"agent.cost.usd",
+		"agent.tokens.total",
+	} {
+		if !seen[want] {
+			t.Errorf("resumed turn recorded no %q — the turns carrying human-approved "+
+				"actions are missing from the metrics backend", want)
+		}
+	}
+}
+
+// TestPark_AllQuestionParkRendersAsAQuestionCard — a card renderer keys its
+// shape off Kind. A park whose items are all questions must not arrive as an
+// approve/reject prompt, or the human is asked to approve where the model
+// asked them something.
+func TestPark_AllQuestionParkRendersAsAQuestionCard(t *testing.T) {
+	script := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "c-q", Name: "contact_human", Input: map[string]interface{}{"question": "prod or staging?"}},
+		}},
+		{content: "done"},
+	}
+	f := newParkFixture(t, nil, script, "contact_human")
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-qcard", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-qcard")
+
+	if hr.Kind != "question" {
+		t.Errorf("card Kind = %q, want \"question\" for an all-question park", hr.Kind)
+	}
+	if hr.Question != "prod or staging?" {
+		t.Errorf("card Question = %q, want the model's own question verbatim", hr.Question)
+	}
+}
+
+// TestPark_MixedBatchRendersAsAnApprovalCard — anything other than an
+// all-question batch is an approval over the batch.
+func TestPark_MixedBatchRendersAsAnApprovalCard(t *testing.T) {
+	script := []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "c-q", Name: "contact_human", Input: map[string]interface{}{"question": "which env?"}},
+			{ID: "c-w", Name: "export_csv", Input: map[string]interface{}{"v": "w"}},
+		}},
+		{content: "done"},
+	}
+	f := newParkFixture(t, []shuttle.Hook{scopedAskHook{tool: "export_csv"}}, script,
+		"contact_human", "export_csv")
+	ctx := context.Background()
+
+	_, err := f.ag.Chat(ctx, "s-mixcard", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	hr := f.pendingParked(t, "s-mixcard")
+
+	if hr.Kind != "approval" {
+		t.Errorf("mixed-batch card Kind = %q, want \"approval\"", hr.Kind)
+	}
+	if !strings.Contains(hr.Question, "2") {
+		t.Errorf("mixed-batch card Question = %q, want it to name both pending actions", hr.Question)
+	}
+}

--- a/pkg/agent/hitl_park_test.go
+++ b/pkg/agent/hitl_park_test.go
@@ -72,9 +72,10 @@ func (h scopedDenyHook) Evaluate(shuttle.AdmissionRequest) shuttle.Decision {
 }
 
 type parkFixture struct {
-	ag    *Agent
-	store *shuttle.InMemoryHumanRequestStore
-	tools map[string]*countingTool
+	ag       *Agent
+	store    *shuttle.InMemoryHumanRequestStore
+	sessions SessionStorage
+	tools    map[string]*countingTool
 }
 
 // newParkFixture builds a park-enabled agent: hooks govern via the given
@@ -114,7 +115,7 @@ func newParkFixture(t *testing.T, hooks []shuttle.Hook, responses []mockLLMRespo
 		ag.RegisterTool(ct)
 		tools[n] = ct
 	}
-	return &parkFixture{ag: ag, store: store, tools: tools}
+	return &parkFixture{ag: ag, store: store, sessions: sessions, tools: tools}
 }
 
 // pendingParked returns the single pending parked request for the session.

--- a/pkg/agent/park.go
+++ b/pkg/agent/park.go
@@ -27,6 +27,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -101,8 +102,9 @@ func (e *SessionParkedError) Error() string {
 	return fmt.Sprintf("session is waiting for a human decision (request %s)", e.RequestID)
 }
 
-// Typed terminals for ResumeChat callers. All are terminal: the caller must
+// Typed terminals for ResumeChat callers. These are terminal: the caller must
 // finish the request's lifecycle and never retry the resume.
+// ErrClaimNotConfirmed, declared below, is the exception — it is retryable.
 var (
 	// ErrNothingParked: the tail turn is fully complete — there is no batch to
 	// finish and no loop to re-enter.
@@ -121,7 +123,15 @@ var (
 	// session. Covers a missing row, a row from another session, and a
 	// non-parked request type — all indistinguishable to a caller by design.
 	ErrUnknownRequest = errors.New("no pending parked request for this session")
+	// ErrDecisionExpired: the row lapsed before the decision could be claimed.
+	// The turn is closed out; nothing ran.
+	ErrDecisionExpired = errors.New("parked request expired before the decision was applied")
 )
+
+// ErrClaimNotConfirmed: the decision could not be claimed and could not be
+// confirmed as claimed by anyone else. RETRYABLE, unlike the terminals above —
+// the row may still be pending, and nothing has been executed.
+var ErrClaimNotConfirmed = errors.New("parked decision claim could not be confirmed")
 
 // ParkDecision is the human's verdict for one parked batch.
 //
@@ -241,6 +251,105 @@ func sameIDSet(a, b []string) bool {
 	return true
 }
 
+// resumeClaimKey is the response-data field carrying the claim token — the
+// only thing that identifies WHICH resume closed the row.
+const resumeClaimKey = "resume_claim"
+
+// claimParkedRequest takes exclusive ownership of a still-pending decision
+// before any of its batch executes, and reports whether this resume is the
+// owner. Standalone flow only: a pre-decided row is already closed and has
+// nothing left to claim.
+func (a *Agent) claimParkedRequest(ctx context.Context, hr *shuttle.HumanRequest, decision ParkDecision, expired bool) error {
+	if expired {
+		// RespondToRequest cannot close a lapsed row — the store's expiry
+		// guard is its own and no status payload lifts it — and ExpireRequest
+		// carries no response data to stamp a claim with. Nothing executes on
+		// this path (every call is refused), so the close only has to happen.
+		if err := a.hitlPark.store.ExpireRequest(ctx, hr.ID, "system:expiry"); err != nil {
+			return fmt.Errorf("closing lapsed parked request: %w", err)
+		}
+		return nil
+	}
+
+	token := uuid.New().String()
+	status := "rejected"
+	if decision.Approved {
+		status = "approved"
+	}
+	if err := a.hitlPark.store.RespondToRequest(ctx, hr.ID, status, decision.Reason, "human",
+		map[string]interface{}{resumeClaimKey: token}); err != nil {
+		return fmt.Errorf("claiming parked decision: %w", err)
+	}
+
+	// Judge the write by reading the row back — never by its error, which is
+	// nil both when the write landed and when the store refused it as a
+	// deliberate no-op (already decided, or expired since we looked).
+	after, gerr := a.hitlPark.store.Get(ctx, hr.ID)
+	if gerr != nil || after == nil {
+		return fmt.Errorf("verifying parked decision claim: %w", errors.Join(gerr, ErrClaimNotConfirmed))
+	}
+
+	if after.Status == "pending" {
+		// Refused while still pending means the row lapsed between our expiry
+		// check and this write. Close it the one way that works past expiry,
+		// so the session is not left holding a decided-but-open row.
+		if eerr := a.hitlPark.store.ExpireRequest(ctx, hr.ID, "system:expiry"); eerr != nil {
+			zap.L().Error("parked request could not be closed; the session will refuse new turns until it is",
+				zap.String("session_id", hr.SessionID),
+				zap.String("request_id", hr.ID),
+				zap.Error(eerr))
+			return ErrClaimNotConfirmed
+		}
+		return ErrDecisionExpired
+	}
+
+	// "No longer pending" does NOT mean we are the one who closed it. Under
+	// concurrent claims the store's conditional write admits exactly one and
+	// silently no-ops the rest, and every loser then reads back a non-pending
+	// row. Only the token says who won.
+	if got, _ := after.ResponseData[resumeClaimKey].(string); got != token {
+		return ErrUnknownRequest
+	}
+	return nil
+}
+
+// abandonParkedRequest terminally closes a row whose TURN can no longer be
+// resumed. Without it the row stays pending and guardParkedTail refuses every
+// later message on that session.
+func (a *Agent) abandonParkedRequest(ctx context.Context, hr *shuttle.HumanRequest, cause error) {
+	if err := a.hitlPark.store.ExpireRequest(ctx, hr.ID, "system:unresumable"); err != nil {
+		zap.L().Error("unresumable parked request could not be closed; the session will refuse new turns until it is",
+			zap.String("session_id", hr.SessionID),
+			zap.String("request_id", hr.ID),
+			zap.NamedError("cause", cause),
+			zap.Error(err))
+		return
+	}
+	zap.L().Warn("closed a parked request whose turn can no longer be resumed",
+		zap.String("session_id", hr.SessionID),
+		zap.String("request_id", hr.ID),
+		zap.NamedError("cause", cause))
+}
+
+// lockSession serializes resumes of one session within this process, and
+// returns the unlock func. One mutex per live session; not pruned, because a
+// mutex is one pointer and sessions are bounded by the host's own lifetime.
+func (a *Agent) lockSession(sessionID string) func() {
+	a.sessionLocksMu.Lock()
+	if a.sessionLocks == nil {
+		a.sessionLocks = make(map[string]*sync.Mutex)
+	}
+	mu, ok := a.sessionLocks[sessionID]
+	if !ok {
+		mu = &sync.Mutex{}
+		a.sessionLocks[sessionID] = mu
+	}
+	a.sessionLocksMu.Unlock()
+
+	mu.Lock()
+	return mu.Unlock
+}
+
 // closeParkedRequest terminally closes the row whose decision was just
 // applied. This is what keeps a session usable: guardParkedTail refuses a new
 // turn while a parked row is pending, so a decided batch whose row stays
@@ -283,10 +392,20 @@ func (a *Agent) guardParkedTail(ctx context.Context, sessionID string) error {
 			zap.String("session_id", sessionID), zap.Error(err))
 		return nil
 	}
+	now := time.Now()
 	for _, r := range reqs {
-		if r != nil && r.RequestType == "parked" && r.Status == "pending" {
-			return &SessionParkedError{RequestID: r.ID, SessionID: sessionID, ExpiresAt: r.ExpiresAt}
+		if r == nil || r.RequestType != "parked" || r.Status != "pending" {
+			continue
 		}
+		// A LAPSED row no longer holds the session. Nothing sweeps parked rows
+		// — a park has no waiter by design, and the only ExpireRequest callers
+		// are the in-turn waiters and the operator CLI — so matching on
+		// "pending" alone lets a park nobody ever decided refuse every future
+		// turn on this session, permanently.
+		if !r.ExpiresAt.IsZero() && now.After(r.ExpiresAt) {
+			continue
+		}
+		return &SessionParkedError{RequestID: r.ID, SessionID: sessionID, ExpiresAt: r.ExpiresAt}
 	}
 	return nil
 }
@@ -548,20 +667,17 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 	}
 	ctx = session.WithSessionID(ctx, sessionID)
 
-	// Session-handle lifecycle: the resumed turn ADOPTS the handles its parked
-	// half minted (same-process embedders), so a handle the model is about to
-	// use is still live. A nested park re-parks them; any other exit releases
-	// them, closing out the whole turn's handles exactly once. Pooled
-	// embedders adopt nothing (fresh Agent) and drain each park's slot via
-	// ReleaseParkedHandles instead.
-	ctx, handleCollector := a.adoptParkedHandles(ctx, sessionID)
-	parkedAgain := false
-	defer func() {
-		if parkedAgain {
-			return
-		}
-		a.leases.apply(sessionID, handleCollector.ReleaseAll(zap.L()), nil)
-	}()
+	// One resume at a time per session, in this process. The tail walk cannot
+	// be the double-application guard on its own: it reads the batch's rowless
+	// calls BEFORE any of them execute, so two overlapping resumes of one
+	// decision both see work to do and both do it. The pending flow closes
+	// that cross-process too (claimParkedRequest below); the embedder-recorded
+	// flow cannot — its row is already decided, so there is nothing left to
+	// claim — and for that flow this lock is the whole guarantee. A pooled
+	// embedder spreading resumes across processes must deliver an
+	// already-decided resume at most once itself.
+	unlock := a.lockSession(sessionID)
+	defer unlock()
 
 	startTime := time.Now()
 	ctx, span := a.tracer.StartSpan(ctx, "agent.conversation.resume")
@@ -571,7 +687,6 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 	span.SetAttribute("resume.approved", decision.Approved)
 
 	sess := a.memory.GetOrCreateSessionWithAgent(ctx, sessionID, a.config.Name, "")
-	a.seedLeaseHolding(ctx, sessionID)
 
 	// NO DropTurnPayloads / dropInTurnSQLite — the parked turn is still the
 	// current turn. NO user append — resuming is not a new turn. NO graph
@@ -637,6 +752,13 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 
 	batch, rowless, err := locateParkedBatch(sess, itemIDs)
 	if err != nil {
+		// The TURN is unresumable — history moved on, or it already replied.
+		// A still-PENDING row for a turn that can never be resumed holds the
+		// session at guardParkedTail forever, so close it on the way out. A
+		// pre-decided row is already closed.
+		if !preDecided {
+			a.abandonParkedRequest(ctx, hr, err)
+		}
 		span.AddEvent("resume.refused", map[string]interface{}{"reason": err.Error()})
 		return nil, err
 	}
@@ -650,16 +772,46 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 		return nil, bindErr
 	}
 
-	if len(rowless) > 0 {
-		a.completeParkedBatch(agentCtx, sess, batch, rowless, effective, itemIDs)
+	// CLAIM the decision BEFORE executing anything, on the standalone flow
+	// where the row is still pending and can therefore serve as the claim.
+	// Closing afterwards is too late twice over: two resumes both get past
+	// the tail walk and both execute, and a close that the store refuses —
+	// because the row lapsed while the batch ran — returns nil, leaving the
+	// row pending and the session refused at guardParkedTail forever.
+	//
+	// Claiming first also makes a parked batch at-most-once: a crash mid-batch
+	// leaves the row closed and the remainder unrun, the safe direction for
+	// actions a human gated. A pre-decided row is already closed by the
+	// embedder's respond door; the session lock is its only guard.
+	if !preDecided {
+		if err := a.claimParkedRequest(ctx, hr, effective, expired); err != nil {
+			span.AddEvent("resume.refused", map[string]interface{}{"reason": err.Error()})
+			return nil, err
+		}
 	}
 
-	// Close the row the moment its decision has been applied — before the
-	// loop re-entry that may park a NEW request. A row left pending here
-	// wedges every later turn at guardParkedTail. A pre-decided row is
-	// already closed (the embedder's respond door decided it).
-	if !preDecided {
-		a.closeParkedRequest(ctx, hr, effective, expired)
+	// Past this line the decision is ours and the turn is ours to finish.
+	// Session-handle lifecycle: adopt the handles the parked half minted
+	// (same-process embedders), so a handle the model is about to use is still
+	// live. Adoption happens HERE, not at entry: it removes the collector from
+	// the parked slot, so adopting before the decision is validated would let
+	// a refused resume release the handles of a turn that is still parked.
+	// A nested park re-parks them; any other exit releases them, closing out
+	// the whole turn's handles exactly once. Pooled embedders adopt nothing
+	// (fresh Agent) and drain each park's slot via ReleaseParkedHandles.
+	ctx, handleCollector := a.adoptParkedHandles(ctx, sessionID)
+	parkedAgain := false
+	defer func() {
+		if parkedAgain {
+			return
+		}
+		a.leases.apply(sessionID, handleCollector.ReleaseAll(zap.L()), nil)
+	}()
+	a.seedLeaseHolding(ctx, sessionID)
+	agentCtx.Context = ctx
+
+	if len(rowless) > 0 {
+		a.completeParkedBatch(agentCtx, sess, batch, rowless, effective, itemIDs)
 	}
 
 	response, err := a.runConversationLoop(agentCtx)

--- a/pkg/agent/park.go
+++ b/pkg/agent/park.go
@@ -455,6 +455,15 @@ func (a *Agent) guardParkedTail(ctx context.Context, sessionID string, sess *Ses
 			if r == nil || r.RequestType != "parked" || r.Status == "pending" {
 				continue
 			}
+			// Only a VERDICT awaiting application holds the session. "timeout"
+			// is a closure, not a verdict — it is what `looms hitl expire`
+			// writes to retire a stranded park, and what an expiry sweep
+			// writes. Holding on it would make the operator's one recovery
+			// route do nothing, which is worse than the burial this guard
+			// exists to prevent: nobody is coming to apply it.
+			if r.Status != "approved" && r.Status != "rejected" && r.Status != "responded" {
+				continue
+			}
 			if !r.ExpiresAt.IsZero() && now.After(r.ExpiresAt) {
 				continue
 			}

--- a/pkg/agent/park.go
+++ b/pkg/agent/park.go
@@ -238,8 +238,38 @@ func verifyItemBinding(hr *shuttle.HumanRequest, batch Message) error {
 				return ErrStaleDecision
 			}
 		}
+		// The ARGUMENTS the human saw must be the arguments about to run.
+		// Tool and seq alone can carry no information at all: on Gemini
+		// ToolCall.ID IS the function name (pkg/llm/gemini/client.go —
+		// "Gemini doesn't provide call IDs"), so for a single-call batch id,
+		// tool and seq collapse into one fact and every same-tool batch looks
+		// identical. Without this a spent decision — which still loads, since
+		// the embedder-recorded flow accepts a decided row — re-binds to a
+		// LATER batch of the same tool and executes arguments nobody approved.
+		if !sameParkedParams(desc, batch.ToolCalls[idx]) {
+			return ErrStaleDecision
+		}
 	}
 	return nil
+}
+
+// sameParkedParams reports whether a request item's recorded params still
+// describe the call it names. The descriptor holds either the bounded params
+// map or, when that overflowed, the display digest — compare like with like.
+// A descriptor carrying neither cannot vouch for anything and is refused.
+func sameParkedParams(desc map[string]interface{}, call ToolCall) bool {
+	switch recorded := desc["params"].(type) {
+	case string:
+		// Digest form (params_truncated): compare the same rendering.
+		return recorded == shuttle.SummarizeCall(call.Name, call.Input)
+	case map[string]interface{}:
+		bounded, _ := shuttle.BoundParams(call.Input)
+		a, aerr := json.Marshal(recorded)
+		b, berr := json.Marshal(bounded)
+		return aerr == nil && berr == nil && string(a) == string(b)
+	default:
+		return false
+	}
 }
 
 // sameIDSet reports whether two id lists describe the same set.

--- a/pkg/agent/park.go
+++ b/pkg/agent/park.go
@@ -124,7 +124,9 @@ var (
 	// non-parked request type — all indistinguishable to a caller by design.
 	ErrUnknownRequest = errors.New("no pending parked request for this session")
 	// ErrDecisionExpired: the row lapsed before the decision could be claimed.
-	// The turn is closed out; nothing ran.
+	// Nothing ran, and the row is now closed as "timeout" — which the next
+	// resume reads as an embedder-recorded refusal, so retrying DOES finish the
+	// turn with refusal rows. Without a retry the batch stays rowless.
 	ErrDecisionExpired = errors.New("parked request expired before the decision was applied")
 )
 
@@ -163,9 +165,15 @@ type ParkDecision struct {
 // the decision channel and closes the row after applying. A DECIDED row
 // (approved/rejected/timeout) is the embedder-recorded flow: the embedder's
 // respond door decided the row first — under its own expiry CAS — and the
-// resume applies that recorded verdict. Double-application is not guarded
-// here for either state; the tail walk is the guard (an applied batch has its
-// tool rows, so a replay lands in ErrNothingParked/ErrStaleDecision).
+// resume applies that recorded verdict.
+//
+// The standalone flow CLAIMS the row before applying anything, so it is
+// guarded against double application across agents and processes
+// (claimParkedRequest). The embedder-recorded flow has no row left to claim,
+// so its only guards are the per-Agent session lock and the tail walk (an
+// applied batch has its tool rows, so a later replay lands in
+// ErrNothingParked/ErrStaleDecision) — neither of which covers two Agent
+// instances racing. That is the embedder's obligation.
 func (a *Agent) loadParkedRequest(ctx context.Context, sessionID, requestID string) (hr *shuttle.HumanRequest, preDecided bool, err error) {
 	if requestID == "" {
 		return nil, false, ErrUnknownRequest
@@ -266,8 +274,15 @@ func (a *Agent) claimParkedRequest(ctx context.Context, hr *shuttle.HumanRequest
 		// carries no response data to stamp a claim with. Nothing executes on
 		// this path (every call is refused), so the close only has to happen.
 		if err := a.hitlPark.store.ExpireRequest(ctx, hr.ID, "system:expiry"); err != nil {
-			return fmt.Errorf("closing lapsed parked request: %w", err)
+			// Nothing ran and the row may still be pending: retryable.
+			return fmt.Errorf("closing lapsed parked request: %w: %v", ErrClaimNotConfirmed, err)
 		}
+		// ExpireRequest is a documented no-op returning nil on a row that is no
+		// longer pending, and carries no response data to stamp a token into,
+		// so this path CANNOT tell whether it won the close. Nothing executes
+		// here — every call is refused — so two claimants cost duplicate
+		// synthesized refusal rows, not duplicate side effects. The session
+		// lock covers one Agent; a pooled embedder owns the rest.
 		return nil
 	}
 
@@ -278,7 +293,8 @@ func (a *Agent) claimParkedRequest(ctx context.Context, hr *shuttle.HumanRequest
 	}
 	if err := a.hitlPark.store.RespondToRequest(ctx, hr.ID, status, decision.Reason, "human",
 		map[string]interface{}{resumeClaimKey: token}); err != nil {
-		return fmt.Errorf("claiming parked decision: %w", err)
+		// Nothing ran and the row may still be pending: retryable.
+		return fmt.Errorf("claiming parked decision: %w: %v", ErrClaimNotConfirmed, err)
 	}
 
 	// Judge the write by reading the row back — never by its error, which is
@@ -325,6 +341,13 @@ func (a *Agent) abandonParkedRequest(ctx context.Context, hr *shuttle.HumanReque
 			zap.Error(err))
 		return
 	}
+	// The turn is dead, so its parked handles will never be adopted. Give them
+	// back or the collector sits in parkedHandles until the process ends — and
+	// because ReleaseAll feeds the lease ledger, an orphaned collector leaves
+	// the session marked a lease holder, pinning every LATER turn on it to the
+	// RESOURCE_HOLDER scheduling class.
+	a.ReleaseParkedHandles(hr.SessionID)
+
 	zap.L().Warn("closed a parked request whose turn can no longer be resumed",
 		zap.String("session_id", hr.SessionID),
 		zap.String("request_id", hr.ID),
@@ -348,34 +371,6 @@ func (a *Agent) lockSession(sessionID string) func() {
 
 	mu.Lock()
 	return mu.Unlock
-}
-
-// closeParkedRequest terminally closes the row whose decision was just
-// applied. This is what keeps a session usable: guardParkedTail refuses a new
-// turn while a parked row is pending, so a decided batch whose row stays
-// pending would wedge the session for every later message.
-//
-// An expired row cannot be resolved — the store's expiry guard is its own and
-// no status payload lifts it — so it is closed through ExpireRequest, the one
-// path allowed to close past expiry. Close failures are logged, not returned:
-// the human's decision has already been applied to the batch, and failing the
-// resume would strand the turn it just completed.
-func (a *Agent) closeParkedRequest(ctx context.Context, hr *shuttle.HumanRequest, decision ParkDecision, expired bool) {
-	var err error
-	switch {
-	case expired:
-		err = a.hitlPark.store.ExpireRequest(ctx, hr.ID, "system:expiry")
-	case decision.Approved:
-		err = a.hitlPark.store.RespondToRequest(ctx, hr.ID, "approved", decision.Reason, "human", nil)
-	default:
-		err = a.hitlPark.store.RespondToRequest(ctx, hr.ID, "rejected", decision.Reason, "human", nil)
-	}
-	if err != nil {
-		zap.L().Error("parked request could not be closed; the session will refuse new turns until it is",
-			zap.String("session_id", hr.SessionID),
-			zap.String("request_id", hr.ID),
-			zap.Error(err))
-	}
 }
 
 // guardParkedTail refuses a new user turn while the session holds a PENDING
@@ -667,15 +662,19 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 	}
 	ctx = session.WithSessionID(ctx, sessionID)
 
-	// One resume at a time per session, in this process. The tail walk cannot
-	// be the double-application guard on its own: it reads the batch's rowless
-	// calls BEFORE any of them execute, so two overlapping resumes of one
-	// decision both see work to do and both do it. The pending flow closes
-	// that cross-process too (claimParkedRequest below); the embedder-recorded
-	// flow cannot — its row is already decided, so there is nothing left to
-	// claim — and for that flow this lock is the whole guarantee. A pooled
-	// embedder spreading resumes across processes must deliver an
-	// already-decided resume at most once itself.
+	// One resume at a time per session, PER AGENT INSTANCE. The tail walk
+	// cannot be the double-application guard on its own: it reads the batch's
+	// rowless calls BEFORE any of them execute, so two overlapping resumes of
+	// one decision both see work to do and both do it.
+	//
+	// Scope matters here, and this lock is the weaker half. sessionLocks lives
+	// on the Agent, so two Agents share nothing — and a pooled embedder builds
+	// a fresh Agent per call (the pattern ReleaseParkedHandles exists for).
+	// The standalone flow does not depend on it: claimParkedRequest below takes
+	// the ROW, which holds across agents and processes. The embedder-recorded
+	// flow has no row left to claim, so this lock is all it gets — meaning an
+	// embedder that pools agents, or spreads resumes across processes, must
+	// deliver an already-decided resume at most once itself.
 	unlock := a.lockSession(sessionID)
 	defer unlock()
 
@@ -696,12 +695,6 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 		ctx = ContextWithProgressCallback(ctx, progressCallback)
 	}
 	ctx = contextWithResumedTurn(ctx)
-	agentCtx := &agentContext{
-		Context:          ctx,
-		session:          sess,
-		tracer:           a.tracer,
-		progressCallback: progressCallback,
-	}
 
 	// The request row — not the caller's payload — is the batch binding. Its
 	// params keys ARE the items the human saw; a caller-supplied ItemIDs list
@@ -752,11 +745,25 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 
 	batch, rowless, err := locateParkedBatch(sess, itemIDs)
 	if err != nil {
-		// The TURN is unresumable — history moved on, or it already replied.
-		// A still-PENDING row for a turn that can never be resumed holds the
-		// session at guardParkedTail forever, so close it on the way out. A
-		// pre-decided row is already closed.
-		if !preDecided {
+		// Close the row ONLY on positive evidence that the turn is dead:
+		// ErrNotParkedTail means a later turn's user row is physically present
+		// after the batch, so the decision can never be applied.
+		//
+		// ErrNothingParked and ErrStaleDecision are absence of evidence, not
+		// evidence of death, and closing on them destroys a valid approval. An
+		// empty session yields ErrNothingParked, and an empty session is
+		// reachable with the park perfectly intact:
+		// GetOrCreateSessionWithAgent fails OPEN — on a load error it builds a
+		// fresh empty session under the same ID — and LoadSession is
+		// user-scoped (`WHERE id = ? AND user_id = ?`), so a transient store
+		// error, or a resume whose ctx carries a different identity than the
+		// session's owner, both land here. Expiring the row there erases the
+		// human's decision record for good.
+		//
+		// Leaving a row pending is recoverable: guardParkedTail ignores lapsed
+		// rows, so it stops holding the session at its TTL, and an operator can
+		// close it with `looms hitl expire`. Erasing an approval is not.
+		if !preDecided && errors.Is(err, ErrNotParkedTail) {
 			a.abandonParkedRequest(ctx, hr, err)
 		}
 		span.AddEvent("resume.refused", map[string]interface{}{"reason": err.Error()})
@@ -808,7 +815,17 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 		a.leases.apply(sessionID, handleCollector.ReleaseAll(zap.L()), nil)
 	}()
 	a.seedLeaseHolding(ctx, sessionID)
-	agentCtx.Context = ctx
+
+	// Built HERE so it can only ever carry the collector-bearing ctx —
+	// constructing it earlier and re-pointing .Context afterwards works only
+	// as long as nothing in between reads it, which is not a property the next
+	// person moving code through this function should have to preserve.
+	agentCtx := &agentContext{
+		Context:          ctx,
+		session:          sess,
+		tracer:           a.tracer,
+		progressCallback: progressCallback,
+	}
 
 	if len(rowless) > 0 {
 		a.completeParkedBatch(agentCtx, sess, batch, rowless, effective, itemIDs)

--- a/pkg/agent/park.go
+++ b/pkg/agent/park.go
@@ -715,8 +715,6 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 	span.SetAttribute("resume.request_id", decision.RequestID)
 	span.SetAttribute("resume.approved", decision.Approved)
 
-	sess := a.memory.GetOrCreateSessionWithAgent(ctx, sessionID, a.config.Name, "")
-
 	// NO DropTurnPayloads / dropInTurnSQLite — the parked turn is still the
 	// current turn. NO user append — resuming is not a new turn. NO graph
 	// extraction goroutine — there is no new user message to extract from.
@@ -772,6 +770,10 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 	}
 	span.SetAttribute("resume.expired", expired)
 	span.SetAttribute("resume.pre_decided", preDecided)
+
+	// The session is loaded only once the request has been validated: a bogus
+	// or foreign RequestID must not create and persist a session row.
+	sess := a.memory.GetOrCreateSessionWithAgent(ctx, sessionID, a.config.Name, "")
 
 	batch, rowless, err := locateParkedBatch(sess, itemIDs)
 	if err != nil {

--- a/pkg/agent/park.go
+++ b/pkg/agent/park.go
@@ -190,8 +190,18 @@ func (a *Agent) loadParkedRequest(ctx context.Context, sessionID, requestID stri
 		return hr, false, nil
 	case "approved", "rejected", "timeout":
 		return hr, true, nil
+	case "responded":
+		// The documented status for an input/decision request, and the natural
+		// one for a QUESTION park — the human answered, which is that card's
+		// whole verdict. Refusing it stranded the turn: the row is no longer
+		// pending, so the tail guard used to admit a new turn that buried the
+		// batch. On an APPROVAL card "responded" says nothing about approval,
+		// so it stays refused rather than being read as consent.
+		if hr.Kind == "question" {
+			return hr, true, nil
+		}
+		return nil, false, ErrUnknownRequest
 	default:
-		// "responded" or anything else is not a park verdict.
 		return nil, false, ErrUnknownRequest
 	}
 }
@@ -407,7 +417,7 @@ func (a *Agent) lockSession(sessionID string) func() {
 // parked request. Store errors fail open with a warn — the embedder's own
 // admission probe is the primary gate; this guard closes its race with a park
 // landing mid-turn, and must not turn a store hiccup into a dead session.
-func (a *Agent) guardParkedTail(ctx context.Context, sessionID string) error {
+func (a *Agent) guardParkedTail(ctx context.Context, sessionID string, sess *Session) error {
 	if a.hitlPark == nil {
 		return nil
 	}
@@ -432,7 +442,40 @@ func (a *Agent) guardParkedTail(ctx context.Context, sessionID string) error {
 		}
 		return &SessionParkedError{RequestID: r.ID, SessionID: sessionID, ExpiresAt: r.ExpiresAt}
 	}
+
+	// A DECIDED row does not hold the session by status — but the
+	// embedder-recorded flow decides the row BEFORE calling ResumeChat, so
+	// between those two moments the batch is still unapplied and matching on
+	// "pending" alone would admit a new user turn that buries it. The decision
+	// would then be silently discarded and the history would tell the model
+	// the call never completed. Ask the TAIL instead: an assistant batch still
+	// missing tool rows is an unapplied park, whatever the row says.
+	if hr := unappliedParkedTail(sess); hr != nil {
+		for _, r := range reqs {
+			if r == nil || r.RequestType != "parked" || r.Status == "pending" {
+				continue
+			}
+			if !r.ExpiresAt.IsZero() && now.After(r.ExpiresAt) {
+				continue
+			}
+			return &SessionParkedError{RequestID: r.ID, SessionID: sessionID, ExpiresAt: r.ExpiresAt}
+		}
+	}
 	return nil
+}
+
+// unappliedParkedTail reports the tail assistant batch when it still has calls
+// with no tool row — the durable shape a park leaves behind. Returns nil when
+// the tail is complete or there is no batch. Read-only.
+func unappliedParkedTail(sess *Session) *Message {
+	if sess == nil {
+		return nil
+	}
+	batch, rowless, err := locateParkedBatch(sess, nil)
+	if err != nil || len(rowless) == 0 {
+		return nil
+	}
+	return &batch
 }
 
 // resumedTurnKey marks a context as continuing a turn that already ran the
@@ -554,6 +597,18 @@ func (a *Agent) maybeParkBatch(ctx Context, sess *Session, llmResp *LLMResponse)
 	if len(items) == 0 {
 		return nil
 	}
+	// The card is keyed by ToolCall.ID, so an empty or duplicated ID makes the
+	// binding unrepresentable: buildParkParams would collapse two calls into
+	// ONE descriptor (the human approves one action, two run), and an empty ID
+	// can never be matched back to its call. Providers really do produce both
+	// — Ollama can omit the id, and Gemini parallel calls reuse the function
+	// name as the id. Refuse to park; the batch then dispatches inline, where
+	// an Ask with no resolver fails closed.
+	if err := checkParkItemIDs(items); err != nil {
+		zap.L().Warn("not parking a batch whose call IDs cannot bind a decision; dispatching inline",
+			zap.String("session_id", sess.ID), zap.Error(err))
+		return nil
+	}
 
 	now := time.Now()
 	params, truncated := buildParkParams(items)
@@ -609,6 +664,21 @@ func parkKindAndQuestion(items []parkItem) (kind, question string) {
 		return "question", fmt.Sprintf("Answer %d pending question(s)", len(items))
 	}
 	return "approval", fmt.Sprintf("Approve %d pending action(s)?", len(items))
+}
+
+// checkParkItemIDs rejects a batch whose park items cannot be named uniquely.
+func checkParkItemIDs(items []parkItem) error {
+	seen := make(map[string]bool, len(items))
+	for _, it := range items {
+		if it.call.ID == "" {
+			return fmt.Errorf("tool call %q has no ID", it.call.Name)
+		}
+		if seen[it.call.ID] {
+			return fmt.Errorf("tool call ID %q appears more than once", it.call.ID)
+		}
+		seen[it.call.ID] = true
+	}
+	return nil
 }
 
 // parkParamsMaxBytes bounds the whole grouped-request params map. Per-item
@@ -1119,6 +1189,13 @@ func (a *Agent) synthesizeParkedResult(ctx Context, sess *Session, call ToolCall
 		ToolName: call.Name,
 		Input:    call.Input,
 		Result:   res,
+	}
+	// A deny must ride every deny, audited or not (shuttle.AdmissionResult.
+	// PersistedDecision). These rows never pass through Executor.Execute, so
+	// nothing else stamps them — and a NULL verdict here is miscounted by the
+	// analytics fallback that keys on admission_decision IS NULL.
+	if res != nil && !res.Success && res.Error != nil && res.Error.Code == "permission_denied" {
+		execution.AdmissionDecision = "deny"
 	}
 	*st.allToolExecutions = append(*st.allToolExecutions, execution)
 	emitToolCompleted(ctx, 60, call, res, nil)

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -87,6 +87,11 @@ type Agent struct {
 	// parked turn at a time). Pooled embedders — a fresh Agent per call, where
 	// adoption can never happen — drain the slot explicitly at each park via
 	// ReleaseParkedHandles, keeping call-scoped semantics with no leak.
+	// sessionLocks serializes resumes per session inside this process, so two
+	// deliveries of one decision cannot both execute its batch.
+	sessionLocksMu sync.Mutex
+	sessionLocks   map[string]*sync.Mutex
+
 	parkedHandlesMu sync.Mutex
 	parkedHandles   map[string]*mcpadapter.HandleCollector
 

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -83,8 +83,9 @@ type Agent struct {
 
 	// parkedHandles holds the MCP session-handle collector of each session's
 	// parked turn, so a same-process resume adopts its handles instead of
-	// finding them released. One slot per session (guardParkedTail admits one
-	// parked turn at a time). Pooled embedders — a fresh Agent per call, where
+	// finding them released. One slot per session; guardParkedTail now
+	// admits a new turn once a park LAPSES, so a second park can overwrite the
+	// slot — abandonParkedRequest releases before closing a dead turn's row. Pooled embedders — a fresh Agent per call, where
 	// adoption can never happen — drain the slot explicitly at each park via
 	// ReleaseParkedHandles, keeping call-scoped semantics with no leak.
 	// sessionLocks serializes resumes per session inside this process, so two


### PR DESCRIPTION
Follow-up to #382. Ten defects in the merged park-and-resume path, found across three independent review passes. Several were reproduced against `main` before fixing; every mechanism is mutation-verified (removing it fails the suite). `just check` green.

Park is opt-in (`WithHITLPark`) with no in-tree caller, so nothing in loom is broken today — but an embedder turning it on gets all of them.

## Approval bypass

**A spent decision executed a different, unapproved batch.** A decided row still loads — the embedder-recorded flow needs that — so redelivery was refused only by `verifyItemBinding`, which compared tool name and batch position and never the arguments, though `buildParkParams` already records them. Those two facts can carry *zero* information: on Gemini `ToolCall.ID` **is** the function name (`pkg/llm/gemini/client.go` — "Gemini doesn't provide call IDs"), so for a single-call batch the id, tool and seq collapse into one fact.

```
turn 1 approves export_csv{v:"customers_sample"} → runs
turn 2 parks   export_csv{v:"ALL_CUSTOMERS_PII"} → undecided, card unseen
turn 1's decision redelivered → err=nil, the PII export ran
```

The binding now compares the recorded params against the tail call's.

**Unbindable call IDs no longer park.** A duplicate ID collapsed two calls into one card descriptor — the human approves one action, two run — and an empty ID could never be matched back, wedging the session with no library path out. Ollama can omit the id; Gemini parallel calls reuse the function name. Such a batch dispatches inline, where an Ask with no resolver fails closed.

## Double execution and wedged sessions

**A human-approved batch executed twice.** The tail walk was the only guard, and it reads the batch's rowless calls *before* they execute, so two overlapping resumes both acted — both returning `nil`, and landing two tool rows for one `tool_use_id`, which puts duplicate `tool_result` blocks in the next provider request (`compileLocked` emits every contiguous tool row with no dedupe). The decision is now **claimed before anything executes**: written, read back, with a token in `response_data` saying which resume won — because "no longer pending" does not say *who* closed it. That also makes a parked batch at-most-once.

**A TTL lapsing during the batch wedged the session.** The close ran after the batch and was judged by the write's error, but both store writes are documented no-ops returning `nil` when the row is no longer claimable.

**An abandoned park wedged the session permanently** — `guardParkedTail` had no `ExpiresAt` check and nothing sweeps parked rows.

**The append-point guard was blind in the embedder-recorded flow.** It matched on `Status == "pending"`, but that flow decides the row *before* calling `ResumeChat` — so in between, a new user turn was admitted and buried the unapplied batch, silently discarding the approval and leaving the history asserting the call never completed. The guard now also asks the tail: an assistant batch still missing tool rows is an unapplied park whatever the row says.

**A question park answered `responded` was a dead end** — the documented status for an input/decision request, rejected as "not a park verdict" while the row stopped holding the session. Accepted for question cards, where responding *is* the verdict; still refused on an approval card.

## Destructive and lifecycle

**A refusal that proved nothing erased the approval.** `abandonParkedRequest` fired on any `locateParkedBatch` error, but `ErrNothingParked` is absence of evidence — and an empty session yields it with the park intact, because `GetOrCreateSessionWithAgent` fails **open** (a load error builds a fresh empty session under the same ID) and `LoadSession` is user-scoped. A transient store error, or a resume whose ctx carried a different identity, expired the row and destroyed the human's decision record. Since `loadParkedRequest` authorizes only on `hr.SessionID`, a caller who knew a session id and request id but could not read the session could close someone else's approval. Now closes only on `ErrNotParkedTail` — the one signal that is positive evidence.

**Handle adoption ran before validation**, so a refused resume released the handles of a still-parked turn. Moved below the claim. **An abandoned turn leaked its collector**, which pins every later turn on that session to `RESOURCE_HOLDER` via the lease ledger.

**A cross-process resume lost its graph-memory context.** The injection is in-memory only and never persisted; suppressing it on "is a resume" left exactly the turn carrying the approved action with no recall.

**The CLI parked-row guard failed open** on a store error — the silent wrong outcome it was added to prevent. **`looms hitl expire`** now warns that expiring a park releases the session without finishing the turn. **Synthesized refusals** carry `admission_decision: deny`; a NULL is miscounted by the analytics arm keying on `IS NULL`. **The session was created before the request was validated**, so a bogus RequestID persisted a session row.

## Scope, stated honestly

The per-session lock is **per-Agent**, not per-process — `sessionLocks` lives on the `Agent`, and a pooled embedder builds a fresh one per call. The standalone flow does not depend on it (it claims the row, which holds across agents and processes); the embedder-recorded flow has no row left to claim, so an embedder that pools agents or spreads resumes across processes must deliver an already-decided resume at most once itself. That obligation is in the code and the doc.

Also: the noop differential gains a session store on its park-enabled arm — without one the pre-scan gate is off, so it compared park-off against park-off, and a `panic` in `maybeParkBatch` left it green.

## Left open, documented

`docs/architecture/hitl-park-and-resume.md` §8 names what is still missing rather than leaving it for the next reader: abandoned parks are never swept; restart between park and resume is untested although it is the feature's premise; the standalone flow's durable row is not the authorization record (`Approved` is a parameter, the approver is the literal `"human"`); `AskGrant` is a blanket context value a nested-execution tool would inherit; and there is no proto/gRPC surface for resume.

Two test-quality gaps on main I did not close: `TestPark_HandleContinuityAcrossTheGap` asserts map bookkeeping over a collector holding zero handles (nothing in the fixture mints one), and `TestPreflightAdmitParity` never configures a resolver, so `Preflight`'s non-blocking contract is unpinned. Both need fixtures this PR does not build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)