### PR TITLE
fix: Windows test-suite portability (95 failing tests → 0)

### DIFF
--- a/cmd/loom-mcp/main.go
+++ b/cmd/loom-mcp/main.go
@@ -48,6 +48,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/signal"
@@ -79,8 +80,9 @@ func main() {
 	flag.Parse()
 
 	// Configure logging -- CRITICAL: never write to stdout (that's the MCP transport)
-	logger := setupLogger(*logFile, *logLevel)
+	logger, logCloser := setupLogger(*logFile, *logLevel)
 	defer func() { _ = logger.Sync() }()
+	defer func() { _ = logCloser.Close() }()
 
 	logger.Info("starting loom-mcp server",
 		zap.String("grpc_addr", *grpcAddr),
@@ -414,27 +416,31 @@ func edgeBearer(header string) string {
 
 // setupLogger creates a zap logger that writes to a file (or stderr if no file specified).
 // IMPORTANT: The logger must NEVER write to stdout because stdout is the MCP stdio transport.
-func setupLogger(logFile, logLevel string) *zap.Logger {
-	logger, err := buildLogger(logFile, logLevel)
+// The returned io.Closer releases the underlying log file handle (a no-op for stderr) and
+// must be closed by the caller on shutdown.
+func setupLogger(logFile, logLevel string) (*zap.Logger, io.Closer) {
+	logger, closer, err := buildLogger(logFile, logLevel)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to setup logger: %v\n", err)
 		os.Exit(1)
 	}
-	return logger
+	return logger, closer
 }
 
 // buildLogger is the testable core of setupLogger. It returns an error instead
 // of calling os.Exit so tests can exercise all code paths.
-func buildLogger(logFile, logLevel string) (*zap.Logger, error) {
+func buildLogger(logFile, logLevel string) (*zap.Logger, io.Closer, error) {
 	level := parseLogLevel(logLevel)
 
 	var output zapcore.WriteSyncer
+	var closer io.Closer = io.NopCloser(nil)
 	if logFile != "" {
 		f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600) // #nosec G304 -- log file path from CLI flag
 		if err != nil {
-			return nil, fmt.Errorf("open log file %s: %w", logFile, err)
+			return nil, nil, fmt.Errorf("open log file %s: %w", logFile, err)
 		}
 		output = zapcore.AddSync(f)
+		closer = f
 	} else {
 		// Write to stderr (not stdout!) as a fallback
 		output = zapcore.AddSync(os.Stderr)
@@ -450,7 +456,7 @@ func buildLogger(logFile, logLevel string) (*zap.Logger, error) {
 		level,
 	)
 
-	return zap.New(core), nil
+	return zap.New(core), closer, nil
 }
 
 // parseLogLevel converts a string log level to a zapcore.Level.

--- a/cmd/loom-mcp/main_test.go
+++ b/cmd/loom-mcp/main_test.go
@@ -51,9 +51,10 @@ func TestBuildLogger_ToFile(t *testing.T) {
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "test.log")
 
-	logger, err := buildLogger(logPath, "info")
+	logger, closer, err := buildLogger(logPath, "info")
 	require.NoError(t, err)
 	require.NotNil(t, logger)
+	t.Cleanup(func() { _ = closer.Close() })
 
 	// Write a log entry and verify it lands in the file
 	logger.Info("hello from test")
@@ -68,9 +69,10 @@ func TestBuildLogger_ToStderr(t *testing.T) {
 	// When logFile is empty, buildLogger should succeed and not panic.
 	// It writes to stderr, which we can't easily capture, but we can
 	// verify the logger is usable.
-	logger, err := buildLogger("", "debug")
+	logger, closer, err := buildLogger("", "debug")
 	require.NoError(t, err)
 	require.NotNil(t, logger)
+	t.Cleanup(func() { _ = closer.Close() })
 
 	// Should not panic
 	logger.Debug("stderr test")
@@ -78,7 +80,7 @@ func TestBuildLogger_ToStderr(t *testing.T) {
 
 func TestBuildLogger_InvalidPath(t *testing.T) {
 	// A path inside a non-existent directory should return an error.
-	_, err := buildLogger("/no/such/directory/test.log", "info")
+	_, _, err := buildLogger("/no/such/directory/test.log", "info")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "open log file")
 }
@@ -95,8 +97,9 @@ func TestBuildLogger_NeverUsesStdout(t *testing.T) {
 	require.NoError(t, err)
 	os.Stdout = stdoutW
 
-	logger, err := buildLogger(logPath, "info")
+	logger, closer, err := buildLogger(logPath, "info")
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = closer.Close() })
 
 	logger.Info("should go to file only")
 	logger.Error("error should also go to file only")
@@ -157,8 +160,9 @@ func TestBuildLogger_LevelFiltering(t *testing.T) {
 			dir := t.TempDir()
 			logPath := filepath.Join(dir, "test.log")
 
-			logger, err := buildLogger(logPath, tt.level)
+			logger, closer, err := buildLogger(logPath, tt.level)
 			require.NoError(t, err)
+			t.Cleanup(func() { _ = closer.Close() })
 
 			tt.logFunc(logger)
 			_ = logger.Sync()

--- a/internal/supabaseauth/auth_test.go
+++ b/internal/supabaseauth/auth_test.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -67,10 +68,14 @@ func TestStore_FileFallback(t *testing.T) {
 	assert.Equal(t, "at", loaded.AccessToken)
 	assert.Equal(t, "a@b.c", loaded.Email)
 
-	// File must be 0600.
-	info, err := statFile(st.FilePath)
-	require.NoError(t, err)
-	assert.Equal(t, "-rw-------", info)
+	// File must be 0600. Windows has no POSIX permission-bit model (os.Chmod
+	// there only toggles the read-only attribute), so this is unverifiable
+	// on that platform the same way it is on Unix.
+	if runtime.GOOS != "windows" {
+		info, err := statFile(st.FilePath)
+		require.NoError(t, err)
+		assert.Equal(t, "-rw-------", info)
+	}
 
 	require.NoError(t, st.Clear())
 	cleared, err := st.Load()

--- a/pkg/agent/context_dump.go
+++ b/pkg/agent/context_dump.go
@@ -64,6 +64,28 @@ type contextDumper struct {
 	turns map[string]int // sessionID -> last emitted turn number
 }
 
+// liveDumpers tracks every sink opened by this process. Production agents run
+// for the life of the process and never drain it (the OS reclaims file
+// handles on exit); it exists so tests -- which construct many agents per
+// process against t.TempDir() sinks, spread across many rig helpers -- have
+// one place to release every handle before their temp dir is removed,
+// instead of each rig having to remember to do so itself.
+var (
+	liveDumpersMu sync.Mutex
+	liveDumpers   []*contextDumper
+)
+
+// closeLiveContextDumpers closes and forgets every sink opened since the last
+// call. Test-only; production processes never call this.
+func closeLiveContextDumpers() {
+	liveDumpersMu.Lock()
+	defer liveDumpersMu.Unlock()
+	for _, d := range liveDumpers {
+		_ = d.close()
+	}
+	liveDumpers = nil
+}
+
 // envContextDumpVar is the environment switch that enables context dumping
 // independently of Config.Debug.ContextDump.
 const envContextDumpVar = "LOOM_DEBUG_CONTEXT_DUMP"
@@ -149,11 +171,17 @@ func newContextDumper(agentID string) (*contextDumper, error) {
 		return nil, fmt.Errorf("open context dump sink %q: %w", path, err)
 	}
 
-	return &contextDumper{
+	d := &contextDumper{
 		path:  path,
 		file:  f,
 		turns: make(map[string]int),
-	}, nil
+	}
+
+	liveDumpersMu.Lock()
+	liveDumpers = append(liveDumpers, d)
+	liveDumpersMu.Unlock()
+
+	return d, nil
 }
 
 // contextDumpDir resolves the parent directory for per-run sinks. It honors
@@ -197,6 +225,16 @@ func (d *contextDumper) write(rec contextDumpRecord) error {
 		return fmt.Errorf("write context dump record: %w", err)
 	}
 	return nil
+}
+
+// close releases the sink file handle. Production agents run for the life of
+// the process and never call this (the OS reclaims the handle on exit); it
+// exists so tests -- which construct many agents per process against
+// t.TempDir() sinks -- can release the handle before the temp dir is removed.
+func (d *contextDumper) close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.file.Close()
 }
 
 // dumpTools projects tools into their serializable form, skipping nil entries.

--- a/pkg/agent/context_dump_test.go
+++ b/pkg/agent/context_dump_test.go
@@ -185,6 +185,11 @@ func redirectCtxDumpSink(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
 	t.Setenv(envDebugDirVar, root)
+	// Release every sink opened during this test before t.TempDir()'s own
+	// cleanup removes the directory it lives in -- Windows can't remove a
+	// file a still-open handle points at. No test in this package runs in
+	// parallel, so draining the process-wide list here is scoped correctly.
+	t.Cleanup(closeLiveContextDumpers)
 	return filepath.Join(root, "context-dumps")
 }
 

--- a/pkg/communication/interrupt/queue_test.go
+++ b/pkg/communication/interrupt/queue_test.go
@@ -16,7 +16,7 @@ package interrupt
 import (
 	"context"
 	"fmt"
-	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -355,13 +355,7 @@ func TestPersistentQueue_Persistence(t *testing.T) {
 	defer func() { _ = router.Close() }()
 
 	// Use temp file instead of :memory: to test persistence
-	// Use unique temp file per test run to avoid collisions
-	dbPath := fmt.Sprintf("/tmp/interrupt_queue_test_%d.db", time.Now().UnixNano())
-
-	// Clean up temp file at end
-	defer func() {
-		_ = os.Remove(dbPath)
-	}()
+	dbPath := filepath.Join(t.TempDir(), "interrupt_queue_test.db")
 
 	// Create queue and enqueue
 	queue, err := NewPersistentQueue(ctx, dbPath, router)
@@ -756,7 +750,8 @@ func TestDebugWithSQL_RetryLoop(t *testing.T) {
 	router := NewRouter(ctx)
 	defer func() { _ = router.Close() }()
 
-	queue, err := NewPersistentQueue(ctx, "/tmp/test_retry.db", router)
+	dbPath := filepath.Join(t.TempDir(), "test_retry.db")
+	queue, err := NewPersistentQueue(ctx, dbPath, router)
 	require.NoError(t, err)
 	defer func() { _ = queue.Close() }()
 

--- a/pkg/communication/queue.go
+++ b/pkg/communication/queue.go
@@ -113,8 +113,20 @@ type MessageQueue struct {
 	totalFailed   atomic.Int64
 	totalExpired  atomic.Int64
 
+	// idSeq disambiguates IDs minted within the same clock tick. time.Now()'s
+	// resolution varies by OS/hardware; a tight loop can call UnixNano() faster
+	// than the clock advances, which previously produced colliding message IDs.
+	idSeq atomic.Uint64
+
 	// Lifecycle
 	closed atomic.Bool
+}
+
+// nextID returns a process-unique, monotonically distinguishable ID: the
+// current time plus a per-queue sequence number, so two IDs minted within the
+// same clock tick never collide regardless of OS timer resolution.
+func (q *MessageQueue) nextID(prefix string) string {
+	return fmt.Sprintf("%s-%d-%d", prefix, time.Now().UnixNano(), q.idSeq.Add(1))
 }
 
 // NewMessageQueue creates a new message queue with SQLite persistence.
@@ -227,7 +239,7 @@ func (q *MessageQueue) Enqueue(ctx context.Context, msg *QueueMessage) error {
 
 	// Set defaults
 	if msg.ID == "" {
-		msg.ID = fmt.Sprintf("qmsg-%d", time.Now().UnixNano())
+		msg.ID = q.nextID("qmsg")
 	}
 	if msg.EnqueuedAt.IsZero() {
 		msg.EnqueuedAt = time.Now()
@@ -707,7 +719,7 @@ const DefaultQueueTimeout = 30
 // It creates a QueueMessage and enqueues it for the destination agent.
 func (q *MessageQueue) Send(ctx context.Context, fromAgent, toAgent, messageType string, payload *loomv1.MessagePayload, metadata map[string]string) (string, error) {
 	msg := &QueueMessage{
-		ID:          fmt.Sprintf("%s-%d", toAgent, time.Now().UnixNano()),
+		ID:          q.nextID(toAgent),
 		ToAgent:     toAgent,
 		FromAgent:   fromAgent,
 		MessageType: messageType,
@@ -752,7 +764,7 @@ func (q *MessageQueue) SendAndReceive(ctx context.Context, fromAgent, toAgent, m
 	start := time.Now()
 
 	// Generate unique correlation ID
-	correlationID := fmt.Sprintf("corr-%s-%d", fromAgent, time.Now().UnixNano())
+	correlationID := q.nextID("corr-" + fromAgent)
 	if span != nil {
 		span.SetAttribute("correlation_id", correlationID)
 	}
@@ -775,7 +787,7 @@ func (q *MessageQueue) SendAndReceive(ctx context.Context, fromAgent, toAgent, m
 
 	// Send request message with correlation ID
 	msg := &QueueMessage{
-		ID:            fmt.Sprintf("%s-req-%d", toAgent, time.Now().UnixNano()),
+		ID:            q.nextID(toAgent + "-req"),
 		ToAgent:       toAgent,
 		FromAgent:     fromAgent,
 		MessageType:   messageType,

--- a/pkg/config/paths_test.go
+++ b/pkg/config/paths_test.go
@@ -8,12 +8,24 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// absPathFixture returns a path that is genuinely absolute per
+// filepath.IsAbs on the current OS -- "/custom/..." is rooted but not
+// absolute on Windows (no drive letter), so tests that need an
+// already-absolute input use this instead of a Unix-only literal.
+func absPathFixture(elem ...string) string {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(append([]string{`C:\`}, elem...)...)
+	}
+	return filepath.Join(append([]string{"/"}, elem...)...)
+}
 
 func TestGetLoomDataDir(t *testing.T) {
 	// Save original env var
@@ -38,7 +50,7 @@ func TestGetLoomDataDir(t *testing.T) {
 	})
 
 	t.Run("use LOOM_DATA_DIR when set", func(t *testing.T) {
-		customDir := "/custom/loom/data"
+		customDir := absPathFixture("custom", "loom", "data")
 		_ = os.Setenv("LOOM_DATA_DIR", customDir)
 
 		dataDir := GetLoomDataDir()
@@ -91,7 +103,7 @@ func TestGetLoomSubDir(t *testing.T) {
 	})
 
 	t.Run("respect LOOM_DATA_DIR for subdirectories", func(t *testing.T) {
-		customDir := "/custom/loom"
+		customDir := absPathFixture("custom", "loom")
 		_ = os.Setenv("LOOM_DATA_DIR", customDir)
 
 		patternsDir := GetLoomSubDir("patterns")
@@ -117,8 +129,8 @@ func TestExpandPath(t *testing.T) {
 		},
 		{
 			name:     "absolute path unchanged",
-			input:    "/absolute/path",
-			expected: "/absolute/path",
+			input:    absPathFixture("absolute", "path"),
+			expected: absPathFixture("absolute", "path"),
 		},
 		{
 			name:  "relative path made absolute",

--- a/pkg/config/project_loader_test.go
+++ b/pkg/config/project_loader_test.go
@@ -289,21 +289,21 @@ func TestResolveRelativePath(t *testing.T) {
 	}{
 		{
 			name:    "relative path",
-			baseDir: "/project",
+			baseDir: absPathFixture("project"),
 			path:    "./agents/test.yaml",
-			want:    "/project/agents/test.yaml",
+			want:    filepath.Join(absPathFixture("project"), "agents", "test.yaml"),
 		},
 		{
 			name:    "absolute path unchanged",
-			baseDir: "/project",
-			path:    "/absolute/path/test.yaml",
-			want:    "/absolute/path/test.yaml",
+			baseDir: absPathFixture("project"),
+			path:    absPathFixture("absolute", "path", "test.yaml"),
+			want:    absPathFixture("absolute", "path", "test.yaml"),
 		},
 		{
 			name:    "parent directory",
-			baseDir: "/project/subdir",
+			baseDir: absPathFixture("project", "subdir"),
 			path:    "../agents/test.yaml",
-			want:    "/project/agents/test.yaml", // filepath.Join cleans paths
+			want:    filepath.Join(absPathFixture("project"), "agents", "test.yaml"), // filepath.Join cleans paths
 		},
 	}
 

--- a/pkg/evals/golden.go
+++ b/pkg/evals/golden.go
@@ -56,7 +56,7 @@ func CompareWithGoldenFile(goldenFilePath string, actualOutput string, threshold
 // UpdateGoldenFile updates a golden file with new content
 func UpdateGoldenFile(goldenFilePath string, content string) error {
 	// Create directory if it doesn't exist
-	dir := strings.TrimSuffix(goldenFilePath, "/"+strings.Split(goldenFilePath, "/")[len(strings.Split(goldenFilePath, "/"))-1])
+	dir := filepath.Dir(goldenFilePath)
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		return fmt.Errorf("failed to create golden file directory: %w", err)
 	}

--- a/pkg/metaagent/learning/config_loader_test.go
+++ b/pkg/metaagent/learning/config_loader_test.go
@@ -80,7 +80,7 @@ spec:
 	assert.True(t, config.Enabled)
 	assert.Equal(t, loomv1.AutonomyLevel_AUTONOMY_HUMAN_APPROVAL, config.AutonomyLevel)
 	assert.Equal(t, "30m", config.AnalysisInterval)
-	assert.Contains(t, config.WatchEvalSuites[0], "eval-suites/test.yaml")
+	assert.Contains(t, filepath.ToSlash(config.WatchEvalSuites[0]), "eval-suites/test.yaml")
 	assert.Equal(t, []string{"sql", "rest"}, config.Domains)
 
 	// Circuit breaker

--- a/pkg/metaagent/learning/dogfood_analysis_test.go
+++ b/pkg/metaagent/learning/dogfood_analysis_test.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -347,8 +347,7 @@ func runDogfoodScenario(t *testing.T, scenario struct {
 	tracer := observability.NewNoOpTracer()
 
 	// Setup database
-	dbPath := fmt.Sprintf("/tmp/loom-dogfood-%s-%d.db", scenario.domain, time.Now().UnixNano())
-	defer func() { _ = os.Remove(dbPath) }()
+	dbPath := filepath.Join(t.TempDir(), fmt.Sprintf("loom-dogfood-%s.db", scenario.domain))
 
 	db, err := sql.Open("sqlite3", dbPath)
 	require.NoError(t, err)
@@ -359,6 +358,7 @@ func runDogfoodScenario(t *testing.T, scenario struct {
 
 	collector, err := NewMetricsCollector(dbPath, tracer)
 	require.NoError(t, err)
+	defer func() { _ = collector.Close() }()
 
 	engine := NewLearningEngine(collector, tracer)
 

--- a/pkg/metaagent/learning/judge_integration_test.go
+++ b/pkg/metaagent/learning/judge_integration_test.go
@@ -514,6 +514,7 @@ func setupLearningAgent(t *testing.T, db *sql.DB, tracker *PatternEffectivenessT
 	dbPath := t.TempDir() + "/metrics.db"
 	collector, err := NewMetricsCollector(dbPath, tracer)
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = collector.Close() })
 
 	// Create learning engine
 	engine := NewLearningEngine(collector, tracer)

--- a/pkg/metaagent/learning/learning_agent_e2e_test.go
+++ b/pkg/metaagent/learning/learning_agent_e2e_test.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -37,8 +37,7 @@ func TestEndToEnd_FullLearningLoop(t *testing.T) {
 	tracer := observability.NewNoOpTracer()
 
 	// Setup database
-	dbPath := fmt.Sprintf("/tmp/loom-e2e-test-%d.db", time.Now().UnixNano())
-	defer func() { _ = os.Remove(dbPath) }()
+	dbPath := filepath.Join(t.TempDir(), "loom-e2e-test.db")
 
 	db, err := sql.Open("sqlite3", dbPath)
 	require.NoError(t, err)
@@ -51,6 +50,7 @@ func TestEndToEnd_FullLearningLoop(t *testing.T) {
 	// Create metrics collector
 	collector, err := NewMetricsCollector(dbPath, tracer)
 	require.NoError(t, err)
+	defer func() { _ = collector.Close() }()
 
 	// Create learning engine
 	engine := NewLearningEngine(collector, tracer)
@@ -266,8 +266,7 @@ func TestEndToEnd_AutonomyLevels(t *testing.T) {
 	for _, tt := range autonomyTests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup
-			dbPath := fmt.Sprintf("/tmp/loom-e2e-autonomy-%s-%d.db", tt.name, time.Now().UnixNano())
-			defer func() { _ = os.Remove(dbPath) }()
+			dbPath := filepath.Join(t.TempDir(), fmt.Sprintf("loom-e2e-autonomy-%s.db", tt.name))
 
 			db, err := sql.Open("sqlite3", dbPath)
 			require.NoError(t, err)
@@ -278,6 +277,7 @@ func TestEndToEnd_AutonomyLevels(t *testing.T) {
 
 			collector, err := NewMetricsCollector(dbPath, tracer)
 			require.NoError(t, err)
+			defer func() { _ = collector.Close() }()
 
 			engine := NewLearningEngine(collector, tracer)
 
@@ -302,8 +302,7 @@ func TestEndToEnd_CircuitBreaker(t *testing.T) {
 	tracer := observability.NewNoOpTracer()
 
 	// Setup
-	dbPath := fmt.Sprintf("/tmp/loom-e2e-circuit-%d.db", time.Now().UnixNano())
-	defer func() { _ = os.Remove(dbPath) }()
+	dbPath := filepath.Join(t.TempDir(), "loom-e2e-circuit.db")
 
 	db, err := sql.Open("sqlite3", dbPath)
 	require.NoError(t, err)
@@ -314,6 +313,7 @@ func TestEndToEnd_CircuitBreaker(t *testing.T) {
 
 	collector, err := NewMetricsCollector(dbPath, tracer)
 	require.NoError(t, err)
+	defer func() { _ = collector.Close() }()
 
 	engine := NewLearningEngine(collector, tracer)
 
@@ -342,8 +342,7 @@ func TestEndToEnd_ConcurrentOperations(t *testing.T) {
 	tracer := observability.NewNoOpTracer()
 
 	// Setup
-	dbPath := fmt.Sprintf("/tmp/loom-e2e-concurrent-%d.db", time.Now().UnixNano())
-	defer func() { _ = os.Remove(dbPath) }()
+	dbPath := filepath.Join(t.TempDir(), "loom-e2e-concurrent.db")
 
 	db, err := sql.Open("sqlite3", dbPath)
 	require.NoError(t, err)
@@ -354,6 +353,7 @@ func TestEndToEnd_ConcurrentOperations(t *testing.T) {
 
 	collector, err := NewMetricsCollector(dbPath, tracer)
 	require.NoError(t, err)
+	defer func() { _ = collector.Close() }()
 
 	engine := NewLearningEngine(collector, tracer)
 
@@ -416,8 +416,7 @@ func TestEndToEnd_Dogfooding(t *testing.T) {
 	tracer := observability.NewNoOpTracer()
 
 	// Setup
-	dbPath := fmt.Sprintf("/tmp/loom-e2e-dogfood-%d.db", time.Now().UnixNano())
-	defer func() { _ = os.Remove(dbPath) }()
+	dbPath := filepath.Join(t.TempDir(), "loom-e2e-dogfood.db")
 
 	db, err := sql.Open("sqlite3", dbPath)
 	require.NoError(t, err)
@@ -428,6 +427,7 @@ func TestEndToEnd_Dogfooding(t *testing.T) {
 
 	collector, err := NewMetricsCollector(dbPath, tracer)
 	require.NoError(t, err)
+	defer func() { _ = collector.Close() }()
 
 	engine := NewLearningEngine(collector, tracer)
 

--- a/pkg/observability/span_exporter_test.go
+++ b/pkg/observability/span_exporter_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -101,6 +102,9 @@ func TestEmbeddedTracer_WithSpanExporter(t *testing.T) {
 	_, span := tracer.StartSpan(ctx, "test.operation",
 		WithAttribute("key", "value"),
 	)
+	// Ensure real wall-clock time elapses so Duration is deterministically
+	// nonzero regardless of the OS clock's tick resolution.
+	time.Sleep(1 * time.Millisecond)
 	tracer.EndSpan(span)
 
 	// Verify span was exported with all lifecycle fields

--- a/pkg/orchestration/workflow_config_test.go
+++ b/pkg/orchestration/workflow_config_test.go
@@ -8,6 +8,7 @@ package orchestration
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -570,6 +571,9 @@ spec:
 }
 
 func TestLoadWorkflowFromYAML_FilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod on Windows only toggles the read-only attribute; it cannot make a file unreadable to its owner")
+	}
 	yaml := `
 apiVersion: loom/v1
 kind: Workflow

--- a/pkg/patterns/library.go
+++ b/pkg/patterns/library.go
@@ -339,9 +339,10 @@ func (lib *Library) loadFromFilesystem(name string) (*Pattern, error) {
 		data, err := os.ReadFile(cleanPath) // #nosec G304 -- path validated above
 		if err == nil {
 			relPath := path
-			if lib.patternsDir != "" && strings.HasPrefix(path, lib.patternsDir) {
-				relPath = strings.TrimPrefix(path, lib.patternsDir)
-				relPath = strings.TrimPrefix(relPath, string(filepath.Separator))
+			if lib.patternsDir != "" {
+				if rel, relErr := filepath.Rel(lib.patternsDir, path); relErr == nil {
+					relPath = rel
+				}
 			}
 			pattern, err := lib.parsePattern(data, name, relPath)
 			if err != nil {
@@ -543,11 +544,16 @@ func (lib *Library) indexFilesystem() []PatternSummary {
 
 		name := strings.TrimSuffix(filepath.Base(path), ".yaml")
 
-		// Compute relative path from patternsDir
+		// Compute relative path from patternsDir. filepath.Rel (unlike a
+		// string-prefix trim) is separator-agnostic, so this holds even
+		// though lib.patternsDir is stored verbatim as given by the caller
+		// (e.g. "../../patterns") while WalkDir renders path with the OS
+		// native separator.
 		relPath := path
-		if lib.patternsDir != "" && strings.HasPrefix(path, lib.patternsDir) {
-			relPath = strings.TrimPrefix(path, lib.patternsDir)
-			relPath = strings.TrimPrefix(relPath, string(filepath.Separator))
+		if lib.patternsDir != "" {
+			if rel, relErr := filepath.Rel(lib.patternsDir, path); relErr == nil {
+				relPath = rel
+			}
 		}
 
 		// Cache the path for this pattern

--- a/pkg/patterns/validation_test.go
+++ b/pkg/patterns/validation_test.go
@@ -324,9 +324,10 @@ func TestPatternCategorization(t *testing.T) {
 		t.Run(filepath.Base(path), func(t *testing.T) {
 			// Skip special themed directories that don't follow backend_type convention
 			actualDir := filepath.Dir(path)
+			actualDirSlash := filepath.ToSlash(actualDir)
 			specialDirs := []string{"fun", "nasa", "weaver"}
 			for _, specialDir := range specialDirs {
-				if strings.Contains(actualDir, "/"+specialDir) || strings.HasSuffix(actualDir, "/"+specialDir) {
+				if strings.Contains(actualDirSlash, "/"+specialDir) || strings.HasSuffix(actualDirSlash, "/"+specialDir) {
 					t.Skipf("Skipping pattern in themed directory '%s'", specialDir)
 					return
 				}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -56,6 +56,7 @@ func setupTestScheduler(t *testing.T) *Scheduler {
 		HotReload:    false,
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = scheduler.Stop(context.Background()) })
 
 	return scheduler
 }

--- a/pkg/server/workflow_ref_test.go
+++ b/pkg/server/workflow_ref_test.go
@@ -44,6 +44,7 @@ func newWorkflowTestServer(t *testing.T) (*MultiAgentServer, string) {
 		Logger:    zaptest.NewLogger(t),
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = reg.Close() })
 	s := &MultiAgentServer{logger: zaptest.NewLogger(t)}
 	s.SetAgentRegistry(reg)
 	return s, dir

--- a/pkg/shuttle/builtin/communication_test.go
+++ b/pkg/shuttle/builtin/communication_test.go
@@ -24,6 +24,7 @@ func createTestQueue(t *testing.T) *communication.MessageQueue {
 	queue, err := communication.NewMessageQueue(tmpFile, nil, zap.NewNop())
 	require.NoError(t, err)
 	require.NotNil(t, queue)
+	t.Cleanup(func() { _ = queue.Close() })
 	return queue
 }
 

--- a/pkg/shuttle/builtin/document_parse.go
+++ b/pkg/shuttle/builtin/document_parse.go
@@ -285,7 +285,10 @@ func (t *DocumentParseTool) cleanPath(path string) (string, error) {
 	// Clean the path
 	cleanPath := filepath.Clean(path)
 
-	// Security check: prevent access to sensitive system directories
+	// Security check: prevent access to sensitive system directories.
+	// filepath.Clean renders the OS-native separator (backslash on Windows),
+	// so compare on a slash-normalized form -- otherwise these Unix entries
+	// never match a cleaned Windows path.
 	blacklistedPaths := []string{
 		"/etc",
 		"/bin",
@@ -296,10 +299,13 @@ func (t *DocumentParseTool) cleanPath(path string) (string, error) {
 		"/Library/Security",
 		"/private/etc",
 		"/private/var/root",
+		"C:/Windows/System32",
+		"C:/Windows/SysWOW64",
 	}
 
+	slashPath := filepath.ToSlash(cleanPath)
 	for _, blocked := range blacklistedPaths {
-		if strings.HasPrefix(cleanPath, blocked) {
+		if strings.HasPrefix(slashPath, blocked) {
 			return "", fmt.Errorf("access denied to system directory: %s", blocked)
 		}
 	}

--- a/pkg/shuttle/builtin/document_parse_test.go
+++ b/pkg/shuttle/builtin/document_parse_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -682,8 +683,15 @@ func TestDocumentParseTool_FileTooLarge(t *testing.T) {
 func TestDocumentParseTool_SecurityCheck(t *testing.T) {
 	tool := NewDocumentParseTool("")
 
+	// "/etc/passwd" isn't a rooted absolute path in Go's Windows semantics
+	// (no drive letter), so use the platform's own sensitive-path fixture.
+	blockedPath := "/etc/passwd"
+	if runtime.GOOS == "windows" {
+		blockedPath = `C:\Windows\System32\config\SAM`
+	}
+
 	result, err := tool.Execute(context.Background(), map[string]interface{}{
-		"file_path": "/etc/passwd",
+		"file_path": blockedPath,
 	})
 
 	require.NoError(t, err)

--- a/pkg/shuttle/builtin/file_read.go
+++ b/pkg/shuttle/builtin/file_read.go
@@ -260,11 +260,18 @@ func isSensitiveReadPath(path string) bool {
 		"/private/etc/shadow",
 		"/private/etc/passwd",
 		"/private/etc/sudoers",
+		"C:/Windows/System32/config/SAM",
+		"C:/Windows/System32/config/SYSTEM",
 	}
+
+	// Compare on a slash-normalized form: callers pass paths through
+	// filepath.Clean, which renders the OS-native separator (backslash on
+	// Windows), so these Unix entries would otherwise never match.
+	slashPath := filepath.ToSlash(path)
 
 	// Exact match for very sensitive files
 	for _, s := range sensitive {
-		if path == s {
+		if slashPath == s {
 			return true
 		}
 	}
@@ -274,10 +281,11 @@ func isSensitiveReadPath(path string) bool {
 		"/proc",
 		"/sys",
 		"/dev",
+		"C:/Windows/System32/config",
 	}
 
 	for _, prefix := range protectedDirs {
-		if strings.HasPrefix(path, prefix+"/") || path == prefix {
+		if strings.HasPrefix(slashPath, prefix+"/") || slashPath == prefix {
 			return true
 		}
 	}

--- a/pkg/shuttle/builtin/file_read_test.go
+++ b/pkg/shuttle/builtin/file_read_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -207,8 +208,15 @@ func TestFileReadTool_Execute_Base64Encoding(t *testing.T) {
 func TestFileReadTool_Execute_SensitivePath(t *testing.T) {
 	tool := NewFileReadTool("")
 
+	// "/etc/shadow" isn't a rooted absolute path in Go's Windows semantics
+	// (no drive letter), so use the platform's own sensitive-path fixture.
+	blockedPath := "/etc/shadow"
+	if runtime.GOOS == "windows" {
+		blockedPath = `C:\Windows\System32\config\SAM`
+	}
+
 	result, err := tool.Execute(context.Background(), map[string]interface{}{
-		"path": "/etc/shadow",
+		"path": blockedPath,
 	})
 
 	require.NoError(t, err)

--- a/pkg/shuttle/builtin/file_write.go
+++ b/pkg/shuttle/builtin/file_write.go
@@ -249,11 +249,17 @@ func isSensitivePath(path string) bool {
 		"/dev",
 		"/proc",
 		"/sys",
+		"C:/Windows/System32",
+		"C:/Windows/SysWOW64",
 	}
 
+	// Compare on a slash-normalized form: callers pass paths through
+	// filepath.Clean, which renders the OS-native separator (backslash on
+	// Windows), so these Unix entries would otherwise never match.
+	slashPath := filepath.ToSlash(path)
 	for _, prefix := range sensitive {
 		// Check if path equals prefix or is within prefix directory
-		if path == prefix || strings.HasPrefix(path, prefix+string(filepath.Separator)) {
+		if slashPath == prefix || strings.HasPrefix(slashPath, prefix+"/") {
 			return true
 		}
 	}

--- a/pkg/shuttle/builtin/shell_execute.go
+++ b/pkg/shuttle/builtin/shell_execute.go
@@ -708,11 +708,15 @@ func isBlockedWorkingDir(path string) bool {
 		"C:\\Windows\\WinSxS",
 	}
 
-	cleanPath := filepath.Clean(path)
+	// filepath.Clean renders the OS-native separator (backslash on Windows), so
+	// compare on a slash-normalized form; otherwise the Unix entries above never
+	// match a cleaned Windows path and vice versa.
+	cleanPath := filepath.ToSlash(filepath.Clean(path))
 
 	// Check exact match or prefix
 	for _, blocked := range blockedDirs {
-		if cleanPath == blocked || strings.HasPrefix(cleanPath, blocked+string(filepath.Separator)) {
+		blockedSlash := filepath.ToSlash(blocked)
+		if cleanPath == blockedSlash || strings.HasPrefix(cleanPath, blockedSlash+"/") {
 			return true
 		}
 	}

--- a/pkg/shuttle/builtin/shell_execute_test.go
+++ b/pkg/shuttle/builtin/shell_execute_test.go
@@ -257,10 +257,15 @@ func TestShellExecuteTool_Execute_Windows(t *testing.T) {
 			},
 		},
 		{
+			// "default" shell resolution tries PowerShell before cmd, and
+			// PowerShell's `cd` (Set-Location) prints nothing for a bare
+			// call, unlike cmd.exe's builtin. Pin the shell so the test
+			// doesn't depend on which one auto-detection picks.
 			name: "working directory",
 			params: map[string]interface{}{
 				"command":     "cd",
 				"working_dir": "C:\\Windows\\Temp",
+				"shell":       "cmd",
 			},
 			expectSuccess: true,
 			validateResult: func(t *testing.T, data map[string]interface{}) {

--- a/pkg/skills/eviction_test.go
+++ b/pkg/skills/eviction_test.go
@@ -164,6 +164,9 @@ func TestOnSkillEviction_CalledOnEviction(t *testing.T) {
 	)
 
 	o.ActivateSkill("sess-1", &Skill{Name: "a"}, "test", "", 0.1)
+	// Ensure real wall-clock time elapses before eviction so activeFor is
+	// deterministically nonzero regardless of the OS clock's tick resolution.
+	time.Sleep(2 * time.Millisecond)
 	o.ActivateSkill("sess-1", &Skill{Name: "b"}, "test", "", 0.7)
 	// This should evict "a" (lowest confidence).
 	o.ActivateSkill("sess-1", &Skill{Name: "c"}, "test", "", 0.9)

--- a/pkg/storage/backend/sqlite_backend.go
+++ b/pkg/storage/backend/sqlite_backend.go
@@ -42,6 +42,7 @@ type SQLiteBackend struct {
 	taskStore         task.TaskStore
 	taskDB            *sql.DB // owned connection for task store; closed in Close()
 	migrator          *sqlite.Migrator
+	migratorDB        *sql.DB // owned connection backing migrator; closed in Close()
 	dbPath            string
 	tracer            observability.Tracer
 }
@@ -164,6 +165,7 @@ func NewSQLiteBackend(cfg *loomv1.SQLiteStorageConfig, tracer observability.Trac
 		taskStore:         taskStore,
 		taskDB:            taskDB,
 		migrator:          migrator,
+		migratorDB:        migratorDB,
 		dbPath:            dbPath,
 		tracer:            tracer,
 	}, nil
@@ -258,6 +260,11 @@ func (b *SQLiteBackend) Close() error {
 	if b.taskDB != nil {
 		if err := b.taskDB.Close(); err != nil && firstErr == nil {
 			firstErr = fmt.Errorf("task db close: %w", err)
+		}
+	}
+	if b.migratorDB != nil {
+		if err := b.migratorDB.Close(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("migrator db close: %w", err)
 		}
 	}
 

--- a/pkg/visualization/tool_test.go
+++ b/pkg/visualization/tool_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -28,6 +29,7 @@ func TestVisualizationTool_Execute(t *testing.T) {
 	}
 
 	topNJSON, _ := json.Marshal(topNResult)
+	outputPath := filepath.Join(t.TempDir(), "loom-test-report.html")
 
 	params := map[string]interface{}{
 		"datasets": []interface{}{
@@ -38,7 +40,7 @@ func TestVisualizationTool_Execute(t *testing.T) {
 		},
 		"title":       "Test Report",
 		"summary":     "This is a test report",
-		"output_path": "/tmp/loom-test-report.html",
+		"output_path": outputPath,
 		"theme":       "dark",
 	}
 
@@ -54,20 +56,20 @@ func TestVisualizationTool_Execute(t *testing.T) {
 
 	// Verify result data
 	data := result.Data.(map[string]interface{})
-	if data["output_path"] != "/tmp/loom-test-report.html" {
-		t.Errorf("output_path = %v, want /tmp/loom-test-report.html", data["output_path"])
+	if data["output_path"] != outputPath {
+		t.Errorf("output_path = %v, want %v", data["output_path"], outputPath)
 	}
 	if data["visualizations"] != 1 {
 		t.Errorf("visualizations = %v, want 1", data["visualizations"])
 	}
 
 	// Verify file was created
-	if _, err := os.Stat("/tmp/loom-test-report.html"); os.IsNotExist(err) {
+	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
 		t.Error("Output file was not created")
 	}
 
 	// Read and verify HTML content
-	htmlBytes, err := os.ReadFile("/tmp/loom-test-report.html")
+	htmlBytes, err := os.ReadFile(outputPath)
 	if err != nil {
 		t.Fatalf("Failed to read output file: %v", err)
 	}
@@ -86,9 +88,6 @@ func TestVisualizationTool_Execute(t *testing.T) {
 			t.Errorf("HTML missing required element: %s", elem)
 		}
 	}
-
-	// Cleanup
-	_ = os.Remove("/tmp/loom-test-report.html")
 }
 
 // TestVisualizationTool_InvalidParams tests parameter validation

--- a/test/loadtest/multiturn_profile_test.go
+++ b/test/loadtest/multiturn_profile_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime/pprof"
 	"testing"
 	"time"
@@ -16,7 +17,7 @@ import (
 // TestProfile_MultiTurn_Latency sends sequential requests to a single session
 // and measures per-turn latency, writing a CPU profile for the hot phase.
 // Run with: go test -tags fts5 -v -run TestProfile_MultiTurn_Latency ./test/loadtest/
-// Then: go tool pprof -http=:8080 /tmp/loom_multiturn_cpu.prof
+// Then: go tool pprof -http=:8080 <path logged at profiling start> (os.TempDir(), e.g. /tmp on Unix, %TEMP% on Windows)
 func TestProfile_MultiTurn_Latency(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping profiling test in -short mode")
@@ -73,10 +74,11 @@ func TestProfile_MultiTurn_Latency(t *testing.T) {
 	for turn := 5; turn < totalTurns; turn++ {
 		// Start profiling at turn 80
 		if turn == 80 && cpuFile == nil {
-			cpuFile, err = os.Create("/tmp/loom_multiturn_cpu.prof")
+			cpuPath := filepath.Join(os.TempDir(), "loom_multiturn_cpu.prof")
+			cpuFile, err = os.Create(cpuPath)
 			require.NoError(t, err)
 			require.NoError(t, pprof.StartCPUProfile(cpuFile))
-			t.Log("CPU profiling started at turn 80")
+			t.Logf("CPU profiling started at turn 80, writing to %s", cpuPath)
 		}
 
 		start := time.Now()
@@ -123,13 +125,14 @@ func TestProfile_MultiTurn_Latency(t *testing.T) {
 	if cpuFile != nil {
 		pprof.StopCPUProfile()
 		require.NoError(t, cpuFile.Close())
-		t.Logf("CPU profile written to /tmp/loom_multiturn_cpu.prof")
+		t.Logf("CPU profile written to %s", filepath.Join(os.TempDir(), "loom_multiturn_cpu.prof"))
 	}
 
 	// Write memory profile
-	memFile, err := os.Create("/tmp/loom_multiturn_mem.prof")
+	memPath := filepath.Join(os.TempDir(), "loom_multiturn_mem.prof")
+	memFile, err := os.Create(memPath)
 	require.NoError(t, err)
 	require.NoError(t, pprof.WriteHeapProfile(memFile))
 	require.NoError(t, memFile.Close())
-	t.Logf("Memory profile written to /tmp/loom_multiturn_mem.prof")
+	t.Logf("Memory profile written to %s", memPath)
 }


### PR DESCRIPTION
## Summary

Fixes ~95 tests that fail on Windows (`go test -tags fts5 ./...`), traced to a handful of distinct root causes rather than patched one-off. `go test -tags fts5 ./...` is now fully green on Windows.

- **`f36b441`** — SQLite migrator connection leak (`SQLiteBackend.Close`) that kept the DB file locked on Windows.
- **`a10de8b`** — `loom-mcp`'s log file handle was never closed; `buildLogger`/`setupLogger` now return an `io.Closer`, closed on shutdown.
- **`c5987eb`** — Two real cross-platform bugs: `pkg/evals/golden.go` split paths on `"/"` (created the golden file as a directory on Windows); `pkg/patterns/library.go` compared native-separator paths against a forward-slash literal, silently loading **0 of 158 patterns** on Windows.
- **`f1b8911`** — Sensitive-path blocklists (`pkg/shuttle/builtin`) only ever matched Unix paths on Windows due to the same separator issue — meaning file tools weren't actually blocking sensitive-directory access on that platform. Fixed the comparisons and added real Windows entries.
- **`343f5af`** — `pkg/communication` message IDs derived from `time.Now().UnixNano()` alone could collide within one clock tick, silently dropping messages. Added a per-queue atomic sequence.
- **`c818020`** — Various test helpers opened a resource with `Close()`/`Stop()` that was never called, or wrote to hardcoded `/tmp` (invalid on Windows). Windows can't remove a file with an open handle, unlike Unix.
- **`0233f83`** — Tests compared `filepath.Join`/`Abs` output against hardcoded forward-slash literals, which never match Windows' backslash form.
- **`6e86598`** — POSIX permission-bit assertions (chmod 0600/0000) skipped on Windows via `runtime.GOOS`, following the existing convention in `shell_execute_test.go` — Windows' ACL model doesn't represent these the same way.
- **`6f16803`** — Two duration assertions measured back-to-back operations with no elapsed wall-clock time; added a small sleep so the measurement is deterministic.

No test assertion, threshold, or enforcement was weakened — every fix is either mechanical (path separators, cleanup ordering, temp paths) or a `runtime.GOOS` skip for a concept that doesn't exist on that platform.

**Not code bugs** (confirmed by isolating and reproducing directly, no source changes made):
- `pkg/mcp/conformance` (9 tests) — was a corrupted local npx cache on the dev machine; cleared it, all pass.
- `go test -race` — ThreadSanitizer fails to allocate shadow memory on every package on this machine, consistent with Windows Mandatory ASLR blocking TSan's fixed-address reservation. A machine security-policy issue, not fixable in source.

## Test plan
- [x] `go test -tags fts5 ./...` passes clean on Windows (0 failures, verified across two full runs)
- [x] `go build -tags fts5 ./...` passes
- [x] CI (Linux/macOS/Windows build matrix + Linux race suite) — awaiting this PR's checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)