### PR TITLE
chore(proto): pin buf remote plugin versions

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -2,15 +2,15 @@ version: v2
 managed:
   enabled: false
 plugins:
-  - remote: buf.build/protocolbuffers/go
+  - remote: buf.build/protocolbuffers/go:v1.36.11
     out: gen/go
     opt:
       - paths=source_relative
-  - remote: buf.build/grpc/go
+  - remote: buf.build/grpc/go:v1.6.2
     out: gen/go
     opt:
       - paths=source_relative
-  - remote: buf.build/grpc-ecosystem/gateway
+  - remote: buf.build/grpc-ecosystem/gateway:v2.29.0
     out: gen/go
     opt:
       - paths=source_relative


### PR DESCRIPTION
## Summary

- Pin the 3 unpinned BSR remote plugins in `buf.gen.yaml` to exact versions, eliminating `gen/` drift when developers run `buf generate` with different buf CLI versions
- Pinned versions: `protocolbuffers/go:v1.36.11`, `grpc/go:v1.6.2`, `grpc-ecosystem/gateway:v2.29.0`
- The fourth plugin (`grpc-ecosystem/openapiv2:v2.22.0`) was already pinned

## Type of Change

- [x] Infrastructure/Build change

## Testing

- [x] Ran `buf generate` locally (buf 1.72.0) with pinned versions — zero diff against committed `gen/` output (produced by CI's buf 1.50.0)
- [x] `git diff --exit-code gen/` confirms no drift

## Proto Changes

- [x] No `.proto` files modified — only `buf.gen.yaml` plugin version pins
- [x] No breaking changes — generated output is byte-identical

## Documentation

- N/A — no user-facing changes

## Security

- N/A

## Performance

- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)