### PR TITLE
fix(agent): stop the output-token breaker firing on turns that made progress

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -2530,9 +2530,13 @@ func (a *Agent) runConversationLoop(ctx Context) (*Response, error) {
 			}
 
 			if llmResp.StopReason == "max_tokens" {
-				// tools is this provider call's advertised set, so a tool that
-				// takes no arguments is not mistaken for a truncated call.
-				hasEmptyToolCall := detectEmptyToolCall(llmResp.ToolCalls, tools)
+				// tools is this provider call's advertised set, so a call can be
+				// checked against the schema it was advertised with: a tool that
+				// takes no arguments is not mistaken for a truncated call, and a
+				// call missing what its schema demands is not mistaken for a
+				// complete one.
+				toolState := classifyToolCalls(llmResp.ToolCalls, tools)
+				hasEmptyToolCall := toolState == toolCallStateIncomplete
 
 				switch {
 				case threshold < 0:
@@ -2579,12 +2583,12 @@ func (a *Agent) runConversationLoop(ctx Context) (*Response, error) {
 						"output_tokens": llmResp.Usage.OutputTokens,
 					})
 
-				default:
-					// max_tokens with non-truncated tool calls. These calls are
-					// complete and executable, so the turn IS forward progress
-					// and the run of consecutive truncated turns ends here —
-					// the same reasoning the zero-tool-call branch above
-					// applies to a complete text response.
+				case toolState == toolCallStateComplete:
+					// max_tokens, and every call carries everything its schema
+					// demands. These calls are executable, so the turn IS
+					// forward progress and the run of consecutive truncated
+					// turns ends here — the same reasoning the zero-tool-call
+					// branch above applies to a complete text response.
 					//
 					// This previously neither counted nor cleared, which made
 					// outputTokenExhaustions a lifetime tally instead of the
@@ -2597,9 +2601,30 @@ func (a *Agent) runConversationLoop(ctx Context) (*Response, error) {
 					// introduced to fix (see
 					// TestOutputTokenCB_SessionAccumulation_Regression), in the
 					// one branch that fix did not cover.
+					//
+					// Clearing is gated on COMPLETE rather than on "not
+					// visibly empty": a malformed call reaches this switch with
+					// a populated-looking input (the OpenAI and Azure clients
+					// store an unparseable arguments string as {"_raw": ...}),
+					// and treating that as progress would let an alternating
+					// stream of broken calls reset the counter forever and
+					// disarm the breaker on exactly the providers whose
+					// truncation is most visible.
 					failureTracker.clearOutputTokenExhaustion()
 
-					span.AddEvent("output_token.non_truncated_toolcall", map[string]interface{}{
+					span.AddEvent("output_token.complete_toolcall_cleared", map[string]interface{}{
+						"stop_reason":     llmResp.StopReason,
+						"tool_call_count": len(llmResp.ToolCalls),
+					})
+
+				default:
+					// toolCallStateUnknown: max_tokens with calls whose
+					// completeness cannot be established (an unadvertised tool,
+					// or one advertising no schema). Don't count — there is no
+					// evidence of truncation — but don't clear either, because
+					// clearing asserts progress we cannot demonstrate. This is
+					// the pre-existing conservative behavior of this branch.
+					span.AddEvent("output_token.indeterminate_toolcall", map[string]interface{}{
 						"stop_reason":        llmResp.StopReason,
 						"tool_call_count":    len(llmResp.ToolCalls),
 						"has_empty_toolcall": hasEmptyToolCall,

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -2530,7 +2530,9 @@ func (a *Agent) runConversationLoop(ctx Context) (*Response, error) {
 			}
 
 			if llmResp.StopReason == "max_tokens" {
-				hasEmptyToolCall := detectEmptyToolCall(llmResp.ToolCalls)
+				// tools is this provider call's advertised set, so a tool that
+				// takes no arguments is not mistaken for a truncated call.
+				hasEmptyToolCall := detectEmptyToolCall(llmResp.ToolCalls, tools)
 
 				switch {
 				case threshold < 0:
@@ -2578,8 +2580,25 @@ func (a *Agent) runConversationLoop(ctx Context) (*Response, error) {
 					})
 
 				default:
-					// max_tokens with non-truncated tool calls: agent may still make progress
-					// on the next turn. Don't count, don't clear — let it continue.
+					// max_tokens with non-truncated tool calls. These calls are
+					// complete and executable, so the turn IS forward progress
+					// and the run of consecutive truncated turns ends here —
+					// the same reasoning the zero-tool-call branch above
+					// applies to a complete text response.
+					//
+					// This previously neither counted nor cleared, which made
+					// outputTokenExhaustions a lifetime tally instead of the
+					// consecutive count the threshold is documented against: a
+					// session under sustained output pressure never got a
+					// clearing turn, so truncated turns scattered among
+					// productive ones still summed to the threshold and failed
+					// the whole message. That is the same defect class as the
+					// verbose-text-response regression this switch was
+					// introduced to fix (see
+					// TestOutputTokenCB_SessionAccumulation_Regression), in the
+					// one branch that fix did not cover.
+					failureTracker.clearOutputTokenExhaustion()
+
 					span.AddEvent("output_token.non_truncated_toolcall", map[string]interface{}{
 						"stop_reason":        llmResp.StopReason,
 						"tool_call_count":    len(llmResp.ToolCalls),

--- a/pkg/agent/circuit_breaker_test.go
+++ b/pkg/agent/circuit_breaker_test.go
@@ -252,7 +252,7 @@ func TestDetectEmptyToolCall(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := detectEmptyToolCall(tt.toolCalls)
+			result := detectEmptyToolCall(tt.toolCalls, nil)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/pkg/agent/circuit_breaker_test.go
+++ b/pkg/agent/circuit_breaker_test.go
@@ -252,7 +252,7 @@ func TestDetectEmptyToolCall(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := detectEmptyToolCall(tt.toolCalls, nil)
+			result := classifyToolCalls(tt.toolCalls, nil) == toolCallStateIncomplete
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/pkg/agent/conversation_helpers.go
+++ b/pkg/agent/conversation_helpers.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/teradata-labs/loom/pkg/shuttle"
 )
 
 // failureSignature uniquely identifies a tool call failure for tracking consecutive failures.
@@ -244,8 +246,23 @@ func (t *consecutiveFailureTracker) checkOutputTokenCircuitBreaker(threshold int
 // detectEmptyToolCall checks if any tool call has an empty Input object.
 // This is a strong indicator that the LLM output was truncated mid-generation.
 // Returns true if empty tool call detected.
-func detectEmptyToolCall(toolCalls []ToolCall) bool {
+//
+// tools is the advertised tool set for the current provider call, used to tell a
+// genuinely argument-less call apart from a truncated one: a tool that requires
+// no arguments is EXPECTED to be invoked with an empty input, so emptiness says
+// nothing about truncation for it. Pass nil to skip that check and apply the
+// emptiness heuristics to every call (the historical behavior).
+func detectEmptyToolCall(toolCalls []ToolCall, tools []shuttle.Tool) bool {
 	for _, tc := range toolCalls {
+		// A no-argument tool call is complete as it stands. Without this, every
+		// invocation of a tool like list_skills or a bare status/list call read
+		// as truncated, and on a turn that also hit max_tokens it counted
+		// toward the output-token circuit breaker — 8 of them failed the whole
+		// message even though nothing was ever truncated.
+		if !toolRequiresArguments(tc.Name, tools) {
+			continue
+		}
+
 		// Check if Input is empty or only has zero values
 		if len(tc.Input) == 0 {
 			return true
@@ -266,6 +283,28 @@ func detectEmptyToolCall(toolCalls []ToolCall) bool {
 	}
 
 	return false
+}
+
+// toolRequiresArguments reports whether the named tool's advertised schema
+// declares at least one required parameter.
+//
+// It answers true for a tool it cannot describe — an unknown name, or one with
+// no schema — so the emptiness heuristics in detectEmptyToolCall still apply
+// unchanged there. That is the conservative direction: a call we cannot
+// characterize keeps the pre-existing truncation detection rather than being
+// waved through.
+func toolRequiresArguments(name string, tools []shuttle.Tool) bool {
+	for _, t := range tools {
+		if t == nil || t.Name() != name {
+			continue
+		}
+		schema := t.InputSchema()
+		if schema == nil {
+			return true
+		}
+		return len(schema.Required) > 0
+	}
+	return true
 }
 
 // TokenBudgetConfig holds configuration for token budget management.

--- a/pkg/agent/conversation_helpers.go
+++ b/pkg/agent/conversation_helpers.go
@@ -243,50 +243,8 @@ func (t *consecutiveFailureTracker) checkOutputTokenCircuitBreaker(threshold int
 	return fmt.Errorf("%s", msg)
 }
 
-// detectEmptyToolCall checks if any tool call has an empty Input object.
-// This is a strong indicator that the LLM output was truncated mid-generation.
-// Returns true if empty tool call detected.
-//
-// tools is the advertised tool set for the current provider call, used to tell a
-// genuinely argument-less call apart from a truncated one: a tool that requires
-// no arguments is EXPECTED to be invoked with an empty input, so emptiness says
-// nothing about truncation for it. Pass nil to skip that check and apply the
-// emptiness heuristics to every call (the historical behavior).
-func detectEmptyToolCall(toolCalls []ToolCall, tools []shuttle.Tool) bool {
-	for _, tc := range toolCalls {
-		// A no-argument tool call is complete as it stands. Without this, every
-		// invocation of a tool like list_skills or a bare status/list call read
-		// as truncated, and on a turn that also hit max_tokens it counted
-		// toward the output-token circuit breaker — 8 of them failed the whole
-		// message even though nothing was ever truncated.
-		if !toolRequiresArguments(tc.Name, tools) {
-			continue
-		}
-
-		// Check if Input is empty or only has zero values
-		if len(tc.Input) == 0 {
-			return true
-		}
-
-		// Check if all values are empty/zero
-		allEmpty := true
-		for _, v := range tc.Input {
-			if v != nil && v != "" && v != 0 && v != false {
-				allEmpty = false
-				break
-			}
-		}
-
-		if allEmpty {
-			return true
-		}
-	}
-
-	return false
-}
-
 // toolRequiresArguments reports whether the named tool's advertised schema
-// declares at least one required parameter.
+// demands any property, at the root or through a composite branch.
 //
 // It answers true for a tool it cannot describe — an unknown name, or one with
 // no schema — so the emptiness heuristics in detectEmptyToolCall still apply
@@ -294,15 +252,180 @@ func detectEmptyToolCall(toolCalls []ToolCall, tools []shuttle.Tool) bool {
 // characterize keeps the pre-existing truncation detection rather than being
 // waved through.
 func toolRequiresArguments(name string, tools []shuttle.Tool) bool {
+	schema, ok := advertisedSchema(name, tools)
+	if !ok || schema == nil {
+		return true
+	}
+	return schemaDemandsProperty(schema, 0)
+}
+
+// advertisedSchema returns the input schema the named tool was advertised with.
+// ok is false when the tool is not in the advertised set at all, which is a
+// different state from a tool that advertises no schema.
+func advertisedSchema(name string, tools []shuttle.Tool) (schema *shuttle.JSONSchema, ok bool) {
 	for _, t := range tools {
 		if t == nil || t.Name() != name {
 			continue
 		}
-		schema := t.InputSchema()
-		if schema == nil {
-			return true
+		return t.InputSchema(), true
+	}
+	return nil, false
+}
+
+// maxSchemaDepth bounds composite-branch recursion. Tool schemas arrive from
+// MCP servers and other third parties, so nesting is not under our control.
+const maxSchemaDepth = 16
+
+// schemaDemandsProperty reports whether schema requires at least one property,
+// counting composite branches: a schema with an empty root "required" can still
+// demand a property through oneOf/anyOf/allOf, which MCP tools do use.
+func schemaDemandsProperty(schema *shuttle.JSONSchema, depth int) bool {
+	if schema == nil || depth > maxSchemaDepth {
+		return false
+	}
+	if len(schema.Required) > 0 {
+		return true
+	}
+	for _, branches := range [][]*shuttle.JSONSchema{schema.OneOf, schema.AnyOf, schema.AllOf} {
+		for _, b := range branches {
+			if schemaDemandsProperty(b, depth+1) {
+				return true
+			}
 		}
-		return len(schema.Required) > 0
+	}
+	return false
+}
+
+// schemaRequirementsMet reports whether input carries every property schema
+// demands. Root "required" always applies; allOf branches must all be met;
+// oneOf/anyOf need at least one met branch.
+//
+// oneOf is checked as "at least one" rather than JSON Schema's "exactly one".
+// The question here is only whether the model finished emitting the arguments,
+// and answering it in the permissive direction keeps a well-formed call from
+// being read as truncated.
+func schemaRequirementsMet(schema *shuttle.JSONSchema, input map[string]interface{}, depth int) bool {
+	if schema == nil || depth > maxSchemaDepth {
+		return true
+	}
+	for _, key := range schema.Required {
+		if _, present := input[key]; !present {
+			return false
+		}
+	}
+	for _, b := range schema.AllOf {
+		if !schemaRequirementsMet(b, input, depth+1) {
+			return false
+		}
+	}
+	for _, branches := range [][]*shuttle.JSONSchema{schema.OneOf, schema.AnyOf} {
+		if len(branches) == 0 {
+			continue
+		}
+		met := false
+		for _, b := range branches {
+			if schemaRequirementsMet(b, input, depth+1) {
+				met = true
+				break
+			}
+		}
+		if !met {
+			return false
+		}
+	}
+	return true
+}
+
+// providerRawArgsKey is the marker the OpenAI and Azure OpenAI clients store
+// when a tool call's arguments JSON does not parse: pkg/llm/openai/client.go and
+// pkg/llm/azureopenai/client.go both fall back to Input{"_raw": <partial>} on
+// both their non-streaming and streaming paths.
+//
+// That is precisely what a call truncated at max_tokens looks like on those
+// providers — a partial arguments string that never closed — so the marker is a
+// positive signal of an INCOMPLETE call, even though the resulting map is
+// non-empty and would otherwise read as fully populated.
+const providerRawArgsKey = "_raw"
+
+// toolCallState is how much can be established about the tool calls on a
+// max_tokens turn. The three states exist because "not visibly empty" is not
+// the same as "known to be complete", and the circuit breaker must only treat
+// the latter as forward progress.
+type toolCallState int
+
+const (
+	// toolCallStateUnknown: completeness could not be established — the tool was
+	// not in the advertised set, or advertised no schema to check against.
+	toolCallStateUnknown toolCallState = iota
+	// toolCallStateComplete: every call carries everything its schema demands.
+	toolCallStateComplete
+	// toolCallStateIncomplete: at least one call is truncated or malformed.
+	toolCallStateIncomplete
+)
+
+// classifyToolCalls aggregates the per-call verdicts for a turn: any incomplete
+// call makes the turn incomplete; otherwise any unestablished call makes it
+// unknown; only an all-complete turn is complete.
+func classifyToolCalls(toolCalls []ToolCall, tools []shuttle.Tool) toolCallState {
+	state := toolCallStateComplete
+	for _, tc := range toolCalls {
+		switch classifyToolCall(tc, tools) {
+		case toolCallStateIncomplete:
+			return toolCallStateIncomplete
+		case toolCallStateUnknown:
+			state = toolCallStateUnknown
+		case toolCallStateComplete:
+			// leave state as-is
+		}
+	}
+	return state
+}
+
+// classifyToolCall establishes what can be said about a single tool call.
+func classifyToolCall(tc ToolCall, tools []shuttle.Tool) toolCallState {
+	// The provider could not parse the arguments at all. This is checked before
+	// anything else, and regardless of what the tool requires: an argument-less
+	// tool never produces a parse failure, so a _raw marker on one is still a
+	// broken call.
+	if _, raw := tc.Input[providerRawArgsKey]; raw {
+		return toolCallStateIncomplete
+	}
+
+	schema, advertised := advertisedSchema(tc.Name, tools)
+	if !advertised || schema == nil {
+		// Nothing to check against. Keep the historical emptiness heuristic so
+		// detection does not weaken, but never report completeness we cannot
+		// establish — an unknown call must not clear a truncation run.
+		if inputLooksEmpty(tc.Input) {
+			return toolCallStateIncomplete
+		}
+		return toolCallStateUnknown
+	}
+
+	if !schemaDemandsProperty(schema, 0) {
+		// An argument-less tool is expected to be called with an empty input,
+		// so emptiness says nothing about truncation for it.
+		return toolCallStateComplete
+	}
+	if !schemaRequirementsMet(schema, tc.Input, 0) {
+		return toolCallStateIncomplete
+	}
+	if inputLooksEmpty(tc.Input) {
+		return toolCallStateIncomplete
+	}
+	return toolCallStateComplete
+}
+
+// inputLooksEmpty is the historical truncation heuristic: an absent input, or
+// one whose values are all zero-valued.
+func inputLooksEmpty(input map[string]interface{}) bool {
+	if len(input) == 0 {
+		return true
+	}
+	for _, v := range input {
+		if v != nil && v != "" && v != 0 && v != false {
+			return false
+		}
 	}
 	return true
 }

--- a/pkg/agent/conversation_helpers.go
+++ b/pkg/agent/conversation_helpers.go
@@ -243,22 +243,6 @@ func (t *consecutiveFailureTracker) checkOutputTokenCircuitBreaker(threshold int
 	return fmt.Errorf("%s", msg)
 }
 
-// toolRequiresArguments reports whether the named tool's advertised schema
-// demands any property, at the root or through a composite branch.
-//
-// It answers true for a tool it cannot describe — an unknown name, or one with
-// no schema — so the emptiness heuristics in detectEmptyToolCall still apply
-// unchanged there. That is the conservative direction: a call we cannot
-// characterize keeps the pre-existing truncation detection rather than being
-// waved through.
-func toolRequiresArguments(name string, tools []shuttle.Tool) bool {
-	schema, ok := advertisedSchema(name, tools)
-	if !ok || schema == nil {
-		return true
-	}
-	return schemaDemandsProperty(schema, 0)
-}
-
 // advertisedSchema returns the input schema the named tool was advertised with.
 // ok is false when the tool is not in the advertised set at all, which is a
 // different state from a tool that advertises no schema.
@@ -272,13 +256,31 @@ func advertisedSchema(name string, tools []shuttle.Tool) (schema *shuttle.JSONSc
 	return nil, false
 }
 
-// maxSchemaDepth bounds composite-branch recursion. Tool schemas arrive from
-// MCP servers and other third parties, so nesting is not under our control.
+// advertisedTool returns the tool the call names, so the caller can reuse the
+// executor's own parameter normalization against it.
+func advertisedTool(name string, tools []shuttle.Tool) shuttle.Tool {
+	for _, t := range tools {
+		if t != nil && t.Name() == name {
+			return t
+		}
+	}
+	return nil
+}
+
+// maxSchemaDepth bounds schema recursion. Tool schemas arrive from MCP servers
+// and other third parties, so nesting is not under our control. Exhausting the
+// bound yields toolCallStateUnknown, never complete: past it nothing has been
+// established, and saying otherwise would clear a run on an unread schema.
 const maxSchemaDepth = 16
 
-// schemaDemandsProperty reports whether schema requires at least one property,
-// counting composite branches: a schema with an empty root "required" can still
-// demand a property through oneOf/anyOf/allOf, which MCP tools do use.
+// schemaDemandsProperty reports whether schema requires at least one property at
+// its own level, counting composite branches: a schema with an empty root
+// "required" can still demand a property through oneOf/anyOf/allOf, which MCP
+// tools do use.
+//
+// This is deliberately a question about THIS level only — it decides whether an
+// empty input is acceptable for the call. Nested requirements bite only when the
+// value carrying them is actually present, which checkAgainstSchema handles.
 func schemaDemandsProperty(schema *shuttle.JSONSchema, depth int) bool {
 	if schema == nil || depth > maxSchemaDepth {
 		return false
@@ -296,44 +298,123 @@ func schemaDemandsProperty(schema *shuttle.JSONSchema, depth int) bool {
 	return false
 }
 
-// schemaRequirementsMet reports whether input carries every property schema
-// demands. Root "required" always applies; allOf branches must all be met;
-// oneOf/anyOf need at least one met branch.
+// checkAgainstSchema decides how much can be established about value under
+// schema, descending through present properties and array items.
 //
-// oneOf is checked as "at least one" rather than JSON Schema's "exactly one".
-// The question here is only whether the model finished emitting the arguments,
-// and answering it in the permissive direction keeps a well-formed call from
-// being read as truncated.
-func schemaRequirementsMet(schema *shuttle.JSONSchema, input map[string]interface{}, depth int) bool {
-	if schema == nil || depth > maxSchemaDepth {
-		return true
+// Descending matters: a root-only check positively reports "complete" for input
+// whose nested objects are missing what they demand, and the accounting above
+// treats complete as forward progress. The visualization tool is the concrete
+// case — its root requires "datasets", but each dataset item requires "name" and
+// "data", so {"datasets":[{}], ...} passes a root-only check and is rejected by
+// the tool itself.
+//
+// Only structural presence is checked. Semantic constraints (enum, pattern,
+// range) are NOT evidence that the model stopped emitting mid-call, and treating
+// a violated one as truncation would fire the breaker on a complete answer.
+func checkAgainstSchema(schema *shuttle.JSONSchema, value interface{}, depth int) toolCallState {
+	if schema == nil {
+		return toolCallStateComplete
 	}
+	if depth > maxSchemaDepth {
+		return toolCallStateUnknown
+	}
+
+	switch v := value.(type) {
+	case map[string]interface{}:
+		return checkObject(schema, v, depth)
+	case []interface{}:
+		if schema.Items == nil {
+			return toolCallStateComplete
+		}
+		state := toolCallStateComplete
+		for _, item := range v {
+			switch checkAgainstSchema(schema.Items, item, depth+1) {
+			case toolCallStateIncomplete:
+				return toolCallStateIncomplete
+			case toolCallStateUnknown:
+				state = toolCallStateUnknown
+			case toolCallStateComplete:
+			}
+		}
+		return state
+	default:
+		// A scalar, or a shape this walker does not model. If the schema demands
+		// properties of it, the value cannot satisfy them and nothing can be
+		// established; otherwise there is nothing to check.
+		if schemaDemandsProperty(schema, depth) {
+			return toolCallStateUnknown
+		}
+		return toolCallStateComplete
+	}
+}
+
+// checkObject applies one schema node to one object value: its own required
+// keys, its composite branches, then each present property in turn.
+func checkObject(schema *shuttle.JSONSchema, obj map[string]interface{}, depth int) toolCallState {
 	for _, key := range schema.Required {
-		if _, present := input[key]; !present {
-			return false
+		if _, present := obj[key]; !present {
+			return toolCallStateIncomplete
 		}
 	}
+
+	state := toolCallStateComplete
+	demote := func(s toolCallState) bool {
+		switch s {
+		case toolCallStateIncomplete:
+			return true
+		case toolCallStateUnknown:
+			state = toolCallStateUnknown
+		case toolCallStateComplete:
+		}
+		return false
+	}
+
 	for _, b := range schema.AllOf {
-		if !schemaRequirementsMet(b, input, depth+1) {
-			return false
+		if demote(checkAgainstSchema(b, obj, depth+1)) {
+			return toolCallStateIncomplete
 		}
 	}
 	for _, branches := range [][]*shuttle.JSONSchema{schema.OneOf, schema.AnyOf} {
 		if len(branches) == 0 {
 			continue
 		}
-		met := false
+		// At least one branch must hold. oneOf is checked as "at least one"
+		// rather than JSON Schema's "exactly one": the question is only whether
+		// the model finished emitting arguments, and the permissive direction
+		// keeps a well-formed call from reading as truncated.
+		best := toolCallStateIncomplete
 		for _, b := range branches {
-			if schemaRequirementsMet(b, input, depth+1) {
-				met = true
-				break
+			switch checkAgainstSchema(b, obj, depth+1) {
+			case toolCallStateComplete:
+				best = toolCallStateComplete
+			case toolCallStateUnknown:
+				if best != toolCallStateComplete {
+					best = toolCallStateUnknown
+				}
+			case toolCallStateIncomplete:
 			}
 		}
-		if !met {
-			return false
+		if best == toolCallStateIncomplete {
+			return toolCallStateIncomplete
+		}
+		if best == toolCallStateUnknown {
+			state = toolCallStateUnknown
 		}
 	}
-	return true
+
+	// Descend into the properties that are actually present. An absent optional
+	// property carries no requirement; an absent required one was caught above.
+	for key, sub := range schema.Properties {
+		val, present := obj[key]
+		if !present {
+			continue
+		}
+		if demote(checkAgainstSchema(sub, val, depth+1)) {
+			return toolCallStateIncomplete
+		}
+	}
+
+	return state
 }
 
 // providerRawArgsKey is the marker the OpenAI and Azure OpenAI clients store
@@ -345,7 +426,35 @@ func schemaRequirementsMet(schema *shuttle.JSONSchema, input map[string]interfac
 // providers — a partial arguments string that never closed — so the marker is a
 // positive signal of an INCOMPLETE call, even though the resulting map is
 // non-empty and would otherwise read as fully populated.
+//
+// The name is not reserved by JSON Schema or by the Tool contract, so it is only
+// read as a marker when the advertised schema does not itself define a property
+// called "_raw"; a tool that legitimately takes one keeps its own meaning.
 const providerRawArgsKey = "_raw"
+
+// schemaDefinesRawKey reports whether the schema declares "_raw" as a real
+// property of its own, at the root or in a composite branch.
+func schemaDefinesRawKey(schema *shuttle.JSONSchema, depth int) bool {
+	if schema == nil || depth > maxSchemaDepth {
+		return false
+	}
+	if _, ok := schema.Properties[providerRawArgsKey]; ok {
+		return true
+	}
+	for _, key := range schema.Required {
+		if key == providerRawArgsKey {
+			return true
+		}
+	}
+	for _, branches := range [][]*shuttle.JSONSchema{schema.OneOf, schema.AnyOf, schema.AllOf} {
+		for _, b := range branches {
+			if schemaDefinesRawKey(b, depth+1) {
+				return true
+			}
+		}
+	}
+	return false
+}
 
 // toolCallState is how much can be established about the tool calls on a
 // max_tokens turn. The three states exist because "not visibly empty" is not
@@ -355,7 +464,8 @@ type toolCallState int
 
 const (
 	// toolCallStateUnknown: completeness could not be established — the tool was
-	// not in the advertised set, or advertised no schema to check against.
+	// not in the advertised set, advertised no schema, or carries a shape this
+	// walker cannot read.
 	toolCallStateUnknown toolCallState = iota
 	// toolCallStateComplete: every call carries everything its schema demands.
 	toolCallStateComplete
@@ -383,16 +493,21 @@ func classifyToolCalls(toolCalls []ToolCall, tools []shuttle.Tool) toolCallState
 
 // classifyToolCall establishes what can be said about a single tool call.
 func classifyToolCall(tc ToolCall, tools []shuttle.Tool) toolCallState {
-	// The provider could not parse the arguments at all. This is checked before
-	// anything else, and regardless of what the tool requires: an argument-less
-	// tool never produces a parse failure, so a _raw marker on one is still a
-	// broken call.
-	if _, raw := tc.Input[providerRawArgsKey]; raw {
+	tool := advertisedTool(tc.Name, tools)
+	var schema *shuttle.JSONSchema
+	if tool != nil {
+		schema = tool.InputSchema()
+	}
+
+	// The provider could not parse the arguments at all. Checked before anything
+	// else, and regardless of what the tool demands: an argument-less tool never
+	// produces a parse failure, so the marker still means a broken call. Skipped
+	// only when the tool genuinely declares a "_raw" property of its own.
+	if _, raw := tc.Input[providerRawArgsKey]; raw && !schemaDefinesRawKey(schema, 0) {
 		return toolCallStateIncomplete
 	}
 
-	schema, advertised := advertisedSchema(tc.Name, tools)
-	if !advertised || schema == nil {
+	if tool == nil || schema == nil {
 		// Nothing to check against. Keep the historical emptiness heuristic so
 		// detection does not weaken, but never report completeness we cannot
 		// establish — an unknown call must not clear a truncation run.
@@ -402,18 +517,25 @@ func classifyToolCall(tc ToolCall, tools []shuttle.Tool) toolCallState {
 		return toolCallStateUnknown
 	}
 
+	// Judge the same parameter map the executor will run. Execute normalizes
+	// root keys to the schema's spelling before dispatch, so a call sending
+	// snake_case for a camelCase property executes fine; checking raw keys here
+	// would count that executable call as incomplete and fire the breaker on
+	// exactly the productive turns this accounting exists to protect.
+	input := shuttle.NormalizeParametersToSchema(tool, tc.Input)
+
 	if !schemaDemandsProperty(schema, 0) {
-		// An argument-less tool is expected to be called with an empty input,
-		// so emptiness says nothing about truncation for it.
-		return toolCallStateComplete
-	}
-	if !schemaRequirementsMet(schema, tc.Input, 0) {
+		// An argument-less tool is expected to be called with an empty input, so
+		// emptiness says nothing about truncation for it. Its nested content, if
+		// any, is still checked below.
+		if len(input) == 0 {
+			return toolCallStateComplete
+		}
+	} else if inputLooksEmpty(input) {
 		return toolCallStateIncomplete
 	}
-	if inputLooksEmpty(tc.Input) {
-		return toolCallStateIncomplete
-	}
-	return toolCallStateComplete
+
+	return checkAgainstSchema(schema, map[string]interface{}(input), 0)
 }
 
 // inputLooksEmpty is the historical truncation heuristic: an absent input, or

--- a/pkg/agent/output_token_cb_accounting_test.go
+++ b/pkg/agent/output_token_cb_accounting_test.go
@@ -212,9 +212,10 @@ func TestOutputTokenCB_NoArgumentToolIsNotTruncation(t *testing.T) {
 	}
 }
 
-// TestToolRequiresArguments states the schema rule directly, including the
-// conservative fallback for a call the advertised set cannot describe.
-func TestToolRequiresArguments(t *testing.T) {
+// TestClassifyToolCall_EmptyInput states the schema rule for an empty input
+// directly, including the conservative fallback for a call the advertised set
+// cannot describe.
+func TestClassifyToolCall_EmptyInput(t *testing.T) {
 	required := &schemaTool{
 		name:     "needs_args",
 		required: []string{"path"},
@@ -230,28 +231,23 @@ func TestToolRequiresArguments(t *testing.T) {
 	tests := []struct {
 		name string
 		tool string
-		want bool
+		want toolCallState
 		why  string
 	}{
-		{"required parameter", "needs_args", true, "emptiness is evidence of truncation"},
-		{"only optional parameters", "optional_args", false, "calling it with {} is legitimate"},
-		{"no parameters at all", "no_args", false, "an empty input is the only valid input"},
-		{"unknown tool name", "never_registered", true, "fall back to the historical heuristic"},
+		{"required parameter", "needs_args", toolCallStateIncomplete, "the demanded property never arrived"},
+		{"only optional parameters", "optional_args", toolCallStateComplete, "calling it with {} is legitimate"},
+		{"no parameters at all", "no_args", toolCallStateComplete, "an empty input is the only valid input"},
+		{"unknown tool name", "never_registered", toolCallStateIncomplete, "fall back to the historical heuristic"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := toolRequiresArguments(tt.tool, tools); got != tt.want {
-				t.Errorf("toolRequiresArguments(%q) = %v, want %v — %s", tt.tool, got, tt.want, tt.why)
+			call := ToolCall{Name: tt.tool, Input: map[string]interface{}{}}
+			if got := classifyToolCall(call, tools); got != tt.want {
+				t.Errorf("classifyToolCall(%q, {}) = %v, want %v — %s", tt.tool, got, tt.want, tt.why)
 			}
 		})
 	}
-
-	t.Run("nil tool set keeps historical behavior", func(t *testing.T) {
-		if !toolRequiresArguments("anything", nil) {
-			t.Error("a nil advertised set must apply the emptiness heuristics unchanged")
-		}
-	})
 }
 
 // TestDetectEmptyToolCall_SchemaAware pins the detector against a real
@@ -538,5 +534,259 @@ func TestClassifyToolCalls_Aggregation(t *testing.T) {
 				t.Errorf("classifyToolCalls() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// visualizationShapedTool mirrors pkg/visualization's real schema: the root
+// requires "datasets", and each dataset ITEM requires "name" and "data". A
+// root-only requirement check calls {"datasets":[{}],...} complete, while the
+// tool itself rejects the dataset.
+func visualizationShapedTool() *schemaTool {
+	item := &shuttle.JSONSchema{
+		Type: "object",
+		Properties: map[string]*shuttle.JSONSchema{
+			"name": {Type: "string"},
+			"data": {Type: "string"},
+		},
+		Required: []string{"name", "data"},
+	}
+	return &schemaTool{
+		name:     "generate_visualization",
+		required: []string{"datasets", "title", "summary", "output_path"},
+		props: map[string]*shuttle.JSONSchema{
+			"datasets":    {Type: "array", Items: item},
+			"title":       {Type: "string"},
+			"summary":     {Type: "string"},
+			"output_path": {Type: "string"},
+		},
+	}
+}
+
+// TestOutputTokenCB_NestedMissingRequiredDoesNotClear is the round-3 blocker:
+// every ROOT key is present, so a root-only check reports the turn complete and
+// clears the run, even though the nested dataset is missing what its own schema
+// demands and the real tool rejects it. Alternating that with an empty call
+// would keep the breaker permanently disarmed.
+func TestOutputTokenCB_NestedMissingRequiredDoesNotClear(t *testing.T) {
+	nestedPartial := scriptedResponse{
+		toolCalls: []llmtypes.ToolCall{{
+			ID:   "t-nested",
+			Name: "generate_visualization",
+			Input: map[string]interface{}{
+				"datasets":    []interface{}{map[string]interface{}{}},
+				"title":       "t",
+				"summary":     "s",
+				"output_path": "x",
+			},
+		}},
+		stopReason: "max_tokens",
+	}
+	empty := scriptedResponse{
+		toolCalls:  []llmtypes.ToolCall{{ID: "t-empty", Name: "generate_visualization", Input: map[string]interface{}{}}},
+		stopReason: "max_tokens",
+	}
+
+	llm := &scriptedStopReasonLLM{responses: alternate(empty, nestedPartial, 6)}
+	ag := newOutputCBAgent(t, 3, llm, visualizationShapedTool())
+
+	_, err := ag.Chat(context.Background(), "s-nested", "go")
+	if !isCircuitBreakerErr(err) {
+		t.Fatalf("a nested partial turn must not clear the run, got err=%v", err)
+	}
+}
+
+// TestClassifyToolCall_NestedRequirements pins the walker directly, including a
+// composite nested UNDER a required property.
+func TestClassifyToolCall_NestedRequirements(t *testing.T) {
+	viz := visualizationShapedTool()
+
+	nestedOneOf := &schemaTool{
+		name:     "nested_composite",
+		required: []string{"target"},
+		props: map[string]*shuttle.JSONSchema{
+			"target": {
+				Type: "object",
+				OneOf: []*shuttle.JSONSchema{
+					{Required: []string{"id"}},
+					{Required: []string{"name"}},
+				},
+			},
+		},
+	}
+	tools := []shuttle.Tool{viz, nestedOneOf}
+
+	full := func() map[string]interface{} {
+		return map[string]interface{}{
+			"datasets": []interface{}{
+				map[string]interface{}{"name": "n", "data": "d"},
+			},
+			"title": "t", "summary": "s", "output_path": "x",
+		}
+	}
+
+	tests := []struct {
+		name string
+		call ToolCall
+		want toolCallState
+		why  string
+	}{
+		{
+			name: "nested item missing its required keys",
+			call: ToolCall{Name: "generate_visualization", Input: map[string]interface{}{
+				"datasets": []interface{}{map[string]interface{}{}},
+				"title":    "t", "summary": "s", "output_path": "x",
+			}},
+			want: toolCallStateIncomplete,
+			why:  "the tool rejects a dataset without name/data",
+		},
+		{
+			name: "one bad item among good ones",
+			call: ToolCall{Name: "generate_visualization", Input: map[string]interface{}{
+				"datasets": []interface{}{
+					map[string]interface{}{"name": "n", "data": "d"},
+					map[string]interface{}{"name": "n"},
+				},
+				"title": "t", "summary": "s", "output_path": "x",
+			}},
+			want: toolCallStateIncomplete,
+			why:  "every item must satisfy the item schema",
+		},
+		{
+			name: "fully populated nested input",
+			call: ToolCall{Name: "generate_visualization", Input: full()},
+			want: toolCallStateComplete,
+			why:  "root and nested requirements both met",
+		},
+		{
+			name: "empty array satisfies the item schema vacuously",
+			call: ToolCall{Name: "generate_visualization", Input: map[string]interface{}{
+				"datasets": []interface{}{}, "title": "t", "summary": "s", "output_path": "x",
+			}},
+			want: toolCallStateComplete,
+			why:  "no item is present to be missing anything",
+		},
+		{
+			name: "nested oneOf with no branch satisfied",
+			call: ToolCall{Name: "nested_composite", Input: map[string]interface{}{
+				"target": map[string]interface{}{"unrelated": 1},
+			}},
+			want: toolCallStateIncomplete,
+			why:  "a composite under a required property is still checked",
+		},
+		{
+			name: "nested oneOf with a branch satisfied",
+			call: ToolCall{Name: "nested_composite", Input: map[string]interface{}{
+				"target": map[string]interface{}{"id": "abc"},
+			}},
+			want: toolCallStateComplete,
+			why:  "one satisfied branch is enough",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyToolCall(tt.call, tools); got != tt.want {
+				t.Errorf("classifyToolCall() = %v, want %v — %s", got, tt.want, tt.why)
+			}
+		})
+	}
+}
+
+// camelTool requires a camelCase property, which is what the executor's
+// normalization exists to reconcile with the snake_case models commonly emit.
+type camelTool struct {
+	schemaTool
+	mu       sync.Mutex
+	gotKeys  []string
+	executed int
+}
+
+func (t *camelTool) Execute(_ context.Context, params map[string]interface{}) (*shuttle.Result, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.executed++
+	for k := range params {
+		t.gotKeys = append(t.gotKeys, k)
+	}
+	return &shuttle.Result{Success: true, Data: "ok"}, nil
+}
+
+// TestOutputTokenCB_SnakeCaseInputIsNotIncomplete covers the normalization
+// mismatch: Executor.Execute normalizes root keys to the schema's spelling
+// before dispatch, so a call sending user_id for a required userId executes
+// fine. Judging the raw provider spelling would count each such turn as
+// incomplete and hard-fail a productive session at the threshold — reproducing
+// the exact false positive this accounting is meant to prevent.
+func TestOutputTokenCB_SnakeCaseInputIsNotIncomplete(t *testing.T) {
+	tool := &camelTool{schemaTool: schemaTool{
+		name:     "lookup_user",
+		required: []string{"userId"},
+		props:    map[string]*shuttle.JSONSchema{"userId": {Type: "string"}},
+	}}
+
+	snake := scriptedResponse{
+		toolCalls: []llmtypes.ToolCall{
+			{ID: "t-snake", Name: "lookup_user", Input: map[string]interface{}{"user_id": "123"}},
+		},
+		stopReason: "max_tokens",
+	}
+	llm := &scriptedStopReasonLLM{responses: []scriptedResponse{snake, snake, snake, snake, snake}}
+
+	ag := newOutputCBAgent(t, 3, llm, tool)
+	_, err := ag.Chat(context.Background(), "s-snake", "go")
+
+	if isCircuitBreakerErr(err) {
+		t.Fatalf("breaker fired on calls the executor normalizes and runs: %v", err)
+	}
+
+	tool.mu.Lock()
+	defer tool.mu.Unlock()
+	if tool.executed == 0 {
+		t.Fatal("expected the tool to actually execute")
+	}
+	for _, k := range tool.gotKeys {
+		if k != "userId" {
+			t.Errorf("tool received key %q, want the normalized \"userId\"", k)
+		}
+	}
+}
+
+// TestClassifyToolCall_RawIsAProperty guards the marker against a tool that
+// legitimately declares "_raw": its own meaning must win over the provider
+// parse-failure convention.
+func TestClassifyToolCall_RawIsAProperty(t *testing.T) {
+	rawTool := &schemaTool{
+		name:     "store_blob",
+		required: []string{"_raw"},
+		props:    map[string]*shuttle.JSONSchema{"_raw": {Type: "string"}},
+	}
+	tools := []shuttle.Tool{rawTool}
+
+	call := ToolCall{Name: "store_blob", Input: map[string]interface{}{"_raw": "payload"}}
+	if got := classifyToolCall(call, tools); got != toolCallStateComplete {
+		t.Errorf("classifyToolCall() = %v, want complete — the tool declares _raw itself", got)
+	}
+}
+
+// TestCheckAgainstSchema_DepthExhaustionIsUnknown pins the traversal bound as
+// failing to unknown, never to complete: past the bound nothing has been
+// established, and reporting completeness there would clear a run on an unread
+// schema.
+func TestCheckAgainstSchema_DepthExhaustionIsUnknown(t *testing.T) {
+	// A chain deeper than maxSchemaDepth, each level demanding the next.
+	leaf := &shuttle.JSONSchema{Type: "object", Required: []string{"missing"}}
+	schema := leaf
+	value := map[string]interface{}{}
+	for i := 0; i < maxSchemaDepth+4; i++ {
+		schema = &shuttle.JSONSchema{
+			Type:       "object",
+			Properties: map[string]*shuttle.JSONSchema{"next": schema},
+			Required:   []string{"next"},
+		}
+		value = map[string]interface{}{"next": value}
+	}
+
+	if got := checkAgainstSchema(schema, value, 0); got == toolCallStateComplete {
+		t.Error("depth exhaustion must not report complete")
 	}
 }

--- a/pkg/agent/output_token_cb_accounting_test.go
+++ b/pkg/agent/output_token_cb_accounting_test.go
@@ -70,18 +70,33 @@ func (m *scriptedStopReasonLLM) Name() string  { return "scripted-stop-reason" }
 func (m *scriptedStopReasonLLM) Model() string { return "scripted-v1" }
 
 // schemaTool is a no-op tool with a caller-supplied input schema, so a test can
-// state exactly whether the tool requires arguments.
+// state exactly what the tool demands — including through composite branches,
+// which MCP tool schemas use and which a root-only "required" check misses.
 type schemaTool struct {
 	name     string
 	required []string
 	props    map[string]*shuttle.JSONSchema
+	oneOf    []*shuttle.JSONSchema
+	anyOf    []*shuttle.JSONSchema
+	allOf    []*shuttle.JSONSchema
+	noSchema bool
 }
 
 func (t *schemaTool) Name() string        { return t.name }
 func (t *schemaTool) Description() string { return "test tool " + t.name }
 func (t *schemaTool) Backend() string     { return "" }
 func (t *schemaTool) InputSchema() *shuttle.JSONSchema {
-	return &shuttle.JSONSchema{Type: "object", Properties: t.props, Required: t.required}
+	if t.noSchema {
+		return nil
+	}
+	return &shuttle.JSONSchema{
+		Type:       "object",
+		Properties: t.props,
+		Required:   t.required,
+		OneOf:      t.oneOf,
+		AnyOf:      t.anyOf,
+		AllOf:      t.allOf,
+	}
 }
 func (t *schemaTool) Execute(_ context.Context, _ map[string]interface{}) (*shuttle.Result, error) {
 	return &shuttle.Result{Success: true, Data: "ok"}, nil
@@ -289,8 +304,238 @@ func TestDetectEmptyToolCall_SchemaAware(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := detectEmptyToolCall(tt.toolCalls, tools); got != tt.want {
-				t.Errorf("detectEmptyToolCall() = %v, want %v", got, tt.want)
+			if got := classifyToolCalls(tt.toolCalls, tools) == toolCallStateIncomplete; got != tt.want {
+				t.Errorf("classifyToolCalls() incomplete = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// requiresSQL is the tool used by the containment tests below: one required
+// property, so an input lacking it is incomplete however populated it looks.
+func requiresSQL() *schemaTool {
+	return &schemaTool{
+		name:     "run_query",
+		required: []string{"sql"},
+		props:    map[string]*shuttle.JSONSchema{"sql": {Type: "string"}, "limit": {Type: "number"}},
+	}
+}
+
+func truncatedCall() scriptedResponse {
+	return scriptedResponse{
+		toolCalls:  []llmtypes.ToolCall{{ID: "t-empty", Name: "run_query", Input: map[string]interface{}{}}},
+		stopReason: "max_tokens",
+	}
+}
+
+// alternate builds a script that interleaves a and b, n times each.
+func alternate(a, b scriptedResponse, n int) []scriptedResponse {
+	var script []scriptedResponse
+	for i := 0; i < n; i++ {
+		script = append(script, a, b)
+	}
+	return script
+}
+
+// TestOutputTokenCB_MalformedArgsDoNotClear is the containment regression for
+// the reset path.
+//
+// When a tool call's arguments JSON does not parse, the OpenAI and Azure OpenAI
+// clients store the partial string as Input{"_raw": ...} — which is exactly what
+// truncation at max_tokens looks like on those providers, and which the old
+// emptiness heuristic read as a fully populated input. Clearing on "not visibly
+// empty" therefore let an alternating stream of broken calls reset the counter
+// forever, disarming the breaker on the providers whose truncation is most
+// visible. The breaker must still fire.
+func TestOutputTokenCB_MalformedArgsDoNotClear(t *testing.T) {
+	malformed := scriptedResponse{
+		toolCalls: []llmtypes.ToolCall{
+			// A partial arguments string, cut off mid-JSON.
+			{ID: "t-raw", Name: "run_query", Input: map[string]interface{}{"_raw": `{"sql":`}},
+		},
+		stopReason: "max_tokens",
+	}
+
+	llm := &scriptedStopReasonLLM{responses: alternate(truncatedCall(), malformed, 6)}
+	ag := newOutputCBAgent(t, 3, llm, requiresSQL())
+
+	_, err := ag.Chat(context.Background(), "s-malformed", "go")
+	if !isCircuitBreakerErr(err) {
+		t.Fatalf("breaker must still fire when the non-empty turns are unparseable arguments, got err=%v", err)
+	}
+}
+
+// TestOutputTokenCB_MissingRequiredKeyDoesNotClear is the same containment
+// property for a call that parsed cleanly but stopped before emitting the
+// property its schema demands.
+func TestOutputTokenCB_MissingRequiredKeyDoesNotClear(t *testing.T) {
+	missingRequired := scriptedResponse{
+		toolCalls: []llmtypes.ToolCall{
+			// "limit" is real and non-falsy, but the required "sql" never arrived.
+			{ID: "t-partial", Name: "run_query", Input: map[string]interface{}{"limit": 5}},
+		},
+		stopReason: "max_tokens",
+	}
+
+	llm := &scriptedStopReasonLLM{responses: alternate(truncatedCall(), missingRequired, 6)}
+	ag := newOutputCBAgent(t, 3, llm, requiresSQL())
+
+	_, err := ag.Chat(context.Background(), "s-missing-required", "go")
+	if !isCircuitBreakerErr(err) {
+		t.Fatalf("breaker must still fire when the non-empty turns omit a required property, got err=%v", err)
+	}
+}
+
+// TestOutputTokenCB_IndeterminateToolCallDoesNotClear covers the third state: a
+// call whose completeness cannot be established must not count as truncation,
+// but must not clear a run either — clearing asserts progress that has not been
+// demonstrated.
+func TestOutputTokenCB_IndeterminateToolCallDoesNotClear(t *testing.T) {
+	// Advertises no schema, so nothing can be checked against it.
+	opaque := &schemaTool{name: "opaque_tool", noSchema: true}
+
+	indeterminate := scriptedResponse{
+		toolCalls: []llmtypes.ToolCall{
+			{ID: "t-opaque", Name: "opaque_tool", Input: map[string]interface{}{"anything": "here"}},
+		},
+		stopReason: "max_tokens",
+	}
+
+	llm := &scriptedStopReasonLLM{responses: alternate(truncatedCall(), indeterminate, 6)}
+	ag := newOutputCBAgent(t, 3, llm, requiresSQL(), opaque)
+
+	_, err := ag.Chat(context.Background(), "s-indeterminate", "go")
+	if !isCircuitBreakerErr(err) {
+		t.Fatalf("an unverifiable call must not clear a truncation run, got err=%v", err)
+	}
+}
+
+// TestClassifyToolCall_CompositeSchemas covers the requirement forms a
+// root-level "required" check alone misses. MCP tool schemas use these.
+func TestClassifyToolCall_CompositeSchemas(t *testing.T) {
+	// Each branch demands a different property, and the root demands nothing —
+	// so a root-only check would call this tool argument-less and wave {} through.
+	oneOfTool := &schemaTool{
+		name: "by_id_or_name",
+		props: map[string]*shuttle.JSONSchema{
+			"id":   {Type: "string"},
+			"name": {Type: "string"},
+		},
+		oneOf: []*shuttle.JSONSchema{
+			{Required: []string{"id"}},
+			{Required: []string{"name"}},
+		},
+	}
+	anyOfTool := &schemaTool{
+		name:  "by_any",
+		anyOf: []*shuttle.JSONSchema{{Required: []string{"a"}}, {Required: []string{"b"}}},
+	}
+	allOfTool := &schemaTool{
+		name:  "needs_both",
+		allOf: []*shuttle.JSONSchema{{Required: []string{"a"}}, {Required: []string{"b"}}},
+	}
+	tools := []shuttle.Tool{oneOfTool, anyOfTool, allOfTool}
+
+	tests := []struct {
+		name string
+		call ToolCall
+		want toolCallState
+		why  string
+	}{
+		{
+			name: "oneOf with no properties at all is incomplete",
+			call: ToolCall{Name: "by_id_or_name", Input: map[string]interface{}{}},
+			want: toolCallStateIncomplete,
+			why:  "every branch demands a property, so {} satisfies none of them",
+		},
+		{
+			name: "oneOf with one branch satisfied is complete",
+			call: ToolCall{Name: "by_id_or_name", Input: map[string]interface{}{"id": "abc"}},
+			want: toolCallStateComplete,
+			why:  "satisfying a single branch is a finished call",
+		},
+		{
+			name: "oneOf with the other branch satisfied is complete",
+			call: ToolCall{Name: "by_id_or_name", Input: map[string]interface{}{"name": "abc"}},
+			want: toolCallStateComplete,
+			why:  "branch order must not matter",
+		},
+		{
+			name: "anyOf with no branch satisfied is incomplete",
+			call: ToolCall{Name: "by_any", Input: map[string]interface{}{"unrelated": "x"}},
+			want: toolCallStateIncomplete,
+			why:  "a populated input that satisfies nothing is not progress",
+		},
+		{
+			name: "allOf with only one branch satisfied is incomplete",
+			call: ToolCall{Name: "needs_both", Input: map[string]interface{}{"a": 1}},
+			want: toolCallStateIncomplete,
+			why:  "allOf demands every branch",
+		},
+		{
+			name: "allOf fully satisfied is complete",
+			call: ToolCall{Name: "needs_both", Input: map[string]interface{}{"a": 1, "b": 2}},
+			want: toolCallStateComplete,
+			why:  "both branches met",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyToolCall(tt.call, tools); got != tt.want {
+				t.Errorf("classifyToolCall() = %v, want %v — %s", got, tt.want, tt.why)
+			}
+		})
+	}
+}
+
+// TestClassifyToolCall_RawMarkerAlwaysIncomplete pins the parse-failure marker
+// as a positive incompleteness signal, ahead of every other consideration —
+// including on a tool that demands nothing, where an empty input would
+// otherwise be perfectly valid.
+func TestClassifyToolCall_RawMarkerAlwaysIncomplete(t *testing.T) {
+	tools := []shuttle.Tool{
+		requiresSQL(),
+		&schemaTool{name: "list_skills"},
+		&schemaTool{name: "opaque_tool", noSchema: true},
+	}
+
+	for _, name := range []string{"run_query", "list_skills", "opaque_tool", "never_advertised"} {
+		t.Run(name, func(t *testing.T) {
+			call := ToolCall{Name: name, Input: map[string]interface{}{"_raw": `{"sql":`}}
+			if got := classifyToolCall(call, tools); got != toolCallStateIncomplete {
+				t.Errorf("classifyToolCall(%q with _raw) = %v, want incomplete", name, got)
+			}
+		})
+	}
+}
+
+// TestClassifyToolCalls_Aggregation states how a turn's verdict is combined
+// across several calls: incomplete dominates, then unknown, and only an
+// all-complete turn is complete.
+func TestClassifyToolCalls_Aggregation(t *testing.T) {
+	tools := []shuttle.Tool{requiresSQL(), &schemaTool{name: "opaque_tool", noSchema: true}}
+
+	good := ToolCall{Name: "run_query", Input: map[string]interface{}{"sql": "SELECT 1"}}
+	bad := ToolCall{Name: "run_query", Input: map[string]interface{}{}}
+	opaque := ToolCall{Name: "opaque_tool", Input: map[string]interface{}{"x": 1}}
+
+	tests := []struct {
+		name  string
+		calls []ToolCall
+		want  toolCallState
+	}{
+		{"no calls at all", nil, toolCallStateComplete},
+		{"all complete", []ToolCall{good, good}, toolCallStateComplete},
+		{"one incomplete dominates", []ToolCall{good, bad}, toolCallStateIncomplete},
+		{"incomplete outranks unknown", []ToolCall{opaque, bad}, toolCallStateIncomplete},
+		{"unknown outranks complete", []ToolCall{good, opaque}, toolCallStateUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyToolCalls(tt.calls, tools); got != tt.want {
+				t.Errorf("classifyToolCalls() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/agent/output_token_cb_accounting_test.go
+++ b/pkg/agent/output_token_cb_accounting_test.go
@@ -1,0 +1,297 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package agent
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/teradata-labs/loom/pkg/shuttle"
+	llmtypes "github.com/teradata-labs/loom/pkg/types"
+)
+
+// These tests drive the REAL conversation-loop accounting rather than
+// re-deriving the branch decisions in the test body, which is what the
+// tracker-level tests in circuit_breaker_test.go do. That distinction matters:
+// both defects fixed here lived in the switch in conversationLoop, so no
+// tracker-level test could observe them — and TestOutputTokenCircuitBreaker_
+// Integration actually encoded the corrected behavior ("else → clear") while
+// the code did something different, with nothing driving the code to notice.
+
+// scriptedStopReasonLLM returns a scripted sequence of responses, including
+// each one's stop reason. It exists because the shared mockToolCallingLLM's
+// mockLLMResponse cannot express a stop reason, and the output-token circuit
+// breaker keys entirely off it.
+type scriptedStopReasonLLM struct {
+	mu        sync.Mutex
+	responses []scriptedResponse
+	idx       int
+}
+
+type scriptedResponse struct {
+	content    string
+	toolCalls  []llmtypes.ToolCall
+	stopReason string
+}
+
+func (m *scriptedStopReasonLLM) Chat(_ context.Context, _ []llmtypes.Message, _ []shuttle.Tool) (*llmtypes.LLMResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Past the end of the script, end the turn cleanly so a test that does not
+	// trip the breaker terminates instead of looping to MaxTurns.
+	if m.idx >= len(m.responses) {
+		return &llmtypes.LLMResponse{Content: "done", StopReason: "end_turn"}, nil
+	}
+	r := m.responses[m.idx]
+	m.idx++
+	return &llmtypes.LLMResponse{
+		Content:    r.content,
+		ToolCalls:  r.toolCalls,
+		StopReason: r.stopReason,
+		Usage:      llmtypes.Usage{InputTokens: 10, OutputTokens: 10},
+	}, nil
+}
+
+func (m *scriptedStopReasonLLM) Name() string  { return "scripted-stop-reason" }
+func (m *scriptedStopReasonLLM) Model() string { return "scripted-v1" }
+
+// schemaTool is a no-op tool with a caller-supplied input schema, so a test can
+// state exactly whether the tool requires arguments.
+type schemaTool struct {
+	name     string
+	required []string
+	props    map[string]*shuttle.JSONSchema
+}
+
+func (t *schemaTool) Name() string        { return t.name }
+func (t *schemaTool) Description() string { return "test tool " + t.name }
+func (t *schemaTool) Backend() string     { return "" }
+func (t *schemaTool) InputSchema() *shuttle.JSONSchema {
+	return &shuttle.JSONSchema{Type: "object", Properties: t.props, Required: t.required}
+}
+func (t *schemaTool) Execute(_ context.Context, _ map[string]interface{}) (*shuttle.Result, error) {
+	return &shuttle.Result{Success: true, Data: "ok"}, nil
+}
+
+// newOutputCBAgent builds an agent whose only variable is the scripted LLM and
+// the registered tools, with a low CB threshold so a scenario stays short.
+func newOutputCBAgent(t *testing.T, threshold int, llm *scriptedStopReasonLLM, tools ...shuttle.Tool) *Agent {
+	t.Helper()
+	cfg := DefaultConfig()
+	cfg.PatternConfig = DefaultPatternConfig()
+	cfg.PatternConfig.UseLLMClassifier = false
+	cfg.MaxTurns = 50
+	cfg.MaxToolExecutions = 50
+	cfg.OutputTokenCBThreshold = threshold
+
+	ag := NewAgent(&mockBackend{}, llm, WithConfig(cfg))
+	for _, tl := range tools {
+		ag.RegisterTool(tl)
+	}
+	return ag
+}
+
+func isCircuitBreakerErr(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "circuit breaker")
+}
+
+// TestOutputTokenCB_CompleteToolCallEndsTheRun is the ratchet regression.
+//
+// A turn that hits max_tokens but returns COMPLETE, executable tool calls is
+// forward progress, so it must end the run of consecutive truncated turns. The
+// default branch of the accounting switch previously neither counted nor
+// cleared, which made the counter a lifetime tally: under sustained output
+// pressure no turn ever cleared it, so truncated turns scattered among
+// productive ones still summed to the threshold and failed the whole message.
+func TestOutputTokenCB_CompleteToolCallEndsTheRun(t *testing.T) {
+	tool := &schemaTool{
+		name:     "run_query",
+		required: []string{"sql"},
+		props:    map[string]*shuttle.JSONSchema{"sql": {Type: "string"}},
+	}
+
+	truncated := scriptedResponse{
+		toolCalls:  []llmtypes.ToolCall{{ID: "t1", Name: "run_query", Input: map[string]interface{}{}}},
+		stopReason: "max_tokens",
+	}
+	complete := scriptedResponse{
+		toolCalls: []llmtypes.ToolCall{
+			{ID: "t2", Name: "run_query", Input: map[string]interface{}{"sql": "SELECT 1"}},
+		},
+		stopReason: "max_tokens",
+	}
+
+	// Alternate truncated / complete well past the threshold. Every truncated
+	// turn is separated by real progress, so no run of 3 ever forms.
+	var script []scriptedResponse
+	for i := 0; i < 6; i++ {
+		script = append(script, truncated, complete)
+	}
+	llm := &scriptedStopReasonLLM{responses: script}
+
+	ag := newOutputCBAgent(t, 3, llm, tool)
+	_, err := ag.Chat(context.Background(), "s-ratchet", "go")
+
+	if isCircuitBreakerErr(err) {
+		t.Fatalf("circuit breaker fired on interleaved truncated/complete turns: %v", err)
+	}
+}
+
+// TestOutputTokenCB_ConsecutiveTruncatedStillFires is the counterpart: the fix
+// above must not disarm the breaker for the case it exists to catch.
+func TestOutputTokenCB_ConsecutiveTruncatedStillFires(t *testing.T) {
+	tool := &schemaTool{
+		name:     "run_query",
+		required: []string{"sql"},
+		props:    map[string]*shuttle.JSONSchema{"sql": {Type: "string"}},
+	}
+
+	truncated := scriptedResponse{
+		toolCalls:  []llmtypes.ToolCall{{ID: "t1", Name: "run_query", Input: map[string]interface{}{}}},
+		stopReason: "max_tokens",
+	}
+	llm := &scriptedStopReasonLLM{responses: []scriptedResponse{truncated, truncated, truncated, truncated}}
+
+	ag := newOutputCBAgent(t, 3, llm, tool)
+	_, err := ag.Chat(context.Background(), "s-consecutive", "go")
+
+	if !isCircuitBreakerErr(err) {
+		t.Fatalf("expected the circuit breaker to fire on 3 consecutive truncated turns, got err=%v", err)
+	}
+}
+
+// TestOutputTokenCB_NoArgumentToolIsNotTruncation covers the schema-aware half.
+//
+// A tool that requires no arguments is invoked with an empty input by design.
+// That used to read as a truncated call, so repeatedly calling a tool like
+// list_skills on turns that also hit the output limit tripped the breaker and
+// failed the message even though nothing was ever truncated.
+func TestOutputTokenCB_NoArgumentToolIsNotTruncation(t *testing.T) {
+	noArgs := &schemaTool{name: "list_skills"}
+
+	call := scriptedResponse{
+		toolCalls:  []llmtypes.ToolCall{{ID: "t1", Name: "list_skills", Input: map[string]interface{}{}}},
+		stopReason: "max_tokens",
+	}
+	llm := &scriptedStopReasonLLM{responses: []scriptedResponse{call, call, call, call, call}}
+
+	ag := newOutputCBAgent(t, 3, llm, noArgs)
+	_, err := ag.Chat(context.Background(), "s-noargs", "go")
+
+	if isCircuitBreakerErr(err) {
+		t.Fatalf("circuit breaker fired on a legitimately argument-less tool: %v", err)
+	}
+}
+
+// TestToolRequiresArguments states the schema rule directly, including the
+// conservative fallback for a call the advertised set cannot describe.
+func TestToolRequiresArguments(t *testing.T) {
+	required := &schemaTool{
+		name:     "needs_args",
+		required: []string{"path"},
+		props:    map[string]*shuttle.JSONSchema{"path": {Type: "string"}},
+	}
+	optionalOnly := &schemaTool{
+		name:  "optional_args",
+		props: map[string]*shuttle.JSONSchema{"recursive": {Type: "boolean"}},
+	}
+	noArgs := &schemaTool{name: "no_args"}
+	tools := []shuttle.Tool{required, optionalOnly, noArgs}
+
+	tests := []struct {
+		name string
+		tool string
+		want bool
+		why  string
+	}{
+		{"required parameter", "needs_args", true, "emptiness is evidence of truncation"},
+		{"only optional parameters", "optional_args", false, "calling it with {} is legitimate"},
+		{"no parameters at all", "no_args", false, "an empty input is the only valid input"},
+		{"unknown tool name", "never_registered", true, "fall back to the historical heuristic"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := toolRequiresArguments(tt.tool, tools); got != tt.want {
+				t.Errorf("toolRequiresArguments(%q) = %v, want %v — %s", tt.tool, got, tt.want, tt.why)
+			}
+		})
+	}
+
+	t.Run("nil tool set keeps historical behavior", func(t *testing.T) {
+		if !toolRequiresArguments("anything", nil) {
+			t.Error("a nil advertised set must apply the emptiness heuristics unchanged")
+		}
+	})
+}
+
+// TestDetectEmptyToolCall_SchemaAware pins the detector against a real
+// advertised set, complementing the nil-schema table in circuit_breaker_test.go.
+func TestDetectEmptyToolCall_SchemaAware(t *testing.T) {
+	needsArgs := &schemaTool{
+		name:     "run_query",
+		required: []string{"sql"},
+		props:    map[string]*shuttle.JSONSchema{"sql": {Type: "string"}},
+	}
+	noArgs := &schemaTool{name: "list_skills"}
+	tools := []shuttle.Tool{needsArgs, noArgs}
+
+	tests := []struct {
+		name      string
+		toolCalls []ToolCall
+		want      bool
+	}{
+		{
+			name:      "argument-less tool with empty input is not truncation",
+			toolCalls: []ToolCall{{ID: "a", Name: "list_skills", Input: map[string]interface{}{}}},
+			want:      false,
+		},
+		{
+			name:      "argument-less tool with nil input is not truncation",
+			toolCalls: []ToolCall{{ID: "a", Name: "list_skills", Input: nil}},
+			want:      false,
+		},
+		{
+			name:      "required-argument tool with empty input is truncation",
+			toolCalls: []ToolCall{{ID: "a", Name: "run_query", Input: map[string]interface{}{}}},
+			want:      true,
+		},
+		{
+			name: "required-argument tool with real input is fine",
+			toolCalls: []ToolCall{
+				{ID: "a", Name: "run_query", Input: map[string]interface{}{"sql": "SELECT 1"}},
+			},
+			want: false,
+		},
+		{
+			name: "a truncated call alongside an argument-less one is still detected",
+			toolCalls: []ToolCall{
+				{ID: "a", Name: "list_skills", Input: map[string]interface{}{}},
+				{ID: "b", Name: "run_query", Input: map[string]interface{}{}},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectEmptyToolCall(tt.toolCalls, tools); got != tt.want {
+				t.Errorf("detectEmptyToolCall() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/shuttle/executor.go
+++ b/pkg/shuttle/executor.go
@@ -235,7 +235,7 @@ func stampAdmissionDecision(result *Result, auditDecision string) {
 // executing the tool body. With no admission chain AND no permission checker
 // it returns NoDecision immediately — before any registry work — so an
 // ungoverned agent's pre-scan stays a pure pass. Otherwise params are
-// normalized with the same normalizeParametersToSchema call Execute uses; a
+// normalized with the same NormalizeParametersToSchema call Execute uses; a
 // registry miss attempts tryDynamicRegistration exactly as Execute does —
 // registration is an execution-required side effect that merely happens
 // earlier — and a failed registration returns NoDecision, leaving execution
@@ -261,7 +261,7 @@ func (e *Executor) Preflight(ctx context.Context, toolName string, params map[st
 		tool = dynamicTool
 	}
 
-	normalizedParams := normalizeParametersToSchema(tool, params)
+	normalizedParams := NormalizeParametersToSchema(tool, params)
 
 	if e.permissionChecker != nil {
 		if err := e.permissionChecker.CheckPermission(ctx, toolName, normalizedParams); err != nil {
@@ -305,7 +305,7 @@ func (e *Executor) Execute(ctx context.Context, toolName string, params map[stri
 	// Normalize parameters BEFORE admission so the chain and the tool body see
 	// one map: the matcher must judge the exact params the tool would receive,
 	// or the caller's key spelling would decide whether a binding matches.
-	normalizedParams := normalizeParametersToSchema(tool, params)
+	normalizedParams := NormalizeParametersToSchema(tool, params)
 
 	// Stamp the audit verdict at every exit — success, deny, and each error
 	// return — through the one deferred call (the key is reserved: with no
@@ -384,7 +384,7 @@ func (e *Executor) Execute(ctx context.Context, toolName string, params map[stri
 func (e *Executor) ExecuteWithTool(ctx context.Context, tool Tool, params map[string]interface{}) (result *Result, err error) {
 	// Normalize parameters BEFORE admission so the chain and the tool body see
 	// one map (same invariant as Execute).
-	normalizedParams := normalizeParametersToSchema(tool, params)
+	normalizedParams := NormalizeParametersToSchema(tool, params)
 
 	// Stamp the audit verdict at every exit through the one deferred call.
 	var adm AdmissionResult
@@ -604,9 +604,19 @@ func (e *Executor) Stats() ExecutorStats {
 	}
 }
 
-// normalizeParametersToSchema attempts to normalize parameter names to match the tool's schema.
+// NormalizeParametersToSchema attempts to normalize parameter names to match the tool's schema.
 // This handles the common issue where LLMs use snake_case but tools expect camelCase (or vice versa).
-func normalizeParametersToSchema(tool Tool, params map[string]interface{}) map[string]interface{} {
+//
+// It is exported because a caller that reasons about a tool call BEFORE dispatch
+// has to see the same parameter map Execute will actually run, or it draws
+// conclusions the executor then contradicts. The output-token circuit breaker in
+// pkg/agent is one such caller: judged against raw provider key spelling, an
+// executable snake_case call reads as missing its required camelCase property.
+//
+// Note this normalizes ROOT keys only, against schema.Properties. Nested keys are
+// passed through untouched, so a caller inspecting nested requirements must not
+// normalize them either, or it will disagree with what the tool receives.
+func NormalizeParametersToSchema(tool Tool, params map[string]interface{}) map[string]interface{} {
 	if len(params) == 0 {
 		return params
 	}


### PR DESCRIPTION
## Why

The output-token circuit breaker exists to stop an agent that is stuck emitting tool calls it can never finish. Two accounting defects made it fire on sessions that were **not** stuck, ending the whole message with a hard error.

This was found while investigating a Tera 2.0 demo environment where field users reported "tools loop, then it errors out" — including during a live customer demo.

## 1. A tool that takes no arguments read as truncated

`detectEmptyToolCall` treated an empty `Input` as evidence the model was cut off mid-generation:

```go
if len(tc.Input) == 0 {
    return true
}
```

Plenty of tools legitimately take no arguments — a list or status call — and are *always* invoked with `{}`. `list_skills` is one. On a turn that also hit `max_tokens`, every such call counted as a truncated turn.

It now consults the advertised tool set: a tool whose schema declares no required parameter is expected to be called with an empty input, so emptiness says nothing about truncation for it. A tool the advertised set cannot describe (unknown name, or no schema) keeps the previous heuristics, and passing a nil set is exactly the old behavior — so the conservative direction is preserved everywhere the schema does not clearly say otherwise.

## 2. A productive turn did not end the run of truncated ones

The accounting switch had a branch for `max_tokens` with **complete** tool calls that neither counted nor cleared:

```go
default:
    // max_tokens with non-truncated tool calls: agent may still make progress
    // on the next turn. Don't count, don't clear — let it continue.
```

Those calls are complete and executable, so the turn *is* forward progress. Leaving the counter untouched made `outputTokenExhaustions` a lifetime tally instead of the consecutive count the threshold is documented against. A session under sustained output pressure never got a clearing turn, so truncated turns scattered among productive ones still summed to the threshold — and the error then reported them as "consecutive", which they were not. It is also why the symptom looks like *many* tool calls before the failure rather than exactly `threshold` of them.

This is the same defect class as the verbose-text-response regression this switch was introduced to fix (`TestOutputTokenCB_SessionAccumulation_Regression`: *"the old code ... never cleared it between user turns when stop_reason was max_tokens"*), in the one branch that fix did not cover. It now clears, matching the zero-tool-call branch beside it.

## On the testing gap

Both defects lived in `conversationLoop`, where no tracker-level test could observe them. `TestOutputTokenCircuitBreaker_Integration` re-derives the branch decisions in the test body rather than driving the loop — and its own `else → clear` already encoded the corrected behavior for case 2, so the test and the code disagreed with nothing to notice.

The new tests drive the real loop through a scripted LLM that can express a stop reason (the shared `mockLLMResponse` cannot, which is likely why this path was never covered end to end).

**Each new test was confirmed to fail with its fix reverted:**

- `TestOutputTokenCB_CompleteToolCallEndsTheRun` → `circuit breaker fired on interleaved truncated/complete turns: ... triggered after 3 consecutive turns`
- `TestOutputTokenCB_NoArgumentToolIsNotTruncation` → `circuit breaker fired on a legitimately argument-less tool`
- `TestDetectEmptyToolCall_SchemaAware` → `detectEmptyToolCall() = true, want false`

`TestOutputTokenCB_ConsecutiveTruncatedStillFires` guards the other direction: the breaker still fires on genuinely consecutive truncated turns, so neither fix disarms it.

## Scope / compatibility

- `detectEmptyToolCall` is unexported; the signature change is internal to `pkg/agent`.
- The all-falsy-values heuristic is deliberately left alone — this PR only decides *whether that judgment applies to a given tool*, so every existing `TestDetectEmptyToolCall` expectation is unchanged (it now passes `nil` for the tool set).
- No config, API, or behavior change for an agent that is genuinely stuck.

## Verification

- `GOWORK=off go test -tags fts5 -race -short ./pkg/agent/...` — pass
- `gofmt -s -l`, `go vet ./pkg/agent/...`, `golangci-lint run ./pkg/agent/...` — clean (0 issues)
