### PR TITLE
feat(agent): resource-await park — end the turn on a success result awaiting a resource

### DIFF
--- a/docs/architecture/resource-await-park.md
+++ b/docs/architecture/resource-await-park.md
@@ -1,0 +1,92 @@
+# Resource-Await Park
+
+**Status:** Implemented (`pkg/agent/park_resource.go`)
+**Relates to:** HITL park-and-resume (`docs/architecture/hitl-park-and-resume.md`),
+in-turn resource wait (`pkg/mcp/adapter/resource_wait.go`, issue #343)
+
+## Problem
+
+A tool that starts a long-running job follows the MCP event-based resource
+pattern: it returns immediately with a success result carrying a
+`resource_link` (`gdp://jobs/{id}`), and the caller is expected to subscribe
+and act on `notifications/resources/updated`. Neither existing mechanism fits:
+
+- **In-turn resource wait** (issue #343) triggers only on *failed* calls,
+  blocks inside the turn (60s budget, bounded further by the embedder's
+  request watchdog), and *retries the tool* on wake — re-running a job
+  starter starts a second job.
+- **HITL park** ends the turn durably, but parks *pre-execution* on a human
+  gate, and an approved resume *re-executes* ordinary tools — same
+  double-start hazard — while its result-injection primitive was gated to
+  `contact_human`.
+
+## Mechanism
+
+```
+tool executes ── success result + _meta["com.teradata.loom/await-resource"]
+        │                          (adapter stamps shuttle.Result.AwaitResource)
+        ▼
+ResourceAwaitHandler.PrepareWait(session, call, uri)     ← embedder subscribes
+        │ error → result passes to the model unchanged (degrade)
+        ▼
+row withheld (call stays rowless) ─ after the batch loop, ONE parked
+HumanRequest row (RequestType "parked", Kind "resource", descriptor
+{seq, kind, tool, params, uri} per call) ─ TurnParkedError ends the turn
+        │
+        ▼  … resource reaches terminal state; embedder records the decision …
+ResumeChat(ParkDecision{Approved, Results[callID] = terminal payload})
+        │
+        ▼
+completeParkedBatch: resource items NEVER dispatch — the payload is injected
+verbatim as the call's successful result Data (synthesizeParkedResult), or a
+synthesized failure ("resource_wait_failed" / "MISSING_RESULT") lands so the
+model can re-plan. The loop re-enters and the turn finishes.
+```
+
+Key decisions:
+
+- **Subscribe-before-park.** `PrepareWait` runs before anything is withheld;
+  a wait nobody can watch refuses the park and the original result passes
+  through. The parked row is persisted only after every `PrepareWait` of the
+  batch succeeded; the embedder correlates wait→row via the park notifier or
+  the request store (descriptor key `"uri"`).
+- **Fail-safe un-hold.** A park row that fails to persist commits every held
+  call's original result as its normal tool row (`commitToolRow`) and calls
+  `AbandonWait` — nothing strands rowless without a row to resume it.
+- **No re-execution, ever.** At resume time the item's recorded descriptor
+  kind (the row, not the caller's payload) routes resource items away from
+  every dispatch arm, mirroring how the row's status overrides the payload's
+  `Approved`.
+- **Conversation loop only.** The hold gate (`batchState.parkableTail`)
+  carries the pre-scan's durability preconditions and is set only by the
+  loop; a resumed batch's remaining calls pass AwaitResource results through
+  rather than nesting a park.
+- **Binding rules inherited from HITL park.** Descriptors are keyed by
+  `ToolCall.ID`; an empty or batch-duplicated ID cannot be bound (and a
+  duplicate would alias the held call to a sibling's row in the tail walk),
+  so such results pass through instead of holding.
+
+## What the embedder owns
+
+Loom owns the protocol and the turn lifecycle; the embedder owns everything
+with a lifetime longer than a call:
+
+- the subscription itself (`pkg/mcp/client.Subscribe` / `SubscribeResource`),
+  its reconnect loop, and re-subscribe-after-restart reconciliation;
+- reading the resource's terminal content (`ReadResource`) and composing
+  `ParkDecision.Results`;
+- recording the decision on the row and delivering the resume exactly once
+  across processes (same obligation the HITL design doc states for
+  embedder-recorded resumes);
+- TTL/orphan policy for jobs that never complete (an unresumed row lapses at
+  the park TTL like any other parked request).
+
+## Marker
+
+`protocol.MetaAwaitResource` = `"com.teradata.loom/await-resource"`, value
+`{"uri": "<resource uri>"}`, on a *successful* `tools/call` result's `_meta`.
+Core MCP 2026-07-28 defines no long-running-operation marker (the tasks
+extension is a separate, unadopted spec), so the key lives under loom's
+reverse-DNS prefix per the `_meta` naming rules. Servers loom's adapter does
+not front can be bridged by any embedder-owned tool bridge stamping
+`shuttle.Result.AwaitResource` itself.

--- a/docs/guides/mcp-tool-call-lifecycle.md
+++ b/docs/guides/mcp-tool-call-lifecycle.md
@@ -94,7 +94,11 @@ diagnostic data), not as a retry condition, and never triggers a park.
 
 ### What Does NOT Trigger a Park
 
-- Successful results (regardless of content).
+- Successful results — unless the result's `_meta` carries the
+  `com.teradata.loom/await-resource` marker AND the embedding application
+  wired `agent.WithResourceAwait`, in which case the TURN parks durably
+  rather than the call waiting in-turn (a different mechanism entirely; see
+  `docs/architecture/resource-await-park.md`).
 - Error results without `resource_link` content.
 - Error results with an embedded plain `resource` content item only.
 - Any call on a legacy (pre-2026-07-28) connection.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -2754,6 +2754,10 @@ func (a *Agent) runConversationLoop(ctx Context) (*Response, error) {
 		if maxPerTurn <= 0 {
 			maxPerTurn = 10 // default
 		}
+		batchIDCount := make(map[string]int, len(llmResp.ToolCalls))
+		for _, c := range llmResp.ToolCalls {
+			batchIDCount[c.ID]++
+		}
 		st := &batchState{
 			span:               span,
 			turnCount:          turnCount,
@@ -2764,6 +2768,8 @@ func (a *Agent) runConversationLoop(ctx Context) (*Response, error) {
 			tools:              &tools,
 			recovery:           recovery,
 			turnDedup:          make(map[string]*shuttle.Result),
+			parkableTail:       a.hitlPark != nil && assistantPersisted && a.memory.HasStore(),
+			batchIDCount:       batchIDCount,
 		}
 
 		for i, toolCall := range llmResp.ToolCalls {
@@ -2781,6 +2787,12 @@ func (a *Agent) runConversationLoop(ctx Context) (*Response, error) {
 			// Sidecars never advance the turn and hold no special status beyond
 			// that (HLD §4.5).
 			a.appendMessage(ctx, session, sidecar, false)
+		}
+
+		// Resource-await park (park_resource.go): calls held during dispatch
+		// end the turn HERE, after every other call's row and sidecar landed.
+		if parkErr := a.maybeParkResourceBatch(ctx, session, st, llmResp); parkErr != nil {
+			return nil, parkErr
 		}
 	}
 
@@ -2807,6 +2819,15 @@ type batchState struct {
 	turnToolCount   int
 	turnDedup       map[string]*shuttle.Result
 	pendingSidecars []Message
+
+	// Resource-await park (park_resource.go). parkableTail mirrors the
+	// pre-scan's durability gate and is set ONLY by the conversation loop —
+	// the resume path leaves it false, so completions never nest a resource
+	// park. batchIDCount guards descriptor bindability; awaitHeld carries the
+	// calls whose rows are withheld for maybeParkResourceBatch.
+	parkableTail bool
+	batchIDCount map[string]int
+	awaitHeld    []heldAwait
 }
 
 // dispatchOneCall runs one call of a tool batch through the full per-call
@@ -2964,6 +2985,27 @@ func (a *Agent) dispatchOneCall(ctx Context, session *Session, toolCall ToolCall
 		ctx.Tracer().EndSpan(toolSpan)
 	}
 
+	// Resource-await hold (park_resource.go): a successful result asking to be
+	// awaited is withheld from the transcript — no execution record, no tool
+	// row — so the batch tail stays rowless for the park that follows the
+	// batch loop. Every refusal path falls through to the normal commit.
+	if a.maybeHoldForResourceAwait(ctx, session, toolCall, i, st, result, err) {
+		return
+	}
+
+	a.commitToolRow(ctx, session, toolCall, st, result, err, toolSpan)
+}
+
+// commitToolRow is the commit tail of dispatchOneCall — execution record,
+// dedup cache, persistence, failure tracking, the tool row, and sidecar
+// buffering — extracted so the resource-await un-hold path (a park row that
+// failed to persist) can commit a withheld result identically, just later.
+// toolSpan may be nil on that deferred path; the span ended with the original
+// dispatch.
+func (a *Agent) commitToolRow(ctx Context, session *Session, toolCall ToolCall, st *batchState, result *shuttle.Result, err error, toolSpan *observability.Span) {
+	span := st.span
+	dedupKey := toolCall.Name + "|" + canonicalJSON(toolCall.Input)
+
 	// Record execution
 	execution := ToolExecution{
 		ToolName:          toolCall.Name,
@@ -2986,7 +3028,9 @@ func (a *Agent) dispatchOneCall(ctx Context, session *Session, toolCall ToolCall
 	// Persist tool execution
 	if persistErr := a.memory.PersistToolExecution(ctx, session.ID, execution); persistErr != nil {
 		// Log but don't fail
-		toolSpan.RecordError(persistErr)
+		if toolSpan != nil {
+			toolSpan.RecordError(persistErr)
+		}
 	}
 
 	// === FEATURE INTEGRATION: Consecutive Failure Tracking ===

--- a/pkg/agent/park.go
+++ b/pkg/agent/park.go
@@ -153,6 +153,14 @@ type ParkDecision struct {
 	Approved  bool
 	Reason    string
 	Answers   map[string]string
+
+	// Results maps resource-item ToolCall.IDs to the payload injected verbatim
+	// as that call's successful result Data on an approved resume — the
+	// embedder composes it from the awaited resource's terminal content
+	// (resource-await park, park_resource.go). Ignored for approval/question
+	// items. Like Answers, it rides the caller's payload in both flows; the
+	// row's status still decides Approved.
+	Results map[string]interface{}
 }
 
 // loadParkedRequest resolves the decision's request to a parked row that
@@ -572,8 +580,9 @@ func (a *Agent) isParkQuestion(ctx Context, call ToolCall) bool {
 type parkItem struct {
 	call     ToolCall
 	seq      int
-	kind     string // "approval" | "question"
+	kind     string // "approval" | "question" | "resource"
 	question string
+	uri      string // resource items only: the awaited resource
 }
 
 // maybeParkBatch is the pre-scan: every call of the batch — contact_human
@@ -661,10 +670,20 @@ func (a *Agent) maybeParkBatch(ctx Context, sess *Session, llmResp *LLMResponse)
 // model's own question verbatim; anything mixed is an approval over the batch.
 func parkKindAndQuestion(items []parkItem) (kind, question string) {
 	questions := 0
+	resources := 0
 	for _, it := range items {
 		if it.kind == "question" {
 			questions++
 		}
+		if it.kind == "resource" {
+			resources++
+		}
+	}
+	// A resource card asks the human for nothing — it reports a wait. Only an
+	// all-resource batch renders as one (the pre-scan and the post-dispatch
+	// hold can never mix kinds in one row today; defensive all-or-approval).
+	if resources == len(items) {
+		return "resource", fmt.Sprintf("Waiting for %d background operation(s) to complete", len(items))
 	}
 	if questions == len(items) {
 		if len(items) == 1 && items[0].question != "" {
@@ -716,6 +735,9 @@ func buildParkParams(items []parkItem) (map[string]interface{}, bool) {
 		}
 		if it.kind == "question" {
 			desc["question"] = it.question
+		}
+		if it.kind == "resource" {
+			desc["uri"] = it.uri
 		}
 		out[it.call.ID] = desc
 	}
@@ -939,7 +961,7 @@ func (a *Agent) ResumeChat(ctx context.Context, sessionID string, decision ParkD
 	}
 
 	if len(rowless) > 0 {
-		a.completeParkedBatch(agentCtx, sess, batch, rowless, effective, itemIDs)
+		a.completeParkedBatch(agentCtx, sess, batch, rowless, effective, itemIDs, parkedItemKinds(hr))
 	}
 
 	response, err := a.runConversationLoop(agentCtx)
@@ -1103,7 +1125,7 @@ func locateParkedBatch(sess *Session, itemIDs []string) (Message, []ToolCall, er
 // dispatch ungranted, so an ask that appeared while the turn waited — a host
 // gate that trips on budget, quota, or time of day — parks or fails closed
 // exactly as it would in a fresh turn instead of being silently admitted.
-func (a *Agent) completeParkedBatch(ctx Context, sess *Session, batch Message, rowless []ToolCall, decision ParkDecision, itemIDs []string) {
+func (a *Agent) completeParkedBatch(ctx Context, sess *Session, batch Message, rowless []ToolCall, decision ParkDecision, itemIDs []string, kinds map[string]string) {
 	maxPerTurn := a.config.MaxIterations
 	if maxPerTurn <= 0 {
 		maxPerTurn = 10
@@ -1150,6 +1172,11 @@ func (a *Agent) completeParkedBatch(ctx Context, sess *Session, batch Message, r
 
 	for _, call := range rowless {
 		switch {
+		case kinds[call.ID] == "resource":
+			// The call's tool body already RAN when the turn parked — every
+			// resource arm synthesizes, none dispatches, whatever the decision
+			// payload claims (re-execution would double a job start).
+			a.completeResourceItem(ctx, sess, call, decision, st)
 		case !decision.Approved:
 			reason := decision.Reason
 			if reason == "" {

--- a/pkg/agent/park_resource.go
+++ b/pkg/agent/park_resource.go
@@ -1,0 +1,240 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// This file implements resource-await park: the SUCCESS-path counterpart of
+// HITL park. A tool that starts a long-running job returns immediately with a
+// result asking to be awaited (shuttle.Result.AwaitResource — stamped by the
+// MCP adapter from the protocol.MetaAwaitResource result _meta, or by any
+// embedder-owned tool bridge). Instead of handing that placeholder result to
+// the model, the turn parks on the same durable human_requests machinery HITL
+// park uses (kind "resource"), and the embedder resumes it with the
+// resource's terminal content injected as the call's tool result
+// (ParkDecision.Results). The parked call's tool body is NEVER re-executed on
+// resume — re-running a job starter would start a second job.
+package agent
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/teradata-labs/loom/pkg/shuttle"
+)
+
+// ResourceAwaitRequest names one held call and the resource whose terminal
+// state carries its real outcome.
+type ResourceAwaitRequest struct {
+	SessionID string
+	CallID    string
+	Tool      string
+	URI       string
+}
+
+// ResourceAwaitHandler is the embedder's watcher seam. PrepareWait is called
+// BEFORE the turn commits to parking — subscribe to the resource there, and
+// return an error to refuse (the call's original result then passes to the
+// model unchanged, the graceful degradation for a resource nobody can watch).
+// The parked request row, whose params name the same URIs (descriptor key
+// "uri"), is persisted only after every PrepareWait of the batch succeeded;
+// correlate wait→row via the park notifier or the request store. AbandonWait
+// is the best-effort undo for a PrepareWait whose park never materialized
+// (the row failed to persist).
+//
+// A nil handler (no WithResourceAwait) disables the feature entirely:
+// AwaitResource results pass through as ordinary successes.
+type ResourceAwaitHandler interface {
+	PrepareWait(ctx context.Context, req ResourceAwaitRequest) error
+	AbandonWait(req ResourceAwaitRequest)
+}
+
+// WithResourceAwait enables resource-await park. It is inert unless
+// WithHITLPark is also configured — the park row and the resume path are the
+// HITL park machinery, so there is nothing durable to park against without it.
+func WithResourceAwait(h ResourceAwaitHandler) Option {
+	return func(a *Agent) {
+		a.resourceAwait = h
+	}
+}
+
+// heldAwait is one dispatched call whose successful result asked to be
+// awaited: the result is withheld from the transcript (no tool row) so the
+// batch tail stays rowless for that call — the parked state locateParkedBatch
+// reads — and the original result is kept for the fail-safe un-hold.
+type heldAwait struct {
+	call   ToolCall
+	seq    int
+	uri    string
+	result *shuttle.Result
+}
+
+// maybeHoldForResourceAwait intercepts a just-executed call whose successful
+// result carries AwaitResource. On a hold it returns true and the caller
+// skips the commit ceremony — no tool row, no persisted execution — leaving
+// the call rowless for maybeParkResourceBatch. Every refusal path returns
+// false, and the result then commits exactly as today.
+func (a *Agent) maybeHoldForResourceAwait(ctx Context, session *Session, toolCall ToolCall, i int, st *batchState, result *shuttle.Result, err error) bool {
+	if err != nil || result == nil || !result.Success || result.AwaitResource == nil {
+		return false
+	}
+	// parkableTail carries the pre-scan's own durability gate (hitlPark wired,
+	// assistant row durable, store present) — set only by the conversation
+	// loop, never by the resume path, so a resumed batch's remaining calls
+	// pass their AwaitResource results through instead of nesting a park.
+	if a.resourceAwait == nil || a.hitlPark == nil || !st.parkableTail {
+		return false
+	}
+	// The park descriptor is keyed by ToolCall.ID, and locateParkedBatch marks
+	// a call rowed when ANY row carries its ID — an empty or batch-duplicated
+	// ID makes the held call's rowless state unrepresentable (same class of
+	// refusal as checkParkItemIDs).
+	if toolCall.ID == "" || st.batchIDCount[toolCall.ID] != 1 {
+		zap.L().Warn("not holding a resource-await result whose call ID cannot bind a park; passing it through",
+			zap.String("session_id", session.ID), zap.String("tool", toolCall.Name))
+		return false
+	}
+	req := ResourceAwaitRequest{
+		SessionID: session.ID,
+		CallID:    toolCall.ID,
+		Tool:      toolCall.Name,
+		URI:       result.AwaitResource.URI,
+	}
+	if perr := a.resourceAwait.PrepareWait(ctx, req); perr != nil {
+		zap.L().Warn("resource-await watcher refused the wait; passing the result through",
+			zap.String("session_id", session.ID),
+			zap.String("tool", toolCall.Name),
+			zap.String("uri", req.URI),
+			zap.Error(perr))
+		return false
+	}
+	st.awaitHeld = append(st.awaitHeld, heldAwait{
+		call:   toolCall,
+		seq:    i,
+		uri:    result.AwaitResource.URI,
+		result: result,
+	})
+	return true
+}
+
+// maybeParkResourceBatch runs after the batch dispatch loop: with held calls
+// it persists ONE grouped parked request (kind "resource", one descriptor per
+// held call carrying its uri) and ends the turn with TurnParkedError. A
+// persist failure un-holds fail-safe: every held call's ORIGINAL result is
+// committed as its tool row — nothing strands rowless without a park row to
+// resume it — and the watcher is told to abandon each wait.
+func (a *Agent) maybeParkResourceBatch(ctx Context, sess *Session, st *batchState, llmResp *LLMResponse) error {
+	if len(st.awaitHeld) == 0 {
+		return nil
+	}
+	held := st.awaitHeld
+	st.awaitHeld = nil
+
+	items := make([]parkItem, 0, len(held))
+	for _, h := range held {
+		items = append(items, parkItem{call: h.call, seq: h.seq, kind: "resource", uri: h.uri})
+	}
+
+	now := time.Now()
+	params, truncated := buildParkParams(items)
+	kind, question := parkKindAndQuestion(items)
+	hr := &shuttle.HumanRequest{
+		ID:              uuid.New().String(),
+		AgentID:         a.id,
+		SessionID:       sess.ID,
+		Question:        question,
+		Context:         map[string]interface{}{"kind": "parked"},
+		RequestType:     "parked",
+		Priority:        "normal",
+		Kind:            kind,
+		Summary:         parkSummary(items),
+		Timeout:         a.hitlPark.ttl,
+		CreatedAt:       now,
+		ExpiresAt:       now.Add(a.hitlPark.ttl),
+		Params:          params,
+		ParamsTruncated: truncated,
+		Status:          "pending",
+	}
+	if err := a.hitlPark.store.Store(ctx, hr); err != nil {
+		zap.L().Warn("resource-await park row failed to persist; committing the held results instead",
+			zap.String("session_id", sess.ID), zap.Error(err))
+		for _, h := range held {
+			a.resourceAwait.AbandonWait(ResourceAwaitRequest{
+				SessionID: sess.ID, CallID: h.call.ID, Tool: h.call.Name, URI: h.uri,
+			})
+			a.commitToolRow(ctx, sess, h.call, st, h.result, nil, nil)
+		}
+		return nil
+	}
+	if a.hitlPark.notifier != nil {
+		_ = a.hitlPark.notifier.Notify(ctx, hr)
+	}
+	return &TurnParkedError{
+		RequestID: hr.ID,
+		SessionID: sess.ID,
+		ExpiresAt: hr.ExpiresAt,
+		Usage:     llmResp.Usage,
+	}
+}
+
+// parkedItemKinds reads each descriptor's recorded kind off the request row —
+// the authority at resume time, mirroring how the row's status overrides the
+// caller's payload. A resource item must never take the approval arms (its
+// tool already ran; re-execution would double a job start), whatever the
+// decision payload claims.
+func parkedItemKinds(hr *shuttle.HumanRequest) map[string]string {
+	kinds := make(map[string]string, len(hr.Params))
+	for id, raw := range hr.Params {
+		if desc, ok := raw.(map[string]interface{}); ok {
+			if k, _ := desc["kind"].(string); k != "" {
+				kinds[id] = k
+			}
+		}
+	}
+	return kinds
+}
+
+// completeResourceItem finishes one resource-parked call on resume. Approved
+// with a recorded payload → the payload IS the call's successful result Data,
+// verbatim (the embedder composed it from the resource's terminal content).
+// Everything else synthesizes a failure the model can re-plan from. No arm
+// runs the tool body.
+func (a *Agent) completeResourceItem(ctx Context, sess *Session, call ToolCall, decision ParkDecision, st *batchState) {
+	if !decision.Approved {
+		reason := decision.Reason
+		if reason == "" {
+			reason = "the awaited resource did not complete"
+		}
+		a.synthesizeParkedResult(ctx, sess, call, &shuttle.Result{
+			Success: false,
+			Error:   &shuttle.Error{Code: "resource_wait_failed", Message: reason, Retryable: false},
+		}, st)
+		return
+	}
+	payload, ok := decision.Results[call.ID]
+	if !ok || payload == nil {
+		a.synthesizeParkedResult(ctx, sess, call, &shuttle.Result{
+			Success: false,
+			Error: &shuttle.Error{
+				Code:      "MISSING_RESULT",
+				Message:   "no terminal resource state was recorded for this call",
+				Retryable: false,
+			},
+		}, st)
+		return
+	}
+	a.synthesizeParkedResult(ctx, sess, call, &shuttle.Result{
+		Success: true,
+		Data:    payload,
+	}, st)
+}

--- a/pkg/agent/park_resource_test.go
+++ b/pkg/agent/park_resource_test.go
@@ -1,0 +1,406 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package agent
+
+// Resource-await park through the real conversation loop: a successful tool
+// result carrying AwaitResource holds its row back and parks the turn on the
+// HITL park machinery (kind "resource"); the embedder's handler is consulted
+// BEFORE the park commits (subscribe-before-park); resume injects the
+// recorded terminal payload as the call's result and NEVER re-executes the
+// tool body — the property the whole feature exists for, since re-running a
+// job starter starts a second job.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
+	"github.com/teradata-labs/loom/pkg/observability"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+)
+
+// awaitingTool starts a "job": success with a placeholder Data and an
+// AwaitResource asking the agent to park on the job resource.
+type awaitingTool struct {
+	name string
+	uri  string
+	runs atomic.Int64
+}
+
+func (t *awaitingTool) Name() string        { return t.name }
+func (t *awaitingTool) Description() string { return "starts a background job" }
+func (t *awaitingTool) InputSchema() *shuttle.JSONSchema {
+	return &shuttle.JSONSchema{
+		Type:       "object",
+		Properties: map[string]*shuttle.JSONSchema{"v": {Type: "string"}},
+	}
+}
+func (t *awaitingTool) Execute(ctx context.Context, params map[string]interface{}) (*shuttle.Result, error) {
+	t.runs.Add(1)
+	return &shuttle.Result{
+		Success:       true,
+		Data:          map[string]interface{}{"status": "working", "job": "j-1"},
+		AwaitResource: &shuttle.AwaitResource{URI: t.uri},
+	}, nil
+}
+func (t *awaitingTool) Backend() string { return "" }
+
+// fakeAwaitHandler records PrepareWait/AbandonWait calls; refuse makes
+// PrepareWait fail.
+type fakeAwaitHandler struct {
+	mu        sync.Mutex
+	prepared  []ResourceAwaitRequest
+	abandoned []ResourceAwaitRequest
+	refuse    error
+}
+
+func (h *fakeAwaitHandler) PrepareWait(_ context.Context, req ResourceAwaitRequest) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.refuse != nil {
+		return h.refuse
+	}
+	h.prepared = append(h.prepared, req)
+	return nil
+}
+
+func (h *fakeAwaitHandler) AbandonWait(req ResourceAwaitRequest) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.abandoned = append(h.abandoned, req)
+}
+
+// failingParkStore refuses Store — the park-row persist failure path.
+type failingParkStore struct {
+	*shuttle.InMemoryHumanRequestStore
+}
+
+func (s *failingParkStore) Store(context.Context, *shuttle.HumanRequest) error {
+	return errors.New("store down")
+}
+
+type resourceParkFixture struct {
+	ag      *Agent
+	store   shuttle.HumanRequestStore
+	mem     *shuttle.InMemoryHumanRequestStore
+	handler *fakeAwaitHandler
+	job     *awaitingTool
+	sibling *countingTool
+}
+
+// jobThenText scripts [start_job + read (plain)] then a final text — the
+// mixed batch every test here drives.
+func jobThenText() []mockLLMResponse {
+	return []mockLLMResponse{
+		{content: "", toolCalls: []llmtypes.ToolCall{
+			{ID: "c-job", Name: "start_job", Input: map[string]interface{}{"v": "j"}},
+			{ID: "c-read", Name: "read_table", Input: map[string]interface{}{"v": "r"}},
+		}},
+		{content: "continued"},
+	}
+}
+
+// newResourceParkFixture mirrors newParkFixture (real session store — park's
+// durability precondition) plus the await handler wiring and the mixed-batch
+// tools. failStore swaps in a park store whose Store always fails.
+func newResourceParkFixture(t *testing.T, handler *fakeAwaitHandler, failStore bool) *resourceParkFixture {
+	t.Helper()
+	cfg := DefaultConfig()
+	cfg.PatternConfig = DefaultPatternConfig()
+	cfg.PatternConfig.UseLLMClassifier = false
+
+	sessions, err := NewSessionStore(filepath.Join(t.TempDir(), "resource-park.db"), observability.NewNoOpTracer())
+	if err != nil {
+		t.Fatalf("session store: %v", err)
+	}
+	t.Cleanup(func() { _ = sessions.Close() })
+
+	mem := shuttle.NewInMemoryHumanRequestStore()
+	var store shuttle.HumanRequestStore = mem
+	if failStore {
+		store = &failingParkStore{InMemoryHumanRequestStore: mem}
+	}
+	opts := []Option{
+		WithConfig(cfg),
+		WithMemory(NewMemoryWithStore(sessions)),
+		WithHITLPark(store, 0, NewProgressNotifier()),
+	}
+	if handler != nil {
+		opts = append(opts, WithResourceAwait(handler))
+	}
+	llm := &mockToolCallingLLM{responses: jobThenText()}
+	ag := NewAgent(&mockBackend{}, llm, opts...)
+	job := &awaitingTool{name: "start_job", uri: "gdp://jobs/42"}
+	sibling := &countingTool{name: "read_table"}
+	ag.RegisterTool(job)
+	ag.RegisterTool(sibling)
+	return &resourceParkFixture{ag: ag, store: store, mem: mem, handler: handler, job: job, sibling: sibling}
+}
+
+// toolRowCount counts persisted tool rows carrying the given ToolUseID.
+func toolRowCount(f *resourceParkFixture, sessionID, callID string) int {
+	msgs := rawSessionMessages(f.ag.memory.GetOrCreateSessionWithAgent(context.Background(), sessionID, f.ag.config.Name, ""))
+	n := 0
+	for _, m := range msgs {
+		if m.Role == "tool" && m.ToolUseID == callID {
+			n++
+		}
+	}
+	return n
+}
+
+func pendingResourcePark(t *testing.T, mem *shuttle.InMemoryHumanRequestStore, sessionID string) *shuttle.HumanRequest {
+	t.Helper()
+	reqs, err := mem.ListBySession(context.Background(), sessionID)
+	if err != nil {
+		t.Fatalf("ListBySession: %v", err)
+	}
+	var out *shuttle.HumanRequest
+	for _, r := range reqs {
+		if r.Status == "pending" && r.RequestType == "parked" {
+			if out != nil {
+				t.Fatalf("more than one pending parked request")
+			}
+			out = r
+		}
+	}
+	if out == nil {
+		t.Fatalf("no pending parked request for %s", sessionID)
+	}
+	return out
+}
+
+func TestResourceAwait_HoldsAndParksTheTurn(t *testing.T) {
+	h := &fakeAwaitHandler{}
+	f := newResourceParkFixture(t, h, false)
+
+	_, err := f.ag.Chat(context.Background(), "s-await", "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("Chat error = %v, want *TurnParkedError", err)
+	}
+
+	// The job STARTED (unlike HITL park, the body ran — that is the point).
+	if got := f.job.runs.Load(); got != 1 {
+		t.Fatalf("start_job ran %d times, want 1", got)
+	}
+	// The sibling ran and its row landed; the awaited call's row is withheld.
+	if got := f.sibling.runs.Load(); got != 1 {
+		t.Fatalf("read_table ran %d times, want 1", got)
+	}
+	if n := toolRowCount(f, "s-await", "c-read"); n != 1 {
+		t.Fatalf("sibling tool rows = %d, want 1", n)
+	}
+	if n := toolRowCount(f, "s-await", "c-job"); n != 0 {
+		t.Fatalf("awaited call tool rows = %d, want 0 (withheld)", n)
+	}
+
+	// Subscribe-before-park: the handler saw the wait before the row landed.
+	if len(h.prepared) != 1 || h.prepared[0].URI != "gdp://jobs/42" ||
+		h.prepared[0].CallID != "c-job" || h.prepared[0].Tool != "start_job" ||
+		h.prepared[0].SessionID != "s-await" {
+		t.Fatalf("prepared = %+v", h.prepared)
+	}
+	if len(h.abandoned) != 0 {
+		t.Fatalf("abandoned = %+v, want none", h.abandoned)
+	}
+
+	// The row: kind resource, one descriptor for the awaited call, uri bound.
+	hr := pendingResourcePark(t, f.mem, "s-await")
+	if hr.ID != parked.RequestID || hr.Kind != "resource" {
+		t.Fatalf("request shape wrong: kind=%q id match=%v", hr.Kind, hr.ID == parked.RequestID)
+	}
+	desc, ok := hr.Params["c-job"].(map[string]interface{})
+	if !ok || len(hr.Params) != 1 {
+		t.Fatalf("params = %+v, want single c-job descriptor", hr.Params)
+	}
+	if desc["kind"] != "resource" || desc["uri"] != "gdp://jobs/42" || desc["tool"] != "start_job" {
+		t.Fatalf("descriptor = %+v", desc)
+	}
+}
+
+func TestResourceAwait_NoHandlerPassesThrough(t *testing.T) {
+	f := newResourceParkFixture(t, nil, false)
+
+	resp, err := f.ag.Chat(context.Background(), "s-nohandler", "go")
+	if err != nil {
+		t.Fatalf("Chat error = %v, want pass-through completion", err)
+	}
+	if resp.Content != "continued" {
+		t.Fatalf("content = %q, want %q", resp.Content, "continued")
+	}
+	// The original result committed as an ordinary row.
+	if n := toolRowCount(f, "s-nohandler", "c-job"); n != 1 {
+		t.Fatalf("awaited call tool rows = %d, want 1 (passed through)", n)
+	}
+}
+
+func TestResourceAwait_HandlerRefusalPassesThrough(t *testing.T) {
+	h := &fakeAwaitHandler{refuse: fmt.Errorf("nobody can watch that")}
+	f := newResourceParkFixture(t, h, false)
+
+	resp, err := f.ag.Chat(context.Background(), "s-refused", "go")
+	if err != nil {
+		t.Fatalf("Chat error = %v, want pass-through completion", err)
+	}
+	if resp.Content != "continued" {
+		t.Fatalf("content = %q, want %q", resp.Content, "continued")
+	}
+	if n := toolRowCount(f, "s-refused", "c-job"); n != 1 {
+		t.Fatalf("awaited call tool rows = %d, want 1 (passed through)", n)
+	}
+	if len(h.abandoned) != 0 {
+		t.Fatalf("abandoned = %+v, want none (nothing was prepared)", h.abandoned)
+	}
+}
+
+func TestResourceAwait_ParkRowFailureCommitsHeldResultAndAbandons(t *testing.T) {
+	h := &fakeAwaitHandler{}
+	f := newResourceParkFixture(t, h, true)
+
+	resp, err := f.ag.Chat(context.Background(), "s-storefail", "go")
+	if err != nil {
+		t.Fatalf("Chat error = %v, want fail-safe completion", err)
+	}
+	if resp.Content != "continued" {
+		t.Fatalf("content = %q, want %q", resp.Content, "continued")
+	}
+	// The held original result was committed — nothing strands rowless.
+	if n := toolRowCount(f, "s-storefail", "c-job"); n != 1 {
+		t.Fatalf("awaited call tool rows = %d, want 1 (fail-safe commit)", n)
+	}
+	// The prepared wait was told to stand down.
+	if len(h.abandoned) != 1 || h.abandoned[0].URI != "gdp://jobs/42" {
+		t.Fatalf("abandoned = %+v, want the one prepared wait", h.abandoned)
+	}
+}
+
+// parkForResume drives a fixture to the parked state and returns the row.
+func parkForResume(t *testing.T, f *resourceParkFixture, sessionID string) *shuttle.HumanRequest {
+	t.Helper()
+	_, err := f.ag.Chat(context.Background(), sessionID, "go")
+	var parked *TurnParkedError
+	if !errors.As(err, &parked) {
+		t.Fatalf("expected park, got %v", err)
+	}
+	return pendingResourcePark(t, f.mem, sessionID)
+}
+
+func TestResourceAwait_ResumeInjectsRecordedResultWithoutReExecution(t *testing.T) {
+	h := &fakeAwaitHandler{}
+	f := newResourceParkFixture(t, h, false)
+	hr := parkForResume(t, f, "s-inject")
+
+	payload := map[string]interface{}{"status": "completed", "result": "42 rows loaded"}
+	resp, err := f.ag.ResumeChat(context.Background(), "s-inject", ParkDecision{
+		RequestID: hr.ID,
+		Approved:  true,
+		Results:   map[string]interface{}{"c-job": payload},
+	}, nil)
+	if err != nil {
+		t.Fatalf("ResumeChat error = %v", err)
+	}
+	if resp.Content != "continued" {
+		t.Fatalf("content = %q, want %q", resp.Content, "continued")
+	}
+
+	// THE property: the tool body did not run again.
+	if got := f.job.runs.Load(); got != 1 {
+		t.Fatalf("start_job ran %d times, want exactly 1 (no re-execution on resume)", got)
+	}
+
+	// The injected payload IS the call's result Data, verbatim.
+	msgs := rawSessionMessages(f.ag.memory.GetOrCreateSessionWithAgent(context.Background(), "s-inject", f.ag.config.Name, ""))
+	var row *Message
+	for i := range msgs {
+		if msgs[i].Role == "tool" && msgs[i].ToolUseID == "c-job" {
+			row = &msgs[i]
+		}
+	}
+	if row == nil || row.ToolResult == nil || !row.ToolResult.Success {
+		t.Fatalf("no successful injected row for c-job")
+	}
+	data, ok := row.ToolResult.Data.(map[string]interface{})
+	if !ok || data["status"] != "completed" || data["result"] != "42 rows loaded" {
+		t.Fatalf("injected Data = %+v", row.ToolResult.Data)
+	}
+}
+
+func TestResourceAwait_ResumeNotApprovedSynthesizesWaitFailure(t *testing.T) {
+	h := &fakeAwaitHandler{}
+	f := newResourceParkFixture(t, h, false)
+	hr := parkForResume(t, f, "s-reject")
+
+	resp, err := f.ag.ResumeChat(context.Background(), "s-reject", ParkDecision{
+		RequestID: hr.ID,
+		Approved:  false,
+		Reason:    "job did not complete before the wait expired",
+	}, nil)
+	if err != nil {
+		t.Fatalf("ResumeChat error = %v", err)
+	}
+	if resp.Content != "continued" {
+		t.Fatalf("content = %q, want the loop to continue", resp.Content)
+	}
+	if got := f.job.runs.Load(); got != 1 {
+		t.Fatalf("start_job ran %d times, want exactly 1", got)
+	}
+	msgs := rawSessionMessages(f.ag.memory.GetOrCreateSessionWithAgent(context.Background(), "s-reject", f.ag.config.Name, ""))
+	var row *Message
+	for i := range msgs {
+		if msgs[i].Role == "tool" && msgs[i].ToolUseID == "c-job" {
+			row = &msgs[i]
+		}
+	}
+	if row == nil || row.ToolResult == nil || row.ToolResult.Success {
+		t.Fatalf("expected synthesized failure row for c-job")
+	}
+	if row.ToolResult.Error == nil || row.ToolResult.Error.Code != "resource_wait_failed" ||
+		row.ToolResult.Error.Message != "job did not complete before the wait expired" {
+		t.Fatalf("synthesized error = %+v", row.ToolResult.Error)
+	}
+}
+
+func TestResourceAwait_ResumeApprovedWithoutPayloadSynthesizesMissingResult(t *testing.T) {
+	h := &fakeAwaitHandler{}
+	f := newResourceParkFixture(t, h, false)
+	hr := parkForResume(t, f, "s-missing")
+
+	_, err := f.ag.ResumeChat(context.Background(), "s-missing", ParkDecision{
+		RequestID: hr.ID,
+		Approved:  true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("ResumeChat error = %v", err)
+	}
+	if got := f.job.runs.Load(); got != 1 {
+		t.Fatalf("start_job ran %d times, want exactly 1", got)
+	}
+	msgs := rawSessionMessages(f.ag.memory.GetOrCreateSessionWithAgent(context.Background(), "s-missing", f.ag.config.Name, ""))
+	var row *Message
+	for i := range msgs {
+		if msgs[i].Role == "tool" && msgs[i].ToolUseID == "c-job" {
+			row = &msgs[i]
+		}
+	}
+	if row == nil || row.ToolResult == nil || row.ToolResult.Success ||
+		row.ToolResult.Error == nil || row.ToolResult.Error.Code != "MISSING_RESULT" {
+		t.Fatalf("expected MISSING_RESULT row, got %+v", row)
+	}
+}

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -81,6 +81,12 @@ type Agent struct {
 	// human decision ends the turn (TurnParkedError) instead of holding it.
 	hitlPark *hitlParkConfig
 
+	// resourceAwait, when non-nil (WithResourceAwait), enables resource-await
+	// park: a successful tool result carrying AwaitResource ends the turn
+	// parked until the named resource reaches a terminal state. Requires
+	// hitlPark (the same durable-row machinery finishes the turn).
+	resourceAwait ResourceAwaitHandler
+
 	// parkedHandles holds the MCP session-handle collector of each session's
 	// parked turn, so a same-process resume adopts its handles instead of
 	// finding them released. One slot per session; guardParkedTail now

--- a/pkg/mcp/adapter/shuttle.go
+++ b/pkg/mcp/adapter/shuttle.go
@@ -380,6 +380,13 @@ func (a *MCPToolAdapter) Execute(ctx context.Context, params map[string]interfac
 		ExecutionTimeMs: executionTime,
 		Metadata:        metadata,
 	}
+	// Success-path long-running-job marker (protocol.MetaAwaitResource): the
+	// server says this result's real outcome is the named resource's terminal
+	// state. Stamped onto the generic contract so the agent loop can park the
+	// turn without knowing MCP; ignored by agents with no await handler.
+	if uri := protocol.AwaitResourceURI(mcpResult.Meta); uri != "" {
+		result.AwaitResource = &shuttle.AwaitResource{URI: uri}
+	}
 	for _, ev := range leaseEvents {
 		shuttle.AppendLeaseEvent(result, ev)
 	}

--- a/pkg/mcp/adapter/shuttle_test.go
+++ b/pkg/mcp/adapter/shuttle_test.go
@@ -1831,3 +1831,75 @@ func TestExecute_ConcurrentCalls(t *testing.T) {
 		assert.Contains(t, resultStr, "result for id=", "goroutine %d should have correct result", i)
 	}
 }
+
+func TestExecute_AwaitResourceMetaStampsResult(t *testing.T) {
+	// A SUCCESSFUL result whose _meta carries protocol.MetaAwaitResource is
+	// stamped onto the generic contract (shuttle.Result.AwaitResource) so the
+	// agent loop can park the turn without knowing MCP.
+	testTool := protocol.Tool{
+		Name:        "start_job",
+		Description: "Start a background job",
+		InputSchema: map[string]interface{}{"type": "object"},
+	}
+
+	handler := func(method string, params json.RawMessage) (interface{}, *protocol.Error) {
+		switch method {
+		case "tools/list":
+			return protocol.ToolListResult{Tools: []protocol.Tool{testTool}}, nil
+		case "tools/call":
+			return protocol.CallToolResult{
+				Content: []protocol.Content{
+					{Type: "text", Text: `{"job_id":"j-1","status":"working"}`},
+					{Type: "resource_link", URI: "gdp://jobs/j-1", Name: "gdp-job-j-1"},
+				},
+				Meta: map[string]interface{}{
+					protocol.MetaAwaitResource: map[string]interface{}{"uri": "gdp://jobs/j-1"},
+				},
+			}, nil
+		default:
+			return nil, protocol.NewError(protocol.MethodNotFound, "unknown method: "+method, nil)
+		}
+	}
+
+	mcpClient, _ := newMockClientWithHandler(t, handler)
+	adapter := NewMCPToolAdapter(mcpClient, testTool, "gdp")
+
+	result, err := adapter.Execute(context.Background(), map[string]interface{}{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.Success)
+	require.NotNil(t, result.AwaitResource, "the _meta marker must stamp AwaitResource")
+	assert.Equal(t, "gdp://jobs/j-1", result.AwaitResource.URI)
+}
+
+func TestExecute_NoAwaitMetaLeavesResultUnstamped(t *testing.T) {
+	testTool := protocol.Tool{
+		Name:        "read_file",
+		Description: "Read a file",
+		InputSchema: map[string]interface{}{"type": "object"},
+	}
+
+	handler := func(method string, params json.RawMessage) (interface{}, *protocol.Error) {
+		switch method {
+		case "tools/list":
+			return protocol.ToolListResult{Tools: []protocol.Tool{testTool}}, nil
+		case "tools/call":
+			return protocol.CallToolResult{
+				Content: []protocol.Content{{Type: "text", Text: "plain"}},
+				// A malformed marker (wrong value shape) must not stamp either.
+				Meta: map[string]interface{}{protocol.MetaAwaitResource: "gdp://jobs/j-1"},
+			}, nil
+		default:
+			return nil, protocol.NewError(protocol.MethodNotFound, "unknown method: "+method, nil)
+		}
+	}
+
+	mcpClient, _ := newMockClientWithHandler(t, handler)
+	adapter := NewMCPToolAdapter(mcpClient, testTool, "fs")
+
+	result, err := adapter.Execute(context.Background(), map[string]interface{}{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.Success)
+	assert.Nil(t, result.AwaitResource)
+}

--- a/pkg/mcp/protocol/await.go
+++ b/pkg/mcp/protocol/await.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// This file defines the loom-specific result-_meta marker a server stamps on
+// a SUCCESSFUL tools/call result to say "the real outcome of this call is the
+// named resource's terminal state — await it instead of treating this result
+// as final". It is the success-path counterpart of the failure-path
+// resource_link convention resource_wait consumes: core MCP 2026-07-28 has no
+// native long-running-operation marker (the tasks extension is a separate,
+// unadopted spec), so the marker lives under loom's own reverse-DNS prefix
+// per the _meta key naming rules.
+package protocol
+
+// MetaAwaitResource is the result-_meta key. Its value is an object naming
+// the resource to await: {"uri": "<resource uri>"}.
+const MetaAwaitResource = "com.teradata.loom/await-resource"
+
+// AwaitResourceURI extracts the awaited resource URI from a result's _meta,
+// returning "" when the marker is absent or malformed. Malformed markers are
+// deliberately not errors: the result is still a valid tool result, it just
+// doesn't ask to be awaited.
+func AwaitResourceURI(meta map[string]interface{}) string {
+	if meta == nil {
+		return ""
+	}
+	obj, ok := meta[MetaAwaitResource].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	uri, _ := obj["uri"].(string)
+	return uri
+}

--- a/pkg/mcp/protocol/await_test.go
+++ b/pkg/mcp/protocol/await_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package protocol
+
+import "testing"
+
+func TestAwaitResourceURI(t *testing.T) {
+	tests := []struct {
+		name string
+		meta map[string]interface{}
+		want string
+	}{
+		{name: "nil meta", meta: nil, want: ""},
+		{name: "absent key", meta: map[string]interface{}{"other": 1}, want: ""},
+		{
+			name: "well-formed",
+			meta: map[string]interface{}{MetaAwaitResource: map[string]interface{}{"uri": "gdp://jobs/1"}},
+			want: "gdp://jobs/1",
+		},
+		{
+			name: "wrong value shape",
+			meta: map[string]interface{}{MetaAwaitResource: "gdp://jobs/1"},
+			want: "",
+		},
+		{
+			name: "missing uri field",
+			meta: map[string]interface{}{MetaAwaitResource: map[string]interface{}{"name": "x"}},
+			want: "",
+		},
+		{
+			name: "non-string uri",
+			meta: map[string]interface{}{MetaAwaitResource: map[string]interface{}{"uri": 7}},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AwaitResourceURI(tt.meta); got != tt.want {
+				t.Errorf("AwaitResourceURI() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/mcp/protocol/types.go
+++ b/pkg/mcp/protocol/types.go
@@ -123,6 +123,7 @@ type CallToolResult struct {
 	Content           []Content              `json:"content"`                     // Array of content items
 	IsError           bool                   `json:"isError,omitempty"`           // Deprecated, use proper errors
 	StructuredContent map[string]interface{} `json:"structuredContent,omitempty"` // Structured output (MCP 2025-03-26)
+	Meta              map[string]interface{} `json:"_meta,omitempty"`             // Result _meta (e.g. MetaAwaitResource)
 }
 
 // Content represents different types of content (text, image, resource)

--- a/pkg/shuttle/tool.go
+++ b/pkg/shuttle/tool.go
@@ -69,6 +69,21 @@ type Result struct {
 	// DataReference points to large result data in shared memory
 	// When set, Data field should contain only a brief summary
 	DataReference *loomv1.DataReference
+
+	// AwaitResource, on a SUCCESSFUL result, asks the agent to park the turn
+	// until the named resource reaches a terminal state instead of handing
+	// this result to the model — the long-running-job pattern, where the tool
+	// returns immediately and the real outcome arrives later as the resource's
+	// content. Honored only when the agent has a ResourceAwaitHandler wired
+	// (agent.WithResourceAwait); otherwise the result passes through as-is.
+	AwaitResource *AwaitResource
+}
+
+// AwaitResource names the resource whose next terminal update carries the
+// real outcome of the call that returned it.
+type AwaitResource struct {
+	// URI of the resource to await (e.g. "gdp://jobs/123").
+	URI string
 }
 
 // Error represents a tool execution error with structured information.


### PR DESCRIPTION
## Problem

A tool that starts a long-running job follows the MCP event-based resource pattern: it returns immediately with a success result naming a resource (`gdp://jobs/{id}`), and the caller subscribes and acts on `notifications/resources/updated`. Neither existing mechanism fits:

- **In-turn resource wait** (#343) triggers only on *failed* calls, blocks inside the turn (60s budget), and *retries the tool* on wake — re-running a job starter starts a second job.
- **HITL park** ends the turn durably but parks *pre-execution*, and an approved resume *re-executes* ordinary tools (same double-start hazard); its injection primitive was gated to `contact_human`.

## Mechanism

1. **Marker** — `protocol.MetaAwaitResource` (`com.teradata.loom/await-resource`), a result-`_meta` key a server stamps on a *successful* `tools/call` result: `{"uri": "..."}`. `protocol.CallToolResult` gains the `_meta` field it rides on; the MCP adapter stamps it onto the generic contract as `shuttle.Result.AwaitResource` (any embedder-owned bridge can stamp the field directly). Core 2026-07-28 has no native long-running-op marker — the tasks extension is a separate, unadopted spec — hence the reverse-DNS loom key.
2. **Hold** — a successful result carrying `AwaitResource` is withheld from the transcript (no tool row, the parked rowless-tail state) *after* the embedder's new `ResourceAwaitHandler.PrepareWait` accepts (subscribe-before-park; refusal or no handler degrades to pass-through). Gated by the same durability preconditions as the HITL pre-scan, conversation loop only (a resumed batch never nests a park).
3. **Park** — after the batch loop, ONE grouped parked `HumanRequest` (RequestType `parked`, new Kind `resource`, per-call descriptor `{seq, kind, tool, params, uri}`) and `TurnParkedError`. A persist failure fail-safes: every held call's original result commits as its normal tool row (new `commitToolRow` — dispatchOneCall's commit tail extracted verbatim) and `AbandonWait` fires.
4. **Resume** — `ParkDecision.Results` (call id → terminal payload) rides the caller's payload like `Answers`; the row's descriptor kind (not the payload) routes resource items away from **every** dispatch arm: approved+payload injects the payload verbatim as the call's successful result (`synthesizeParkedResult`), refusal synthesizes `resource_wait_failed` with the embedder's reason, approved-without-payload synthesizes `MISSING_RESULT`. **No arm re-executes the tool body.**

## Embedder contract

The embedder owns everything with a lifetime longer than a call: the subscription (`client.Subscribe`/`SubscribeResource`) and its reconnect/restart reconciliation, the terminal `ReadResource`, recording the decision, at-most-once resume delivery, and TTL policy. First consumer: tera-backend's MCP resource watcher (design in that repo, `docs/mcp-resource-subscription-park-design.md`).

## Verification

- 7 new `TestResourceAwait_*` tests through the real conversation loop (hold+park shape, sibling rows land, subscribe-before-park ordering, no-handler / refusal / store-failure degradations incl. `AbandonWait`, injection verbatim, no re-execution on any resume arm, `resource_wait_failed` / `MISSING_RESULT`).
- Adapter stamping tests (well-formed marker stamps; absent/malformed does not) + protocol table test.
- Full `pkg/agent`, `pkg/shuttle`, `pkg/mcp/...` suites green with `-race -count=1`; `golangci-lint` clean.
- Docs: `docs/architecture/resource-await-park.md` + the lifecycle guide's success-result carve-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)