### PR TITLE
fix(agent): give synthetic messages their own persisted role

### DIFF
--- a/docs/reference/streaming.md
+++ b/docs/reference/streaming.md
@@ -1092,7 +1092,7 @@ message SessionStatusUpdate {
 Sent when a new message is added to the session conversation (e.g., from a sub-agent response, tool result, or user input).
 
 **Fields**:
-- `role`: Message role - `user`, `assistant`, or `tool` (only these roles are sent)
+- `role`: Message role - `user`, `assistant`, `tool`, `skill_body`, or `hygiene_injection` (only these roles are sent). `skill_body` and `hygiene_injection` are synthetic, agent-authored roles — a loaded skill's instructions and a hygiene-retry nudge, respectively — persisted separately from the literal end user; see `pkg/agent/llm_retry.go`'s `IsSyntheticWireUserRole`.
 - `content`: The message text
 - `message_timestamp`: When the message was created (Unix timestamp)
 - `tool_name`: 🚧 Defined in proto but not yet populated by the server implementation

--- a/docs/reference/streaming.md
+++ b/docs/reference/streaming.md
@@ -1092,7 +1092,7 @@ message SessionStatusUpdate {
 Sent when a new message is added to the session conversation (e.g., from a sub-agent response, tool result, or user input).
 
 **Fields**:
-- `role`: Message role - `user`, `assistant`, `tool`, `skill_body`, or `hygiene_injection` (only these roles are sent). `skill_body` and `hygiene_injection` are synthetic, agent-authored roles — a loaded skill's instructions and a hygiene-retry nudge, respectively — persisted separately from the literal end user; see `pkg/agent/llm_retry.go`'s `IsSyntheticWireUserRole`.
+- `role`: Message role - `user`, `assistant`, `tool`, `skill_body`, `hygiene_injection`, `empty_response_retry`, or `synthesis_prompt` (only these roles are sent). `skill_body`, `hygiene_injection`, `empty_response_retry`, and `synthesis_prompt` are synthetic, agent-authored roles — a loaded skill's instructions, a hygiene-retry nudge, an empty-response retry nudge, and a forced-final-answer synthesis prompt, respectively — persisted separately from the literal end user; see `pkg/agent/llm_retry.go`'s `IsSyntheticWireUserRole`.
 - `content`: The message text
 - `message_timestamp`: When the message was created (Unix timestamp)
 - `tool_name`: 🚧 Defined in proto but not yet populated by the server implementation

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -38,6 +38,16 @@ const (
 	// HygieneInjection is an end-of-turn hygiene retry nudge. Same
 	// wire-folding treatment as SkillBody, different producer.
 	HygieneInjection Role = "hygiene_injection"
+
+	// EmptyResponseRetry is the one-shot nudge appended when the LLM
+	// returns an empty response, asking it to try again. Same
+	// wire-folding treatment as SkillBody, different producer.
+	EmptyResponseRetry Role = "empty_response_retry"
+
+	// SynthesisPrompt is the forced-final-answer request appended when the
+	// turn/execution budget is exhausted. Same wire-folding treatment as
+	// SkillBody, different producer.
+	SynthesisPrompt Role = "synthesis_prompt"
 )
 
 // FinishReason represents the reason a message finished.

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -29,6 +29,15 @@ const (
 	Assistant Role = "assistant"
 	Tool      Role = "tool"
 	System    Role = "system"
+
+	// SkillBody is a loaded skill's full instructions, injected by
+	// manage_skills as a sidecar. Reaches the LLM as user-turn content
+	// (folded in pkg/agent.normalizeWireRoles) but is not the human's turn.
+	SkillBody Role = "skill_body"
+
+	// HygieneInjection is an end-of-turn hygiene retry nudge. Same
+	// wire-folding treatment as SkillBody, different producer.
+	HygieneInjection Role = "hygiene_injection"
 )
 
 // FinishReason represents the reason a message finished.

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package message
+
+import "testing"
+
+// The persisted-role string a producer writes (pkg/agent) and the TUI's
+// typed Role must be the same literal, or the bare cast in
+// internal/tui/adapter/messages.go:ProtoToMessage silently produces a role
+// the TUI never explicitly handles.
+func TestSyntheticRoles_MatchPersistedStrings(t *testing.T) {
+	if SkillBody != "skill_body" {
+		t.Fatalf("SkillBody = %q, want %q", SkillBody, "skill_body")
+	}
+	if HygieneInjection != "hygiene_injection" {
+		t.Fatalf("HygieneInjection = %q, want %q", HygieneInjection, "hygiene_injection")
+	}
+}

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -26,4 +26,10 @@ func TestSyntheticRoles_MatchPersistedStrings(t *testing.T) {
 	if HygieneInjection != "hygiene_injection" {
 		t.Fatalf("HygieneInjection = %q, want %q", HygieneInjection, "hygiene_injection")
 	}
+	if EmptyResponseRetry != "empty_response_retry" {
+		t.Fatalf("EmptyResponseRetry = %q, want %q", EmptyResponseRetry, "empty_response_retry")
+	}
+	if SynthesisPrompt != "synthesis_prompt" {
+		t.Fatalf("SynthesisPrompt = %q, want %q", SynthesisPrompt, "synthesis_prompt")
+	}
 }

--- a/internal/tui/components/chat/chat.go
+++ b/internal/tui/components/chat/chat.go
@@ -376,7 +376,7 @@ func (m *messageListCmp) handleNewMessage(msg message.Message) tea.Cmd {
 		return m.handleNewUserMessage(msg)
 	case message.Assistant:
 		return m.handleNewAssistantMessage(msg)
-	case message.SkillBody, message.HygieneInjection:
+	case message.SkillBody, message.HygieneInjection, message.EmptyResponseRetry, message.SynthesisPrompt:
 		return m.handleNewSyntheticMessage(msg)
 	case message.Tool:
 		return m.handleToolMessage(msg)
@@ -611,7 +611,7 @@ func (m *messageListCmp) convertMessagesToUI(sessionMessages []message.Message, 
 			if msg.FinishPart() != nil && msg.FinishPart().Reason == message.FinishReasonEndTurn {
 				uiMessages = append(uiMessages, messages.NewAssistantSection(msg, time.Unix(m.lastUserMessageTime, 0)))
 			}
-		case message.SkillBody, message.HygieneInjection:
+		case message.SkillBody, message.HygieneInjection, message.EmptyResponseRetry, message.SynthesisPrompt:
 			// Synthetic content, not the human's turn — do not touch
 			// lastUserMessageTime, which anchors the assistant response timer
 			// to the real user's send time.

--- a/internal/tui/components/chat/chat.go
+++ b/internal/tui/components/chat/chat.go
@@ -376,6 +376,8 @@ func (m *messageListCmp) handleNewMessage(msg message.Message) tea.Cmd {
 		return m.handleNewUserMessage(msg)
 	case message.Assistant:
 		return m.handleNewAssistantMessage(msg)
+	case message.SkillBody, message.HygieneInjection:
+		return m.handleNewSyntheticMessage(msg)
 	case message.Tool:
 		return m.handleToolMessage(msg)
 	}
@@ -385,6 +387,12 @@ func (m *messageListCmp) handleNewMessage(msg message.Message) tea.Cmd {
 // handleNewUserMessage adds a new user message to the list and updates the timestamp.
 func (m *messageListCmp) handleNewUserMessage(msg message.Message) tea.Cmd {
 	m.lastUserMessageTime = msg.CreatedAt
+	return m.listCmp.AppendItem(messages.NewMessageCmp(msg))
+}
+
+// handleNewSyntheticMessage appends a skill-body or hygiene-injection
+// message to the list without treating it as the human's turn.
+func (m *messageListCmp) handleNewSyntheticMessage(msg message.Message) tea.Cmd {
 	return m.listCmp.AppendItem(messages.NewMessageCmp(msg))
 }
 
@@ -603,6 +611,11 @@ func (m *messageListCmp) convertMessagesToUI(sessionMessages []message.Message, 
 			if msg.FinishPart() != nil && msg.FinishPart().Reason == message.FinishReasonEndTurn {
 				uiMessages = append(uiMessages, messages.NewAssistantSection(msg, time.Unix(m.lastUserMessageTime, 0)))
 			}
+		case message.SkillBody, message.HygieneInjection:
+			// Synthetic content, not the human's turn — do not touch
+			// lastUserMessageTime, which anchors the assistant response timer
+			// to the real user's send time.
+			uiMessages = append(uiMessages, messages.NewMessageCmp(msg))
 		}
 	}
 

--- a/internal/tui/components/chat/messages/messages.go
+++ b/internal/tui/components/chat/messages/messages.go
@@ -140,10 +140,11 @@ func (m *messageCmp) View() string {
 		return m.style().PaddingLeft(1).Render(m.anim.View())
 	}
 	if m.message.ID != "" {
-		// this is a user or assistant message
 		switch m.message.Role {
 		case message.User:
 			return m.renderUserMessage()
+		case message.SkillBody, message.HygieneInjection:
+			return m.renderSyntheticNote()
 		default:
 			return m.renderAssistantMessage()
 		}
@@ -178,9 +179,14 @@ func (msg *messageCmp) style() lipgloss.Style {
 	}
 
 	style := t.S().Text
-	if msg.message.Role == message.User {
+	switch msg.message.Role {
+	case message.User:
 		style = style.PaddingLeft(1).BorderLeft(true).BorderStyle(borderStyle).BorderForeground(t.Primary)
-	} else {
+	case message.SkillBody, message.HygieneInjection:
+		// Always the plain, unfocused shape — a synthetic note is never the
+		// focus target a human bubble or assistant block can be.
+		style = style.PaddingLeft(2)
+	default:
 		if msg.focused {
 			style = style.PaddingLeft(1).BorderLeft(true).BorderStyle(borderStyle).BorderForeground(t.GreenDark)
 		} else {
@@ -269,6 +275,22 @@ func (m *messageCmp) renderUserMessage() string {
 
 	joined := lipgloss.JoinVertical(lipgloss.Left, parts...)
 	return m.style().Render(joined)
+}
+
+// renderSyntheticNote renders a skill-body or hygiene-injection message: a
+// muted, single-style note distinct from both the human bubble and the
+// assistant content block, since neither the user nor the assistant
+// authored it.
+func (m *messageCmp) renderSyntheticNote() string {
+	t := styles.CurrentTheme()
+	label := "Skill loaded"
+	if m.message.Role == message.HygieneInjection {
+		label = "Hygiene retry requested"
+	}
+	noteStyle := t.S().Base.Foreground(t.FgHalfMuted)
+	header := noteStyle.Bold(true).Render(label)
+	body := noteStyle.Render(m.toMarkdown(m.message.Content().String()))
+	return lipgloss.JoinVertical(lipgloss.Left, header, body)
 }
 
 // toMarkdown converts text content to rendered markdown using the configured renderer

--- a/internal/tui/components/chat/messages/messages.go
+++ b/internal/tui/components/chat/messages/messages.go
@@ -290,7 +290,8 @@ func (m *messageCmp) renderSyntheticNote() string {
 	noteStyle := t.S().Base.Foreground(t.FgHalfMuted)
 	header := noteStyle.Bold(true).Render(label)
 	body := noteStyle.Render(m.toMarkdown(m.message.Content().String()))
-	return lipgloss.JoinVertical(lipgloss.Left, header, body)
+	joined := lipgloss.JoinVertical(lipgloss.Left, header, body)
+	return m.style().Render(joined)
 }
 
 // toMarkdown converts text content to rendered markdown using the configured renderer

--- a/internal/tui/components/chat/messages/messages.go
+++ b/internal/tui/components/chat/messages/messages.go
@@ -143,7 +143,7 @@ func (m *messageCmp) View() string {
 		switch m.message.Role {
 		case message.User:
 			return m.renderUserMessage()
-		case message.SkillBody, message.HygieneInjection:
+		case message.SkillBody, message.HygieneInjection, message.EmptyResponseRetry, message.SynthesisPrompt:
 			return m.renderSyntheticNote()
 		default:
 			return m.renderAssistantMessage()
@@ -182,7 +182,7 @@ func (msg *messageCmp) style() lipgloss.Style {
 	switch msg.message.Role {
 	case message.User:
 		style = style.PaddingLeft(1).BorderLeft(true).BorderStyle(borderStyle).BorderForeground(t.Primary)
-	case message.SkillBody, message.HygieneInjection:
+	case message.SkillBody, message.HygieneInjection, message.EmptyResponseRetry, message.SynthesisPrompt:
 		// Always the plain, unfocused shape — a synthetic note is never the
 		// focus target a human bubble or assistant block can be.
 		style = style.PaddingLeft(2)
@@ -277,15 +277,20 @@ func (m *messageCmp) renderUserMessage() string {
 	return m.style().Render(joined)
 }
 
-// renderSyntheticNote renders a skill-body or hygiene-injection message: a
-// muted, single-style note distinct from both the human bubble and the
-// assistant content block, since neither the user nor the assistant
-// authored it.
+// renderSyntheticNote renders a skill-body, hygiene-injection,
+// empty-response-retry, or synthesis-prompt message: a muted, single-style
+// note distinct from both the human bubble and the assistant content block,
+// since neither the user nor the assistant authored it.
 func (m *messageCmp) renderSyntheticNote() string {
 	t := styles.CurrentTheme()
 	label := "Skill loaded"
-	if m.message.Role == message.HygieneInjection {
+	switch m.message.Role {
+	case message.HygieneInjection:
 		label = "Hygiene retry requested"
+	case message.EmptyResponseRetry:
+		label = "Retry requested"
+	case message.SynthesisPrompt:
+		label = "Synthesis requested"
 	}
 	noteStyle := t.S().Base.Foreground(t.FgHalfMuted)
 	header := noteStyle.Bold(true).Render(label)

--- a/internal/tui/components/chat/messages/messages_test.go
+++ b/internal/tui/components/chat/messages/messages_test.go
@@ -58,6 +58,34 @@ func TestMessageCmp_HygieneInjection_RendersAsSyntheticNote(t *testing.T) {
 	}
 }
 
+func TestMessageCmp_EmptyResponseRetry_RendersAsSyntheticNote(t *testing.T) {
+	msg := newTestMessage(t, message.EmptyResponseRetry, "Your previous response was empty. Please provide a response.")
+	cmp := NewMessageCmp(msg)
+	cmp.SetSize(80, 20)
+
+	out := cmp.View()
+	if !strings.Contains(out, "Retry requested") {
+		t.Errorf("expected a retry-requested label, got: %s", out)
+	}
+	if !strings.Contains(out, "previous response was empty") {
+		t.Errorf("expected the empty-response retry content, got: %s", out)
+	}
+}
+
+func TestMessageCmp_SynthesisPrompt_RendersAsSyntheticNote(t *testing.T) {
+	msg := newTestMessage(t, message.SynthesisPrompt, "You must provide your final answer NOW with whatever information you have gathered so far.")
+	cmp := NewMessageCmp(msg)
+	cmp.SetSize(80, 20)
+
+	out := cmp.View()
+	if !strings.Contains(out, "Synthesis requested") {
+		t.Errorf("expected a synthesis-requested label, got: %s", out)
+	}
+	if !strings.Contains(out, "final answer NOW") {
+		t.Errorf("expected the synthesis prompt content, got: %s", out)
+	}
+}
+
 // A synthetic note is never a focus target — unlike the user bubble and the
 // assistant content block, focusing it must not change its rendering.
 func TestMessageCmp_SkillBody_FocusHasNoEffect(t *testing.T) {

--- a/internal/tui/components/chat/messages/messages_test.go
+++ b/internal/tui/components/chat/messages/messages_test.go
@@ -57,3 +57,19 @@ func TestMessageCmp_HygieneInjection_RendersAsSyntheticNote(t *testing.T) {
 		t.Errorf("expected the injection content, got: %s", out)
 	}
 }
+
+// A synthetic note is never a focus target — unlike the user bubble and the
+// assistant content block, focusing it must not change its rendering.
+func TestMessageCmp_SkillBody_FocusHasNoEffect(t *testing.T) {
+	msg := newTestMessage(t, message.SkillBody, "## Skill: SQL Optimization")
+	cmp := NewMessageCmp(msg)
+	cmp.SetSize(80, 20)
+
+	unfocused := cmp.View()
+	cmp.Focus()
+	focused := cmp.View()
+
+	if unfocused != focused {
+		t.Errorf("expected synthetic note rendering to be focus-independent, got different output:\nunfocused: %q\nfocused:   %q", unfocused, focused)
+	}
+}

--- a/internal/tui/components/chat/messages/messages_test.go
+++ b/internal/tui/components/chat/messages/messages_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package messages
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/teradata-labs/loom/internal/message"
+)
+
+func newTestMessage(t *testing.T, role message.Role, content string) message.Message {
+	t.Helper()
+	m := message.NewMessage("m-1", "sess-1", role)
+	m.AddPart(message.ContentText{Text: content})
+	return m
+}
+
+// A skill body must render as a muted note, not the human bubble
+// (renderUserMessage) or the assistant content block (renderAssistantMessage)
+// — rendering it as either would misrepresent who "said" it.
+func TestMessageCmp_SkillBody_RendersAsSyntheticNote(t *testing.T) {
+	msg := newTestMessage(t, message.SkillBody, "## Skill: SQL Optimization")
+	cmp := NewMessageCmp(msg)
+	cmp.SetSize(80, 20)
+
+	out := cmp.View()
+	if !strings.Contains(out, "Skill loaded") {
+		t.Errorf("expected a skill-loaded label, got: %s", out)
+	}
+	if !strings.Contains(out, "SQL Optimization") {
+		t.Errorf("expected the skill body content, got: %s", out)
+	}
+}
+
+func TestMessageCmp_HygieneInjection_RendersAsSyntheticNote(t *testing.T) {
+	msg := newTestMessage(t, message.HygieneInjection, "Task-board hygiene check found violations")
+	cmp := NewMessageCmp(msg)
+	cmp.SetSize(80, 20)
+
+	out := cmp.View()
+	if !strings.Contains(out, "Hygiene retry requested") {
+		t.Errorf("expected a hygiene-retry label, got: %s", out)
+	}
+	if !strings.Contains(out, "hygiene check found violations") {
+		t.Errorf("expected the injection content, got: %s", out)
+	}
+}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -3044,7 +3044,7 @@ func (a *Agent) dispatchOneCall(ctx Context, session *Session, toolCall ToolCall
 	if result != nil && result.Metadata != nil {
 		if textBody, ok := result.Metadata["text_body"].(string); ok && textBody != "" {
 			st.pendingSidecars = append(st.pendingSidecars, Message{
-				Role:      "user",
+				Role:      "skill_body",
 				Content:   textBody,
 				AgentID:   a.id,
 				Timestamp: time.Now(),

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -2647,7 +2647,7 @@ func (a *Agent) runConversationLoop(ctx Context) (*Response, error) {
 				// One-shot retry: nudge the LLM to produce a response.
 				emptyRetried = true
 				a.appendMessage(ctx, session, Message{
-					Role:      "user",
+					Role:      "empty_response_retry",
 					Content:   "Your previous response was empty. Please provide a response summarizing what you found or explaining what went wrong.",
 					AgentID:   a.id,
 					Timestamp: time.Now(),
@@ -3077,7 +3077,7 @@ func (a *Agent) synthesizeFinalResponse(ctx Context, session *Session, turnCount
 	// Include explicit format instructions since they may have been compressed in context
 	synthesisPrompt := "You must provide your final answer NOW with whatever information you have gathered so far. Summarize your findings: what actions were taken, what results were produced, and any remaining steps the user would need to complete manually. Be concise and actionable. You MUST respond with text — do not return an empty response."
 	a.appendMessage(ctx, session, Message{
-		Role:      "user",
+		Role:      "synthesis_prompt",
 		Content:   synthesisPrompt,
 		AgentID:   a.id, // Track which agent created this synthesis request
 		Timestamp: time.Now(),

--- a/pkg/agent/hygiene.go
+++ b/pkg/agent/hygiene.go
@@ -68,11 +68,12 @@ func (a *Agent) runEndOfTurnHygiene(ctx context.Context, session *Session, retry
 	}
 
 	if outcome != nil && outcome.ShouldRetry && outcome.InjectionMessage != "" {
-		// Append the synthetic message to the session so the LLM sees it
-		// on the next turn. The role is "user" because the LLM treats it
-		// as input to act on, not as a system directive.
+		// Append the synthetic message to the session so the LLM sees it on
+		// the next turn as user-turn content (folded in
+		// normalizeWireRoles), but persisted under its own role so it is
+		// never mistaken for something the human typed.
 		a.appendMessage(ctx, session, Message{
-			Role:      "user",
+			Role:      "hygiene_injection",
 			Content:   outcome.InjectionMessage,
 			AgentID:   a.id,
 			Timestamp: time.Now(),

--- a/pkg/agent/hygiene_test.go
+++ b/pkg/agent/hygiene_test.go
@@ -153,7 +153,7 @@ func TestEndOfTurnHygiene_RequireFix_InjectsAndRetriesOnce(t *testing.T) {
 	// LLM sees it on the next turn.
 	require.Len(t, rig.session.Messages, 1)
 	msg := rig.session.Messages[0]
-	assert.Equal(t, "user", msg.Role)
+	assert.Equal(t, "hygiene_injection", msg.Role)
 	assert.Contains(t, msg.Content, "Task-board hygiene check found violations")
 	assert.Contains(t, msg.Content, "open-unstarted")
 	assert.Contains(t, msg.Content, "in-progress-orphan")

--- a/pkg/agent/llm_retry.go
+++ b/pkg/agent/llm_retry.go
@@ -26,11 +26,59 @@ import (
 	"go.uber.org/zap"
 )
 
+// IsSyntheticWireUserRole reports whether role is a persisted Loom-internal
+// role that must be delivered to the LLM as user-turn content — the
+// skill-body sidecar or a hygiene retry injection — as opposed to the
+// literal end user. Exported so pkg/server's live-streaming gate
+// (isNewMessageUpdateRole) shares this definition instead of maintaining
+// the same two-string set independently.
+func IsSyntheticWireUserRole(role string) bool {
+	switch role {
+	case "skill_body", "hygiene_injection":
+		return true
+	default:
+		return false
+	}
+}
+
+// normalizeWireRoles returns a copy of messages where synthetic
+// Loom-internal roles read "user". The persisted and in-memory session
+// messages are never mutated; only this local copy, built immediately
+// before the provider call, changes. Returns the input slice unchanged
+// (no allocation) when nothing needs folding — the common case, since most
+// turns carry no skill-body or hygiene-injection rows at all.
+func normalizeWireRoles(messages []Message) []Message {
+	needsFold := false
+	for _, m := range messages {
+		if IsSyntheticWireUserRole(m.Role) {
+			needsFold = true
+			break
+		}
+	}
+	if !needsFold {
+		return messages
+	}
+
+	out := make([]Message, len(messages))
+	for i, m := range messages {
+		if IsSyntheticWireUserRole(m.Role) {
+			m.Role = "user"
+		}
+		out[i] = m
+	}
+	return out
+}
+
 // chatWithRetry wraps LLM Chat calls with slot scheduling, capacity
 // observation, and exponential backoff retry logic. If the provider supports
 // streaming and a progress callback is configured, it will use streaming
 // with token buffering to emit real-time progress.
 func (a *Agent) chatWithRetry(ctx Context, messages []Message, tools []shuttle.Tool) (resp *LLMResponse, err error) {
+	// Fold synthetic Loom-internal roles to the wire "user" role before
+	// anything else sees this slice — including the debug dump below, which
+	// must capture the true wire-bound view, not the persisted role.
+	messages = normalizeWireRoles(messages)
+
 	// Debug tap: one context dump per provider call, before any dispatch branch.
 	// No-op unless the dump switch is on. Covers streaming, no-retry, and the
 	// retry loop alike since every path fans out from here.

--- a/pkg/agent/llm_retry.go
+++ b/pkg/agent/llm_retry.go
@@ -28,13 +28,14 @@ import (
 
 // IsSyntheticWireUserRole reports whether role is a persisted Loom-internal
 // role that must be delivered to the LLM as user-turn content — the
-// skill-body sidecar or a hygiene retry injection — as opposed to the
-// literal end user. Exported so pkg/server's live-streaming gate
-// (isNewMessageUpdateRole) shares this definition instead of maintaining
-// the same two-string set independently.
+// skill-body sidecar, a hygiene retry injection, an empty-response retry
+// nudge, or a synthesis prompt — as opposed to the literal end user.
+// Exported so pkg/server's live-streaming gate (isNewMessageUpdateRole)
+// shares this definition instead of maintaining the same string set
+// independently.
 func IsSyntheticWireUserRole(role string) bool {
 	switch role {
-	case "skill_body", "hygiene_injection":
+	case "skill_body", "hygiene_injection", "empty_response_retry", "synthesis_prompt":
 		return true
 	default:
 		return false

--- a/pkg/agent/llm_retry_wire_roles_test.go
+++ b/pkg/agent/llm_retry_wire_roles_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/teradata-labs/loom/pkg/observability"
+	"github.com/teradata-labs/loom/pkg/shuttle"
+	llmtypes "github.com/teradata-labs/loom/pkg/types"
+)
+
+// wireRoleRecorderLLM captures the Role of every message it receives, so the
+// test can assert on exactly what reached the "provider."
+type wireRoleRecorderLLM struct {
+	lastRoles []string
+}
+
+func (w *wireRoleRecorderLLM) Chat(_ context.Context, messages []Message, _ []shuttle.Tool) (*LLMResponse, error) {
+	w.lastRoles = nil
+	for _, m := range messages {
+		w.lastRoles = append(w.lastRoles, m.Role)
+	}
+	return &LLMResponse{Content: "ok", Usage: llmtypes.Usage{TotalTokens: 1}}, nil
+}
+func (w *wireRoleRecorderLLM) Name() string  { return "wire-role-recorder" }
+func (w *wireRoleRecorderLLM) Model() string { return "wire-role-recorder-model" }
+
+// The provider must see skill_body and hygiene_injection as "user" — the
+// LLM-attention optimization this whole design exists to preserve.
+func TestChatWithRetry_FoldsSyntheticRolesToUserOnWire(t *testing.T) {
+	llm := &wireRoleRecorderLLM{}
+	a := &Agent{id: "wire-role-test", llm: llm, config: &Config{}}
+	ctx := &agentContext{Context: context.Background(), tracer: observability.NewNoOpTracer()}
+
+	input := []Message{
+		{Role: "system", Content: "rom"},
+		{Role: "skill_body", Content: "## Skill: SQL Optimization"},
+		{Role: "hygiene_injection", Content: "fix your last response"},
+		{Role: "assistant", Content: "ok"},
+	}
+
+	_, err := a.chatWithRetry(ctx, input, nil)
+	require.NoError(t, err)
+	require.Equal(t, []string{"system", "user", "user", "assistant"}, llm.lastRoles)
+
+	// The caller's slice must be untouched — the fold builds a copy.
+	require.Equal(t, "skill_body", input[1].Role, "fold must not mutate the caller's slice")
+	require.Equal(t, "hygiene_injection", input[2].Role, "fold must not mutate the caller's slice")
+}
+
+// The common case — no synthetic roles present — must not allocate a
+// throwaway copy on every turn. normalizeWireRoles returns the input slice
+// itself (same backing array) when there is nothing to fold.
+func TestNormalizeWireRoles_NoOpReturnsSameSliceWhenNothingToFold(t *testing.T) {
+	input := []Message{
+		{Role: "system", Content: "rom"},
+		{Role: "user", Content: "hi"},
+		{Role: "assistant", Content: "ok"},
+	}
+
+	out := normalizeWireRoles(input)
+
+	require.Len(t, out, len(input))
+	// require.Same checks pointer identity (==), not require.Equal's
+	// reflect.DeepEqual — DeepEqual would report two *different* arrays with
+	// equal contents as "equal" too, which would defeat this test's purpose.
+	require.Same(t, &input[0], &out[0], "no fold needed: must return the same backing array, not a copy")
+}

--- a/pkg/agent/llm_retry_wire_roles_test.go
+++ b/pkg/agent/llm_retry_wire_roles_test.go
@@ -40,8 +40,9 @@ func (w *wireRoleRecorderLLM) Chat(_ context.Context, messages []Message, _ []sh
 func (w *wireRoleRecorderLLM) Name() string  { return "wire-role-recorder" }
 func (w *wireRoleRecorderLLM) Model() string { return "wire-role-recorder-model" }
 
-// The provider must see skill_body and hygiene_injection as "user" — the
-// LLM-attention optimization this whole design exists to preserve.
+// The provider must see skill_body, hygiene_injection, empty_response_retry,
+// and synthesis_prompt as "user" — the LLM-attention optimization this whole
+// design exists to preserve.
 func TestChatWithRetry_FoldsSyntheticRolesToUserOnWire(t *testing.T) {
 	llm := &wireRoleRecorderLLM{}
 	a := &Agent{id: "wire-role-test", llm: llm, config: &Config{}}
@@ -51,16 +52,20 @@ func TestChatWithRetry_FoldsSyntheticRolesToUserOnWire(t *testing.T) {
 		{Role: "system", Content: "rom"},
 		{Role: "skill_body", Content: "## Skill: SQL Optimization"},
 		{Role: "hygiene_injection", Content: "fix your last response"},
+		{Role: "empty_response_retry", Content: "your previous response was empty"},
+		{Role: "synthesis_prompt", Content: "you must provide your final answer now"},
 		{Role: "assistant", Content: "ok"},
 	}
 
 	_, err := a.chatWithRetry(ctx, input, nil)
 	require.NoError(t, err)
-	require.Equal(t, []string{"system", "user", "user", "assistant"}, llm.lastRoles)
+	require.Equal(t, []string{"system", "user", "user", "user", "user", "assistant"}, llm.lastRoles)
 
 	// The caller's slice must be untouched — the fold builds a copy.
 	require.Equal(t, "skill_body", input[1].Role, "fold must not mutate the caller's slice")
 	require.Equal(t, "hygiene_injection", input[2].Role, "fold must not mutate the caller's slice")
+	require.Equal(t, "empty_response_retry", input[3].Role, "fold must not mutate the caller's slice")
+	require.Equal(t, "synthesis_prompt", input[4].Role, "fold must not mutate the caller's slice")
 }
 
 // The common case — no synthetic roles present — must not allocate a

--- a/pkg/agent/recall_tool.go
+++ b/pkg/agent/recall_tool.go
@@ -37,7 +37,9 @@ const recallTruncationTailFormat = `[range truncated — continue: recall("msg:%
 // RecallTool retrieves conversation that is no longer shown, by an address
 // cited in the session summary (HLD §6). It returns the span's user and
 // assistant rows as stored — call signatures included, since they live inside
-// the assistant row and are what makes "re-run" literal — and omits role='tool'
+// the assistant row and are what makes "re-run" literal — plus the
+// skill_body and hygiene_injection rows (IsSyntheticWireUserRole), which are
+// recoverable text content under the same rationale. It omits role='tool'
 // rows entirely; a result's only door is re-running its call.
 type RecallTool struct {
 	agent *Agent
@@ -117,8 +119,12 @@ func (t *RecallTool) Execute(ctx context.Context, input map[string]interface{}) 
 	truncatedFrom := int64(0)
 	for _, m := range messages {
 		// Omit role='tool' rows entirely — a result's only door is re-running
-		// its call (HLD §6).
-		if m.Role != "user" && m.Role != "assistant" {
+		// its call (HLD §6). skill_body and hygiene_injection rows pass this
+		// check alongside user/assistant: they are recoverable text content,
+		// stored under their own persisted role instead of the literal
+		// "user" (see IsSyntheticWireUserRole), not results whose only door
+		// is re-running a call.
+		if m.Role != "user" && m.Role != "assistant" && !IsSyntheticWireUserRole(m.Role) {
 			continue
 		}
 		row := renderRecalledRow(m)

--- a/pkg/agent/recall_tool_test.go
+++ b/pkg/agent/recall_tool_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package agent
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/teradata-labs/loom/pkg/observability"
+	"github.com/teradata-labs/loom/pkg/session"
+)
+
+// TestRecallTool_IncludesSyntheticRoles proves that skill_body and
+// hygiene_injection rows — recoverable text content exactly like user and
+// assistant rows — are not silently dropped by the recall tool's allowlist.
+// Before the role split these rows were persisted under role="user" and so
+// passed the old `m.Role != "user" && m.Role != "assistant"` check; after
+// the split they carry their own roles and must pass via
+// IsSyntheticWireUserRole instead. Only role="tool" rows are legitimately
+// excluded (HLD §6: their only door is re-running the call).
+func TestRecallTool_IncludesSyntheticRoles(t *testing.T) {
+	tmpfile := t.TempDir() + "/recall-test.db"
+	defer func() { _ = os.Remove(tmpfile) }()
+
+	tracer := observability.NewNoOpTracer()
+	store, err := NewSessionStore(tmpfile, tracer)
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	ctx := context.Background()
+	const sessionID = "sess-recall-synthetic"
+
+	require.NoError(t, store.SaveSession(ctx, &Session{
+		ID:        sessionID,
+		Context:   map[string]interface{}{},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}))
+
+	const skillBodySentinel = "alpha-skill-body-sentinel-content"
+	const hygieneSentinel = "hygiene-retry-nudge-sentinel-content"
+
+	userMsg := &Message{Role: "user", Content: "load alpha", Timestamp: time.Now()}
+	require.NoError(t, store.SaveMessage(ctx, sessionID, userMsg, true))
+
+	skillBodyMsg := &Message{Role: "skill_body", Content: skillBodySentinel, Timestamp: time.Now()}
+	require.NoError(t, store.SaveMessage(ctx, sessionID, skillBodyMsg, false))
+
+	hygieneMsg := &Message{Role: "hygiene_injection", Content: hygieneSentinel, Timestamp: time.Now()}
+	require.NoError(t, store.SaveMessage(ctx, sessionID, hygieneMsg, false))
+
+	assistantMsg := &Message{Role: "assistant", Content: "done", Timestamp: time.Now()}
+	require.NoError(t, store.SaveMessage(ctx, sessionID, assistantMsg, false))
+
+	toolMsg := &Message{Role: "tool", Content: "tool-result-must-stay-excluded", ToolUseID: "c1", Timestamp: time.Now()}
+	require.NoError(t, store.SaveMessage(ctx, sessionID, toolMsg, false))
+
+	ag := &Agent{memory: NewMemoryWithStore(store)}
+	tool := NewRecallTool(ag)
+
+	callCtx := session.WithSessionID(ctx, sessionID)
+	result, err := tool.Execute(callCtx, map[string]interface{}{
+		"range": "msg:" + userMsg.ID + "-" + toolMsg.ID,
+	})
+	require.NoError(t, err)
+	require.True(t, result.Success)
+
+	out, ok := result.Data.(string)
+	require.True(t, ok, "recall result data must be a string")
+
+	require.Contains(t, out, skillBodySentinel, "skill_body rows must be recoverable via recall, not silently dropped")
+	require.Contains(t, out, "skill_body:", "skill_body rows must be rendered under their own role")
+
+	require.Contains(t, out, hygieneSentinel, "hygiene_injection rows must be recoverable via recall, not silently dropped")
+	require.Contains(t, out, "hygiene_injection:", "hygiene_injection rows must be rendered under their own role")
+
+	require.NotContains(t, out, "tool-result-must-stay-excluded", "role=tool rows stay excluded — their only door is re-running the call")
+
+	require.True(t, strings.Contains(out, "load alpha") && strings.Contains(out, "done"),
+		"user/assistant rows must remain recallable alongside the synthetic roles")
+}

--- a/pkg/agent/skill_role_separation_test.go
+++ b/pkg/agent/skill_role_separation_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Teradata
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The skill body must be persisted under its own role, not "user" — that is
+// the whole point of this change. buildSkillsCutoverRig, alphaBodySentinel,
+// mockToolCallingLLM/mockLLMResponse (agent_integration_test.go:988-995),
+// and loadCall/finalTurn (manage_skills_tool_black_box_test.go:231-241) are
+// all already defined in the agent package's existing test files.
+func TestSkillBodySidecar_PersistedUnderSkillBodyRole(t *testing.T) {
+	llm := &mockToolCallingLLM{responses: []mockLLMResponse{
+		loadCall("c1", "alpha-skill"),
+		finalTurn(),
+	}}
+	rig := buildSkillsCutoverRig(t, llm, false)
+
+	ctx := context.Background()
+	_, err := rig.agent.Chat(ctx, "sess-role-check", "load alpha")
+	require.NoError(t, err)
+
+	sess := rig.agent.memory.GetOrCreateSessionWithAgent(ctx, "sess-role-check", rig.agent.config.Name, "")
+
+	// NOTE: deviates from the brief's literal loop body (see task-6-report.md
+	// "Concerns"): the brief's require.NotEqual(t, "user", m.Role) ran
+	// unconditionally over every message, which also fails on the genuine
+	// human turn ("load alpha", legitimately Role: "user") — making the test
+	// unable to pass even after the producer flip. Scoped here to the sidecar
+	// message itself (identified by alphaBodySentinel), matching what the
+	// docstring above says the test verifies.
+	found := false
+	for _, m := range sess.GetMessages() {
+		if !strings.Contains(m.Content, alphaBodySentinel) {
+			continue
+		}
+		found = true
+		require.Equal(t, "skill_body", m.Role, "the skill body must be persisted under role \"skill_body\", not \"user\"")
+	}
+	require.True(t, found, "the skill body must be persisted under role \"skill_body\"")
+}

--- a/pkg/agent/skill_role_separation_test.go
+++ b/pkg/agent/skill_role_separation_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	llmtypes "github.com/teradata-labs/loom/pkg/llm/types"
 )
 
 // The skill body must be persisted under its own role, not "user" — that is
@@ -55,4 +57,86 @@ func TestSkillBodySidecar_PersistedUnderSkillBodyRole(t *testing.T) {
 		require.Equal(t, "skill_body", m.Role, "the skill body must be persisted under role \"skill_body\", not \"user\"")
 	}
 	require.True(t, found, "the skill body must be persisted under role \"skill_body\"")
+}
+
+// The empty-response retry nudge must be persisted under its own role, not
+// "user". Fixture mirrors TestAgent_EmptyResponseRetry
+// (agent_integration_test.go): a tool call turn, then an empty LLM
+// response (which fires the one-shot retry nudge), then a real response.
+func TestEmptyResponseRetry_PersistedUnderEmptyResponseRetryRole(t *testing.T) {
+	mockLLM := &mockToolCallingLLM{
+		responses: []mockLLMResponse{
+			{
+				content:   "",
+				toolCalls: []llmtypes.ToolCall{{ID: "call_1", Name: "calculator", Input: map[string]interface{}{"expression": "1+1"}}},
+			},
+			{content: ""}, // empty response — should trigger the retry nudge
+			{content: "The answer is 2 based on my work"},
+		},
+	}
+
+	patternCfg := DefaultPatternConfig()
+	patternCfg.UseLLMClassifier = false
+
+	ag := NewAgent(&mockBackend{}, mockLLM, WithConfig(&Config{
+		MaxTurns:          25,
+		MaxToolExecutions: 50,
+		PatternConfig:     patternCfg,
+	}))
+	ag.RegisterTool(&mockCalculatorTool{})
+
+	ctx := context.Background()
+	resp, err := ag.Chat(ctx, "empty-retry-role-check", "Calculate 1+1")
+	require.NoError(t, err)
+	require.Equal(t, "The answer is 2 based on my work", resp.Content)
+
+	sess := ag.memory.GetOrCreateSessionWithAgent(ctx, "empty-retry-role-check", ag.config.Name, "")
+
+	const nudgeSentinel = "Your previous response was empty"
+	found := false
+	for _, m := range sess.GetMessages() {
+		if !strings.Contains(m.Content, nudgeSentinel) {
+			continue
+		}
+		found = true
+		require.Equal(t, "empty_response_retry", m.Role, "the empty-response retry nudge must be persisted under role \"empty_response_retry\", not \"user\"")
+	}
+	require.True(t, found, "the empty-response retry nudge must be persisted")
+}
+
+// The synthesis prompt must be persisted under its own role, not "user".
+// Fixture mirrors TestAgent_MaxTurnsLimit (agent_integration_test.go): an
+// LLM that keeps requesting tools indefinitely, exhausting MaxTurns and
+// forcing synthesizeFinalResponse to fire the synthesis prompt.
+func TestSynthesisPrompt_PersistedUnderSynthesisPromptRole(t *testing.T) {
+	mockLLM := &mockToolCallingLLM{
+		alwaysCallTools: true,
+	}
+
+	patternCfg := DefaultPatternConfig()
+	patternCfg.UseLLMClassifier = false
+
+	ag := NewAgent(&mockBackend{}, mockLLM, WithConfig(&Config{
+		MaxTurns:          5,
+		MaxToolExecutions: 50,
+		PatternConfig:     patternCfg,
+	}))
+	ag.RegisterTool(&mockCalculatorTool{})
+
+	ctx := context.Background()
+	_, err := ag.Chat(ctx, "synthesis-prompt-role-check", "Keep calling tools")
+	require.NoError(t, err)
+
+	sess := ag.memory.GetOrCreateSessionWithAgent(ctx, "synthesis-prompt-role-check", ag.config.Name, "")
+
+	const synthesisSentinel = "You must provide your final answer NOW"
+	found := false
+	for _, m := range sess.GetMessages() {
+		if !strings.Contains(m.Content, synthesisSentinel) {
+			continue
+		}
+		found = true
+		require.Equal(t, "synthesis_prompt", m.Role, "the synthesis prompt must be persisted under role \"synthesis_prompt\", not \"user\"")
+	}
+	require.True(t, found, "the synthesis prompt must be persisted")
 }

--- a/pkg/server/multi_agent.go
+++ b/pkg/server/multi_agent.go
@@ -4623,6 +4623,23 @@ func (s *MultiAgentServer) GetScheduleHistory(ctx context.Context, req *loomv1.G
 	}, nil
 }
 
+// isNewMessageUpdateRole reports whether a persisted message role should
+// produce a SessionUpdate_NewMessage on the live WeaveProgress stream.
+// skill_body and hygiene_injection are synthetic (agent-authored) content,
+// not the literal end user, but a streaming consumer still needs to see
+// them arrive in real time with their own role — the same way
+// GetConversationHistory already returns them (server.go:547-567).
+// Delegates the synthetic-role check to agent.IsSyntheticWireUserRole
+// rather than re-declaring that two-string set here.
+func isNewMessageUpdateRole(role string) bool {
+	switch role {
+	case "assistant", "user", "tool":
+		return true
+	default:
+		return agent.IsSyntheticWireUserRole(role)
+	}
+}
+
 // SubscribeToSession subscribes to real-time updates for a session.
 // Streams updates when new messages arrive in the session conversation.
 // This allows clients to receive asynchronous responses from workflow coordinators
@@ -4718,7 +4735,7 @@ func (s *MultiAgentServer) SubscribeToSession(req *loomv1.SubscribeToSessionRequ
 				}
 
 				// Populate based on message role
-				if msg.Role == "assistant" || msg.Role == "user" || msg.Role == "tool" {
+				if isNewMessageUpdateRole(msg.Role) {
 					update.UpdateType = &loomv1.SessionUpdate_NewMessage{
 						NewMessage: &loomv1.NewMessageUpdate{
 							Role:             msg.Role,

--- a/pkg/server/multi_agent_new_message_gate_test.go
+++ b/pkg/server/multi_agent_new_message_gate_test.go
@@ -2,12 +2,13 @@ package server
 
 import "testing"
 
-// The four roles below must all produce a SessionUpdate_NewMessage — this
-// mirrors the exact condition at multi_agent.go:4721. skill_body and
-// hygiene_injection are synthetic content that still needs to reach a live
-// streaming consumer with their correct (non-"user") role.
+// The roles below must all produce a SessionUpdate_NewMessage — this
+// mirrors the exact condition at multi_agent.go:4721. skill_body,
+// hygiene_injection, empty_response_retry, and synthesis_prompt are
+// synthetic content that still needs to reach a live streaming consumer
+// with their correct (non-"user") role.
 func TestNewMessageUpdateGate_IncludesSyntheticRoles(t *testing.T) {
-	included := []string{"assistant", "user", "tool", "skill_body", "hygiene_injection"}
+	included := []string{"assistant", "user", "tool", "skill_body", "hygiene_injection", "empty_response_retry", "synthesis_prompt"}
 	for _, role := range included {
 		if !isNewMessageUpdateRole(role) {
 			t.Errorf("role %q should produce a SessionUpdate_NewMessage", role)

--- a/pkg/server/multi_agent_new_message_gate_test.go
+++ b/pkg/server/multi_agent_new_message_gate_test.go
@@ -1,0 +1,19 @@
+package server
+
+import "testing"
+
+// The four roles below must all produce a SessionUpdate_NewMessage — this
+// mirrors the exact condition at multi_agent.go:4721. skill_body and
+// hygiene_injection are synthetic content that still needs to reach a live
+// streaming consumer with their correct (non-"user") role.
+func TestNewMessageUpdateGate_IncludesSyntheticRoles(t *testing.T) {
+	included := []string{"assistant", "user", "tool", "skill_body", "hygiene_injection"}
+	for _, role := range included {
+		if !isNewMessageUpdateRole(role) {
+			t.Errorf("role %q should produce a SessionUpdate_NewMessage", role)
+		}
+	}
+	if isNewMessageUpdateRole("system") {
+		t.Errorf("role \"system\" should NOT produce a SessionUpdate_NewMessage (unchanged behavior)")
+	}
+}


### PR DESCRIPTION
## Description

Four kinds of agent-authored message content were persisted under the literal `Role: "user"` purely as an LLM-attention optimization (the model pays more attention to user-role turns): a loaded skill's full instructions, an end-of-turn hygiene-retry nudge, an empty-response retry nudge, and a final-answer synthesis prompt. Because all four used the literal `"user"` role, the TUI (and any other consumer reading persisted messages — `GetConversationHistory`, the live `SubscribeToSession` stream, the recall tool) could not tell them apart from something the human actually typed, so they rendered as ordinary human chat bubbles.

This PR gives each its own persisted role (`skill_body`, `hygiene_injection`, `empty_response_retry`, `synthesis_prompt`) while preserving the LLM-attention behavior unchanged: a single fold function, `normalizeWireRoles`, rewrites all four to `"user"` on a throwaway copy, called once at the top of `Agent.chatWithRetry` — the sole entry point every conversational LLM call (streaming, direct, retried) passes through. **No LLM provider client is touched** (Anthropic, Bedrock, OpenAI, Gemini, Ollama, Azure OpenAI all still only ever see `Role: "user"` on the wire, byte-for-byte as before). Persistence, the TUI, the live streaming gate, and internal "last user message" scans (lazy-tool triggers, graph-memory recall query, `firstUserLine`) all now see the distinct role.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] 🧪 Test update
- [ ] 🏗️ Infrastructure/Build change

## Related Issues

N/A — no tracked issue; this came out of a design exploration (`docs/architecture/skill-injection-flow.md`, not included in this PR — see Additional Context) into why the skill-body sidecar renders as a human message in the TUI.

## Changes Made

- **The fold** (`pkg/agent/llm_retry.go`): `IsSyntheticWireUserRole(role string) bool` — the single source of truth for which persisted roles are synthetic — and `normalizeWireRoles`, called at the top of `chatWithRetry`. No-op copy elided (returns the input slice unchanged, no allocation) when nothing needs folding, since most turns carry none of these roles.
- **The four producers flipped** to their own role: skill-body sidecar (`agent.go`, via `manage_skills`), hygiene-retry injection (`hygiene.go`), empty-response retry nudge (`agent.go`), synthesis prompt (`agent.go`, in `synthesizeFinalResponse`).
- **Live streaming gate** (`pkg/server/multi_agent.go`): `isNewMessageUpdateRole` widened to delegate to `IsSyntheticWireUserRole` for the four new roles, so `SubscribeToSession` still surfaces them (previously implicit since they were literally `"user"`).
- **Recall tool** (`pkg/agent/recall_tool.go`): the seq-range recall allowlist widened the same way — these are directly recoverable text content like `user`/`assistant` rows, not `tool` rows (whose exclusion is about needing to re-run the call).
- **TUI rendering** (`internal/tui/components/chat/messages/messages.go`, `internal/tui/components/chat/chat.go`): all four roles render as a muted, labeled note — visually distinct from both the human bubble and the assistant's content block — instead of falling through to either.
- **Docs**: `docs/reference/streaming.md`'s streamed-role list updated to match.
- **No changes**: proto files, database schema/migrations, any LLM provider client (`pkg/llm/anthropic`, `pkg/llm/bedrock`, `pkg/llm/openai`, `pkg/llm/gemini`, `pkg/llm/ollama`, `pkg/llm/azureopenai`).

## Testing

### Test Checklist

- [x] All new and existing tests pass (`go test -tags fts5 ./...`) for every package this PR touches — see note below on environment limitations for the exact commands used
- [ ] Race detector shows zero race conditions (`just race-check`) — **could not be run locally**: `-race` fails to allocate ThreadSanitizer's shadow memory on the Windows machine this was developed on (a machine-specific limitation, reproduced consistently, unrelated to this code). Needs verification in CI before merge.
- [x] Code builds successfully (`go build -tags fts5 ./...`)
- [ ] All checks pass (`just check`) — `just check` reaches a pre-existing `proto-format-check` failure (CRLF/buf-toolchain drift on the Windows checkout, in files this PR never touches) before it gets to build/test; the build/test portions were run directly and are clean

### Test Coverage

- [x] Added tests for new functionality
- [x] Updated tests for modified functionality
- [ ] No tests needed — N/A, tests were added throughout

New/extended tests: the fold and its no-allocation fast path (`pkg/agent/llm_retry_wire_roles_test.go`), the streaming gate (`pkg/server/multi_agent_new_message_gate_test.go`), TUI rendering (`internal/tui/components/chat/messages/messages_test.go`), the recall tool (`pkg/agent/recall_tool_test.go`), the message-role constants (`internal/message/message_test.go`), and full `Chat()`-driven integration tests for all four producer flips (`pkg/agent/skill_role_separation_test.go`, `pkg/agent/hygiene_test.go`, plus two more in the same style).

Known, unrelated pre-existing flake observed during testing on this Windows dev machine: some tests using `t.TempDir()` for a context-dump or SQLite-registry sink fail on Go's automatic cleanup (`RemoveAll`: "process cannot access the file because it is being used by another process") — reproduced and confirmed across many tests spanning both files this PR touches and files it doesn't, always cleanup-only with zero assertion failures. Not caused by this change.

## Proto Changes

- [x] No proto changes in this PR

## Documentation

- [x] Code comments added/updated
- [ ] README.md updated (if user-facing changes) — N/A, no user-facing README claims affected
- [ ] ARCHITECTURE.md updated (if architectural changes)
- [ ] TODO.md updated (if implementation plan changed)
- [x] No documentation changes needed beyond `docs/reference/streaming.md` (updated)

**Known gap**: `docs/architecture/skills-system.md`, `docs/architecture/agent-system-design.md`, and `docs/architecture/data-flows.md` still describe the old "skill body enters as a `Role="user"` sidecar" behavior and were not updated as part of this PR — flagged during review, left as a follow-up rather than expanding this PR's scope further.

## Security

- [x] No security implications

## Performance

- [x] No performance impact — the fold's fast path avoids allocating when no message needs folding (the common case, most turns); a two-pass scan cost is accepted in exchange for that.

## Deployment Notes

- [x] No special deployment steps needed — no schema/migration, no config changes. Existing persisted rows already tagged `"user"` from before this change simply continue rendering as ordinary user messages; no backfill needed.

## Checklist

### Required

- [x] I have read the CONTRIBUTING.md guidelines
- [x] My code follows the project's code style (gofmt, proto format)
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (see Known gap above)
- [x] My changes generate no new warnings or errors
- [ ] All CI checks pass (proto, lint, test, build, security) — pending CI run; local verification is limited by the environment notes above
- [ ] Zero race conditions detected — pending CI (`-race` unavailable locally, see Testing)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with `go test -tags fts5 ./...` (not `-race`, see above)
- [x] Commit messages follow convention: `<type>(<scope>): <subject>`

### Optional

- [ ] I have updated the TODO.md with implementation notes
- [ ] I have added usage examples
- [ ] I have updated relevant diagrams
- [ ] I have tested on multiple platforms (Linux, macOS, Windows) — developed and tested on Windows only

## Additional Context

This branch was implemented via a written spec and implementation plan (task-by-task, with a per-task review and one final whole-branch review), including:
- One fix round during implementation (a `style()` case that was never actually wired up to the code that was supposed to use it).
- A final whole-branch review that found two more producers (`empty_response_retry`, `synthesis_prompt`) using the same "persisted as literal `user`" pattern that the original design hadn't scoped in — both are included in this PR.
- A final review fix wave for two other findings: the stale `docs/reference/streaming.md` entry, and the recall-tool exclusion bug (both described above, both fixed and re-reviewed).

---

**Before submitting:** Make sure all required checklist items are completed and all CI checks pass.